### PR TITLE
Use Rc::clone(&ptr) syntax instead of ptr.clone()

### DIFF
--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -188,10 +188,12 @@ impl BlockScope {
         loop {
             parent = match parent {
                 BlockScopeParent::Block(ref scope) => {
-                    last_block_scope = scope.clone();
+                    last_block_scope = Rc::clone(&scope);
                     scope.borrow().parent.clone()
                 }
-                BlockScopeParent::Contract(ref scope) => return (scope.clone(), last_block_scope),
+                BlockScopeParent::Contract(ref scope) => {
+                    return (Rc::clone(&scope), last_block_scope)
+                }
             }
         }
     }
@@ -258,13 +260,14 @@ mod tests {
     };
     use crate::namespace::types::Base;
     use fe_parser::span::Span;
+    use std::rc::Rc;
 
     #[test]
     fn test_scope_resolution_on_first_level_block_scope() {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
         let block_scope_1 =
-            BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
+            BlockScope::from_contract_scope(Span::new(0, 0), Rc::clone(&contract_scope));
         assert_eq!(block_scope_1, block_scope_1.borrow().function_scope());
         assert_eq!(contract_scope, block_scope_1.borrow().contract_scope());
     }
@@ -274,11 +277,11 @@ mod tests {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
         let block_scope_1 =
-            BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
+            BlockScope::from_contract_scope(Span::new(0, 0), Rc::clone(&contract_scope));
         let block_scope_2 = BlockScope::from_block_scope(
             Span::new(0, 0),
             BlockScopeType::IfElse,
-            block_scope_1.clone(),
+            Rc::clone(&block_scope_1),
         );
         assert_eq!(block_scope_1, block_scope_2.borrow().function_scope());
         assert_eq!(contract_scope, block_scope_2.borrow().contract_scope());
@@ -289,7 +292,7 @@ mod tests {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
         let block_scope_1 =
-            BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
+            BlockScope::from_contract_scope(Span::new(0, 0), Rc::clone(&contract_scope));
         block_scope_1
             .borrow_mut()
             .add_base("some_thing".to_string(), Base::Bool);
@@ -304,11 +307,11 @@ mod tests {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
         let block_scope_1 =
-            BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
+            BlockScope::from_contract_scope(Span::new(0, 0), Rc::clone(&contract_scope));
         let block_scope_2 = BlockScope::from_block_scope(
             Span::new(0, 0),
             BlockScopeType::IfElse,
-            block_scope_1.clone(),
+            Rc::clone(&block_scope_1),
         );
         block_scope_1
             .borrow_mut()
@@ -324,11 +327,11 @@ mod tests {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
         let block_scope_1 =
-            BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
+            BlockScope::from_contract_scope(Span::new(0, 0), Rc::clone(&contract_scope));
         let block_scope_2 = BlockScope::from_block_scope(
             Span::new(0, 0),
             BlockScopeType::IfElse,
-            block_scope_1.clone(),
+            Rc::clone(&block_scope_1),
         );
         block_scope_2
             .borrow_mut()
@@ -341,7 +344,7 @@ mod tests {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
         let block_scope_1 =
-            BlockScope::from_contract_scope(Span::new(0, 0), contract_scope.clone());
+            BlockScope::from_contract_scope(Span::new(0, 0), Rc::clone(&contract_scope));
         assert_eq!(
             true,
             block_scope_1
@@ -360,7 +363,7 @@ mod tests {
         let block_scope_2 = BlockScope::from_block_scope(
             Span::new(0, 0),
             BlockScopeType::IfElse,
-            block_scope_1.clone(),
+            Rc::clone(&block_scope_1),
         );
         assert_eq!(
             true,
@@ -380,7 +383,7 @@ mod tests {
         let block_scope_3 = BlockScope::from_block_scope(
             Span::new(0, 0),
             BlockScopeType::Loop,
-            block_scope_2.clone(),
+            Rc::clone(&block_scope_2),
         );
         assert_eq!(
             true,

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -263,7 +263,7 @@ fn expr_call(
             .iter()
             // Side effect: Performs semantic analysis on each call arg and adds its attributes to
             // the context
-            .map(|argument| call_arg(scope.clone(), context.clone(), argument))
+            .map(|argument| call_arg(Rc::clone(&scope), Rc::clone(&context), argument))
             .collect::<Result<_, _>>()?;
 
         if let fe::Expr::Attribute { value: _, attr } = &func.node {

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -210,11 +210,11 @@ fn if_statement(
             or_else,
         } => {
             let body_scope =
-                BlockScope::from_block_scope(stmt.span, BlockScopeType::IfElse, scope.clone());
-            traverse_statements(body_scope, context.clone(), body)?;
+                BlockScope::from_block_scope(stmt.span, BlockScopeType::IfElse, Rc::clone(&scope));
+            traverse_statements(body_scope, Rc::clone(&context), body)?;
             let or_else_scope =
-                BlockScope::from_block_scope(stmt.span, BlockScopeType::IfElse, scope.clone());
-            traverse_statements(or_else_scope, context.clone(), or_else)?;
+                BlockScope::from_block_scope(stmt.span, BlockScopeType::IfElse, Rc::clone(&scope));
+            traverse_statements(or_else_scope, Rc::clone(&context), or_else)?;
             verify_is_boolean(scope, context, test)
         }
         _ => unreachable!(),
@@ -236,8 +236,8 @@ fn while_loop(
                 unimplemented!();
             }
             let body_scope =
-                BlockScope::from_block_scope(stmt.span, BlockScopeType::Loop, scope.clone());
-            traverse_statements(body_scope, context.clone(), body)?;
+                BlockScope::from_block_scope(stmt.span, BlockScopeType::Loop, Rc::clone(&scope));
+            traverse_statements(body_scope, Rc::clone(&context), body)?;
             verify_is_boolean(scope, context, test)
         }
         _ => unreachable!(),
@@ -291,7 +291,7 @@ fn assert(
     stmt: &Spanned<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Assert { test, msg } = &stmt.node {
-        verify_is_boolean(scope.clone(), context.clone(), test)?;
+        verify_is_boolean(Rc::clone(&scope), Rc::clone(&context), test)?;
         if let Some(msg) = msg {
             // TODO: type check for a string once strings are supported
             let _msg_attributes = expressions::expr(scope, context, msg)?;
@@ -329,7 +329,7 @@ fn func_return(
     stmt: &Spanned<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Return { value: Some(value) } = &stmt.node {
-        let attributes = expressions::expr(scope.clone(), context.clone(), value)?;
+        let attributes = expressions::expr(Rc::clone(&scope), Rc::clone(&context), value)?;
 
         match context
             .borrow()


### PR DESCRIPTION
### What was wrong?

We had mixed use of `Rc<T>` with some places using `ptr.clone()` and whereas others used `Rc::clone(&ptr)`.

### How was it fixed?

Change to use the idiomatic syntax preferred by the official Rust book.

Further reading:

https://github.com/rust-lang/rust/pull/42137#issuecomment-304908345
https://github.com/nical/rfcs/blob/rc-newref-clone/text/0000-rc-newref-clone.md
