### PR TITLE
Implicitly return empty tuple when nothing else is returned

### DIFF
--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -170,6 +170,7 @@ fn type_desc<'a>(
             Ok(VarType::FixedArray(Box::new(inner), *dimension))
         }
         fe::TypeDesc::Map { .. } => Err(CompileError::static_str("maps not supported in ABI")),
+        fe::TypeDesc::Tuple { .. } => unimplemented!(),
     }
 }
 

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -78,6 +78,7 @@ fn assign_map(
         Type::Array(array) => Ok(operations::mem_to_sto(array, sptr, value)),
         Type::Base(base) => Ok(operations::val_to_sto(base, sptr, value)),
         Type::Map(_) => unreachable!(),
+        Type::Tuple(_) => unimplemented!(),
     }
 }
 

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -19,6 +19,7 @@ pub fn var_decl(
         return match typ {
             FixedSize::Base(_) => var_decl_base(context, stmt),
             FixedSize::Array(array) => var_decl_array(context, stmt, array.to_owned()),
+            FixedSize::Tuple(_) => unimplemented!(),
         };
     }
 

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -232,6 +232,7 @@ fn keyed_storage_map(typ: Map, map: yul::Expression, key: yul::Expression) -> yu
         Type::Array(array) => operations::sto_to_mem(array, sptr),
         Type::Base(base) => operations::sto_to_val(base, sptr),
         Type::Map(_) => sptr,
+        Type::Tuple(_) => unimplemented!(),
     }
 }
 

--- a/compiler/src/yul/operations.rs
+++ b/compiler/src/yul/operations.rs
@@ -92,6 +92,7 @@ pub fn decode(typ: FixedSize, ptr: yul::Expression) -> yul::Expression {
 
             unimplemented!()
         }
+        FixedSize::Tuple(_) => unimplemented!(),
     }
 }
 

--- a/compiler/src/yul/runtime/abi.rs
+++ b/compiler/src/yul/runtime/abi.rs
@@ -26,10 +26,11 @@ pub fn dispatcher(attributes: Vec<FunctionAttributes>) -> Result<yul::Statement,
 fn dispatch_arm(attributes: FunctionAttributes) -> Result<yul::Case, CompileError> {
     let selector = selector(attributes.name.clone(), &attributes.param_types);
 
-    if let Some(return_type) = attributes.return_type {
+    if !attributes.return_type.is_empty_tuple() {
         let selection = selection(attributes.name, &attributes.param_types)?;
-        let return_data = operations::encode(vec![return_type.to_owned()], vec![selection]);
-        let return_size = literal_expression! {(return_type.abi_size())};
+        let return_data =
+            operations::encode(vec![attributes.return_type.to_owned()], vec![selection]);
+        let return_size = literal_expression! {(attributes.return_type.abi_size())};
 
         let selection_with_return = statement! { return([return_data], [return_size]) };
 

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -10,11 +10,11 @@ use std::fs;
     fixture_file,
     error,
     case("mismatch_return_type.fe", "[Str(\"semantic error: TypeError\")]"),
-    case("unexpected_return.fe", "[Str(\"semantic error: UnexpectedReturn\")]"),
+    case("unexpected_return.fe", "[Str(\"semantic error: TypeError\")]"),
     case("missing_return.fe", "[Str(\"semantic error: MissingReturn\")]"),
     case(
         "return_call_to_fn_without_return.fe",
-        "[Str(\"semantic error: NotAnExpression\")]"
+        "[Str(\"semantic error: TypeError\")]"
     ),
     case(
         "return_call_to_fn_with_param_type_mismatch.fe",

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -48,6 +48,9 @@ pub enum TypeDesc<'a> {
         from: Box<Spanned<TypeDesc<'a>>>,
         to: Box<Spanned<TypeDesc<'a>>>,
     },
+    Tuple {
+        items: Vec<Spanned<TypeDesc<'a>>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -5,6 +5,7 @@
 pub enum SemanticError {
     MissingReturn,
     NotAnExpression,
+    NotSubscriptable,
     UnassignableExpression,
     UndefinedValue,
     UnexpectedReturn,

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -67,7 +67,7 @@ impl ExpressionAttributes {
 pub struct FunctionAttributes {
     pub name: String,
     pub param_types: Vec<FixedSize>,
-    pub return_type: Option<FixedSize>,
+    pub return_type: FixedSize,
 }
 
 /// Contains contextual information about a Fe module and can be queried using

--- a/semantics/src/namespace/operations.rs
+++ b/semantics/src/namespace/operations.rs
@@ -13,7 +13,8 @@ pub fn index(value: Type, index: Type) -> Result<Type, SemanticError> {
     match value {
         Type::Array(array) => index_array(array, index),
         Type::Map(map) => index_map(map, index),
-        Type::Base(_) => Err(SemanticError::TypeError),
+        Type::Base(_) => Err(SemanticError::NotSubscriptable),
+        Type::Tuple(_) => Err(SemanticError::NotSubscriptable),
     }
 }
 

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -24,7 +24,7 @@ pub enum ContractDef {
     Function {
         is_public: bool,
         params: Vec<FixedSize>,
-        returns: Option<FixedSize>,
+        returns: FixedSize,
     },
     Map {
         index: usize,
@@ -118,7 +118,7 @@ impl ContractScope {
         name: String,
         is_public: bool,
         params: Vec<FixedSize>,
-        returns: Option<FixedSize>,
+        returns: FixedSize,
     ) {
         self.interface.push(name.clone());
         self.defs.insert(

--- a/semantics/src/traversal/contracts.rs
+++ b/semantics/src/traversal/contracts.rs
@@ -70,9 +70,9 @@ pub fn contract_def(
                             param_types: params.clone(),
                             return_type: returns.clone(),
                         });
-                        if let Some(returns) = returns.clone() {
+                        if !returns.is_empty_tuple() {
                             runtime_operations.push(RuntimeOperations::AbiEncode {
-                                params: vec![returns],
+                                params: vec![returns.clone()],
                             })
                         }
                     }
@@ -105,6 +105,7 @@ fn contract_field(
             Type::Map(map) => scope.borrow_mut().add_map(name.node.to_string(), map),
             Type::Array { .. } => unimplemented!(),
             Type::Base(_) => unimplemented!(),
+            Type::Tuple(_) => unimplemented!(),
         };
 
         return Ok(());

--- a/semantics/src/traversal/declarations.rs
+++ b/semantics/src/traversal/declarations.rs
@@ -34,6 +34,7 @@ pub fn var_decl(
         match declared_type.clone() {
             FixedSize::Base(base) => scope.borrow_mut().add_base(name, base),
             FixedSize::Array(array) => scope.borrow_mut().add_array(name, array),
+            FixedSize::Tuple(_) => unimplemented!(),
         };
         context.borrow_mut().add_declaration(stmt, declared_type);
 


### PR DESCRIPTION
### What was wrong?

Currently, functions that do not return anything are a special case from the perspective of the type system. There is no way to capture anything from a call to such functions. In fact, a call to a function that does not return anything is treated as a semantic error.

E.g.

```
contract Foo:

def child():
    y = 1

def parent():
    x = self.child()  # semantic error
```

We [recently discussed](https://github.com/ethereum/fe/pull/103#discussion_r514078077) to change this and follow the model of rust which treats any function that does not explicitly return a value as one that returns an empty tuple `()`.

The core motivation for that is that it generalizes the handling of functions by getting rid of different branching logic based on whether a function does or does not return a value. In the new models, functions simply always return, even if only a zero sized empty tuple.

This means, that the code above would be valid and that the type of `x` would be `()` since this is what `child` returns.

These function definitions should be equivalent and the shorter ones can be treated as syntactic sugar to the first.

Full length form:
```
def child() -> ():
    y = 1
    return ()
```

No explicit return in signature:
```
def child():
    y = 1
    return ()
```

No explicit return statement:
```
def child() -> ():
    y = 1
```

No return in signature and function body:
```
def child():
    y = 1
```

**Notice that support for the `()` syntax is out of scope for this PR and is only meant to explain the planned changes that this PR is working towards.** 

### How was it fixed?

1. Introduced a `Tuple` type to the type system
2. Changed `return_type` of `FunctionAttributes` from `Option<FixedSize>` to `FixedSize` which means that function return values cease to be *optional* past the parser stage (They continue to be optional in the parser because of the shorthand function definition syntax)
3. Changed checks that had branching logic for returning / non-returning functions to be strictly focused on the return type
