### PR TITLE
Disable MacOS builds on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,8 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-        - os: macOS-latest
+        # Ignoring Mac until we find a solution to: https://github.com/ethereum/fe/pull/106/checks?check_run_id=1322145918
+        # - os: macOS-latest
     steps:
     - uses: actions/checkout@v2
     - name: Cache Rust dependencies


### PR DESCRIPTION
### What was wrong?

CI is [currently failing for Mac Builds](https://github.com/ethereum/fe/pull/106/checks?check_run_id=1322145918)

### What I tried

1. Pin to an older rust nightly
2. Pin to an older Mac Version

None of that worked.

### How was it fixed?

Disabled Mac for the lack of a better fix :cry: 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Clean up commit history
