### PR TITLE
Nested maps

### DIFF
--- a/compiler/src/yul/mappers/mod.rs
+++ b/compiler/src/yul/mappers/mod.rs
@@ -5,3 +5,4 @@ mod declarations;
 mod expressions;
 mod functions;
 pub mod module;
+mod operations;

--- a/compiler/src/yul/mappers/operations.rs
+++ b/compiler/src/yul/mappers/operations.rs
@@ -1,0 +1,21 @@
+use fe_semantics::namespace::types::{
+    Base,
+    FixedSize,
+};
+use yultsur::*;
+
+/// Loads a base value in storage.
+///
+/// The return expression contains a base value.
+pub fn sload(base: Base, sptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (base.size()) };
+    expression! { sloadn([sptr], [size]) }
+}
+
+/// Copies a fixed size value from storage to memory.
+///
+/// The return expression contains a memory pointer.
+pub fn scopy(fixed_size: FixedSize, sptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (fixed_size.size()) };
+    expression! { scopy([sptr], [size]) }
+}

--- a/compiler/src/yul/runtime/abi.rs
+++ b/compiler/src/yul/runtime/abi.rs
@@ -70,7 +70,7 @@ fn selection_as_statement(
 #[test]
 fn test_selector_literal_basic() {
     assert_eq!(
-        selector("foo".to_string(), &vec![]).to_string(),
+        selector("foo".to_string(), &[]).to_string(),
         String::from("0xc2985578"),
     )
 }
@@ -78,7 +78,7 @@ fn test_selector_literal_basic() {
 #[test]
 fn test_selector_literal() {
     assert_eq!(
-        selector("bar".to_string(), &vec![FixedSize::Base(Base::U256)]).to_string(),
+        selector("bar".to_string(), &[FixedSize::Base(Base::U256)]).to_string(),
         String::from("0x0423a132"),
     )
 }

--- a/compiler/src/yul/runtime/functions.rs
+++ b/compiler/src/yul/runtime/functions.rs
@@ -24,6 +24,7 @@ pub fn avail() -> yul::Statement {
     function_definition! {
         function avail() -> ptr {
             (ptr := mload(0x00))
+            (if (eq(ptr, 0x00)) { (ptr := 0x20) })
         }
     }
 }

--- a/compiler/tests/erc20.rs
+++ b/compiler/tests/erc20.rs
@@ -1,7 +1,6 @@
 //! Delete this file once the erc20 contract can be compiled and add a new
 //! test in evm_contracts that validates the behavior of the erc20 contract.
 
-use fe_parser;
 use std::fs;
 
 #[test]

--- a/compiler/tests/fixtures/nested_map.fe
+++ b/compiler/tests/fixtures/nested_map.fe
@@ -1,0 +1,15 @@
+contract Foo:
+    bar: map<address, map<address, u256>>
+    baz: map<address, map<u256, bool>>
+
+    pub def read_bar(a: address, b: address) -> u256:
+        return self.bar[a][b]
+
+    pub def write_bar(a: address, b: address, value: u256):
+        self.bar[a][b] = value
+
+    pub def read_baz(a: address, b: u256) -> bool:
+        return self.baz[a][b]
+
+    pub def write_baz(a: address, b: u256, value: bool):
+        self.baz[a][b] = value

--- a/compiler/tests/fixtures/return_sender.fe
+++ b/compiler/tests/fixtures/return_sender.fe
@@ -1,3 +1,3 @@
 contract Foo:
-    pub def bar(x: u256) -> address:
+    pub def bar() -> address:
         return msg.sender

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -39,6 +39,13 @@ pub struct ExpressionAttributes {
     pub location: Location,
 }
 
+impl ExpressionAttributes {
+    /// Convenience method for matching type and location.
+    pub fn to_tuple(&self) -> (Type, Location) {
+        (self.typ.clone(), self.location.clone())
+    }
+}
+
 /// Contains contextual information relating to a function definition AST node.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionAttributes {

--- a/semantics/src/traversal/assignments.rs
+++ b/semantics/src/traversal/assignments.rs
@@ -101,8 +101,8 @@ mod tests {
     use crate::namespace::types::{
         Array,
         Base,
-        FixedSize,
         Map,
+        Type,
     };
     use crate::traversal::assignments::assign;
     use crate::Context;
@@ -120,8 +120,8 @@ mod tests {
         contract_scope.borrow_mut().add_map(
             "foobar".to_string(),
             Map {
-                key: FixedSize::Base(Base::U256),
-                value: FixedSize::Base(Base::U256),
+                key: Base::U256,
+                value: Box::new(Type::Base(Base::U256)),
             },
         );
         let function_scope = FunctionScope::new(contract_scope);

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -5,13 +5,10 @@ use crate::namespace::scopes::{
     FunctionScope,
     Shared,
 };
-use crate::namespace::types::{
-    Array,
-    Map,
-};
+
+use crate::namespace::operations;
 use crate::namespace::types::{
     Base,
-    FixedSize,
     Type,
 };
 use crate::{
@@ -144,52 +141,24 @@ fn expr_subscript(
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Subscript { value, slices } = &exp.node {
         let value_attributes = expr(Rc::clone(&scope), Rc::clone(&context), value)?;
-        let _index_attributes = slices_index(scope, context, slices)?;
+        let index_attributes = slices_index(scope, context, slices)?;
 
-        // TODO: Perform type checking
-
-        let attributes = match value_attributes {
-            ExpressionAttributes {
-                typ:
-                    Type::Map(Map {
-                        key: _,
-                        value: FixedSize::Base(base),
-                    }),
-                location: Location::Storage { .. },
-            } => ExpressionAttributes {
-                typ: Type::Base(base),
-                location: Location::Value,
-            },
-            ExpressionAttributes {
-                typ:
-                    Type::Map(Map {
-                        key: _,
-                        value: FixedSize::Array(array),
-                    }),
-                location: Location::Storage { .. },
-            } => ExpressionAttributes {
-                typ: Type::Array(array),
-                location: Location::Memory,
-            },
-            ExpressionAttributes {
-                typ: Type::Array(_),
-                location: Location::Storage { .. },
-            } => unimplemented!(),
-            ExpressionAttributes {
-                typ:
-                    Type::Array(Array {
-                        dimension: _,
-                        inner,
-                    }),
-                location: Location::Memory,
-            } => ExpressionAttributes {
-                typ: Type::Base(inner),
-                location: Location::Value,
-            },
-            _ => unimplemented!(),
+        let typ = operations::index(value_attributes.typ.clone(), index_attributes.typ)?;
+        let location = match value_attributes.typ {
+            Type::Map(map) => {
+                match *map.value {
+                    Type::Base(_) => Location::Value,
+                    Type::Array(_) => Location::Memory,
+                    // Index value is ignored. We may want to introduce a new location
+                    // variant named StorageRuntime or something to suit this case.
+                    Type::Map(_) => Location::Storage { index: 0 },
+                }
+            }
+            Type::Array(_) => Location::Value,
+            Type::Base(_) => unreachable!(),
         };
 
-        return Ok(attributes);
+        return Ok(ExpressionAttributes { typ, location });
     }
 
     unreachable!()
@@ -288,7 +257,6 @@ mod tests {
     use crate::namespace::types::{
         Array,
         Base,
-        FixedSize,
         Map,
         Type,
     };
@@ -321,13 +289,15 @@ mod tests {
         location: Location::Memory,
     };
 
-    static ADDR_U256_MAP_STO: ExpressionAttributes = ExpressionAttributes {
-        typ: Type::Map(Map {
-            key: FixedSize::Base(Base::Address),
-            value: FixedSize::Base(Base::U256),
-        }),
-        location: Location::Storage { index: 0 },
-    };
+    fn addr_u256_map_sto() -> ExpressionAttributes {
+        ExpressionAttributes {
+            typ: Type::Map(Map {
+                key: Base::Address,
+                value: Box::new(Type::Base(Base::U256)),
+            }),
+            location: Location::Storage { index: 0 },
+        }
+    }
 
     fn scope() -> Shared<FunctionScope> {
         let module_scope = ModuleScope::new();
@@ -368,7 +338,7 @@ mod tests {
         case(
             "self.my_addr_u256_map[my_addr_array[42]] + 26",
             &[
-                (0, 21, &ADDR_U256_MAP_STO), (22, 35, &ADDR_ARRAY_MEM), (36, 38, &U256_VAL),
+                (0, 21, &addr_u256_map_sto()), (22, 35, &ADDR_ARRAY_MEM), (36, 38, &U256_VAL),
                 (43, 45, &U256_VAL), (22, 39, &ADDR_VAL), (0, 40, &U256_VAL), (0, 45, &U256_VAL)
             ]
         ),
@@ -388,8 +358,8 @@ mod tests {
         scope.borrow_mut().contract_scope().borrow_mut().add_map(
             "my_addr_u256_map".to_string(),
             Map {
-                key: FixedSize::Base(Base::Address),
-                value: FixedSize::Base(Base::U256),
+                key: Base::Address,
+                value: Box::new(Type::Base(Base::U256)),
             },
         );
 

--- a/semantics/tests/analysis.rs
+++ b/semantics/tests/analysis.rs
@@ -7,7 +7,6 @@ use fe_semantics;
 use fe_semantics::namespace::types::{
     Array,
     Base,
-    FixedSize,
     Map,
     Type,
 };
@@ -31,16 +30,18 @@ static BYTES_MEM: ExpressionAttributes = ExpressionAttributes {
     location: Location::Memory,
 };
 
-static ADDR_BYTES_MAP_STO: ExpressionAttributes = ExpressionAttributes {
-    typ: Type::Map(Map {
-        key: FixedSize::Base(Base::Address),
-        value: FixedSize::Array(Array {
-            dimension: 100,
-            inner: Base::Byte,
+fn addr_bytes_map_sto() -> ExpressionAttributes {
+    ExpressionAttributes {
+        typ: Type::Map(Map {
+            key: Base::Address,
+            value: Box::new(Type::Array(Array {
+                dimension: 100,
+                inner: Base::Byte,
+            })),
         }),
-    }),
-    location: Location::Storage { index: 0 },
-};
+        location: Location::Storage { index: 0 },
+    }
+}
 
 fn mock_spanned_expr(start: usize, end: usize) -> Spanned<fe::Expr<'static>> {
     Spanned {
@@ -72,7 +73,7 @@ fn guest_book_analysis() {
         (200, 210, &ADDR_VAL),
         (214, 222, &BYTES_MEM),
         (253, 261, &BYTES_MEM),
-        (326, 341, &ADDR_BYTES_MAP_STO),
+        (326, 341, &addr_bytes_map_sto()),
         (326, 347, &BYTES_MEM),
         (342, 346, &ADDR_VAL),
     ] {

--- a/spec/index.md
+++ b/spec/index.md
@@ -496,26 +496,28 @@ limited capabilities.
 
 The list of types is:
 
-* Primitive types:
-    * [Boolean] — `true` or `false`
-    * [Numeric] — integer
-* Sequence types:
-    * [Tuple]
-    * [Array]
-    * [Bytes]
-* User-defined types:
-    * [Struct]
-    * [Enum]
-    * [Contract]
+* Data types
+    * Base types:
+        * [Boolean] — `true` or `false`
+        * [Address] - Ethereum address
+        * [Numeric] — integer
+    * Reference types:
+        * [Tuple]
+        * [Array]
+        * [Bytes]
+        * [Struct]
+        * [Enum]
+        * [HashMap]
+* Other types:
     * [Event]
-* Function types:
+    * [Contract]
     * [Function]
-* Map types:
-    * [HashMap]
 
 ### 5.1.1.1 Boolean type
 
-The `bool` type is a datatype which can be either `true` or `false`.
+The `bool` type is a data type which can be either `true` or `false`.
+
+Example:
 
 ```rust
 x = true
@@ -580,13 +582,15 @@ MISSING
 
 ### 5.1.1.11. HashMap type
 
-MISSING
+Maps a key to a value.
 
-Example
+Example:
 
 ```
 map<TKey,TValue>
 ```
+
+Where TKey is a base type and TValue is any data type.
 
 ### 5.1.1.12. Bytes type
 


### PR DESCRIPTION
### What was wrong?

closes #77 

We weren't able to compile maps with nested map values.

### How was it fixed?

- [x] Update the definition of maps to include maps as a value type
- [x] Add semantic analysis and mapping for map value types
- [x] Add testing
- [x] Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md)
- [x] Clean up commit history

There's a file I added named [operations](https://github.com/ethereum/fe/blob/fed15791844da5717a4c1c5bf4f14feeeb71a2d1/compiler/src/yul/mappers/operations.rs) that should be used to form basic Yul operations. I'll follow up this PR with another that addresses #19 (the issue is a bit outdated) and moves the Yul code generation taking place in the semantic library to the operations module. This is mentioned briefly in #39:

> There are still some things that need to be refactored, but for the sake of keeping this PR at a reasonable size, they were ignored. The best example of this is that we still use methods defined within our types module to form Yul expressions and statements. These Yul elements should instead be formed exclusively in the mapper pass.