### PR TITLE
Assert statements.

### DIFF
--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -101,7 +101,7 @@ fn func_stmt(
         fe::FuncStmt::For { .. } => unimplemented!(),
         fe::FuncStmt::While { .. } => unimplemented!(),
         fe::FuncStmt::If { .. } => unimplemented!(),
-        fe::FuncStmt::Assert { .. } => unimplemented!(),
+        fe::FuncStmt::Assert { .. } => assert(context, stmt),
         fe::FuncStmt::Expr { .. } => expr(context, stmt),
         fe::FuncStmt::Pass => unimplemented!(),
         fe::FuncStmt::Break => unimplemented!(),
@@ -153,6 +153,16 @@ fn emit(context: &Context, stmt: &Spanned<fe::FuncStmt>) -> Result<yul::Statemen
         return Err(CompileError::static_str(
             "emit statements must contain a call expression",
         ));
+    }
+
+    unreachable!()
+}
+
+fn assert(context: &Context, stmt: &Spanned<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
+    if let fe::FuncStmt::Assert { test, msg: _ } = &stmt.node {
+        let test = expressions::expr(context, test)?;
+
+        return Ok(statement! { if (iszero([test])) { (revert(0, 0)) } });
     }
 
     unreachable!()

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -223,6 +223,27 @@ fn test_revert() {
     })
 }
 
+#[test]
+fn test_assert() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "assert.fe", "Foo", vec![]);
+
+        let exit1 = harness.capture_call(&mut executor, "bar", &vec![u256_token(4)]);
+
+        assert!(matches!(
+            exit1,
+            evm::Capture::Exit((evm::ExitReason::Revert(_), _))
+        ));
+
+        let exit2 = harness.capture_call(&mut executor, "bar", &vec![u256_token(42)]);
+
+        assert!(matches!(
+            exit2,
+            evm::Capture::Exit((evm::ExitReason::Succeed(_), _))
+        ))
+    })
+}
+
 #[rstest(fixture_file, input, expected,
     case("call_statement_without_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args.fe", vec![], Some(u256_token(100))),

--- a/compiler/tests/fixtures/assert.fe
+++ b/compiler/tests/fixtures/assert.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(baz: u256):
+        assert baz > 5

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -7,8 +7,10 @@ use crate::namespace::scopes::{
     Shared,
 };
 use crate::namespace::types::{
+    Base,
     FixedSize,
     Tuple,
+    Type,
 };
 use crate::traversal::_utils::spanned_expression;
 use crate::traversal::{
@@ -140,7 +142,7 @@ fn func_stmt(
         fe::FuncStmt::For { .. } => unimplemented!(),
         fe::FuncStmt::While { .. } => unimplemented!(),
         fe::FuncStmt::If { .. } => unimplemented!(),
-        fe::FuncStmt::Assert { .. } => unimplemented!(),
+        fe::FuncStmt::Assert { .. } => assert(scope, context, stmt),
         fe::FuncStmt::Expr { .. } => expr(scope, context, stmt),
         fe::FuncStmt::Pass => unimplemented!(),
         fe::FuncStmt::Break => unimplemented!(),
@@ -182,6 +184,27 @@ fn emit(
 
         for arg in args.node.iter() {
             call_arg(Rc::clone(&scope), Rc::clone(&context), arg)?;
+        }
+
+        return Ok(());
+    }
+
+    unreachable!()
+}
+
+fn assert(
+    scope: Shared<FunctionScope>,
+    context: Shared<Context>,
+    stmt: &Spanned<fe::FuncStmt>,
+) -> Result<(), SemanticError> {
+    if let fe::FuncStmt::Assert { test, msg } = &stmt.node {
+        let test_attributes = expressions::expr(scope.clone(), context.clone(), test)?;
+        if test_attributes.typ != Type::Base(Base::Bool) {
+            return Err(SemanticError::TypeError);
+        }
+        if let Some(msg) = msg {
+            // TODO: type check for a string once strings are supported
+            let _msg_attributes = expressions::expr(scope, context, msg)?;
         }
 
         return Ok(());


### PR DESCRIPTION
### What was wrong?

closes #86 

We did not support assert statements.

### How was it fixed?

Added support for assert statements. This does not include support for revert messages if the assert fails.

For example, the message in the statement `assert x > 5, "not greater than five"` will just be ignored. We can add this after basic string support is implemented, but it's not necessarily required for the Fe erc20 contract.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
