### PR TITLE
Implement support for break statement

### DIFF
--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -111,7 +111,7 @@ fn func_stmt(
         fe::FuncStmt::Assert { .. } => assert(context, stmt),
         fe::FuncStmt::Expr { .. } => expr(context, stmt),
         fe::FuncStmt::Pass => unimplemented!(),
-        fe::FuncStmt::Break => unimplemented!(),
+        fe::FuncStmt::Break => break_statement(context, stmt),
         fe::FuncStmt::Continue => unimplemented!(),
         fe::FuncStmt::Revert => revert(stmt),
     }
@@ -194,6 +194,17 @@ fn assert(context: &Context, stmt: &Spanned<fe::FuncStmt>) -> Result<yul::Statem
         let test = expressions::expr(context, test)?;
 
         return Ok(statement! { if (iszero([test])) { (revert(0, 0)) } });
+    }
+
+    unreachable!()
+}
+
+fn break_statement(
+    _context: &Context,
+    stmt: &Spanned<fe::FuncStmt>,
+) -> Result<yul::Statement, CompileError> {
+    if let fe::FuncStmt::Break {} = &stmt.node {
+        return Ok(statement! { break });
     }
 
     unreachable!()

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -9,6 +9,11 @@ use std::fs;
 #[rstest(
     fixture_file,
     error,
+    case("break_without_loop.fe", "[Str(\"semantic error: BreakWithoutLoop\")]"),
+    case(
+        "break_without_loop_2.fe",
+        "[Str(\"semantic error: BreakWithoutLoop\")]"
+    ),
     case(
         "not_in_scope.fe",
         "[Str(\"semantic error: UndefinedValue { value: \\\"y\\\" }\")]"

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -246,6 +246,8 @@ fn test_assert() {
 
 #[rstest(fixture_file, input, expected,
     case("while_loop.fe", vec![], Some(u256_token(3))),
+    case("while_loop_with_break.fe", vec![], Some(u256_token(1))),
+    case("while_loop_with_break_2.fe", vec![], Some(u256_token(1))),
     case("if_statement.fe", vec![6], Some(u256_token(1))),
     case("if_statement.fe", vec![4], Some(u256_token(0))),
     case("if_statement_2.fe", vec![6], Some(u256_token(1))),

--- a/compiler/tests/fixtures/compile_errors/break_without_loop.fe
+++ b/compiler/tests/fixtures/compile_errors/break_without_loop.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar():
+        break

--- a/compiler/tests/fixtures/compile_errors/break_without_loop_2.fe
+++ b/compiler/tests/fixtures/compile_errors/break_without_loop_2.fe
@@ -1,0 +1,5 @@
+contract Foo:
+
+    pub def bar():
+        if true:
+            break

--- a/compiler/tests/fixtures/while_loop_with_break.fe
+++ b/compiler/tests/fixtures/while_loop_with_break.fe
@@ -1,0 +1,7 @@
+contract Foo:
+    pub def bar() -> u256:
+        val: u256 = 0
+        while val < 2:
+            val = val + 1
+            break
+        return val

--- a/compiler/tests/fixtures/while_loop_with_break_2.fe
+++ b/compiler/tests/fixtures/while_loop_with_break_2.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub def bar() -> u256:
+        val: u256 = 0
+        while val < 2:
+            val = val + 1
+            if val == 1:
+                break
+        return val

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -3,6 +3,7 @@
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum SemanticError {
+    BreakWithoutLoop,
     MissingReturn,
     NotAnExpression,
     NotSubscriptable,


### PR DESCRIPTION
### What was wrong?

We don't support `break` statements yet.

### How was it fixed?

1. Added a new `BlockScopeType` to `BlockScope` that can be one of `Function`, `IfElse` or `Loop`.
2. Added `pub fn inherits_type(&self, typ: BlockScopeType) -> bool` to `BlockScope` to be able to tell if certain statements (e.g. `break`, `continue`) can be used within the current scope or not.
3. Semantic pass checks with `inherits_type` if placement is ok and returns `SemanticError::BreakWithoutLoop` if not
4. Mapper pass maps `break` to YUL
