### PR TITLE
Allow compile to YUL even when YUL is invalid

### DIFF
--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -10,11 +10,26 @@ pub struct CompilerOutput {
     pub bytecode: String,
 }
 
+pub enum CompileStage {
+    AllUpToYul,
+    AllUpToBytecode,
+}
+
 /// Compiles Fe to bytecode. It uses Yul as an intermediate representation.
-pub fn compile(src: &str) -> Result<CompilerOutput, CompileError> {
+pub fn compile(src: &str, targets: CompileStage) -> Result<CompilerOutput, CompileError> {
     let solc_temp = include_str!("solc_temp.json");
     let yul_output = yul::compile(src)?;
     let yul_src = yul_output.yul.replace("\"", "\\\"");
+
+    if let CompileStage::AllUpToYul = targets {
+        return Ok(CompilerOutput {
+            ast: yul_output.ast,
+            bytecode: String::new(),
+            tokens: yul_output.tokens,
+            yul: yul_src,
+        });
+    }
+
     let input = solc_temp.replace("{src}", &yul_src);
     let raw_output = solc::compile(&input);
     let output: serde_json::Value = serde_json::from_str(&raw_output)?;

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "solc-backend")]
 
 use fe_compiler::errors::CompileError;
+use fe_compiler::evm::CompileStage;
 
 use rstest::rstest;
 use std::fs;
@@ -24,7 +25,7 @@ fn test_compile_errors(fixture_file: &str, error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))
         .expect("Unable to read fixture file");
 
-    match fe_compiler::evm::compile(&src) {
+    match fe_compiler::evm::compile(&src, CompileStage::AllUpToBytecode) {
         Err(CompileError { errors }) => assert_eq!(format!("{:?}", errors), error),
         _ => panic!(
             "Compiling succeeded when it was expected to fail with: {}",

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -2,6 +2,7 @@
 use ethabi;
 use evm;
 
+use compiler::evm::CompileStage;
 use evm_runtime::{
     ExitReason,
     Handler,
@@ -142,7 +143,8 @@ fn deploy_contract(executor: &mut Executor, fixture: &str, name: &str) -> Contra
     let src = fs::read_to_string(format!("tests/fixtures/{}", fixture))
         .expect("Unable to read fixture file");
 
-    let output = compiler::evm::compile(&src).expect("Unable to compile to bytecode");
+    let output = compiler::evm::compile(&src, CompileStage::AllUpToBytecode)
+        .expect("Unable to compile to bytecode");
     let json_abi = compiler::abi::build(&src)
         .expect("Unable to build the module ABIs")
         .contracts[name]

--- a/src/main_full.rs
+++ b/src/main_full.rs
@@ -14,6 +14,8 @@ use clap::{
     Arg,
 };
 
+use fe_compiler::evm::CompileStage;
+
 const DEFAULT_OUTPUT_DIR_NAME: &str = "output";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -89,7 +91,7 @@ fn compile(src_file: &str, output_dir: &str, targets: Vec<CompilationTarget>) ->
 
     let contents = fs::read_to_string(src_file)?;
 
-    let output = fe_compiler::evm::compile(&contents)
+    let output = fe_compiler::evm::compile(&contents, to_compile_stage(&targets))
         .map_err(|e| Error::new(ErrorKind::Other, format!("{:?}", e)))?;
 
     for target in targets {
@@ -114,4 +116,14 @@ fn compile(src_file: &str, output_dir: &str, targets: Vec<CompilationTarget>) ->
     }
 
     Ok(())
+}
+
+fn to_compile_stage(targets: &[CompilationTarget]) -> CompileStage {
+    for target in targets {
+        if let CompilationTarget::Bytecode = target {
+            return CompileStage::AllUpToBytecode;
+        }
+    }
+
+    CompileStage::AllUpToYul
 }


### PR DESCRIPTION
### What was wrong?

Sometimes, especially during development, we would like to inspect a piece of generated YUL code even if it is invalid, meaning that we can not derive proper bytecode from it.

Naturally one would think that by using `<path-to-fe-file> --emit yul` instead of `<path-to-fe-file> --emit yul, bytecode` we could simply remove the request for compiling to bytecode to see the faulty YUL code. But that's not how the internals of the compiler work up to now because compilation is currently an all-or-nothing operation. 

### How was it fixed?

1. The compile module got support for a new `CompileStage` enum that controls if we should stop after generating YUL (which currently implies generating tokens and AST) or generate everything up to the bytecode

2. The CLI only uses `CompileStage::AllUpToBytecode` only if the generation of `bytecode` is actually requested by the user.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
