### PR TITLE
Add deploy script for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
- ![](https://raw.githubusercontent.com/ethereum/fe/master/logo/fe_svg/fe_source.svg)
+
+<img src="https://raw.githubusercontent.com/ethereum/fe/master/logo/fe_svg/fe_source.svg" width="150px">
  
 Fe is an emerging smart contract language for the Ethereum blockchain.
 
@@ -7,7 +8,7 @@ Fe is an emerging smart contract language for the Ethereum blockchain.
 
 ## Getting started
 
-- [Build the compiler](docs/build.md)
+- [Build the compiler](https://github.com/ethereum/fe/blob/master/docs/build.md)
 
 ## Overview
 
@@ -187,5 +188,5 @@ considered to represent the exact prioritization of work items.
 
 ## Community
 
-Twitter: [@official_fe](https://twitter.com/official_fe)
-Chat: [gitter/ethereum/fe](http://gitter.im/ethereum/fe)
+- Twitter: [@official_fe](https://twitter.com/official_fe)
+- Chat: [gitter/ethereum/fe](http://gitter.im/ethereum/fe)

--- a/deploy-website.sh
+++ b/deploy-website.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+echo -e "\033[0;32mDeploying website...\033[0m"
+
+# Ensure we start from a clean state
+rm -rf target/doc
+
+cargo doc --no-deps --all
+
+# delete old gh-pages-tmp branch
+git branch -D gh-pages-tmp
+
+# Recreate it
+git checkout -b gh-pages-tmp
+
+# Rustdoc generates the index.html in a child folder and leaves it up to us to how
+# to get there. For now, we just use this client side redirect.
+cat > target/doc/index.html <<EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<link rel="canonical" href="fe/index.html"/>
+<noscript>
+	<meta http-equiv="refresh" content="0;URL=fe/index.html">
+</noscript>
+<!--[if lt IE 9]><script type="text/javascript">var IE_fix=true;</script><![endif]-->
+<script type="text/javascript">
+	var url = "fe/index.html";
+	if(typeof IE_fix != "undefined") // IE8 and lower fix to pass the http referer
+	{
+		document.write("redirecting...");
+		var referLink = document.createElement("a");
+		referLink.href = url;
+		document.body.appendChild(referLink);
+		referLink.click();
+	}
+	else { window.location.replace(url); } // All other browsers
+</script>
+</head>
+</html>
+EOF
+
+# Add changes to git.
+git add -f target/doc
+
+# Commit changes.
+msg="Generated site on `date`"
+if [ $# -eq 1 ]
+  then msg="$1"
+fi
+git commit -m "$msg"
+
+git subtree split -P target/doc -b gh-pages-dist
+
+# Push to Github Pages
+git push -f upstream gh-pages-dist:gh-pages
+
+# Go where we came from
+git checkout -
+
+# Delete temporary branches
+git branch -D gh-pages-tmp
+git branch -D gh-pages-dist

--- a/deploy-website.sh
+++ b/deploy-website.sh
@@ -40,6 +40,10 @@ cat > target/doc/index.html <<EOF
 </html>
 EOF
 
+cat > target/doc/CNAME <<EOF
+fe.ethereum.org
+EOF
+
 # Add changes to git.
 git add -f target/doc
 


### PR DESCRIPTION
### What was wrong?

We don't have a site up that hosts our docs. Unfortunately, getting our docs up on https://docs.rs isn't so simple because our Git dependencies make it impossible to get Fe on https://crates.io which would be needed to host the docs on docs.rs.

Fortunately, we can still use `cargo docs` to generate the docs and host the site ourselves.

### How was it fixed?

1. Created a shell script `deploy-website.sh` that takes care of generating the site and pushing its contents into the `gh-pages` branch of this repo. This is an orphaned branch simply to host the artifacts of the generated site. This is a one-click-deploy-no-questions-asked deployment. Assuming one uses `upstream` to point to this repo, invoking `deploy-website.sh` is all it takes to update the live site.

2. A few minor fixes to the Readme.

The site is currently live at https://ethereum.github.io/fe but I hope it will soon be reachable via https://fe.ethereum.org

:tada: 

![image](https://user-images.githubusercontent.com/521109/98256320-b3558a00-1f7e-11eb-98d8-11b0fe6c3180.png)


### Further remarks

Rustdoc appears to be very limited and not really suited to host anything but strict API docs. I believe that, longer term, we will want to host a proper website, including guides and online editor (#70) and just link to the API docs from there. For now, the API docs *are* the website.

I have also [opened up an issue with devops](https://github.com/ethereum/devops/issues/573) to get this hosted on https://fe.ethereum.org