### PR TITLE
Implement support for continue statement

### DIFF
--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -112,7 +112,7 @@ fn func_stmt(
         fe::FuncStmt::Expr { .. } => expr(context, stmt),
         fe::FuncStmt::Pass => unimplemented!(),
         fe::FuncStmt::Break => break_statement(context, stmt),
-        fe::FuncStmt::Continue => unimplemented!(),
+        fe::FuncStmt::Continue => continue_statement(context, stmt),
         fe::FuncStmt::Revert => revert(stmt),
     }
 }
@@ -205,6 +205,17 @@ fn break_statement(
 ) -> Result<yul::Statement, CompileError> {
     if let fe::FuncStmt::Break {} = &stmt.node {
         return Ok(statement! { break });
+    }
+
+    unreachable!()
+}
+
+fn continue_statement(
+    _context: &Context,
+    stmt: &Spanned<fe::FuncStmt>,
+) -> Result<yul::Statement, CompileError> {
+    if let fe::FuncStmt::Continue {} = &stmt.node {
+        return Ok(statement! { continue });
     }
 
     unreachable!()

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -9,6 +9,14 @@ use std::fs;
 #[rstest(
     fixture_file,
     error,
+    case(
+        "continue_without_loop.fe",
+        "[Str(\"semantic error: ContinueWithoutLoop\")]"
+    ),
+    case(
+        "continue_without_loop_2.fe",
+        "[Str(\"semantic error: ContinueWithoutLoop\")]"
+    ),
     case("break_without_loop.fe", "[Str(\"semantic error: BreakWithoutLoop\")]"),
     case(
         "break_without_loop_2.fe",

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -245,6 +245,7 @@ fn test_assert() {
 }
 
 #[rstest(fixture_file, input, expected,
+    case("while_loop_with_continue.fe", vec![], Some(u256_token(1))),
     case("while_loop.fe", vec![], Some(u256_token(3))),
     case("while_loop_with_break.fe", vec![], Some(u256_token(1))),
     case("while_loop_with_break_2.fe", vec![], Some(u256_token(1))),

--- a/compiler/tests/fixtures/compile_errors/continue_without_loop.fe
+++ b/compiler/tests/fixtures/compile_errors/continue_without_loop.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar():
+        continue

--- a/compiler/tests/fixtures/compile_errors/continue_without_loop_2.fe
+++ b/compiler/tests/fixtures/compile_errors/continue_without_loop_2.fe
@@ -1,0 +1,5 @@
+contract Foo:
+
+    pub def bar():
+        if true:
+            continue

--- a/compiler/tests/fixtures/while_loop_with_continue.fe
+++ b/compiler/tests/fixtures/while_loop_with_continue.fe
@@ -1,0 +1,11 @@
+contract Foo:
+    pub def bar() -> u256:
+        i: u256 = 0
+        counter: u256 = 0
+
+        while i < 2:
+            i = i + 1
+            if i == 1:
+                continue
+            counter = counter + 1
+        return counter

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -4,6 +4,7 @@
 #[derive(Debug, PartialEq)]
 pub enum SemanticError {
     BreakWithoutLoop,
+    ContinueWithoutLoop,
     MissingReturn,
     NotAnExpression,
     NotSubscriptable,


### PR DESCRIPTION
### What was wrong?

We do not support the `continue` statement yet.

### How was it fixed?

- Semantic pass checks that `continue` is used within loop
- Mapper pass maps to YUL
- Added tests to cover functionality as well as raised error on misplaced use