### PR TITLE
Implement call expressions

### DIFF
--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -14,7 +14,7 @@ pub enum ErrorKind {
 /// List of errors encountered during compilation.
 #[derive(Debug)]
 pub struct CompileError {
-    errors: Vec<ErrorKind>,
+    pub errors: Vec<ErrorKind>,
 }
 
 impl Default for CompileError {

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -29,13 +29,24 @@ pub fn expr(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expressio
         fe::Expr::BinOperation { .. } => expr_bin_operation(context, exp),
         fe::Expr::UnaryOperation { .. } => unimplemented!(),
         fe::Expr::CompOperation { .. } => expr_comp_operation(context, exp),
-        fe::Expr::Call { .. } => unimplemented!(),
+        fe::Expr::Call { .. } => expr_call(exp),
         fe::Expr::List { .. } => unimplemented!(),
         fe::Expr::ListComp { .. } => unimplemented!(),
         fe::Expr::Tuple { .. } => unimplemented!(),
         fe::Expr::Str(_) => unimplemented!(),
         fe::Expr::Ellipsis => unimplemented!(),
     }
+}
+
+pub fn expr_call(exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
+    if let fe::Expr::Call { args: _, func } = &exp.node {
+        if let fe::Expr::Attribute { value: _, attr } = &func.node {
+            let func_name = identifier! { (attr.node) };
+            return Ok(expression! { [func_name]() });
+        }
+    }
+
+    unreachable!()
 }
 
 pub fn expr_comp_operation(

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -1,0 +1,27 @@
+#![cfg(feature = "solc-backend")]
+
+use fe_compiler::errors::CompileError;
+
+use rstest::rstest;
+use std::fs;
+
+#[rstest(
+    fixture_file,
+    error,
+    case(
+        "return_call_to_fn_without_return.fe",
+        "[Str(\"semantic error: NotAnExpression\")]"
+    )
+)]
+fn test_compile_errors(fixture_file: &str, error: &str) {
+    let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))
+        .expect("Unable to read fixture file");
+
+    match fe_compiler::evm::compile(&src) {
+        Err(CompileError { errors }) => assert_eq!(format!("{:?}", errors), error),
+        _ => panic!(
+            "Compiling succeeded when it was expected to fail with: {}",
+            error
+        ),
+    }
+}

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -203,6 +203,7 @@ fn test_revert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("return_u256_from_called_fn.fe", vec![], Some(u256_token(42))),
     case("return_u256.fe", vec![], Some(u256_token(42))),
     case("return_identity_u256.fe", vec![42], Some(u256_token(42))),
     // binary operators

--- a/compiler/tests/fixtures/compile_errors/return_call_to_fn_without_return.fe
+++ b/compiler/tests/fixtures/compile_errors/return_call_to_fn_without_return.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+    pub def foo():
+        revert
+
+    pub def bar() -> u256:
+        return self.foo()

--- a/compiler/tests/fixtures/return_u256_from_called_fn.fe
+++ b/compiler/tests/fixtures/return_u256_from_called_fn.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+    pub def foo() -> u256:
+        return 42
+
+    pub def bar() -> u256:
+        return self.foo()

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -3,6 +3,7 @@
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum SemanticError {
+    NotAnExpression,
     UnassignableExpression,
     UndefinedValue,
     TypeError,

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -42,7 +42,7 @@ pub fn expr(
         fe::Expr::BinOperation { .. } => expr_bin_operation(scope, Rc::clone(&context), exp)?,
         fe::Expr::UnaryOperation { .. } => unimplemented!(),
         fe::Expr::CompOperation { .. } => expr_comp_operation(scope, Rc::clone(&context), exp)?,
-        fe::Expr::Call { .. } => unimplemented!(),
+        fe::Expr::Call { .. } => expr_call(scope, exp)?,
         fe::Expr::List { .. } => unimplemented!(),
         fe::Expr::ListComp { .. } => unimplemented!(),
         fe::Expr::Tuple { .. } => unimplemented!(),
@@ -251,6 +251,34 @@ fn expr_bin_operation(
             typ: Type::Base(Base::U256),
             location: Location::Value,
         });
+    }
+
+    unreachable!()
+}
+
+fn expr_call(
+    scope: Shared<FunctionScope>,
+    exp: &Spanned<fe::Expr>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    if let fe::Expr::Call { args: _, func } = &exp.node {
+        if let fe::Expr::Attribute { value: _, attr } = &func.node {
+            let contract_scope = &scope.borrow().parent;
+            let called_func = contract_scope.borrow().def(attr.node.to_string());
+            return match called_func {
+                Some(ContractDef::Function {
+                    params: _,
+                    returns: Some(return_type),
+                }) => Ok(ExpressionAttributes {
+                    typ: return_type.into_type(),
+                    location: Location::Value,
+                }),
+                Some(ContractDef::Function {
+                    params: _,
+                    returns: None,
+                }) => Err(SemanticError::NotAnExpression),
+                _ => unreachable!(),
+            };
+        }
     }
 
     unreachable!()

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -166,7 +166,7 @@ fn func_return(
     stmt: &Spanned<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Return { value: Some(value) } = &stmt.node {
-        let _attributes = expressions::expr(scope, context, value);
+        let _attributes = expressions::expr(scope, context, value)?;
 
         // TODO: Perform type checking
 


### PR DESCRIPTION
### What was wrong?

We currently do not support call expressions (e.g. `return self.foo()`)


### How was it fixed?

- mapped the `expr_call` in the mapper
- in the semantic pass, check if the called function does have a return value and raise a `TypeError` if not
- Added a fixture contract to test the success case
- Started a new category of fixture tests that check for compile errors and added a fixture for the described error case

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Create issue for call expressions with arguments
- [x] Created issue for initial sweep of function definitions