### PR TITLE
Support for events with multiple params.

### DIFF
--- a/compiler/src/yul/runtime/abi.rs
+++ b/compiler/src/yul/runtime/abi.rs
@@ -28,8 +28,8 @@ fn dispatch_arm(attributes: FunctionAttributes) -> Result<yul::Case, CompileErro
 
     if let Some(return_type) = attributes.return_type {
         let selection = selection(attributes.name, &attributes.param_types)?;
-        let return_data = operations::encode(return_type.to_owned(), selection);
-        let return_size = literal_expression! {(return_type.padded_size())};
+        let return_data = operations::encode(vec![return_type.to_owned()], vec![selection]);
+        let return_size = literal_expression! {(return_type.abi_size())};
 
         let selection_with_return = statement! { return([return_data], [return_size]) };
 
@@ -59,7 +59,7 @@ fn selection(name: String, params: &[FixedSize]) -> Result<yul::Expression, Comp
             param.to_owned(),
             literal_expression! { (ptr) },
         ));
-        ptr += param.padded_size();
+        ptr += param.abi_size();
     }
 
     let name = identifier! {(name)};

--- a/compiler/src/yul/runtime/functions.rs
+++ b/compiler/src/yul/runtime/functions.rs
@@ -1,7 +1,12 @@
+use fe_semantics::namespace::types::{
+    AbiEncoding,
+    AbiType,
+    FeSized,
+};
 use yultsur::*;
 
 /// Returns all functions that should be available during runtime.
-pub fn all() -> Vec<yul::Statement> {
+pub fn std() -> Vec<yul::Statement> {
     vec![
         avail(),
         alloc(),
@@ -158,5 +163,93 @@ pub fn dualkeccak256() -> yul::Statement {
             (mstore((add(ptr, 32)), b))
             (return_val := keccak256(ptr, 64))
         }
+    }
+}
+
+/// Dynamically creates an encoding function for any set of type parameters.
+pub fn abi_encode<T: AbiEncoding>(types: Vec<T>) -> yul::Statement {
+    let func_name = abi_encode_name(types.iter().map(|typ| typ.abi_name()).collect());
+    let mut params = vec![];
+    let mut stmts = vec![];
+
+    // iterate over all parameters of our encoding function and create a statement
+    // that encodes them
+    for (i, _) in types.iter().enumerate() {
+        let param_ident = identifier! { (format!("val_{}", i)) };
+        params.push(param_ident.clone());
+        let param_expr = identifier_expression! { [param_ident] };
+
+        let stmt = match types[i].abi_type() {
+            AbiType::UniformRecursive { child, count } => {
+                // we copy each value in memory to a new segment with the correct padding
+                // all values use a left padding
+                let element_count = literal_expression! { (count) };
+                let element_size = literal_expression! { (child.size()) };
+                let element_abi_size = literal_expression! { (child.abi_size()) };
+
+                statement! {
+                    (for {(let i := 0)} (lt(i, [element_count])) {(i := add(i, 1))}
+                    {
+                        (let val_ptr := add([param_expr], (mul(i, [element_size.clone()]))))
+                        (let val := mloadn(val_ptr, [element_size]))
+                        (pop((alloc_mstoren(val, [element_abi_size]))))
+                    })
+                }
+            }
+            AbiType::Terminal => {
+                // we store each terminal value in a new slot
+                // these should always be base types with an `abi_size` of 32 bytes
+                let abi_size = literal_expression! { (types[i].abi_size()) };
+                statement! { pop((alloc_mstoren([param_expr], [abi_size]))) }
+            }
+        };
+        stmts.push(stmt)
+    }
+
+    // our encoding function take a dynamic set of params and generates an encoding
+    // statement for each param
+    function_definition! {
+        function [func_name]([params...]) -> ptr {
+            (ptr := avail())
+            [stmts...]
+        }
+    }
+}
+
+/// Generates an ABI encoding function name for a given set of types.
+pub fn abi_encode_name(names: Vec<String>) -> yul::Identifier {
+    let mut full_name = "abi_encode".to_string();
+
+    for name in names {
+        let safe_name = name.replace("[", "").replace("]", "");
+        full_name.push('_');
+        full_name.push_str(&safe_name);
+    }
+
+    identifier! { (full_name) }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::runtime::functions::{
+        abi_encode,
+        abi_encode_name,
+    };
+    use fe_semantics::namespace::types::Base;
+
+    #[test]
+    fn test_abi_encode_name() {
+        assert_eq!(
+            abi_encode_name(vec!["u256".to_string(), "bytes[100]".to_string()]).to_string(),
+            "abi_encode_u256_bytes100"
+        )
+    }
+
+    #[test]
+    fn test_abi_encode() {
+        assert_eq!(
+            abi_encode(vec![Base::U256, Base::Address]).to_string(),
+            "function abi_encode_uint256_address(val_0, val_1) -> ptr { ptr := avail() pop(alloc_mstoren(val_0, 32)) pop(alloc_mstoren(val_1, 32)) }"
+        )
     }
 }

--- a/compiler/tests/fixtures/events.fe
+++ b/compiler/tests/fixtures/events.fe
@@ -1,0 +1,32 @@
+contract Foo:
+    event Nums:
+        idx num1: u256
+        idx num2: u256
+
+    event Bases:
+        idx num: u256
+        idx addr: address
+
+    event Mix:
+        idx num1: u256
+        idx addr: address
+        idx num2: u256
+        idx my_bytes: bytes[100]
+
+    event Addresses:
+        idx addrs: address[2]
+
+    pub def emit_nums():
+        emit Nums(26, 42)
+
+    pub def emit_bases(addr: address):
+        emit Bases(26, addr)
+
+    pub def emit_mix(addr: address, my_bytes: bytes[100]):
+        emit Mix(26, addr, 42, my_bytes)
+
+    pub def emit_addresses(addr1: address, addr2: address):
+        addrs: address[2]
+        addrs[0] = addr1
+        addrs[1] = addr2
+        emit Addresses(addrs)

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -20,6 +20,7 @@ pub enum ModuleDef {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ContractDef {
     Function {
+        is_public: bool,
         params: Vec<FixedSize>,
         returns: Option<FixedSize>,
     },
@@ -112,12 +113,19 @@ impl ContractScope {
     pub fn add_function(
         &mut self,
         name: String,
+        is_public: bool,
         params: Vec<FixedSize>,
         returns: Option<FixedSize>,
     ) {
         self.interface.push(name.clone());
-        self.defs
-            .insert(name, ContractDef::Function { params, returns });
+        self.defs.insert(
+            name,
+            ContractDef::Function {
+                is_public,
+                params,
+                returns,
+            },
+        );
     }
 
     pub fn add_event(&mut self, name: String, event: Event) {

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -251,6 +251,7 @@ fn expr_call(
             let called_func = contract_scope.borrow().def(attr.node.to_string());
             return match called_func {
                 Some(ContractDef::Function {
+                    is_public: _,
                     params,
                     returns: Some(return_type),
                 }) => {
@@ -265,10 +266,9 @@ fn expr_call(
                         location: Location::Value,
                     });
                 }
-                Some(ContractDef::Function {
-                    params: _,
-                    returns: None,
-                }) => Err(SemanticError::NotAnExpression),
+                Some(ContractDef::Function { returns: None, .. }) => {
+                    Err(SemanticError::NotAnExpression)
+                }
                 _ => unreachable!(),
             };
         }


### PR DESCRIPTION
### What was wrong?

closes #87 

Events had very limited support. Basically, you could only emit events with a single `bytes` parameter.

### How was it fixed?

Added ABI encoding for any combination of values and hooked this into event emits.

When an event definition is encountered, an encoding operation is created for the given set of parameters. This encoding operation is then used whenever an event is emitted. The same thing is done with public functions and their external returns.

Here are the encoding operations generated for [events.fe](https://github.com/ethereum/fe/blob/285025b167f0361664f51d0bc53b3cb97c79e11a/compiler/tests/fixtures/events.fe):

```
function abi_encode_uint256_address_uint256_bytes100(val_0, val_1, val_2, val_3) -> ptr
{
    ptr := avail()
    pop(alloc_mstoren(val_0, 32))
    pop(alloc_mstoren(val_1, 32))
    pop(alloc_mstoren(val_2, 32))
    for { let i := 0 } lt(i, 100) { i := add(i, 1) }
    {
        let val_ptr := add(val_3, mul(i, 1))
        let val := mloadn(val_ptr, 1)
        pop(alloc_mstoren(val, 1))
    }
}
function abi_encode_uint256_address(val_0, val_1) -> ptr
{
    ptr := avail()
    pop(alloc_mstoren(val_0, 32))
    pop(alloc_mstoren(val_1, 32))
}
function abi_encode_uint256_uint256(val_0, val_1) -> ptr
{
    ptr := avail()
    pop(alloc_mstoren(val_0, 32))
    pop(alloc_mstoren(val_1, 32))
}
function abi_encode_address2(val_0) -> ptr
{
    ptr := avail()
    for { let i := 0 } lt(i, 2) { i := add(i, 1) }
    {
        let val_ptr := add(val_0, mul(i, 20))
        let val := mloadn(val_ptr, 20)
        pop(alloc_mstoren(val, 32))
    }
}
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
