### PR TITLE
Implement revert

### DIFF
--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -99,8 +99,16 @@ fn func_stmt(
         fe::FuncStmt::Pass => unimplemented!(),
         fe::FuncStmt::Break => unimplemented!(),
         fe::FuncStmt::Continue => unimplemented!(),
-        fe::FuncStmt::Revert => unimplemented!(),
+        fe::FuncStmt::Revert => revert(stmt),
     }
+}
+
+fn revert(stmt: &Spanned<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
+    if let fe::FuncStmt::Revert = &stmt.node {
+        return Ok(statement! { revert(0, 0) });
+    }
+
+    unreachable!()
 }
 
 fn emit(context: &Context, stmt: &Spanned<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -188,6 +188,20 @@ fn evm_sanity() {
     })
 }
 
+#[test]
+fn test_revert() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "revert.fe", "Foo");
+
+        let exit = harness.capture_call(&mut executor, "bar", &vec![]);
+
+        assert!(matches!(
+            exit,
+            evm::Capture::Exit((evm::ExitReason::Revert(_), _))
+        ))
+    })
+}
+
 #[rstest(fixture_file, input, expected,
     case("return_u256.fe", vec![], Some(u256_token(42))),
     case("return_identity_u256.fe", vec![42], Some(u256_token(42))),

--- a/compiler/tests/fixtures/revert.fe
+++ b/compiler/tests/fixtures/revert.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> u256:
+        revert

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -108,7 +108,7 @@ fn func_stmt(
         fe::FuncStmt::Pass => unimplemented!(),
         fe::FuncStmt::Break => unimplemented!(),
         fe::FuncStmt::Continue => unimplemented!(),
-        fe::FuncStmt::Revert => unimplemented!(),
+        fe::FuncStmt::Revert => Ok(()),
     }
 }
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -374,7 +374,24 @@ contract GuestBook:
 
 ### 4.1. Statements
 
-MISSING
+### 4.1.1 `revert` statement
+
+
+> **<sup>Syntax</sup>**\
+> _RevertStatement_ :\
+> &nbsp;&nbsp; `revert`<sup>?</sup>
+
+The revert statement is denoted with the keyword `revert`. Evaluating a `revert`
+statement will cause to revert all state changes made by the call and return with an revert error to the caller.
+
+An example of a `revert` statement:
+
+```
+def transfer(to : address, value : u256):
+    if not self.in_whitelist(to):
+        revert
+    # more logic here
+```
 
 ### 4.2 Expressions
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -431,9 +431,7 @@ Here are examples of these operators being used.
 212 >> 1 == 106
 ```
 
-## 4.2.2 Comparision Operators
-
-## Comparison Operators
+### 4.2.2 Comparision Operators
 
 > **<sup>Syntax</sup>**\
 > _ComparisonExpression_ :\


### PR DESCRIPTION
### What was wrong?

We need to have support for `revert` expressions.

### How was it fixed?

1. Refactored `test_function` into two functions in order to re-use it for revert assertion
2. Mapped  `revert` to `revert(0,0)` in YUL (Ignoring revert reasons #75 for now)
3. Added a contract test for revert
4. Added coverage for `revert` in the spec

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] **Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md)**
- [x] Clean up commit history
