### PR TITLE
Pretty print YUL code

### DIFF
--- a/src/_utils/mod.rs
+++ b/src/_utils/mod.rs
@@ -1,0 +1,39 @@
+/// Formats any kind of structured text that uses curly braces blocks
+pub fn pretty_curly_print(text: &str, indent: usize) -> String {
+    let mut formatted = String::new();
+    let mut level = 0;
+    let mut previous_char: Option<char> = None;
+
+    const CURLY_OPEN: char = '{';
+    const CURLY_CLOSE: char = '}';
+    const WHITESPACE: char = ' ';
+    const NEWLINE: &str = "\n";
+
+    for character in text.chars() {
+        match character {
+            CURLY_OPEN => {
+                level += 1;
+                formatted.push(character);
+                formatted.push_str(NEWLINE);
+                formatted.push_str(&WHITESPACE.to_string().repeat(indent * level));
+            }
+            CURLY_CLOSE => {
+                level -= 1;
+                formatted.push_str(NEWLINE);
+                formatted.push_str(&WHITESPACE.to_string().repeat(indent * level));
+                formatted.push(character);
+                formatted.push_str(NEWLINE);
+                formatted.push_str(&WHITESPACE.to_string().repeat(indent * level));
+            }
+            WHITESPACE => {
+                if !matches!(previous_char, Some(CURLY_CLOSE)) {
+                    formatted.push(character)
+                }
+            }
+            _ => formatted.push(character),
+        }
+        previous_char = Some(character);
+    }
+
+    formatted
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@
 #![doc(include = "../README.md")]
 
 #[cfg(feature = "solc-backend")]
+mod _utils;
+#[cfg(feature = "solc-backend")]
 mod main_full;
 
 #[cfg(not(feature = "solc-backend"))]

--- a/src/main_full.rs
+++ b/src/main_full.rs
@@ -14,6 +14,7 @@ use clap::{
     Arg,
 };
 
+use crate::_utils::pretty_curly_print;
 use fe_compiler::evm::CompileStage;
 
 const DEFAULT_OUTPUT_DIR_NAME: &str = "output";
@@ -110,7 +111,7 @@ fn compile(src_file: &str, output_dir: &str, targets: Vec<CompilationTarget>) ->
             }
             CompilationTarget::Yul => {
                 let mut file_yul = fs::File::create(output_dir.join("out.yul"))?;
-                file_yul.write_all(output.yul.as_bytes())?;
+                file_yul.write_all(pretty_curly_print(&output.yul, 4).as_bytes())?;
             }
         }
     }


### PR DESCRIPTION
### What was wrong?

Inspecting generated YUL code is currently no fun.

If we run this on current master `cargo run --features solc-backend compiler/tests/fixtures/return_addition_u256.fe --emit yul`.

We get a file with these contents:

```
object \"Contract\" { code { let size := datasize(\"runtime\") datacopy(0, dataoffset(\"runtime\"), size) return(0, size) } object \"runtime\" { code { function bar(x, y) -> return_val { let ptr := avail() { return_val := add(x, y) leave } free(ptr) } function avail() -> ptr { ptr := mload(0x00) if eq(ptr, 0x00) { ptr := 0x20 } } function alloc(size) -> ptr { ptr := mload(0x00) if eq(ptr, 0x00) { ptr := 0x20 } mstore(0x00, add(ptr, size)) } function alloc_mstoren(val, size) -> ptr { ptr := alloc(size) mstoren(ptr, val, size) } function free(ptr) { mstore(0x00, ptr) } function ccopy(cptr, size) -> mptr { mptr := alloc(size) calldatacopy(mptr, cptr, size) } function mcopy(mptr, sptr, size) { for { let i := 0 } lt(i, size) { i := add(i, 1) } { let _mptr := add(mptr, i) let _sptr := add(sptr, i) sstoren(_sptr, mloadn(_mptr, 1), 1) } } function scopy(sptr, size) -> mptr { mptr := alloc(size) for { let i := 0 } lt(i, size) { i := add(i, 1) } { let _mptr := add(mptr, i) let _sptr := add(sptr, i) mstoren(_mptr, sloadn(_sptr, 1), 1) } } function mloadn(ptr, size) -> val { val := shr(sub(256, mul(8, size)), mload(ptr)) } function sloadn(ptr, size) -> val { val := shr(sub(256, mul(8, size)), sload(ptr)) } function cloadn(ptr, size) -> val { val := shr(sub(256, mul(8, size)), calldataload(ptr)) } function mstoren(ptr, val, size) { let size_bits := mul(8, size) let left := shl(sub(256, size_bits), val) let right := shr(size_bits, mload(add(ptr, size))) mstore(ptr, or(left, right)) } function sstoren(ptr, val, size) { let size_bits := mul(8, size) let left := shl(sub(256, size_bits), val) let right := shr(size_bits, sload(add(ptr, size))) sstore(ptr, or(left, right)) } function dualkeccak256(a, b) -> return_val { let ptr := avail() mstore(ptr, a) mstore(add(ptr, 32), b) return_val := keccak256(ptr, 64) } function abi_encode_uint256(val_0) -> ptr { ptr := avail() pop(alloc_mstoren(val_0, 32)) } switch cloadn(0, 4) case 0xae42e951 { return(abi_encode_uint256(bar(calldataload(4), calldataload(36))), 32) }  }  } }
```

If we apply this PR, the content instead is:

```
object \"Contract\" {
     code {
         let size := datasize(\"runtime\") datacopy(0, dataoffset(\"runtime\"), size) return(0, size) 
    }
    object \"runtime\" {
         code {
             function bar(x, y) -> return_val {
                 let ptr := avail() {
                     return_val := add(x, y) leave 
                }
                free(ptr) 
            }
            function avail() -> ptr {
                 ptr := mload(0x00) if eq(ptr, 0x00) {
                     ptr := 0x20 
                }
                
            }
            function alloc(size) -> ptr {
                 ptr := mload(0x00) if eq(ptr, 0x00) {
                     ptr := 0x20 
                }
                mstore(0x00, add(ptr, size)) 
            }
            function alloc_mstoren(val, size) -> ptr {
                 ptr := alloc(size) mstoren(ptr, val, size) 
            }
            function free(ptr) {
                 mstore(0x00, ptr) 
            }
            function ccopy(cptr, size) -> mptr {
                 mptr := alloc(size) calldatacopy(mptr, cptr, size) 
            }
            function mcopy(mptr, sptr, size) {
                 for {
                     let i := 0 
                }
                lt(i, size) {
                     i := add(i, 1) 
                }
                {
                     let _mptr := add(mptr, i) let _sptr := add(sptr, i) sstoren(_sptr, mloadn(_mptr, 1), 1) 
                }
                
            }
            function scopy(sptr, size) -> mptr {
                 mptr := alloc(size) for {
                     let i := 0 
                }
                lt(i, size) {
                     i := add(i, 1) 
                }
                {
                     let _mptr := add(mptr, i) let _sptr := add(sptr, i) mstoren(_mptr, sloadn(_sptr, 1), 1) 
                }
                
            }
            function mloadn(ptr, size) -> val {
                 val := shr(sub(256, mul(8, size)), mload(ptr)) 
            }
            function sloadn(ptr, size) -> val {
                 val := shr(sub(256, mul(8, size)), sload(ptr)) 
            }
            function cloadn(ptr, size) -> val {
                 val := shr(sub(256, mul(8, size)), calldataload(ptr)) 
            }
            function mstoren(ptr, val, size) {
                 let size_bits := mul(8, size) let left := shl(sub(256, size_bits), val) let right := shr(size_bits, mload(add(ptr, size))) mstore(ptr, or(left, right)) 
            }
            function sstoren(ptr, val, size) {
                 let size_bits := mul(8, size) let left := shl(sub(256, size_bits), val) let right := shr(size_bits, sload(add(ptr, size))) sstore(ptr, or(left, right)) 
            }
            function dualkeccak256(a, b) -> return_val {
                 let ptr := avail() mstore(ptr, a) mstore(add(ptr, 32), b) return_val := keccak256(ptr, 64) 
            }
            function abi_encode_uint256(val_0) -> ptr {
                 ptr := avail() pop(alloc_mstoren(val_0, 32)) 
            }
            switch cloadn(0, 4) case 0xae42e951 {
                 return(abi_encode_uint256(bar(calldataload(4), calldataload(36))), 32) 
            }
             
        }
         
    }
    
}

```

Let's be clear that :point_up: isn't exactly pretty. All that was done was to format the code according to the opening and closing braces. So, things like `let ptr := avail() mstore(ptr, a) mstore(add(ptr, 32), b) return_val := keccak256(ptr, 64) ` look just as aweful as they did before. But this is mostly doing what I've been doing over and over again manually to make the generated source consumable.

### How was it fixed?

1. Created a utils method `pretty_curly_print` that takes any kind of text and formats it based on opening and closing braces
2. Used it in the CLI to make the generated code more human readable.

Let's be clear, I believe the proper fix would possible be in adding pretty printing functionality to yultsur but I'm not in the mood of going down that bigger rabbit whole. This is an attempt to leave things slightly better than they currently are without making a big investment.

