### PR TITLE
Add support for while loops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,4 +1206,4 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "yultsur"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/yultsur#3bbf3c5c3e0597066dee517b830f23f42b47d751"
+source = "git+https://github.com/g-r-a-n-t/yultsur#3ac1958c1acc13cfcca1ed99c55a4fbfe5769e1d"

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -106,7 +106,7 @@ fn func_stmt(
         fe::FuncStmt::Emit { .. } => emit(context, stmt),
         fe::FuncStmt::AugAssign { .. } => unimplemented!(),
         fe::FuncStmt::For { .. } => unimplemented!(),
-        fe::FuncStmt::While { .. } => unimplemented!(),
+        fe::FuncStmt::While { .. } => while_loop(context, stmt),
         fe::FuncStmt::If { .. } => if_statement(context, stmt),
         fe::FuncStmt::Assert { .. } => assert(context, stmt),
         fe::FuncStmt::Expr { .. } => expr(context, stmt),
@@ -215,6 +215,30 @@ fn func_return(
             }
             None => return Ok(statement! { leave }),
         }
+    }
+
+    unreachable!()
+}
+
+fn while_loop(
+    context: &Context,
+    stmt: &Spanned<fe::FuncStmt>,
+) -> Result<yul::Statement, CompileError> {
+    if let fe::FuncStmt::While {
+        test,
+        body,
+        or_else: _,
+    } = &stmt.node
+    {
+        let test = expressions::expr(context, test)?;
+        let yul_body = multiple_func_stmt(context, body)?;
+
+        return Ok(block_statement! {
+            (for {} ([test]) {}
+            {
+                [yul_body...]
+            })
+        });
     }
 
     unreachable!()

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -9,6 +9,14 @@ use std::fs;
 #[rstest(
     fixture_file,
     error,
+    case(
+        "not_in_scope.fe",
+        "[Str(\"semantic error: UndefinedValue { value: \\\"y\\\" }\")]"
+    ),
+    case(
+        "not_in_scope_2.fe",
+        "[Str(\"semantic error: UndefinedValue { value: \\\"y\\\" }\")]"
+    ),
     case("mismatch_return_type.fe", "[Str(\"semantic error: TypeError\")]"),
     case("unexpected_return.fe", "[Str(\"semantic error: TypeError\")]"),
     case("missing_return.fe", "[Str(\"semantic error: MissingReturn\")]"),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -245,6 +245,7 @@ fn test_assert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("while_loop.fe", vec![], Some(u256_token(3))),
     case("if_statement.fe", vec![6], Some(u256_token(1))),
     case("if_statement.fe", vec![4], Some(u256_token(0))),
     case("if_statement_2.fe", vec![6], Some(u256_token(1))),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -249,6 +249,7 @@ fn test_assert() {
     case("if_statement.fe", vec![6], Some(u256_token(1))),
     case("if_statement.fe", vec![4], Some(u256_token(0))),
     case("if_statement_2.fe", vec![6], Some(u256_token(1))),
+    case("if_statement_with_block_declaration.fe", vec![], Some(u256_token(1))),
     case("call_statement_without_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args_2.fe", vec![], Some(u256_token(100))),

--- a/compiler/tests/fixtures/compile_errors/not_in_scope.fe
+++ b/compiler/tests/fixtures/compile_errors/not_in_scope.fe
@@ -1,0 +1,8 @@
+contract Foo:
+
+    pub def bar() -> u256:
+        if true:
+            y: u256 = 1
+        else:
+            y: u256 = 1
+        return y

--- a/compiler/tests/fixtures/compile_errors/not_in_scope_2.fe
+++ b/compiler/tests/fixtures/compile_errors/not_in_scope_2.fe
@@ -1,0 +1,8 @@
+contract Foo:
+
+    pub def bar() -> u256:
+        i: u256 = 0
+        while i < 1:
+            i = 1
+            y: u256 = 1
+        return y

--- a/compiler/tests/fixtures/if_statement_with_block_declaration.fe
+++ b/compiler/tests/fixtures/if_statement_with_block_declaration.fe
@@ -1,0 +1,9 @@
+contract Foo:
+
+    pub def bar() -> u256:
+        if true:
+            y: u256 = 1
+            return y
+        else:
+            y: u256 = 1
+            return y

--- a/compiler/tests/fixtures/while_loop.fe
+++ b/compiler/tests/fixtures/while_loop.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub def bar() -> u256:
+        val: u256 = 0
+        while val < 2:
+            val = val + 1
+            if val == 2:
+                val = 3
+        return val


### PR DESCRIPTION
### What was wrong?

We do not yet support while loops. Additionally, there were two problems regarding scoping rules:

1. Declarations within block scopes did not work because statements in if/else or while loops where not semantically checked which also means declarations where not respected.

2. After the previous problem was fixed it became obvious that declarations where not properly scoped with block scoping rules. Instead, they were attributed to the enclosing function scope. While this is inline with Python, we like to diverge from Python here to follow rust (or JS/TS `let` scoping rules for that matter) scoping rules which introduces a new scope for each block.

### How was it fixed?

**While Loop Support**

- This builds on top of #116 (because it has some needed helpers)
- Semantic pass
  - refactored repetitive code into `verify_is_boolean` helper function
  - verify `test` expression is boolean
  - raise `unimplemented` if `or_else` is used
- Mapper pass:
  - mapped to the appropriate YUL code
- Tests
  - Added a test that proves the `while` is working and the code block supports arbitrarily big statements 

**Block Scope**

1. `FunctionScope` was renamed to `BlockScope`. The rational here being that functions simply introduce the first level `BlockScope` and are no different from e.g. any other block scope that is introduced by another block within that function.

2. Turn `parent` on `BlockScope` into a `BlockScopeParent` which can either point to a contract or block scope.

3. Ensure `contract_scope` walks upwards to find the contract scope as it may not be the immediate parent

4. Introduce `function_scope` method that finds the block scope that is the top most block scope and hence the immediate child of the `contract_scope`. 

5. Ensure `def` on `BlockScope` performs lookups on parent block scopes effectively inheriting all defs of its (block scope) parents.

6. Ensure `if` / `else` and `while` all introduce new block scopes.

