### PR TITLE
Support AST and Tokens as output targets

### DIFF
--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -4,6 +4,8 @@ use crate::errors::CompileError;
 use crate::yul;
 
 pub struct CompilerOutput {
+    pub tokens: String,
+    pub ast: String,
     pub yul: String,
     pub bytecode: String,
 }
@@ -11,7 +13,8 @@ pub struct CompilerOutput {
 /// Compiles Fe to bytecode. It uses Yul as an intermediate representation.
 pub fn compile(src: &str) -> Result<CompilerOutput, CompileError> {
     let solc_temp = include_str!("solc_temp.json");
-    let yul_src = yul::compile(src)?.replace("\"", "\\\"");
+    let yul_output = yul::compile(src)?;
+    let yul_src = yul_output.yul.replace("\"", "\\\"");
     let input = solc_temp.replace("{src}", &yul_src);
     let raw_output = solc::compile(&input);
     let output: serde_json::Value = serde_json::from_str(&raw_output)?;
@@ -24,8 +27,10 @@ pub fn compile(src: &str) -> Result<CompilerOutput, CompileError> {
     }
 
     Ok(CompilerOutput {
-        yul: yul_src,
+        ast: yul_output.ast,
         bytecode,
+        tokens: yul_output.tokens,
+        yul: yul_src,
     })
 }
 

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -5,8 +5,14 @@ use crate::errors::CompileError;
 mod mappers;
 mod runtime;
 
+pub struct CompilerOutput {
+    pub tokens: String,
+    pub ast: String,
+    pub yul: String,
+}
+
 /// Compiles Fe to Yul.
-pub fn compile(src: &str) -> Result<String, CompileError> {
+pub fn compile(src: &str) -> Result<CompilerOutput, CompileError> {
     let tokens = fe_parser::get_parse_tokens(src)?;
     let fe_module = fe_parser::parsers::file_input(&tokens[..])?.1.node;
     let context = fe_semantics::analysis(&fe_module)?;
@@ -16,7 +22,11 @@ pub fn compile(src: &str) -> Result<String, CompileError> {
         .values()
         .next()
     {
-        return Ok(first_contract.to_string());
+        return Ok(CompilerOutput {
+            tokens: format!("{:?}", tokens),
+            ast: format!("{:?}", fe_module),
+            yul: first_contract.to_string(),
+        });
     }
 
     Err(CompileError::static_str("unable to parse tokens."))

--- a/src/main_full.rs
+++ b/src/main_full.rs
@@ -38,12 +38,14 @@ pub fn main() {
         .arg(
             Arg::with_name("output-dir")
                 .short("o")
+                .long("output-dir")
                 .help("The directory to store the compiler output e.g /tmp/output")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("emit")
                 .short("e")
+                .long("emit")
                 .help("Comma seperated compile targets e.g. -e=bytecode,yul")
                 .default_value("bytecode")
                 .use_delimiter(true)

--- a/src/main_full.rs
+++ b/src/main_full.rs
@@ -20,7 +20,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 arg_enum! {
     #[derive(PartialEq, Debug)]
     pub enum CompilationTarget {
+        Ast,
         Bytecode,
+        Tokens,
         Yul,
     }
 }
@@ -92,9 +94,17 @@ fn compile(src_file: &str, output_dir: &str, targets: Vec<CompilationTarget>) ->
 
     for target in targets {
         match target {
+            CompilationTarget::Ast => {
+                let mut file_ast = fs::File::create(output_dir.join("out.ast"))?;
+                file_ast.write_all(output.ast.as_bytes())?;
+            }
             CompilationTarget::Bytecode => {
                 let mut file_bytecode = fs::File::create(output_dir.join("out.bin"))?;
                 file_bytecode.write_all(output.bytecode.as_bytes())?;
+            }
+            CompilationTarget::Tokens => {
+                let mut file_tokens = fs::File::create(output_dir.join("out.tokens"))?;
+                file_tokens.write_all(output.tokens.as_bytes())?;
             }
             CompilationTarget::Yul => {
                 let mut file_yul = fs::File::create(output_dir.join("out.yul"))?;


### PR DESCRIPTION
### What was wrong?

There's currently no way to instruct the compiler to show the internal representation of Tokens or AST for a given code snippet. Being able to emit these can be beneficial for learning purposes and debugging.

### How was it fixed?

- Unrelated but included in this PR: Map `-e`, `-o` to `--emit` and `--output-dir`
- add support for `ast` and `tokens` target
- internal changed the yul compiler from only emitting the bare yul str to emitting a `CompilerOutput`

```rust
pub struct CompilerOutput {
    pub tokens: String,
    pub ast: String,
    pub yul: String,
}
```
 
