### PR TITLE
Validate return values of function body

### DIFF
--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -8,6 +8,9 @@ use std::fs;
 #[rstest(
     fixture_file,
     error,
+    case("mismatch_return_type.fe", "[Str(\"semantic error: TypeError\")]"),
+    case("unexpected_return.fe", "[Str(\"semantic error: UnexpectedReturn\")]"),
+    case("missing_return.fe", "[Str(\"semantic error: MissingReturn\")]"),
     case(
         "return_call_to_fn_without_return.fe",
         "[Str(\"semantic error: NotAnExpression\")]"

--- a/compiler/tests/fixtures/compile_errors/mismatch_return_type.fe
+++ b/compiler/tests/fixtures/compile_errors/mismatch_return_type.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar() -> address:
+        return 1

--- a/compiler/tests/fixtures/compile_errors/missing_return.fe
+++ b/compiler/tests/fixtures/compile_errors/missing_return.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    baz: map<u256, u256>
+
+    pub def bar() -> u256:
+        self.baz[0] = 1

--- a/compiler/tests/fixtures/compile_errors/unexpected_return.fe
+++ b/compiler/tests/fixtures/compile_errors/unexpected_return.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    baz: map<u256, u256>
+
+    pub def bar():
+        return 1

--- a/parser/src/span.rs
+++ b/parser/src/span.rs
@@ -45,3 +45,9 @@ impl<T> From<&Spanned<T>> for Span {
         spanned.span
     }
 }
+
+impl<T> From<&Box<Spanned<T>>> for Span {
+    fn from(spanned: &Box<Spanned<T>>) -> Self {
+        spanned.span
+    }
+}

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -3,8 +3,10 @@
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum SemanticError {
+    MissingReturn,
     NotAnExpression,
     UnassignableExpression,
     UndefinedValue,
+    UnexpectedReturn,
     TypeError,
 }

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -106,8 +106,8 @@ impl Context {
     }
 
     /// Get information that has been attributed to an expression node.
-    pub fn get_expression(&self, spanned: &Spanned<fe::Expr>) -> Option<&ExpressionAttributes> {
-        self.expressions.get(&spanned.span)
+    pub fn get_expression<T: Into<Span>>(&self, span: T) -> Option<&ExpressionAttributes> {
+        self.expressions.get(&span.into())
     }
 
     /// Attribute contextual information to an emit statement node.
@@ -116,8 +116,8 @@ impl Context {
     }
 
     /// Get information that has been attributed to an emit statement node.
-    pub fn get_emit(&self, spanned: &Spanned<fe::FuncStmt>) -> Option<&Event> {
-        self.emits.get(&spanned.span)
+    pub fn get_emit<T: Into<Span>>(&self, span: T) -> Option<&Event> {
+        self.emits.get(&span.into())
     }
 
     /// Attribute contextual information to a function definition node.
@@ -130,8 +130,8 @@ impl Context {
     }
 
     /// Get information that has been attributed to a function definition node.
-    pub fn get_function(&self, spanned: &Spanned<fe::ContractStmt>) -> Option<&FunctionAttributes> {
-        self.functions.get(&spanned.span)
+    pub fn get_function<T: Into<Span>>(&self, span: T) -> Option<&FunctionAttributes> {
+        self.functions.get(&span.into())
     }
 
     /// Attribute contextual information to a declaration node.
@@ -140,8 +140,8 @@ impl Context {
     }
 
     /// Get information that has been attributed to a declaration node.
-    pub fn get_declaration(&self, spanned: &Spanned<fe::FuncStmt>) -> Option<&FixedSize> {
-        self.declarations.get(&spanned.span)
+    pub fn get_declaration<T: Into<Span>>(&self, span: T) -> Option<&FixedSize> {
+        self.declarations.get(&span.into())
     }
 
     /// Attribute contextual information to a contract definition node.
@@ -154,8 +154,8 @@ impl Context {
     }
 
     /// Get information that has been attributed to a contract definition node.
-    pub fn get_contract(&self, spanned: &Spanned<fe::ModuleStmt>) -> Option<&ContractAttributes> {
-        self.contracts.get(&spanned.span)
+    pub fn get_contract<T: Into<Span>>(&self, span: T) -> Option<&ContractAttributes> {
+        self.contracts.get(&span.into())
     }
 }
 

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -10,6 +10,8 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use fe_parser::span::Span;
+
 pub type Shared<T> = Rc<RefCell<T>>;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -52,6 +54,7 @@ pub struct ContractScope {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionScope {
+    pub span: Span,
     pub parent: Shared<ContractScope>,
     pub defs: HashMap<String, FunctionDef>,
 }
@@ -134,8 +137,9 @@ impl ContractScope {
 }
 
 impl FunctionScope {
-    pub fn new(parent: Shared<ContractScope>) -> Shared<Self> {
+    pub fn new(span: Span, parent: Shared<ContractScope>) -> Shared<Self> {
         Rc::new(RefCell::new(FunctionScope {
+            span,
             parent,
             defs: HashMap::new(),
         }))

--- a/semantics/src/traversal/assignments.rs
+++ b/semantics/src/traversal/assignments.rs
@@ -107,6 +107,7 @@ mod tests {
     use crate::traversal::assignments::assign;
     use crate::Context;
     use fe_parser as parser;
+    use fe_parser::span::Span;
     use rstest::rstest;
     use std::rc::Rc;
 
@@ -124,7 +125,7 @@ mod tests {
                 value: Box::new(Type::Base(Base::U256)),
             },
         );
-        let function_scope = FunctionScope::new(contract_scope);
+        let function_scope = FunctionScope::new(Span::new(0, 0), contract_scope);
         function_scope
             .borrow_mut()
             .add_base("foo".to_string(), Base::U256);

--- a/semantics/src/traversal/declarations.rs
+++ b/semantics/src/traversal/declarations.rs
@@ -57,12 +57,13 @@ mod tests {
     use crate::traversal::declarations::var_decl;
     use crate::Context;
     use fe_parser as parser;
+    use fe_parser::span::Span;
     use std::rc::Rc;
 
     fn scope() -> Shared<FunctionScope> {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
-        FunctionScope::new(contract_scope)
+        FunctionScope::new(Span::new(0, 0), contract_scope)
     }
 
     fn analyze(scope: Shared<FunctionScope>, src: &str) -> Result<Context, SemanticError> {

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -366,7 +366,7 @@ mod tests {
     fn scope() -> Shared<FunctionScope> {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
-        FunctionScope::new(contract_scope)
+        FunctionScope::new(Span::new(0, 0), contract_scope)
     }
 
     fn analyze(scope: Shared<FunctionScope>, src: &str) -> Context {


### PR DESCRIPTION
Fixes #104

### What was wrong?

As explained in #104 we do currently not score well in terms of return value checking. We do not detect when:

1  A method is defined with return value but does not return any value
2. A method is defined with a return value but the actual returned value doesn't match the signature
3. A method is defined to **not** return a value but does return a value

### How was it fixed?

For case 1 and 3, I added checks directly from `func_def` to scan if all code paths return or revert (or the opposite)
For case 2 I gave `func_return` access to the `FunctionAttributes` of the host function to perform type checking

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Clean up commit history
