### PR TITLE
Map comparision operators

### DIFF
--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -156,6 +156,7 @@ fn type_desc<'a>(
 
     match typ {
         fe::TypeDesc::Base { base: "u256" } => Ok(VarType::Uint256),
+        fe::TypeDesc::Base { base: "bool" } => Ok(VarType::Bool),
         fe::TypeDesc::Base { base: "address" } => Ok(VarType::Address),
         fe::TypeDesc::Base { base } => {
             Err(CompileError::str(format!("unrecognized type: {}", base)))

--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -168,6 +168,7 @@ pub enum FuncType {
 #[derive(Debug, PartialEq, Clone)]
 pub enum VarType {
     Uint256,
+    Bool,
     Address,
     FixedBytes(usize),
     FixedArray(Box<VarType>, usize),
@@ -187,6 +188,7 @@ pub enum StateMutability {
 impl fmt::Display for VarType {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
+            VarType::Bool => write!(f, "bool"),
             VarType::Uint256 => write!(f, "uint256"),
             VarType::Address => write!(f, "address"),
             VarType::FixedBytes(size) => write!(f, "bytes{}", size),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -156,6 +156,10 @@ fn address_token(s: &str) -> ethabi::Token {
     ethabi::Token::Address(H160::from_str(s).expect("Couldn't create address from string"))
 }
 
+fn bool_token(val: bool) -> ethabi::Token {
+    ethabi::Token::Bool(val)
+}
+
 fn bytes_token(s: &str) -> ethabi::Token {
     ethabi::Token::FixedBytes(ethabi::FixedBytes::from(s))
 }
@@ -190,28 +194,44 @@ fn return_u256() {
 }
 
 #[rstest(fixture_file, input, expected,
-    case("return_addition_u256.fe", vec![42, 42], Some(84)),
-    case("return_subtraction_u256.fe", vec![42, 42], Some(0)),
-    case("return_multiplication_u256.fe", vec![42, 42], Some(1764)),
-    case("return_division_u256.fe", vec![42, 42], Some(1)),
-    case("return_pow_u256.fe", vec![2, 0], Some(1)),
-    case("return_pow_u256.fe", vec![2, 4], Some(16)),
-    case("return_mod_u256.fe", vec![5, 0], Some(0)),
-    case("return_mod_u256.fe", vec![5, 2], Some(1)),
-    case("return_mod_u256.fe", vec![5, 3], Some(2)),
-    case("return_mod_u256.fe", vec![5, 5], Some(0)),
-    case("return_bitwiseand_u256.fe", vec![12, 25], Some(8)),
-    case("return_bitwiseor_u256.fe", vec![12, 25], Some(29)),
-    case("return_bitwisexor_u256.fe", vec![12, 25], Some(21)),
-    case("return_bitwiseshl_u256.fe", vec![212, 0], Some(212)),
-    case("return_bitwiseshl_u256.fe", vec![212, 1], Some(424)),
-    case("return_bitwiseshr_u256.fe", vec![212, 0], Some(212)),
-    case("return_bitwiseshr_u256.fe", vec![212, 1], Some(106)),
+    case("return_addition_u256.fe", vec![42, 42], Some(u256_token(84))),
+    case("return_subtraction_u256.fe", vec![42, 42], Some(u256_token(0))),
+    case("return_multiplication_u256.fe", vec![42, 42], Some(u256_token(1764))),
+    case("return_division_u256.fe", vec![42, 42], Some(u256_token(1))),
+    case("return_pow_u256.fe", vec![2, 0], Some(u256_token(1))),
+    case("return_pow_u256.fe", vec![2, 4], Some(u256_token(16))),
+    case("return_mod_u256.fe", vec![5, 0], Some(u256_token(0))),
+    case("return_mod_u256.fe", vec![5, 2], Some(u256_token(1))),
+    case("return_mod_u256.fe", vec![5, 3], Some(u256_token(2))),
+    case("return_mod_u256.fe", vec![5, 5], Some(u256_token(0))),
+    case("return_bitwiseand_u256.fe", vec![12, 25], Some(u256_token(8))),
+    case("return_bitwiseor_u256.fe", vec![12, 25], Some(u256_token(29))),
+    case("return_bitwisexor_u256.fe", vec![12, 25], Some(u256_token(21))),
+    case("return_bitwiseshl_u256.fe", vec![212, 0], Some(u256_token(212))),
+    case("return_bitwiseshl_u256.fe", vec![212, 1], Some(u256_token(424))),
+    case("return_bitwiseshr_u256.fe", vec![212, 0], Some(u256_token(212))),
+    case("return_bitwiseshr_u256.fe", vec![212, 1], Some(u256_token(106))),
+    // //comparision operators
+    case("return_eq_u256.fe", vec![1, 1], Some(bool_token(true))),
+    case("return_eq_u256.fe", vec![1, 2], Some(bool_token(false))),
+    case("return_noteq_u256.fe", vec![1, 1], Some(bool_token(false))),
+    case("return_noteq_u256.fe", vec![1, 2], Some(bool_token(true))),
+    case("return_lt_u256.fe", vec![1, 2], Some(bool_token(true))),
+    case("return_lt_u256.fe", vec![1, 1], Some(bool_token(false))),
+    case("return_lt_u256.fe", vec![2, 1], Some(bool_token(false))),
+    case("return_lte_u256.fe", vec![1, 2], Some(bool_token(true))),
+    case("return_lte_u256.fe", vec![1, 1], Some(bool_token(true))),
+    case("return_lte_u256.fe", vec![2, 1], Some(bool_token(false))),
+    case("return_gt_u256.fe", vec![2, 1], Some(bool_token(true))),
+    case("return_gt_u256.fe", vec![1, 1], Some(bool_token(false))),
+    case("return_gt_u256.fe", vec![1, 2], Some(bool_token(false))),
+    case("return_gte_u256.fe", vec![2, 1], Some(bool_token(true))),
+    case("return_gte_u256.fe", vec![1, 1], Some(bool_token(true))),
+    case("return_gte_u256.fe", vec![1, 2], Some(bool_token(false))),
 )]
-fn test_method_return(fixture_file: &str, input: Vec<usize>, expected: Option<usize>) {
+fn test_method_return(fixture_file: &str, input: Vec<usize>, expected: Option<ethabi::Token>) {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, fixture_file, "Foo");
-
         harness.test_function(
             &mut executor,
             "bar",
@@ -220,7 +240,7 @@ fn test_method_return(fixture_file: &str, input: Vec<usize>, expected: Option<us
                 .into_iter()
                 .map(|val| u256_token(val))
                 .collect(),
-            expected.map(|val| u256_token(val)),
+            expected.clone(),
         )
     })
 }

--- a/compiler/tests/fixtures/return_eq_u256.fe
+++ b/compiler/tests/fixtures/return_eq_u256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u256) -> bool:
+        return x == y

--- a/compiler/tests/fixtures/return_gt_u256.fe
+++ b/compiler/tests/fixtures/return_gt_u256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u256) -> bool:
+        return x > y

--- a/compiler/tests/fixtures/return_gte_u256.fe
+++ b/compiler/tests/fixtures/return_gte_u256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u256) -> bool:
+        return x >= y

--- a/compiler/tests/fixtures/return_lt_u256.fe
+++ b/compiler/tests/fixtures/return_lt_u256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u256) -> bool:
+        return x < y

--- a/compiler/tests/fixtures/return_lte_u256.fe
+++ b/compiler/tests/fixtures/return_lte_u256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u256) -> bool:
+        return x <= y

--- a/compiler/tests/fixtures/return_noteq_u256.fe
+++ b/compiler/tests/fixtures/return_noteq_u256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u256) -> bool:
+        return x != y

--- a/spec/index.md
+++ b/spec/index.md
@@ -433,7 +433,37 @@ Here are examples of these operators being used.
 
 ## 4.2.2 Comparision Operators
 
-MISSING
+## Comparison Operators
+
+> **<sup>Syntax</sup>**\
+> _ComparisonExpression_ :\
+> &nbsp;&nbsp; &nbsp;&nbsp; [_Expression_] `==` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `!=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `>` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `<` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `>=` [_Expression_]\
+> &nbsp;&nbsp; | [_Expression_] `<=` [_Expression_]
+
+
+| Symbol | Meaning                  |     Status                 |
+|--------|--------------------------|----------------------------|
+| `==`   | Equal                    |         IMPLEMENTED        |
+| `!=`   | Not equal                |         IMPLEMENTED        |
+| `>`    | Greater than             |         IMPLEMENTED        |
+| `<`    | Less than                |         IMPLEMENTED        |
+| `>=`   | Greater than or equal to |         IMPLEMENTED        |
+| `<=`   | Less than or equal to    |         IMPLEMENTED        |
+
+Here are examples of the comparison operators being used.
+
+```
+123 == 123
+23 != -12
+12 > 11
+11 >= 11
+11 < 12
+11 <= 11
+```
 
 ## 5. Types system
 


### PR DESCRIPTION
### What was wrong?

We do not yet map various comparison expressions (e.g. `==`, `!=` etc)

### How was it fixed?

1. Had to add support for `bool` in various places (I'm being vague because I don't always exactly now yet what I'm doing :joy: )
2. Mapped expressions to their YUL counterparts which for some expressions meant to generate chained calls where the result of one opcode is the input to an `iszero` call
3. Updated the spec

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
