### PR TITLE
Make CI run with solc-backend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Rust dependencies
+      uses: actions/cache@v1.1.2
+      with:
+        path: target
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
     - name: coverage with tarpaulin
       run: |
         ./coverage.sh --out Xml
@@ -27,7 +32,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libboost-all-dev
     - uses: actions/checkout@v2
+    - name: Cache Rust dependencies
+      uses: actions/cache@v1.1.2
+      with:
+        path: target
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
@@ -55,6 +68,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Cache Rust dependencies
+      uses: actions/cache@v1.1.2
+      with:
+        path: target
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libboost-all-dev
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
@@ -63,7 +84,7 @@ jobs:
         override: true
         components: rustfmt, clippy
     - name: Run tests
-      run: cargo test --workspace --verbose
+      run: cargo test --workspace --features solc-backend --verbose
 
   wasm-test:
       runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [workspace]
 members = [".", "parser", "compiler"]
 
+[features]
+solc-backend = ["fe-compiler/solc-backend"]
+
 [dependencies]
 fe-parser = {path = "parser", version = "0.1.0"}
 fe-compiler = {path = "compiler", version = "0.1.0"}

--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -2,8 +2,6 @@
 
 use crate::errors::CompileError;
 use crate::yul;
-use serde_json;
-use solc;
 
 /// Compiles Fe to bytecode. It uses Yul as an intermediate representation.
 pub fn compile(src: &str) -> Result<String, CompileError> {


### PR DESCRIPTION
### What was wrong?

As described in #32, CI does currently not run the tests that compile actual Fe contracts. That's because running these tests depends on compiling `solc-rust` which is time consuming and requires certain system dependencies. Obviously, this is a problem and its not just tests, linting doesn't run over the entire code base either for this reason.

### How was it fixed?

1. Install `libboost-all-dev` system dependency
2. Setup caching for build artifacts (based on `Cargo.lock`)
3. Introduce `solc-backend` flag to the main project and pass it down
4. Run tests with `solc-backend` enabled.

As we can see in the test runs of this PR, jobs run still very fast with 2 - 3 m (except after Christmas / NYE when cache eviction policy kicked in because no one sent PRs for 7 straight days)

![image](https://user-images.githubusercontent.com/521109/94710706-70811080-0347-11eb-97d1-6e715dc72cd2.png)


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
