### PR TITLE
Implement call statements

### DIFF
--- a/compiler/src/yul/mappers/_utils.rs
+++ b/compiler/src/yul/mappers/_utils.rs
@@ -1,0 +1,14 @@
+use fe_parser::ast as fe;
+use fe_parser::span::{
+    Span,
+    Spanned,
+};
+
+/// Creates a new spanned expression. Useful in cases where an `Expr` is nested
+/// within the node of a `Spanned` object.
+pub fn spanned_expression<'a>(span: &Span, exp: &fe::Expr<'a>) -> Spanned<fe::Expr<'a>> {
+    Spanned {
+        node: (*exp).clone(),
+        span: (*span).to_owned(),
+    }
+}

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -1,10 +1,8 @@
 use crate::errors::CompileError;
+use crate::yul::mappers::_utils::spanned_expression;
 use crate::yul::operations;
 use fe_parser::ast as fe;
-use fe_parser::span::{
-    Span,
-    Spanned,
-};
+use fe_parser::span::Spanned;
 use fe_semantics::namespace::types::{
     Array,
     FeSized,
@@ -153,15 +151,6 @@ pub fn slices_index(
     }
 
     unreachable!()
-}
-
-/// Creates a new spanned expression. Useful in cases where an `Expr` is nested
-/// within the node of a `Spanned` object.
-pub fn spanned_expression<'a>(span: &Span, exp: &fe::Expr<'a>) -> Spanned<fe::Expr<'a>> {
-    Spanned {
-        node: (*exp).clone(),
-        span: (*span).to_owned(),
-    }
 }
 
 pub fn slice_index(

--- a/compiler/src/yul/mappers/mod.rs
+++ b/compiler/src/yul/mappers/mod.rs
@@ -1,3 +1,4 @@
+mod _utils;
 mod assignments;
 mod contracts;
 mod declarations;

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -224,6 +224,9 @@ fn test_revert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("call_statement_without_args.fe", vec![], Some(u256_token(100))),
+    case("call_statement_with_args.fe", vec![], Some(u256_token(100))),
+    case("call_statement_with_args_2.fe", vec![], Some(u256_token(100))),
     case("return_bool_true.fe", vec![], Some(bool_token(true))),
     case("return_bool_false.fe", vec![], Some(bool_token(false))),
     case("return_u256_from_called_fn_with_args.fe", vec![], Some(u256_token(200))),

--- a/compiler/tests/fixtures/call_statement_with_args.fe
+++ b/compiler/tests/fixtures/call_statement_with_args.fe
@@ -1,0 +1,9 @@
+contract Foo:
+    baz: map<u256, u256>
+
+    def assign(val: u256):
+        self.baz[0] = val
+
+    pub def bar() -> u256:
+        self.assign(100)
+        return self.baz[0]

--- a/compiler/tests/fixtures/call_statement_with_args_2.fe
+++ b/compiler/tests/fixtures/call_statement_with_args_2.fe
@@ -1,0 +1,10 @@
+contract Foo:
+    baz: map<u256, u256>
+
+    def assign(val: u256) -> u256:
+        self.baz[0] = val
+        return val
+
+    pub def bar() -> u256:
+        self.assign(100)
+        return self.baz[0]

--- a/compiler/tests/fixtures/call_statement_without_args.fe
+++ b/compiler/tests/fixtures/call_statement_without_args.fe
@@ -1,0 +1,9 @@
+contract Foo:
+    baz: map<u256, u256>
+
+    def assign():
+        self.baz[0] = 100
+
+    pub def bar() -> u256:
+        self.assign()
+        return self.baz[0]

--- a/semantics/src/namespace/types.rs
+++ b/semantics/src/namespace/types.rs
@@ -83,6 +83,15 @@ pub struct Tuple {
     pub items: Vec<Base>,
 }
 
+impl Type {
+    pub fn is_empty_tuple(&self) -> bool {
+        if let Type::Tuple(tuple) = &self {
+            return tuple.is_empty();
+        }
+        false
+    }
+}
+
 impl FeSized for FixedSize {
     fn size(&self) -> usize {
         match self {
@@ -138,9 +147,7 @@ impl FixedSize {
 
     pub fn is_empty_tuple(&self) -> bool {
         if let FixedSize::Tuple(tuple) = self {
-            if tuple.size() == 0 {
-                return true;
-            }
+            return tuple.is_empty();
         }
 
         false
@@ -245,6 +252,10 @@ impl Array {
 impl Tuple {
     pub fn empty() -> Tuple {
         Tuple { items: vec![] }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size() == 0
     }
 
     pub fn to_fixed_size(&self) -> FixedSize {

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -141,12 +141,25 @@ fn func_stmt(
         fe::FuncStmt::While { .. } => unimplemented!(),
         fe::FuncStmt::If { .. } => unimplemented!(),
         fe::FuncStmt::Assert { .. } => unimplemented!(),
-        fe::FuncStmt::Expr { .. } => unimplemented!(),
+        fe::FuncStmt::Expr { .. } => expr(scope, context, stmt),
         fe::FuncStmt::Pass => unimplemented!(),
         fe::FuncStmt::Break => unimplemented!(),
         fe::FuncStmt::Continue => unimplemented!(),
         fe::FuncStmt::Revert => Ok(()),
     }
+}
+
+fn expr(
+    scope: Shared<FunctionScope>,
+    context: Shared<Context>,
+    stmt: &Spanned<fe::FuncStmt>,
+) -> Result<(), SemanticError> {
+    if let fe::FuncStmt::Expr { value } = &stmt.node {
+        let spanned = spanned_expression(&stmt.span, value);
+        let _attributes = expressions::expr(scope, context, &spanned)?;
+    }
+
+    Ok(())
 }
 
 fn emit(


### PR DESCRIPTION
### What was wrong?

closes #92 

As stated in  #92, we do currently not have support for call statements (e.g. `self.assign(10, 11)`. 

### How was it fixed?

This is based on #111

- Moved `spanned_expression` helper into _utils module
- Mapped `fe::FuncStmt::Expr` to either the expression directly or to `pop([expr])` in case the return type is anything else than `()`
- In the semantic pass, I just analyzed the `fe::FuncStmt::Expr` as any other expression.
- A few helpers to ease checking for `()` type
