### PR TITLE
FeSized trait and data opertions.

### DIFF
--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -4,6 +4,7 @@ use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use fe_semantics::namespace::types::{
     Array,
+    FeSized,
     FixedSize,
 };
 use fe_semantics::Context;

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -7,7 +7,10 @@ use crate::yul::mappers::{
 };
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
-use fe_semantics::namespace::types::FixedSize;
+use fe_semantics::namespace::types::{
+    FeSized,
+    FixedSize,
+};
 use fe_semantics::Context;
 use yultsur::*;
 

--- a/compiler/src/yul/mappers/operations.rs
+++ b/compiler/src/yul/mappers/operations.rs
@@ -1,21 +1,56 @@
-use fe_semantics::namespace::types::{
-    Base,
-    FixedSize,
-};
+use fe_semantics::namespace::types::FeSized;
 use yultsur::*;
 
-/// Loads a base value in storage.
+/// Loads a value from storage.
 ///
-/// The return expression contains a base value.
-pub fn sload(base: Base, sptr: yul::Expression) -> yul::Expression {
-    let size = literal_expression! { (base.size()) };
+/// The returned expression evaluates to a 256 bit value.
+pub fn sto_to_val<T: FeSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (typ.size()) };
     expression! { sloadn([sptr], [size]) }
 }
 
-/// Copies a fixed size value from storage to memory.
+/// Copies a segment of storage into memory.
 ///
-/// The return expression contains a memory pointer.
-pub fn scopy(fixed_size: FixedSize, sptr: yul::Expression) -> yul::Expression {
-    let size = literal_expression! { (fixed_size.size()) };
+/// The returned expression evaluates to a memory pointer.
+pub fn sto_to_mem<T: FeSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (typ.size()) };
     expression! { scopy([sptr], [size]) }
+}
+
+/// Stores a 256 bit value in storage.
+pub fn val_to_sto<T: FeSized>(
+    typ: T,
+    sptr: yul::Expression,
+    value: yul::Expression,
+) -> yul::Statement {
+    let size = literal_expression! { (typ.size()) };
+    statement! { sstoren([sptr], [value], [size]) }
+}
+
+/// Stores a 256 bit value in memory.
+pub fn val_to_mem<T: FeSized>(
+    typ: T,
+    mptr: yul::Expression,
+    value: yul::Expression,
+) -> yul::Statement {
+    let size = literal_expression! { (typ.size()) };
+    statement! { mstoren([mptr], [value], [size]) }
+}
+
+/// Copies a segment of memory into storage.
+pub fn mem_to_sto<T: FeSized>(
+    typ: T,
+    sptr: yul::Expression,
+    mptr: yul::Expression,
+) -> yul::Statement {
+    let size = literal_expression! { (typ.size()) };
+    statement! { mcopy([mptr], [sptr], [size]) }
+}
+
+/// Loads a value in memory.
+///
+/// The returned expression evaluates to a 256 bit value.
+pub fn mem_to_val<T: FeSized>(typ: T, mptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (typ.size()) };
+    expression! { mloadn([mptr], [size]) }
 }

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -76,7 +76,7 @@ impl ContractHarness {
                 assert_eq!(&output, actual_output)
             }
         } else {
-            panic!("Failed to run function")
+            panic!("Failed to run \"{}\"", name)
         }
     }
 


### PR DESCRIPTION
### What was wrong?

Partially addresses #19 and something that was mentioned in #39.

> There are still some things that need to be refactored, but for the sake of keeping this PR at a reasonable size, they were ignored. The best example of this is that we still use methods defined within our types module to form Yul expressions and statements. These Yul elements should instead be formed exclusively in the mapper pass. 

### How was it fixed?

Created a new [`FeSized` trait](https://github.com/ethereum/fe/blob/f67359d68d63f4a8885a22a067654143d4174d1b/semantics/src/namespace/types.rs#L8) that is analogous to Rust's very own [`Sized` trait](https://doc.rust-lang.org/beta/std/marker/trait.Sized.html), then used this trait to implement a set of [data operations](https://github.com/ethereum/fe/blob/80486998c0fdc41fd31eb223ea2b72ed0b24cb59/compiler/src/yul/mappers/operations.rs) and refactored the compiler to use these operations.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
