### PR TITLE
Add support for if / else statements

### DIFF
--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -13,6 +13,11 @@ use std::fs;
     case("unexpected_return.fe", "[Str(\"semantic error: TypeError\")]"),
     case("missing_return.fe", "[Str(\"semantic error: MissingReturn\")]"),
     case(
+        "missing_return_in_else.fe",
+        "[Str(\"semantic error: MissingReturn\")]"
+    ),
+    case("strict_boolean_if_else.fe", "[Str(\"semantic error: TypeError\")]"),
+    case(
         "return_call_to_fn_without_return.fe",
         "[Str(\"semantic error: TypeError\")]"
     ),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -245,6 +245,9 @@ fn test_assert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("if_statement.fe", vec![6], Some(u256_token(1))),
+    case("if_statement.fe", vec![4], Some(u256_token(0))),
+    case("if_statement_2.fe", vec![6], Some(u256_token(1))),
     case("call_statement_without_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args_2.fe", vec![], Some(u256_token(100))),

--- a/compiler/tests/fixtures/compile_errors/missing_return_in_else.fe
+++ b/compiler/tests/fixtures/compile_errors/missing_return_in_else.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    pub def bar(val: u256) -> u256:
+        if val > 1:
+            return 5
+        else:
+            x = 1

--- a/compiler/tests/fixtures/compile_errors/strict_boolean_if_else.fe
+++ b/compiler/tests/fixtures/compile_errors/strict_boolean_if_else.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    pub def bar(val: u256) -> u256:
+        if val:
+            return 5
+        else:
+            return 1

--- a/compiler/tests/fixtures/if_statement.fe
+++ b/compiler/tests/fixtures/if_statement.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+    pub def bar(input: u256) -> u256:
+        if input > 5:
+            return 1
+        else:
+            return 0

--- a/compiler/tests/fixtures/if_statement_2.fe
+++ b/compiler/tests/fixtures/if_statement_2.fe
@@ -1,0 +1,9 @@
+contract Foo:
+
+    pub def bar(val: u256) -> u256:
+        if val > 5:
+            return 1
+        else:
+            assert true
+
+        return 0


### PR DESCRIPTION
### What was wrong?

Fe does currently not support `if` / `else`  statements.

### How was it fixed?

1. Added support by mapping to the equivalent switch block in YUL
2. Added a check in the semantic pass that the tested expression is of type `Base::Bool`
3. Changed the `validate_all_paths_return_or_revert` check to follow down the branches of `if` / `else` to ensure all paths `return` or `revert`
4. Added a bunch of test cases to cover the functionality.
