### PR TITLE
Add support for returning boolean literal

### DIFF
--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -23,6 +23,7 @@ pub fn expr(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expressio
     match &exp.node {
         fe::Expr::Name(_) => expr_name(context, exp),
         fe::Expr::Num(_) => expr_num(exp),
+        fe::Expr::Bool(_) => expr_bool(exp),
         fe::Expr::Subscript { .. } => expr_subscript(context, exp),
         fe::Expr::Attribute { .. } => expr_attribute(context, exp),
         fe::Expr::Ternary { .. } => unimplemented!(),
@@ -186,6 +187,14 @@ fn expr_name(_context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Express
 fn expr_num(exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
     if let fe::Expr::Num(num) = &exp.node {
         return Ok(literal_expression! {(num)});
+    }
+
+    unreachable!()
+}
+
+fn expr_bool(exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
+    if let fe::Expr::Bool(val) = &exp.node {
+        return Ok(literal_expression! {(val)});
     }
 
     unreachable!()

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -208,6 +208,8 @@ fn test_revert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("return_bool_true.fe", vec![], Some(bool_token(true))),
+    case("return_bool_false.fe", vec![], Some(bool_token(false))),
     case("return_u256_from_called_fn_with_args.fe", vec![], Some(u256_token(200))),
     case("return_u256_from_called_fn.fe", vec![], Some(u256_token(42))),
     case("return_u256.fe", vec![], Some(u256_token(42))),

--- a/compiler/tests/fixtures/return_bool_false.fe
+++ b/compiler/tests/fixtures/return_bool_false.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> bool:
+        return false

--- a/compiler/tests/fixtures/return_bool_true.fe
+++ b/compiler/tests/fixtures/return_bool_true.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> bool:
+        return true

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -236,6 +236,7 @@ pub enum Expr<'a> {
     Tuple {
         elts: Vec<Spanned<Expr<'a>>>,
     },
+    Bool(bool),
     Name(&'a str),
     Num(&'a str),
     Str(Vec<&'a str>),

--- a/parser/src/parsers.rs
+++ b/parser/src/parsers.rs
@@ -1426,6 +1426,14 @@ pub fn slice(input: Cursor) -> ParseResult<Spanned<Slice>> {
 
 pub fn atom(input: Cursor) -> ParseResult<Spanned<Expr>> {
     alt((
+        map(name("true"), |tok| Spanned {
+            node: Expr::Bool(true),
+            span: tok.span,
+        }),
+        map(name("false"), |tok| Spanned {
+            node: Expr::Bool(false),
+            span: tok.span,
+        }),
         list,
         map(group, |exp| Spanned {
             node: exp.node.node,

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -34,6 +34,7 @@ pub fn expr(
     let attributes = match &exp.node {
         fe::Expr::Name(_) => expr_name(scope, exp)?,
         fe::Expr::Num(_) => expr_num(exp)?,
+        fe::Expr::Bool(_) => expr_bool(exp)?,
         fe::Expr::Subscript { .. } => expr_subscript(scope, Rc::clone(&context), exp)?,
         fe::Expr::Attribute { .. } => expr_attribute(scope, exp)?,
         fe::Expr::Ternary { .. } => unimplemented!(),
@@ -111,6 +112,17 @@ fn expr_name(
             }),
             None => Err(SemanticError::UndefinedValue),
         };
+    }
+
+    unreachable!()
+}
+
+fn expr_bool(exp: &Spanned<fe::Expr>) -> Result<ExpressionAttributes, SemanticError> {
+    if let fe::Expr::Bool(_) = &exp.node {
+        return Ok(ExpressionAttributes {
+            location: Location::Value,
+            typ: Type::Base(Base::Bool),
+        });
     }
 
     unreachable!()


### PR DESCRIPTION
### What was wrong?

Fe does currently not support returning boolean literals. The following won't parse:

```
contract Foo:
    pub def bar() -> bool:
        return false
```

### How was it fixed?

1. Added a new expression type `Bool`
2. Changed the parser to map the literals `true`  and `false` to the `Bool` expression
3. Added handling for the new expression in semantic and mapper pass

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
