### PR TITLE
Add support for basic arithmetic operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: fmt
+        args: --all -- --check
 
     - name: Lint with clippy
       uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,8 +66,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
  "regex",
  "rustc-hash",
  "shlex",
@@ -346,6 +346,7 @@ dependencies = [
  "hex",
  "primitive-types",
  "rand",
+ "rstest",
  "serde",
  "serde_json",
  "solc",
@@ -608,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.9"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
+checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -632,11 +633,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2 1.0.21",
 ]
 
 [[package]]
@@ -719,6 +720,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+dependencies = [
+ "cfg-if",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +745,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +764,21 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -757,8 +795,8 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
  "syn",
 ]
 
@@ -828,12 +866,12 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.16"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
  "unicode-xid 0.2.0",
 ]
 
@@ -961,8 +999,8 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
  "syn",
  "wasm-bindgen-shared",
 ]
@@ -986,7 +1024,7 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
 dependencies = [
- "quote 1.0.2",
+ "quote 1.0.7",
  "wasm-bindgen-macro-support",
 ]
 
@@ -996,8 +1034,8 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
  "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -1043,8 +1081,8 @@ dependencies = [
  "anyhow",
  "heck",
  "log",
- "proc-macro2 1.0.9",
- "quote 1.0.2",
+ "proc-macro2 1.0.21",
+ "quote 1.0.7",
  "syn",
  "wasm-bindgen-backend",
  "weedle",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,6 +24,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 stringreader = "0.1"
 # Optional
 solc = { git = "https://github.com/spalladino/solc-rust", branch = "feature/solc-0.6.2", optional = true }
+rstest = "0.6.4"
 
 [dev-dependencies]
 evm = "0.14"

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -142,6 +142,7 @@ mod tests {
         Array,
         Base,
     };
+    use rstest::rstest;
 
     use fe_parser as parser;
 
@@ -167,6 +168,20 @@ mod tests {
         scope.borrow_mut().add_base("bar".to_string(), Base::U256);
 
         assert_eq!(map(scope, "foo = bar"), "foo := bar")
+    }
+
+    #[rstest(
+        assignment,
+        expected_yul,
+        case("foo = 1 + 1", "foo := add(1, 1)"),
+        case("foo = 1 - 1", "foo := sub(1, 1)"),
+        case("foo = 1 * 1", "foo := mul(1, 1)"),
+        case("foo = 1 / 1", "foo := div(1, 1)")
+    )]
+    fn assign_arithmetic_expression(assignment: &str, expected_yul: &str) {
+        let scope = scope();
+
+        assert_eq!(map(scope, assignment), expected_yul)
     }
 
     #[test]

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -8,6 +8,7 @@ use primitive_types::{
     H160,
     U256,
 };
+use rstest::rstest;
 use std::collections::BTreeMap;
 use std::fs;
 use std::iter;
@@ -184,6 +185,29 @@ fn return_u256() {
             "bar",
             vec![u256_token(42)],
             Some(u256_token(42)),
+        )
+    })
+}
+
+#[rstest(fixture_file, input, expected,
+    case("return_addition_u256.vy", vec![42, 42], Some(84)),
+    case("return_subtraction_u256.vy", vec![42, 42], Some(0)),
+    case("return_multiplication_u256.vy", vec![42, 42], Some(1764)),
+    case("return_division_u256.vy", vec![42, 42], Some(1)),
+)]
+fn test_method_return(fixture_file: &str, input: Vec<usize>, expected: Option<usize>) {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, fixture_file, "Foo");
+
+        harness.test_function(
+            &mut executor,
+            "bar",
+            input
+                .clone()
+                .into_iter()
+                .map(|val| u256_token(val))
+                .collect(),
+            expected.map(|val| u256_token(val)),
         )
     })
 }

--- a/compiler/tests/fixtures/return_addition_u256.vy
+++ b/compiler/tests/fixtures/return_addition_u256.vy
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: uint256, y: uint256) -> uint256:
+        return x + y

--- a/compiler/tests/fixtures/return_division_u256.vy
+++ b/compiler/tests/fixtures/return_division_u256.vy
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: uint256, y: uint256) -> uint256:
+        return x / y

--- a/compiler/tests/fixtures/return_multiplication_u256.vy
+++ b/compiler/tests/fixtures/return_multiplication_u256.vy
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: uint256, y: uint256) -> uint256:
+        return x * y

--- a/compiler/tests/fixtures/return_subtraction_u256.vy
+++ b/compiler/tests/fixtures/return_subtraction_u256.vy
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: uint256, y: uint256) -> uint256:
+        return x - y


### PR DESCRIPTION
### What was wrong

As stated in #24 we need to add support for basic arithmetic operations.

### How was it fixed

- Resolving binary expressions for `add`, `sub`, `mul`, `div` to their YUL counterparts
- Added tests in expressions, assignments as well as evm_contracts.  