### PR TITLE
Pretty print tokens and AST in --emit

### DIFF
--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -25,8 +25,8 @@ pub fn compile(src: &str) -> Result<CompilerOutput, CompileError> {
         .next()
     {
         return Ok(CompilerOutput {
-            tokens: format!("{:?}", tokens),
-            ast: format!("{:?}", fe_module),
+            tokens: format!("{:#?}", tokens),
+            ast: format!("{:#?}", fe_module),
             yul: first_contract.to_string(),
         });
     }


### PR DESCRIPTION
### What was wrong?

The generated AST and tokens are all in one giant line.

### How was it fixed?

Using the build in `#?` pretty printing we get some decent formatting.
