### PR TITLE
Sized types in storage

### DIFF
--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -82,10 +82,15 @@ mod tests {
         Array,
         Base,
         FixedSize,
+        Type,
         U256,
     };
     use fe_semantics::test_utils::ContextHarness;
-    use fe_semantics::Context;
+    use fe_semantics::{
+        Context,
+        ExpressionAttributes,
+        Location,
+    };
 
     fn map(context: &Context, src: &str) -> String {
         let tokens = parser::get_parse_tokens(src).expect("Couldn't parse declaration");
@@ -102,6 +107,10 @@ mod tests {
     fn decl_u256() {
         let mut harness = ContextHarness::new("foo: u256 = bar");
         harness.add_declaration("foo: u256 = bar", FixedSize::Base(U256));
+        harness.add_expression(
+            "bar",
+            ExpressionAttributes::new(Type::Base(U256), Location::Value),
+        );
 
         assert_eq!(map(&harness.context, &harness.src), "let foo := bar");
     }

--- a/compiler/src/yul/operations.rs
+++ b/compiler/src/yul/operations.rs
@@ -1,6 +1,9 @@
 use crate::yul::abi::operations as abi_operations;
 use fe_semantics::namespace::events::Event;
-use fe_semantics::namespace::types::FeSized;
+use fe_semantics::namespace::types::{
+    Array,
+    FeSized,
+};
 use yultsur::*;
 
 /// Loads a value from storage.
@@ -75,6 +78,23 @@ pub fn sum(vals: Vec<yul::Expression>) -> yul::Expression {
     vals.into_iter()
         .fold_first(|val1, val2| expression! { add([val1], [val2]) })
         .unwrap()
+}
+
+/// Hashes the storage nonce of a map with a key to determine the value's
+/// location in storage.
+pub fn keyed_map(map: yul::Expression, key: yul::Expression) -> yul::Expression {
+    expression! { dualkeccak256([map], [key]) }
+}
+
+/// Finds the location of an array element base on the element size, element
+/// index, and array location.
+pub fn indexed_array(
+    typ: Array,
+    array: yul::Expression,
+    index: yul::Expression,
+) -> yul::Expression {
+    let inner_size = literal_expression! { (typ.inner.size()) };
+    expression! { add([array], (mul([index], [inner_size]))) }
 }
 
 #[cfg(test)]

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -652,5 +652,28 @@ fn strings() {
                 ],
             )],
         );
-    })
+    });
+}
+
+#[test]
+fn sized_vals_in_sto() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "sized_vals_in_sto.fe", "Foo", vec![]);
+
+        let num = uint_token(68);
+        let nums = u256_array_token((0..42).into_iter().collect());
+        let string = string_token("there are 26 protons in fe");
+
+        harness.test_function(&mut executor, "write_num", vec![num.clone()], None);
+        harness.test_function(&mut executor, "read_num", vec![], Some(num.clone()));
+
+        harness.test_function(&mut executor, "write_nums", vec![nums.clone()], None);
+        harness.test_function(&mut executor, "read_nums", vec![], Some(nums.clone()));
+
+        harness.test_function(&mut executor, "write_str", vec![string.clone()], None);
+        harness.test_function(&mut executor, "read_str", vec![], Some(string.clone()));
+
+        harness.test_function(&mut executor, "emit_event", vec![], None);
+        harness.events_emitted(executor, vec![("MyEvent", vec![num, nums, string])]);
+    });
 }

--- a/compiler/tests/fixtures/sized_vals_in_sto.fe
+++ b/compiler/tests/fixtures/sized_vals_in_sto.fe
@@ -1,0 +1,30 @@
+contract Foo:
+    num: u256
+    nums: u256[42]
+    str: string26
+
+    event MyEvent:
+        num: u256
+        nums: u256[42]
+        str: string26
+
+    pub def write_num(x: u256):
+        self.num = x
+
+    pub def read_num() -> u256:
+        return self.num
+
+    pub def write_nums(x: u256[42]):
+        self.nums = x
+
+    pub def read_nums() -> u256[42]:
+        return self.nums
+
+    pub def write_str(x: string26):
+        self.str = x
+
+    pub def read_str() -> string26:
+        return self.str
+
+    pub def emit_event():
+        emit MyEvent(self.num, self.nums, self.str)

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -8,8 +8,8 @@ pub enum SemanticError {
     MissingReturn,
     NotAnExpression,
     NotSubscriptable,
-    UnassignableExpression,
     UndefinedValue { value: String },
     UnexpectedReturn,
     TypeError,
+    CannotMove,
 }

--- a/semantics/src/traversal/_utils.rs
+++ b/semantics/src/traversal/_utils.rs
@@ -26,8 +26,5 @@ pub fn expression_attributes_to_types(attributes: Vec<ExpressionAttributes>) -> 
 }
 
 pub fn fixed_sizes_to_types(sizes: Vec<FixedSize>) -> Vec<Type> {
-    sizes
-        .iter()
-        .map(|param| param.clone().into_type())
-        .collect()
+    sizes.iter().map(|param| param.clone().into()).collect()
 }


### PR DESCRIPTION
### What was wrong?

Types other than `map` were not supported as contract fields.

### How was it fixed?

1. Nonce values are now assigned to each contract field. For sized values, these nonces are used to generate pointers for each field during compilation.

2. Introduced explicit *moves* for expressions. Expression attributes now have an optional  `move_location` in addition to the original expression `location`. Previously, the `location` of an expression only indicated the final location after a possible implicit move. These moves are no longer implicitly defined, but are instead attributed to the expression. So instead of having something like `my_u256_array[42]` understood as a value type, it is understood as a memory pointer. If the expression is needed by the surrounding context as a value (e.g. `my_value = my_u256_array[42]`), then a move to `Location::Value` is attributed to it. The mapper is then responsible for applying this move to the expression. This approach seems to have simplified things quite a bit and made implementing contract fields less confusing.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] write an issue for storage an memory copying
- [x] Clean up commit history
