### PR TITLE
Support for arguments in call expressions.

### DIFF
--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -1,5 +1,5 @@
 use crate::errors::CompileError;
-use crate::yul::mappers::expressions::spanned_expression;
+use crate::yul::mappers::expressions::call_arg;
 use crate::yul::mappers::{
     assignments,
     declarations,
@@ -133,19 +133,6 @@ fn emit(context: &Context, stmt: &Spanned<fe::FuncStmt>) -> Result<yul::Statemen
     }
 
     unreachable!()
-}
-
-fn call_arg(
-    context: &Context,
-    arg: &Spanned<fe::CallArg>,
-) -> Result<yul::Expression, CompileError> {
-    match &arg.node {
-        fe::CallArg::Arg(value) => {
-            let spanned = spanned_expression(&arg.span, value);
-            expressions::expr(context, &spanned)
-        }
-        fe::CallArg::Kwarg(fe::Kwarg { name: _, value }) => expressions::expr(context, value),
-    }
 }
 
 fn func_return(

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -11,6 +11,10 @@ use std::fs;
     case(
         "return_call_to_fn_without_return.fe",
         "[Str(\"semantic error: NotAnExpression\")]"
+    ),
+    case(
+        "return_call_to_fn_with_param_type_mismatch.fe",
+        "[Str(\"semantic error: TypeError\")]"
     )
 )]
 fn test_compile_errors(fixture_file: &str, error: &str) {

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -208,6 +208,7 @@ fn test_revert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("return_u256_from_called_fn_with_args.fe", vec![], Some(u256_token(200))),
     case("return_u256_from_called_fn.fe", vec![], Some(u256_token(42))),
     case("return_u256.fe", vec![], Some(u256_token(42))),
     case("return_identity_u256.fe", vec![42], Some(u256_token(42))),

--- a/compiler/tests/fixtures/compile_errors/return_call_to_fn_with_param_type_mismatch.fe
+++ b/compiler/tests/fixtures/compile_errors/return_call_to_fn_with_param_type_mismatch.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+    pub def foo(val: address) -> u256:
+        return 42
+
+    pub def bar() -> u256:
+        return self.foo(100)

--- a/compiler/tests/fixtures/return_u256_from_called_fn_with_args.fe
+++ b/compiler/tests/fixtures/return_u256_from_called_fn_with_args.fe
@@ -1,0 +1,11 @@
+contract Foo:
+    baz: map<u256, u256>
+    pub def foo(val1: u256, val2: u256, val3: u256, val4: u256, val5: u256) -> u256:
+        return val1 + val2 + val3 + val4 + val5
+
+    pub def cem() -> u256:
+        return 100
+
+    pub def bar() -> u256:
+        self.baz[0] = 43
+        return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])

--- a/semantics/src/traversal/_utils.rs
+++ b/semantics/src/traversal/_utils.rs
@@ -1,0 +1,15 @@
+use fe_parser::ast as fe;
+use fe_parser::span::{
+  Span,
+  Spanned,
+};
+
+
+/// Creates a new spanned expression. Useful in cases where an `Expr` is nested
+/// within the node of a `Spanned` object.
+pub fn spanned_expression<'a>(span: &Span, exp: &fe::Expr<'a>) -> Spanned<fe::Expr<'a>> {
+  Spanned {
+      node: (*exp).clone(),
+      span: (*span).to_owned(),
+  }
+}

--- a/semantics/src/traversal/_utils.rs
+++ b/semantics/src/traversal/_utils.rs
@@ -1,15 +1,33 @@
+use crate::namespace::types::FixedSize;
+use crate::{
+    ExpressionAttributes,
+    Type,
+};
 use fe_parser::ast as fe;
 use fe_parser::span::{
-  Span,
-  Spanned,
+    Span,
+    Spanned,
 };
-
 
 /// Creates a new spanned expression. Useful in cases where an `Expr` is nested
 /// within the node of a `Spanned` object.
 pub fn spanned_expression<'a>(span: &Span, exp: &fe::Expr<'a>) -> Spanned<fe::Expr<'a>> {
-  Spanned {
-      node: (*exp).clone(),
-      span: (*span).to_owned(),
-  }
+    Spanned {
+        node: (*exp).clone(),
+        span: (*span).to_owned(),
+    }
+}
+
+pub fn expression_attributes_to_types(attributes: Vec<ExpressionAttributes>) -> Vec<Type> {
+    attributes
+        .iter()
+        .map(|attributes| attributes.typ.clone())
+        .collect()
+}
+
+pub fn fixed_sizes_to_types(sizes: Vec<FixedSize>) -> Vec<Type> {
+    sizes
+        .iter()
+        .map(|param| param.clone().into_type())
+        .collect()
 }

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -39,7 +39,7 @@ pub fn expr(
         fe::Expr::BinOperation { .. } => expr_bin_operation(scope, Rc::clone(&context), exp)?,
         fe::Expr::UnaryOperation { .. } => unimplemented!(),
         fe::Expr::CompOperation { .. } => expr_comp_operation(scope, Rc::clone(&context), exp)?,
-        fe::Expr::Call { .. } => expr_call(scope, exp)?,
+        fe::Expr::Call { .. } => expr_call(scope, Rc::clone(&context), exp)?,
         fe::Expr::List { .. } => unimplemented!(),
         fe::Expr::ListComp { .. } => unimplemented!(),
         fe::Expr::Tuple { .. } => unimplemented!(),
@@ -225,22 +225,60 @@ fn expr_bin_operation(
     unreachable!()
 }
 
+pub fn call_arg(
+    scope: Shared<FunctionScope>,
+    context: Shared<Context>,
+    arg: &Spanned<fe::CallArg>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    match &arg.node {
+        fe::CallArg::Arg(value) => {
+            let spanned = spanned_expression(&arg.span, value);
+            expr(scope, context, &spanned)
+        }
+        fe::CallArg::Kwarg(fe::Kwarg { name: _, value }) => expr(scope, context, value),
+    }
+}
+
 fn expr_call(
     scope: Shared<FunctionScope>,
+    context: Shared<Context>,
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    if let fe::Expr::Call { args: _, func } = &exp.node {
+    if let fe::Expr::Call { args, func } = &exp.node {
+        let argument_attributes: Vec<ExpressionAttributes> = args
+            .node
+            .iter()
+            // Side effect: Performs semantic analysis on each call arg and adds its attributes to
+            // the context
+            .map(|argument| call_arg(scope.clone(), context.clone(), argument))
+            .collect::<Result<_, _>>()?;
+
+        let argument_types: Vec<Type> = argument_attributes
+            .iter()
+            .map(|attributes| attributes.typ.clone())
+            .collect();
+
         if let fe::Expr::Attribute { value: _, attr } = &func.node {
             let contract_scope = &scope.borrow().parent;
             let called_func = contract_scope.borrow().def(attr.node.to_string());
             return match called_func {
                 Some(ContractDef::Function {
-                    params: _,
+                    params,
                     returns: Some(return_type),
-                }) => Ok(ExpressionAttributes {
-                    typ: return_type.into_type(),
-                    location: Location::Value,
-                }),
+                }) => {
+                    let param_types: Vec<Type> = params
+                        .iter()
+                        .map(|param| param.clone().into_type())
+                        .collect();
+                    if param_types != argument_types {
+                        return Err(SemanticError::TypeError);
+                    }
+
+                    return Ok(ExpressionAttributes {
+                        typ: return_type.into_type(),
+                        location: Location::Value,
+                    });
+                }
                 Some(ContractDef::Function {
                     params: _,
                     returns: None,

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -16,9 +16,9 @@ use crate::{
     ExpressionAttributes,
     Location,
 };
+use crate::traversal::_utils::spanned_expression;
 use fe_parser::ast as fe;
 use fe_parser::span::{
-    Span,
     Spanned,
 };
 use std::rc::Rc;
@@ -79,14 +79,6 @@ pub fn slices_index(
     unreachable!()
 }
 
-/// Creates a new spanned expression. Useful in cases where an `Expr` is nested
-/// within the node of a `Spanned` object.
-pub fn spanned_expression<'a>(span: &Span, exp: &fe::Expr<'a>) -> Spanned<fe::Expr<'a>> {
-    Spanned {
-        node: (*exp).clone(),
-        span: (*span).to_owned(),
-    }
-}
 
 /// Gather context information for an index and check for type errors.
 pub fn slice_index(

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -7,13 +7,13 @@ use crate::namespace::scopes::{
     Shared,
 };
 use crate::namespace::types::FixedSize;
+use crate::traversal::_utils::spanned_expression;
 use crate::traversal::{
     assignments,
     declarations,
     expressions,
     types,
 };
-use crate::traversal::_utils::spanned_expression;
 use crate::{
     Context,
     FunctionAttributes,

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -13,6 +13,7 @@ use crate::traversal::{
     expressions,
     types,
 };
+use crate::traversal::_utils::spanned_expression;
 use crate::{
     Context,
     FunctionAttributes,
@@ -148,7 +149,7 @@ fn call_arg(
 ) -> Result<(), SemanticError> {
     match &arg.node {
         fe::CallArg::Arg(value) => {
-            let spanned = expressions::spanned_expression(&arg.span, value);
+            let spanned = spanned_expression(&arg.span, value);
             let _attributes = expressions::expr(scope, context, &spanned)?;
             // TODO: Perform type checking
         }

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -43,6 +43,7 @@ pub fn func_def(
             .iter()
             .map(|arg| func_def_arg(Rc::clone(&function_scope), arg))
             .collect::<Result<Vec<_>, _>>()?;
+
         let return_type = return_type
             .as_ref()
             .map(|typ| {

--- a/semantics/src/traversal/mod.rs
+++ b/semantics/src/traversal/mod.rs
@@ -1,3 +1,4 @@
+mod _utils;
 mod assignments;
 mod contracts;
 mod declarations;


### PR DESCRIPTION
### What was wrong?

As mentioned in #89 we do currently not have support for arguments in call expressions.

### How was it fixed?

- Resolving the arguments with `expr`
   - for that, I had to manually span them reusing the span that is around the `CallArg`
- manually built a `yul::Expression::FunctionCall` as I'm not sure how to do that using a macro.
- Added a test that demonstrates the various ways of using arguments in call expressions