### PR TITLE
Basic string support and encoding/decoding of dynamically sized ABI types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.9"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -123,9 +123,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-slice-cast"
@@ -146,19 +146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 
 [[package]]
 name = "cexpr"
@@ -203,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.42"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fb25b677f8bf1eb325017cb6bb8452f87969db0fedb4f757b297bee78a7c62"
+checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 dependencies = [
  "cc",
 ]
@@ -293,21 +284,24 @@ dependencies = [
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "tiny-keccak 2.0.1",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]
 name = "ethereum"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7538b2bb55bde83b500c4e6ea0bdb3b1c0e9e5ae57951941e5412db32c2a8344"
+checksum = "df706418ff7d3874b9506424b04ea0bef569a2b39412b43a27ea86e679be108e"
 dependencies = [
  "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
  "parity-scale-codec",
  "rlp",
  "rlp-derive",
  "serde",
  "sha3 0.9.1",
+ "triehash",
 ]
 
 [[package]]
@@ -326,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "evm"
-version = "0.18.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ae392693d655a526f86dcd9ee0846ee9250f3cef8c6ee67c35ce05d277b7a2"
+checksum = "f1fc70736bd5ec89622647ea9346b70567557917596a39538d76e8f2a17ff59e"
 dependencies = [
  "ethereum",
  "evm-core",
@@ -344,11 +338,10 @@ dependencies = [
 
 [[package]]
 name = "evm-core"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485c128056e9d80afdd6b154b174947ca77c1d889819b1be2a0275d3733256e5"
+checksum = "63c6c39300d7779427f461408d867426e202ea72ac7ece2455689ff0e4bddb6f"
 dependencies = [
- "log",
  "parity-scale-codec",
  "primitive-types",
  "serde",
@@ -356,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "evm-gasometer"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49550ed1f3d504ce8189708dbc153cee38956ac201cba3bc8c3e0816595d41a9"
+checksum = "689c481648c3f45b64b1278077c04284ad535e068c9d6872153c7b74da7ccb03"
 dependencies = [
  "evm-core",
  "evm-runtime",
@@ -367,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "evm-runtime"
-version = "0.18.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9c6338c699169eb3dbc9d355adb5cae0b7bc19b44a9b45edb344aa795e1ac6"
+checksum = "61a148ad1b3e0af31aa03c6c3cc9df3a529e279dad8e29b4ef90dccad32601e4"
 dependencies = [
  "evm-core",
  "primitive-types",
@@ -402,7 +395,7 @@ dependencies = [
  "serde_json",
  "solc",
  "stringreader",
- "tiny-keccak 2.0.1",
+ "tiny-keccak 2.0.2",
  "yultsur",
 ]
 
@@ -426,7 +419,7 @@ dependencies = [
  "fe-parser",
  "hex",
  "rstest",
- "tiny-keccak 2.0.1",
+ "tiny-keccak 2.0.2",
 ]
 
 [[package]]
@@ -462,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if",
  "libc",
@@ -478,10 +471,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.8"
+name = "hash-db"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+
+[[package]]
+name = "hash256-std-hasher"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -530,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
@@ -557,15 +565,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.67"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libloading"
@@ -579,18 +587,18 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nom"
@@ -647,9 +655,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
@@ -675,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.21"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -718,11 +726,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -746,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -758,15 +766,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.15"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7246cd0a0a6ec2239a5405b2b16e3f404fa0dcc6d28f5f5b877bf80e33e0f294"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "rlp"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a44d5ae8afcb238af8b75640907edc6c931efcfab2c854e81ed35fa080f84cd"
+checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
 dependencies = [
  "rustc-hex",
 ]
@@ -829,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "scoped-tls"
@@ -856,18 +864,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -876,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -946,9 +954,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -993,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-keccak"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2953ca5148619bc99695c1274cb54c5275bbb913c6adad87e72eaf8db9787f69"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
@@ -1007,6 +1015,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "triehash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f490aa7aa4e4d07edeba442c007e42e3e7f43aafb5112c5b047fff0b1aa5449c"
+dependencies = [
+ "hash-db",
+ "rlp",
 ]
 
 [[package]]
@@ -1029,21 +1047,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1165,18 +1183,18 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1190,9 +1208,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -164,6 +164,7 @@ fn type_desc<'a>(
         fe::TypeDesc::Base { base: "u256" } => Ok(VarType::Uint256),
         fe::TypeDesc::Base { base: "bool" } => Ok(VarType::Bool),
         fe::TypeDesc::Base { base: "address" } => Ok(VarType::Address),
+        fe::TypeDesc::Base { base } if &base[..6] == "string" => Ok(VarType::String),
         fe::TypeDesc::Base { base } => {
             Err(CompileError::str(format!("unrecognized type: {}", base)))
         }

--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -172,6 +172,7 @@ pub enum VarType {
     Address,
     FixedBytes(usize),
     FixedArray(Box<VarType>, usize),
+    String,
 }
 
 /// The mutability of a public function.
@@ -193,6 +194,7 @@ impl fmt::Display for VarType {
             VarType::Address => write!(f, "address"),
             VarType::FixedBytes(size) => write!(f, "bytes{}", size),
             VarType::FixedArray(inner, dim) => write!(f, "{}[{}]", inner, dim),
+            VarType::String => write!(f, "string"),
         }
     }
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(iterator_fold_self)]
 //! Modules for compiling Fe and building ABIs.
 
 pub mod abi;

--- a/compiler/src/yul/abi/functions.rs
+++ b/compiler/src/yul/abi/functions.rs
@@ -1,0 +1,264 @@
+use crate::yul::abi::utils::{
+    decode_name,
+    encode_name,
+    head_offsets,
+};
+use crate::yul::operations;
+use fe_semantics::namespace::types::{
+    AbiArraySize,
+    AbiDecodeLocation,
+    AbiEncoding,
+    AbiType,
+    AbiUintSize,
+};
+use yultsur::*;
+
+/// Generates an encoding function for any set of type parameters.
+pub fn encode<T: AbiEncoding>(types: Vec<T>) -> yul::Statement {
+    // the name of the function we're generating
+    let func_name = encode_name(&types);
+
+    // create a vector of identifiers and a vector of tuples, which contain
+    // expressions that correspond to the identifiers.
+    //
+    // The identifier vector is injected into the parameter section of our
+    // encoding function and the expressions are used to reference the parameters
+    // while encoding.
+    let (params, typed_params): (Vec<_>, Vec<_>) = types
+        .iter()
+        .enumerate()
+        .map(|(i, typ)| {
+            let ident = identifier! { (format!("val_{}", i)) };
+            let expr = identifier_expression! { [ident.clone()] };
+            (ident, (expr, typ))
+        })
+        .unzip();
+
+    // get the size of the static section
+    let (_, static_size) = head_offsets(&types);
+    let static_size = literal_expression! { (static_size) };
+
+    // we need to keep track of the dynamic section size to properly encode
+    // dynamically-sized array headers.
+    let mut dyn_sizes = vec![];
+    // we also keep a separate vector of dynamically-sized arrays, which we
+    // encode after finishing the static section.
+    let mut dyn_array_params = vec![];
+
+    // map the typed params to encoding statements for headers and statically-sized
+    // values
+    let static_encode_stmts = typed_params
+        .into_iter()
+        .map(|(param, typ)| match typ.abi_type() {
+            AbiType::Array {
+                inner,
+                size: AbiArraySize::Static { size },
+            } => encode_static_array(param, *inner, size),
+            AbiType::Array {
+                inner,
+                size: AbiArraySize::Dynamic,
+            } => {
+                let dyn_offset =
+                    expression! { add([static_size.clone()], [operations::sum(dyn_sizes.clone())]) };
+                let inner = *inner;
+                dyn_sizes.push(dyn_array_data_size(param.clone(), inner.clone()));
+                dyn_array_params.push((param, inner));
+                encode_uint(dyn_offset)
+            }
+            AbiType::Uint { .. } => encode_uint(param),
+        })
+        .collect::<Vec<_>>();
+
+    // map the dynamically-sized arrays to encoding statemnts
+    let dyn_encode_stmts = dyn_array_params
+        .into_iter()
+        .map(|(param, inner)| encode_dyn_array(param, inner))
+        .collect::<Vec<_>>();
+
+    function_definition! {
+        function [func_name]([params...]) -> ptr {
+            (ptr := avail())
+            [static_encode_stmts...]
+            [dyn_encode_stmts...]
+        }
+    }
+}
+
+fn dyn_array_data_size(val: yul::Expression, inner: AbiType) -> yul::Expression {
+    match inner {
+        AbiType::Array { .. } => unimplemented!(),
+        AbiType::Uint {
+            size: AbiUintSize { padded_size, .. },
+        } => {
+            let inner_padded_size = literal_expression! { (padded_size) };
+            let array_size = expression! { mload([val]) };
+            let elements_size = expression! { mul([array_size], [inner_padded_size]) };
+            expression! { add(32, (ceil32([elements_size]))) }
+        }
+    }
+}
+
+fn encode_uint(val: yul::Expression) -> yul::Statement {
+    statement! { pop((alloc_mstoren([val], 32))) }
+}
+
+fn encode_dyn_array(val: yul::Expression, inner: AbiType) -> yul::Statement {
+    let array_size = expression! { mload([val.clone()]) };
+    let array_start = expression! { add([val], 32) };
+    block_statement! {
+        [encode_uint(array_size.clone())]
+        [encode_array(array_start, inner, array_size)]
+    }
+}
+
+fn encode_static_array(val: yul::Expression, inner: AbiType, size: usize) -> yul::Statement {
+    let array_size = literal_expression! { (size) };
+    encode_array(val, inner, array_size)
+}
+
+fn encode_array(
+    val: yul::Expression,
+    inner: AbiType,
+    array_size: yul::Expression,
+) -> yul::Statement {
+    let (inner_data_size, inner_padded_size) = match inner {
+        AbiType::Uint {
+            size:
+                AbiUintSize {
+                    data_size,
+                    padded_size,
+                },
+        } => (
+            literal_expression! { (data_size) },
+            literal_expression! { (padded_size) },
+        ),
+        AbiType::Array { .. } => unimplemented!(),
+    };
+
+    block_statement! {
+        (let array_size := [array_size])
+        (let array_data_size := mul(array_size, [inner_padded_size.clone()]))
+        (for {(let i := 0)} (lt(i, array_size)) {(i := add(i, 1))}
+        {
+            (let val_ptr := add([val], (mul(i, [inner_data_size.clone()]))))
+            (let val := mloadn(val_ptr, [inner_data_size]))
+            (pop((alloc_mstoren(val, [inner_padded_size]))))
+        })
+        (pop((alloc((sub((ceil32(array_data_size)), array_data_size))))))
+    }
+}
+
+/// Generates an decoding function for a single type parameter in either
+/// calldata or memory.
+pub fn decode<T: AbiEncoding>(typ: T, location: AbiDecodeLocation) -> yul::Statement {
+    let func_name = decode_name(&typ, location.clone());
+
+    let decode_expr = match typ.abi_type() {
+        AbiType::Uint { .. } => decode_uint(location),
+        AbiType::Array { inner, size } => decode_array(*inner, size, location),
+    };
+
+    function_definition! {
+         // `start` refers to the beginning of the encoding
+         // `head_ptr` refers to the pointer at which the head is located
+         function [func_name](start, head_ptr) -> val {
+            (val := [decode_expr])
+         }
+    }
+}
+
+fn decode_uint(location: AbiDecodeLocation) -> yul::Expression {
+    match location {
+        AbiDecodeLocation::Memory => expression! { mload(head_ptr) },
+        AbiDecodeLocation::Calldata => expression! { calldataload(head_ptr) },
+    }
+}
+
+fn decode_array(
+    inner: AbiType,
+    size: AbiArraySize,
+    location: AbiDecodeLocation,
+) -> yul::Expression {
+    match inner {
+        // encoding of nested arrays
+        AbiType::Array { .. } => unimplemented!(),
+        // encoding of values that do not need to be unpacked
+        AbiType::Uint {
+            size:
+                AbiUintSize {
+                    padded_size,
+                    data_size,
+                },
+        } if padded_size == data_size => match size {
+            AbiArraySize::Static { size } => {
+                let total_size = size * data_size;
+                let total_size = literal_expression! { (total_size) };
+
+                match location {
+                    AbiDecodeLocation::Calldata => expression! { ccopy(head_ptr, [total_size]) },
+                    AbiDecodeLocation::Memory => expression! { head_ptr },
+                }
+            }
+            AbiArraySize::Dynamic => match location {
+                AbiDecodeLocation::Calldata => {
+                    let data_ptr = expression! { add(start, (calldataload(head_ptr))) };
+                    let array_size = expression! { calldataload([data_ptr.clone()]) };
+                    let data_size = literal_expression! { (data_size) };
+                    let total_size = expression! { add(32, (mul([array_size], [data_size]))) };
+
+                    expression! { ccopy([data_ptr], [total_size]) }
+                }
+                AbiDecodeLocation::Memory => {
+                    expression! { add(start, (mload(head_ptr))) }
+                }
+            },
+        },
+        // encoding of values that need to be packed
+        AbiType::Uint { .. } => unimplemented!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::abi::functions::{
+        decode,
+        encode,
+    };
+    use fe_semantics::namespace::types::{
+        AbiDecodeLocation,
+        Base,
+        FeString,
+    };
+
+    #[test]
+    fn test_encode() {
+        assert_eq!(
+            encode(vec![Base::U256, Base::Address]).to_string(),
+            "function abi_encode_uint256_address(val_0, val_1) -> ptr { ptr := avail() pop(alloc_mstoren(val_0, 32)) pop(alloc_mstoren(val_1, 32)) }"
+        )
+    }
+
+    #[test]
+    fn test_decode_string_mem() {
+        assert_eq!(
+            decode(FeString { max_size: 100 }, AbiDecodeLocation::Memory).to_string(),
+            "function abi_decode_string100_mem(start, head_ptr) -> val { val := add(start, mload(head_ptr)) }"
+        )
+    }
+
+    #[test]
+    fn test_decode_string_calldata() {
+        assert_eq!(
+            decode(FeString { max_size: 100 }, AbiDecodeLocation::Calldata).to_string(),
+            "function abi_decode_string100_calldata(start, head_ptr) -> val { val := ccopy(add(start, calldataload(head_ptr)), add(32, mul(calldataload(add(start, calldataload(head_ptr))), 1))) }"
+        )
+    }
+
+    #[test]
+    fn test_decode_u256_mem() {
+        assert_eq!(
+            decode(Base::U256, AbiDecodeLocation::Memory).to_string(),
+            "function abi_decode_uint256_mem(start, head_ptr) -> val { val := mload(head_ptr) }"
+        )
+    }
+}

--- a/compiler/src/yul/abi/mod.rs
+++ b/compiler/src/yul/abi/mod.rs
@@ -1,0 +1,3 @@
+pub mod functions;
+pub mod operations;
+mod utils;

--- a/compiler/src/yul/abi/operations.rs
+++ b/compiler/src/yul/abi/operations.rs
@@ -1,0 +1,123 @@
+use crate::yul::abi::utils::{
+    ceil_32,
+    decode_name,
+    encode_name,
+    head_offsets,
+};
+use crate::yul::operations;
+use fe_semantics::namespace::types::{
+    AbiArraySize,
+    AbiDecodeLocation,
+    AbiEncoding,
+    AbiType,
+    AbiUintSize,
+};
+use yultsur::*;
+
+/// Returns an expression that encodes the given values and returns a pointer to
+/// the encoding.
+pub fn encode<T: AbiEncoding>(types: Vec<T>, vals: Vec<yul::Expression>) -> yul::Expression {
+    let func_name = encode_name(&types);
+    expression! { [func_name]([vals...]) }
+}
+
+/// Returns an expression that gives size of the encoded values.
+pub fn encode_size<T: AbiEncoding>(types: Vec<T>, vals: Vec<yul::Expression>) -> yul::Expression {
+    let mut static_size = 0;
+    let mut dyn_size = vec![];
+
+    let typed_vals = types.iter().zip(vals);
+
+    for (typ, val) in typed_vals {
+        match typ.abi_type() {
+            AbiType::Uint { .. } => static_size += 32,
+            AbiType::Array { inner, size } => {
+                let inner_size = match *inner {
+                    AbiType::Uint {
+                        size: AbiUintSize { padded_size, .. },
+                    } => padded_size,
+                    AbiType::Array { .. } => unimplemented!(),
+                };
+                match size {
+                    AbiArraySize::Static { size } => static_size += ceil_32(inner_size * size),
+                    AbiArraySize::Dynamic => {
+                        static_size += 64;
+                        let inner_size = literal_expression! { (inner_size) };
+                        let array_size = expression! { mload([val]) };
+                        dyn_size.push(expression! { ceil32((mul([array_size], [inner_size]))) })
+                    }
+                }
+            }
+        }
+    }
+
+    let static_size = literal_expression! { (static_size) };
+    return expression! { add([static_size], [operations::sum(dyn_size)]) };
+}
+
+/// Returns a list of expressions that can be used to decode given types.
+/// `start` is where the encoding starts and `loc` indicates whether the data is
+/// in calldata or memory.
+pub fn decode<T: AbiEncoding>(
+    types: Vec<T>,
+    start: yul::Expression,
+    location: AbiDecodeLocation,
+) -> Vec<yul::Expression> {
+    let heads = head_offsets(&types).0.into_iter().map(|offset| {
+        let offset = literal_expression! { (offset) };
+        expression! { add([start.clone()], [offset]) }
+    });
+    let typed_heads = types.iter().zip(heads);
+
+    typed_heads
+        .into_iter()
+        .map(|(typ, head_ptr)| {
+            let func_name = decode_name(typ, location.clone());
+            expression! { [func_name]([start.clone()], [head_ptr]) }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::abi::operations::{
+        decode,
+        encode,
+        encode_size,
+    };
+    use fe_semantics::namespace::types::{
+        AbiDecodeLocation,
+        Base,
+        FeString,
+    };
+    use yultsur::*;
+
+    #[test]
+    fn test_encode() {
+        assert_eq!(
+            encode(vec![Base::U256], vec![expression! { 42 }]).to_string(),
+            "abi_encode_uint256(42)"
+        )
+    }
+
+    #[test]
+    fn test_encode_size() {
+        assert_eq!(
+            encode_size(vec![Base::U256], vec![expression! { 42 }]).to_string(),
+            "add(32, 0)"
+        )
+    }
+
+    #[test]
+    fn test_decode() {
+        assert_eq!(
+            decode(
+                vec![FeString { max_size: 26 }],
+                expression! { 42 },
+                AbiDecodeLocation::Calldata
+            )[0]
+            .to_string(),
+            "abi_decode_string26_calldata(42, add(42, 0))"
+        )
+    }
+}

--- a/compiler/src/yul/abi/utils.rs
+++ b/compiler/src/yul/abi/utils.rs
@@ -1,0 +1,134 @@
+use fe_semantics::namespace::types::{
+    AbiArraySize,
+    AbiDecodeLocation,
+    AbiEncoding,
+    AbiType,
+    AbiUintSize,
+};
+use yultsur::*;
+
+/// Returns the offset at which each head is located in the static section
+/// of an encoding and the total size of the static section.
+pub fn head_offsets<T: AbiEncoding>(types: &[T]) -> (Vec<usize>, usize) {
+    let mut offsets = vec![];
+    let mut curr_offset = 0;
+
+    for typ in types {
+        offsets.push(curr_offset);
+
+        curr_offset += match typ.abi_type() {
+            AbiType::Array {
+                size: AbiArraySize::Dynamic { .. },
+                ..
+            } => 32,
+            AbiType::Array {
+                size: AbiArraySize::Static { size },
+                inner,
+            } => match *inner {
+                AbiType::Array { .. } => unimplemented!(),
+                AbiType::Uint {
+                    size: AbiUintSize { padded_size, .. },
+                } => ceil_32(padded_size * size),
+            },
+            AbiType::Uint {
+                size: AbiUintSize { padded_size, .. },
+            } => padded_size,
+        };
+    }
+
+    (offsets, curr_offset)
+}
+
+/// Generates an ABI encoding function name for a given set of types.
+pub fn encode_name<T: AbiEncoding>(types: &[T]) -> yul::Identifier {
+    let mut full_name = "abi_encode".to_string();
+
+    for typ in types {
+        full_name.push('_');
+        full_name.push_str(&typ.abi_safe_name());
+    }
+
+    identifier! { (full_name) }
+}
+
+/// Generates an ABI decoding function name for a given type and location.
+pub fn decode_name<T: AbiEncoding>(typ: &T, location: AbiDecodeLocation) -> yul::Identifier {
+    let mut full_name = "abi_decode".to_string();
+    let loc = match location {
+        AbiDecodeLocation::Memory => "mem",
+        AbiDecodeLocation::Calldata => "calldata",
+    };
+    full_name.push('_');
+    full_name.push_str(&typ.abi_safe_name());
+    full_name.push('_');
+    full_name.push_str(loc);
+
+    identifier! { (full_name) }
+}
+
+/// Rounds up to nearest multiple of 32.
+pub fn ceil_32(n: usize) -> usize {
+    ((n + 31) / 32) * 32
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::abi::utils::{
+        decode_name,
+        encode_name,
+        head_offsets,
+    };
+    use fe_semantics::namespace::types::{
+        AbiDecodeLocation,
+        Array,
+        Base,
+        FeString,
+        FixedSize,
+    };
+
+    #[test]
+    fn test_encode_name() {
+        assert_eq!(
+            encode_name(&vec![
+                FixedSize::Base(Base::U256),
+                FixedSize::Array(Array {
+                    inner: Base::Byte,
+                    dimension: 100
+                })
+            ])
+            .to_string(),
+            "abi_encode_uint256_bytes100"
+        )
+    }
+
+    #[test]
+    fn test_decode_name_u256_calldata() {
+        assert_eq!(
+            decode_name(&Base::U256, AbiDecodeLocation::Calldata).to_string(),
+            "abi_decode_uint256_calldata"
+        )
+    }
+
+    #[test]
+    fn test_decode_name() {
+        assert_eq!(
+            decode_name(&FeString { max_size: 42 }, AbiDecodeLocation::Memory).to_string(),
+            "abi_decode_string42_mem"
+        )
+    }
+
+    #[test]
+    fn test_head_offsets() {
+        let types = vec![
+            FixedSize::Array(Array {
+                inner: Base::U256,
+                dimension: 42,
+            }),
+            FixedSize::Base(Base::U256),
+            FixedSize::String(FeString { max_size: 26 }),
+            FixedSize::Base(Base::Address),
+        ];
+
+        assert_eq!(head_offsets(&types), (vec![0, 1344, 1376, 1408], 1440))
+    }
+}

--- a/compiler/src/yul/constructor.rs
+++ b/compiler/src/yul/constructor.rs
@@ -1,9 +1,6 @@
-use crate::yul::{
-    operations,
-    runtime,
-};
+use crate::yul::abi::operations as abi_operations;
 use fe_semantics::namespace::types::{
-    AbiEncoding,
+    AbiDecodeLocation,
     FixedSize,
 };
 use yultsur::*;
@@ -11,7 +8,7 @@ use yultsur::*;
 /// Builds a contract constructor.
 ///
 /// Takes an optional init function and its parameter types.
-pub fn build(init: Option<(yul::Statement, Vec<FixedSize>)>) -> yul::Code {
+pub fn build(init: Option<(yul::Statement, Vec<FixedSize>, Vec<yul::Statement>)>) -> yul::Code {
     // statements that return the contract code
     let deploy_stmts = statements! {
         (let size := datasize("runtime"))
@@ -19,42 +16,39 @@ pub fn build(init: Option<(yul::Statement, Vec<FixedSize>)>) -> yul::Code {
         (return(0, size))
     };
 
-    let block = if let Some((init, params)) = init {
+    let block = if let Some((init, params, runtime)) = init {
         // build a constructor with an init function
 
-        // map the init params to decode expressions
-        let mut offset = 0;
-        let mut decoded_params = vec![];
-        for param in params.iter() {
-            let offset_expr = literal_expression! { (offset) };
-            decoded_params.push(operations::decode_mem(
-                param.to_owned(),
-                expression! { add(mem_start, [offset_expr]) },
-            ));
-            offset += param.abi_size();
-        }
-
-        // The final value of `offset` is equal to the total size of the ABI encoded
-        // parameters. We reuse this to copy the parameters from code to memory.
-        let params_size = literal_expression! { (offset) };
-
-        // the standard runtime functions need to be made available in the constructor
-        let runtime_functions = runtime::functions::std();
+        // decode operations for `__init__` parameters
+        let decoded_params = abi_operations::decode(
+            params,
+            expression! { params_start_mem },
+            AbiDecodeLocation::Memory,
+        );
 
         // Build a constructor that runs a user defined init function. Parameters for
         // init functions are appended to the end of the initialization code.
         //
-        // The start of the init parameters in code is stored in `code_start`. The
-        // parameters are immediately copied from this location into memory at
+        // The start of the init parameters in code is stored in `params_start_code`.
+        // The parameters are immediately copied from this location into memory at
         // `mem_start`. From there, parameters are decoded and passed into the
         // init function.
         block! {
-            (let code_start := datasize("Contract"))
-            (let mem_start := alloc([params_size.clone()]))
-            (codecopy(mem_start, code_start, [params_size]))
+            // copy params to memory where they can be decoded
+            (let params_start_code := datasize("Contract"))
+            (let params_end_code := codesize())
+            (let params_size := sub(params_end_code, params_start_code))
+            (let params_start_mem := alloc(params_size))
+            (codecopy(params_start_mem, params_start_code, params_size))
+
+            // add init function amd run it
             [init]
             (__init__([decoded_params...]))
-            [runtime_functions...]
+
+            // add the runtime functions
+            [runtime...]
+
+            // deploy the contract
             [deploy_stmts...]
         }
     } else {

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -79,6 +79,7 @@ fn assign_map(
         Type::Base(base) => Ok(operations::val_to_sto(base, sptr, value)),
         Type::Map(_) => unreachable!(),
         Type::Tuple(_) => unimplemented!(),
+        Type::String(_) => unimplemented!(),
     }
 }
 

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -20,6 +20,7 @@ pub fn var_decl(
             FixedSize::Base(_) => var_decl_base(context, stmt),
             FixedSize::Array(array) => var_decl_array(context, stmt, array.to_owned()),
             FixedSize::Tuple(_) => unimplemented!(),
+            FixedSize::String(_) => unimplemented!(),
         };
     }
 

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -222,6 +222,7 @@ fn keyed_storage_map(typ: Map, map: yul::Expression, key: yul::Expression) -> yu
         Type::Base(base) => operations::sto_to_val(base, sptr),
         Type::Map(_) => sptr,
         Type::Tuple(_) => unimplemented!(),
+        Type::String(_) => unimplemented!(),
     }
 }
 

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -9,10 +9,6 @@ use crate::yul::mappers::{
 use crate::yul::operations;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
-use fe_semantics::namespace::types::{
-    FeSized,
-    FixedSize,
-};
 use fe_semantics::Context;
 use yultsur::*;
 
@@ -49,41 +45,18 @@ pub fn func_def(
             .collect::<Result<Vec<_>, _>>()?;
         let function_statements = multiple_func_stmt(context, body)?;
 
-        // Different return types require slightly different functions.
-        return match attributes.return_type.to_owned() {
-            // Base types are returned by value. All memory used by the function is cleared.
-            FixedSize::Base(_) => Ok(function_definition! {
-                function [function_name]([param_names...]) -> return_val {
-                    (let ptr := avail())
+        return if attributes.return_type.is_empty_tuple() {
+            Ok(function_definition! {
+                function [function_name]([param_names...]) {
                     [function_statements...]
-                    (free(ptr))
                 }
-            }),
-            // Arrays need to keep memory allocated after completing.
-            FixedSize::Array(array) => {
-                let size = literal_expression! {(array.size())};
-
-                Ok(function_definition! {
-                    function [function_name]([param_names...]) -> return_val {
-                        [function_statements...]
-                        (free((add(return_val, [size]))))
-                    }
-                })
-            }
-            FixedSize::Tuple(tuple) => {
-                if tuple.size() == 0 {
-                    // Nothing is returned. All memory used by the function is freed.
-                    return Ok(function_definition! {
-                        function [function_name]([param_names...]) {
-                            (let ptr := avail())
-                            [function_statements...]
-                            (free(ptr))
-                        }
-                    });
+            })
+        } else {
+            Ok(function_definition! {
+                function [function_name]([param_names...]) -> return_val {
+                    [function_statements...]
                 }
-
-                unimplemented!();
-            }
+            })
         };
     }
 
@@ -204,17 +177,17 @@ fn func_return(
     stmt: &Spanned<fe::FuncStmt>,
 ) -> Result<yul::Statement, CompileError> {
     if let fe::FuncStmt::Return { value } = &stmt.node {
-        match value {
+        return match value {
             Some(value) => {
                 let value = expressions::expr(context, value)?;
 
-                return Ok(yul::Statement::Block(block! {
+                return Ok(block_statement! {
                     (return_val := [value])
                     (leave)
-                }));
+                });
             }
-            None => return Ok(statement! { leave }),
-        }
+            None => Ok(statement! { leave }),
+        };
     }
 
     unreachable!()

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::CompileError;
 
+mod abi;
 mod constructor;
 mod mappers;
 mod operations;

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -1,2 +1,2 @@
-pub mod abi;
+pub mod abi_dispatcher;
 pub mod functions;

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -66,18 +66,18 @@ impl ContractHarness {
     ) {
         let function = &self.abi.functions[name][0];
 
-        if let evm::Capture::Exit((ExitReason::Succeed(_), actual_output)) =
-            self.capture_call(executor, name, &input)
-        {
-            if let Some(output) = output {
-                let actual_output = &function
-                    .decode_output(&actual_output)
-                    .expect("Unable to decode output.")[0];
+        match self.capture_call(executor, name, &input) {
+            evm::Capture::Exit((ExitReason::Succeed(_), actual_output)) => {
+                if let Some(output) = output {
+                    let actual_output = &function
+                        .decode_output(&actual_output)
+                        .expect(&format!("unable to decode output: {:?}", &actual_output))[0];
 
-                assert_eq!(&output, actual_output)
+                    assert_eq!(&output, actual_output)
+                }
             }
-        } else {
-            panic!("Failed to run \"{}\"", name)
+            evm::Capture::Exit((reason, _)) => panic!("failed to run \"{}\": {:?}", name, reason),
+            _ => panic!("trap"),
         }
     }
 
@@ -95,7 +95,7 @@ impl ContractHarness {
                 .abi
                 .events()
                 .find(|e| e.name.eq(name))
-                .expect("Unable to find event for name");
+                .expect("unable to find event for name");
 
             let mut values = None;
             for raw_log in raw_logs.clone() {
@@ -112,7 +112,7 @@ impl ContractHarness {
             if let Some(values) = values {
                 assert_eq!(values, output)
             } else {
-                panic!("No logs for event")
+                panic!("no logs for event")
             }
         }
     }
@@ -180,6 +180,10 @@ fn deploy_contract(
 
 fn u256_token(n: usize) -> ethabi::Token {
     ethabi::Token::Uint(U256::from(n))
+}
+
+fn string_token(s: &str) -> ethabi::Token {
+    ethabi::Token::String(s.to_string())
 }
 
 fn address_token(s: &str) -> ethabi::Token {
@@ -588,5 +592,44 @@ fn constructor() {
         );
 
         harness.test_function(&mut executor, "read_bar", vec![], Some(u256_token(68)));
+    })
+}
+
+#[test]
+fn strings() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(
+            &mut executor,
+            "strings.fe",
+            "Foo",
+            vec![
+                string_token("string 1"),
+                address_token("1000000000000000000000000000000000000001"),
+                string_token("string 2"),
+                u256_token(42),
+                string_token("string 3"),
+            ],
+        );
+
+        harness.test_function(
+            &mut executor,
+            "bar",
+            vec![string_token("string 4"), string_token("string 5")],
+            Some(string_token("string 5")),
+        );
+
+        harness.events_emitted(
+            executor,
+            vec![(
+                "MyEvent",
+                vec![
+                    string_token("string 2"),
+                    u256_token(42),
+                    string_token("string 1"),
+                    string_token("string 3"),
+                    address_token("1000000000000000000000000000000000000001"),
+                ],
+            )],
+        );
     })
 }

--- a/compiler/tests/fixtures/erc20_token.fe
+++ b/compiler/tests/fixtures/erc20_token.fe
@@ -4,8 +4,8 @@ contract ERC20:
 
     _totalSupply: u256
 
-    _name: string
-    _symbol: string
+    _name: string100
+    _symbol: string100
     _decimals: u8
 
     event Approval:
@@ -18,15 +18,15 @@ contract ERC20:
         idx to: address
         value: u256
 
-    def __init__(name: string, symbol: string):
+    def __init__(name: string100, symbol: string100):
         self._name = name
         self._symbol = symbol
         self._decimals = 18
 
-    pub def name() -> string:
+    pub def name() -> string100:
         return self._name
 
-    pub def symbol() -> string:
+    pub def symbol() -> string100:
         return self._symbol
 
     pub def decimals() -> u8:

--- a/compiler/tests/fixtures/strings.fe
+++ b/compiler/tests/fixtures/strings.fe
@@ -1,0 +1,13 @@
+contract Foo:
+    event MyEvent:
+        s2: string26
+        u: u256
+        s1: string42
+        s3: string100
+        a: address
+
+    pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
+        emit MyEvent(s2, u, s1, s3, a)
+
+    pub def bar(s1: string100, s2: string100) -> string100:
+        return s2

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -12,6 +12,7 @@ use crate::errors::SemanticError;
 use crate::namespace::events::Event;
 use crate::namespace::scopes::Shared;
 use crate::namespace::types::{
+    AbiDecodeLocation,
     FixedSize,
     Type,
 };
@@ -33,10 +34,15 @@ pub enum Location {
 }
 
 /// Operations that need to be made available during runtime.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum RuntimeOperations {
     /// Encode a set of fixed sized values.
     AbiEncode { params: Vec<FixedSize> },
+    /// Decode a value.
+    AbiDecode {
+        param: FixedSize,
+        location: AbiDecodeLocation,
+    },
 }
 
 /// Contains contextual information relating to a contract AST node.

--- a/semantics/src/namespace/operations.rs
+++ b/semantics/src/namespace/operations.rs
@@ -15,6 +15,7 @@ pub fn index(value: Type, index: Type) -> Result<Type, SemanticError> {
         Type::Map(map) => index_map(map, index),
         Type::Base(_) => Err(SemanticError::NotSubscriptable),
         Type::Tuple(_) => Err(SemanticError::NotSubscriptable),
+        Type::String(_) => Err(SemanticError::NotSubscriptable),
     }
 }
 

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -1,7 +1,5 @@
 use crate::namespace::events::Event;
 use crate::namespace::types::{
-    Array,
-    Base,
     FixedSize,
     Map,
     Type,
@@ -35,8 +33,7 @@ pub enum ContractDef {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum BlockDef {
-    Base(Base),
-    Array(Array),
+    Variable(Type),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -209,12 +206,8 @@ impl BlockScope {
         }
     }
 
-    pub fn add_array(&mut self, name: String, array: Array) {
-        self.defs.insert(name, BlockDef::Array(array));
-    }
-
-    pub fn add_base(&mut self, name: String, base: Base) {
-        self.defs.insert(name, BlockDef::Base(base));
+    pub fn add_var(&mut self, name: String, typ: Type) {
+        self.defs.insert(name, BlockDef::Variable(typ));
     }
 }
 
@@ -226,7 +219,10 @@ mod tests {
         ContractScope,
         ModuleScope,
     };
-    use crate::namespace::types::Base;
+    use crate::namespace::types::{
+        Base,
+        Type,
+    };
     use fe_parser::span::Span;
 
     #[test]
@@ -258,9 +254,9 @@ mod tests {
             BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
         block_scope_1
             .borrow_mut()
-            .add_base("some_thing".to_string(), Base::Bool);
+            .add_var("some_thing".to_string(), Type::Base(Base::Bool));
         assert_eq!(
-            Some(BlockDef::Base(Base::Bool)),
+            Some(BlockDef::Variable(Type::Base(Base::Bool))),
             block_scope_1.borrow().def("some_thing".to_string())
         );
     }
@@ -274,9 +270,9 @@ mod tests {
         let block_scope_2 = BlockScope::from_block_scope(Span::new(0, 0), block_scope_1.clone());
         block_scope_1
             .borrow_mut()
-            .add_base("some_thing".to_string(), Base::Bool);
+            .add_var("some_thing".to_string(), Type::Base(Base::Bool));
         assert_eq!(
-            Some(BlockDef::Base(Base::Bool)),
+            Some(BlockDef::Variable(Type::Base(Base::Bool))),
             block_scope_2.borrow().def("some_thing".to_string())
         );
     }
@@ -290,7 +286,7 @@ mod tests {
         let block_scope_2 = BlockScope::from_block_scope(Span::new(0, 0), block_scope_1.clone());
         block_scope_2
             .borrow_mut()
-            .add_base("some_thing".to_string(), Base::Bool);
+            .add_var("some_thing".to_string(), Type::Base(Base::Bool));
         assert_eq!(None, block_scope_1.borrow().def("some_thing".to_string()));
     }
 }

--- a/semantics/src/traversal/assignments.rs
+++ b/semantics/src/traversal/assignments.rs
@@ -128,13 +128,13 @@ mod tests {
         let function_scope = BlockScope::from_contract_scope(Span::new(0, 0), contract_scope);
         function_scope
             .borrow_mut()
-            .add_base("foo".to_string(), Base::U256);
-        function_scope.borrow_mut().add_array(
+            .add_var("foo".to_string(), Type::Base(Base::U256));
+        function_scope.borrow_mut().add_var(
             "bar".to_string(),
-            Array {
+            Type::Array(Array {
                 inner: Base::U256,
                 dimension: 100,
-            },
+            }),
         );
         function_scope
     }

--- a/semantics/src/traversal/contracts.rs
+++ b/semantics/src/traversal/contracts.rs
@@ -8,6 +8,7 @@ use crate::namespace::scopes::{
     Shared,
 };
 use crate::namespace::types::{
+    AbiDecodeLocation,
     FixedSize,
     Type,
 };
@@ -70,9 +71,22 @@ pub fn contract_def(
                             param_types: params.clone(),
                             return_type: returns.clone(),
                         });
+                        for param in params {
+                            runtime_operations.push(RuntimeOperations::AbiDecode {
+                                param: param.clone(),
+                                location: AbiDecodeLocation::Calldata,
+                            })
+                        }
                         if !returns.is_empty_tuple() {
                             runtime_operations.push(RuntimeOperations::AbiEncode {
                                 params: vec![returns.clone()],
+                            })
+                        }
+                    } else {
+                        for param in params {
+                            runtime_operations.push(RuntimeOperations::AbiDecode {
+                                param: param.clone(),
+                                location: AbiDecodeLocation::Memory,
                             })
                         }
                     }
@@ -81,6 +95,7 @@ pub fn contract_def(
             }
         }
 
+        runtime_operations.sort();
         runtime_operations.dedup();
 
         let attributes = ContractAttributes {
@@ -106,6 +121,7 @@ fn contract_field(
             Type::Array { .. } => unimplemented!(),
             Type::Base(_) => unimplemented!(),
             Type::Tuple(_) => unimplemented!(),
+            Type::String(_) => unimplemented!(),
         };
 
         return Ok(());

--- a/semantics/src/traversal/declarations.rs
+++ b/semantics/src/traversal/declarations.rs
@@ -4,7 +4,6 @@ use crate::namespace::scopes::{
     Scope,
     Shared,
 };
-use crate::namespace::types::FixedSize;
 use crate::traversal::{
     expressions,
     types,
@@ -31,11 +30,9 @@ pub fn var_decl(
             }
         }
 
-        match declared_type.clone() {
-            FixedSize::Base(base) => scope.borrow_mut().add_base(name, base),
-            FixedSize::Array(array) => scope.borrow_mut().add_array(name, array),
-            FixedSize::Tuple(_) => unimplemented!(),
-        };
+        scope
+            .borrow_mut()
+            .add_var(name, declared_type.clone().into_type());
         context.borrow_mut().add_declaration(stmt, declared_type);
 
         return Ok(());
@@ -54,7 +51,10 @@ mod tests {
         ModuleScope,
         Shared,
     };
-    use crate::namespace::types::Base;
+    use crate::namespace::types::{
+        Base,
+        Type,
+    };
     use crate::traversal::declarations::var_decl;
     use crate::Context;
     use fe_parser as parser;
@@ -89,7 +89,7 @@ mod tests {
         assert_eq!(context.expressions.len(), 3);
         assert_eq!(
             scope.borrow().def("foo".to_string()),
-            Some(BlockDef::Base(Base::U256))
+            Some(BlockDef::Variable(Type::Base(Base::U256)))
         );
     }
 

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -137,11 +137,7 @@ fn func_def_arg(
     let name = arg.node.name.node.to_string();
     let typ = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), &arg.node.typ)?;
 
-    match typ.clone() {
-        FixedSize::Base(base) => scope.borrow_mut().add_base(name, base),
-        FixedSize::Array(array) => scope.borrow_mut().add_array(name, array),
-        FixedSize::Tuple(_) => unimplemented!(),
-    }
+    scope.borrow_mut().add_var(name, typ.clone().into_type());
 
     Ok(typ)
 }


### PR DESCRIPTION
### What was wrong?

We do not support strings or ABI encoding of dynamically sized types. 

### How was it fixed?

Added a new string type and made the necessary updates to our ABI encoding components to support dynamically sized types.

What this does add support for:
- strings in memory
- encoding/decoding of dynamically sized arrays

What this does not support:
- strings in storage
- string literals
- any operations on strings

Strings in the ABI are treated like dynamically sized byte arrays. This is somewhat different than the encoding of statically sized values.

Say we want to encode the following statically sized values `(bytes[100], u256)`, the encoding will look roughly like this:

`|------bytes[100]-------| u256 |`

Both of the values are encoded in-place, since we know the size of each value at compile time.

With dynamically sized values, we need to include the size of each array in the encoding. The encoding is split into two sections: the first being where static values are encoded in-place along with the head's of dynamic values, and the second being where the data of the dynamic values is stored.

So say we want to encode `(bytes, u256)`, that would look like this:

`| bytes_head | u256 | bytes_size |-----bytes_data-----|`

`bytes_head` in this case would be the offset value `64`, which points to the start of bytes in the dynamic section.

In order to encode the heads of dynamically sized values, we must know the size of each dynamic array preceding it. Strings and other "dynamically" sized values in Fe will be stored the same way as their statically sized counterparts, with the exception of having a 32-byte size appended to the front. So, to lookup the size of a dynamically sized type, we just need to call `mload(array_ptr)`. 

When we encounter a dynamically sized value during encoding, we store the sum of the static section and current size of the dynamic section, then move on. When we're finished with the static section, we take all of dynamically sized values and encode them one at a time.

Here is what a generated encoding function looks like:

```javascript
function abi_encode_string26_uint256_string42_string100_address(val_0, val_1, val_2, val_3, val_4) -> ptr
{
    // we return the start of the encoding in memory
    ptr := avail()

    // store headers and static values

    // string26 header
    pop(alloc_mstoren(add(160, 0), 32))
    // uint256 in-place encoding
    pop(alloc_mstoren(val_1, 32))
    // string42 header
    pop(alloc_mstoren(add(160, add(32, ceil32(mul(mload(val_0), 1)))), 32))
    // string100 header (these header statements grow because we need to sum the sized of the other dynamically sized arrays)
    pop(alloc_mstoren(add(160, add(add(32, ceil32(mul(mload(val_0), 1))), add(32, ceil32(mul(mload(val_2), 1))))), 32))
    // address in-place encoding
    pop(alloc_mstoren(val_4, 32))
    
    // store the dynamic arrays

    // store string26
    {
        pop(alloc_mstoren(mload(val_0), 32))
        {
            let array_size := mload(val_0)
            let array_data_size := mul(array_size, 1)
            for { let i := 0 } lt(i, array_size) { i := add(i, 1) }
            {
                let val_ptr := add(add(val_0, 32), mul(i, 1))
                let val := mloadn(val_ptr, 1)
                pop(alloc_mstoren(val, 1))
            }
            // allocate up until the next multiple of 32 so our value is properly padded
            pop(alloc(sub(ceil32(array_data_size), array_data_size)))
        }
    }
    // store string42
    {
        pop(alloc_mstoren(mload(val_2), 32))
        {
            let array_size := mload(val_2)
            let array_data_size := mul(array_size, 1)
            for { let i := 0 } lt(i, array_size) { i := add(i, 1) }
            {
                let val_ptr := add(add(val_2, 32), mul(i, 1))
                let val := mloadn(val_ptr, 1)
                pop(alloc_mstoren(val, 1))
            }
            pop(alloc(sub(ceil32(array_data_size), array_data_size)))
        }
    }
    // store string100
    {
        pop(alloc_mstoren(mload(val_3), 32))
        {
            let array_size := mload(val_3)
            let array_data_size := mul(array_size, 1)
            for { let i := 0 } lt(i, array_size) { i := add(i, 1) }
            {
                let val_ptr := add(add(val_3, 32), mul(i, 1))
                let val := mloadn(val_ptr, 1)
                pop(alloc_mstoren(val, 1))
            }
            pop(alloc(sub(ceil32(array_data_size), array_data_size)))
        }
    }
}
```

[add info about decoding]

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add a new string type
- [x] Add ABI encoding for dynamically sized ABI types
- [x] Implement ABI encoding for strings
- [ ] Create issue for max-sizes in dynamically sized ABI types
- [ ] Create issue for pack/unpack operations
- [x] Update syntax of strings
- [x] Clean up commit history
