### PR TITLE
Add support for more numeric types

### DIFF
--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -162,6 +162,11 @@ fn type_desc<'a>(
 
     match typ {
         fe::TypeDesc::Base { base: "u256" } => Ok(VarType::Uint256),
+        fe::TypeDesc::Base { base: "u128" } => Ok(VarType::Uint128),
+        fe::TypeDesc::Base { base: "u64" } => Ok(VarType::Uint64),
+        fe::TypeDesc::Base { base: "u32" } => Ok(VarType::Uint32),
+        fe::TypeDesc::Base { base: "u16" } => Ok(VarType::Uint16),
+        fe::TypeDesc::Base { base: "u8" } => Ok(VarType::Uint8),
         fe::TypeDesc::Base { base: "bool" } => Ok(VarType::Bool),
         fe::TypeDesc::Base { base: "address" } => Ok(VarType::Address),
         fe::TypeDesc::Base { base } if &base[..6] == "string" => Ok(VarType::String),

--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -168,6 +168,11 @@ pub enum FuncType {
 #[derive(Debug, PartialEq, Clone)]
 pub enum VarType {
     Uint256,
+    Uint128,
+    Uint64,
+    Uint32,
+    Uint16,
+    Uint8,
     Bool,
     Address,
     FixedBytes(usize),
@@ -191,6 +196,11 @@ impl fmt::Display for VarType {
         match self {
             VarType::Bool => write!(f, "bool"),
             VarType::Uint256 => write!(f, "uint256"),
+            VarType::Uint128 => write!(f, "uint128"),
+            VarType::Uint64 => write!(f, "uint64"),
+            VarType::Uint32 => write!(f, "uint32"),
+            VarType::Uint16 => write!(f, "uint16"),
+            VarType::Uint8 => write!(f, "uint8"),
             VarType::Address => write!(f, "address"),
             VarType::FixedBytes(size) => write!(f, "bytes{}", size),
             VarType::FixedArray(inner, dim) => write!(f, "{}[{}]", inner, dim),

--- a/compiler/src/yul/abi/functions.rs
+++ b/compiler/src/yul/abi/functions.rs
@@ -228,12 +228,13 @@ mod tests {
         AbiDecodeLocation,
         Base,
         FeString,
+        U256,
     };
 
     #[test]
     fn test_encode() {
         assert_eq!(
-            encode(vec![Base::U256, Base::Address]).to_string(),
+            encode(vec![U256, Base::Address]).to_string(),
             "function abi_encode_uint256_address(val_0, val_1) -> ptr { ptr := avail() pop(alloc_mstoren(val_0, 32)) pop(alloc_mstoren(val_1, 32)) }"
         )
     }
@@ -257,7 +258,7 @@ mod tests {
     #[test]
     fn test_decode_u256_mem() {
         assert_eq!(
-            decode(Base::U256, AbiDecodeLocation::Memory).to_string(),
+            decode(U256, AbiDecodeLocation::Memory).to_string(),
             "function abi_decode_uint256_mem(start, head_ptr) -> val { val := mload(head_ptr) }"
         )
     }

--- a/compiler/src/yul/abi/operations.rs
+++ b/compiler/src/yul/abi/operations.rs
@@ -87,15 +87,15 @@ mod tests {
     };
     use fe_semantics::namespace::types::{
         AbiDecodeLocation,
-        Base,
         FeString,
+        U256,
     };
     use yultsur::*;
 
     #[test]
     fn test_encode() {
         assert_eq!(
-            encode(vec![Base::U256], vec![expression! { 42 }]).to_string(),
+            encode(vec![U256], vec![expression! { 42 }]).to_string(),
             "abi_encode_uint256(42)"
         )
     }
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn test_encode_size() {
         assert_eq!(
-            encode_size(vec![Base::U256], vec![expression! { 42 }]).to_string(),
+            encode_size(vec![U256], vec![expression! { 42 }]).to_string(),
             "add(32, 0)"
         )
     }

--- a/compiler/src/yul/abi/utils.rs
+++ b/compiler/src/yul/abi/utils.rs
@@ -84,13 +84,14 @@ mod tests {
         Base,
         FeString,
         FixedSize,
+        U256,
     };
 
     #[test]
     fn test_encode_name() {
         assert_eq!(
             encode_name(&vec![
-                FixedSize::Base(Base::U256),
+                FixedSize::Base(U256),
                 FixedSize::Array(Array {
                     inner: Base::Byte,
                     dimension: 100
@@ -104,7 +105,7 @@ mod tests {
     #[test]
     fn test_decode_name_u256_calldata() {
         assert_eq!(
-            decode_name(&Base::U256, AbiDecodeLocation::Calldata).to_string(),
+            decode_name(&U256, AbiDecodeLocation::Calldata).to_string(),
             "abi_decode_uint256_calldata"
         )
     }
@@ -121,10 +122,10 @@ mod tests {
     fn test_head_offsets() {
         let types = vec![
             FixedSize::Array(Array {
-                inner: Base::U256,
+                inner: U256,
                 dimension: 42,
             }),
-            FixedSize::Base(Base::U256),
+            FixedSize::Base(U256),
             FixedSize::String(FeString { max_size: 26 }),
             FixedSize::Base(Base::Address),
         ];

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -116,8 +116,8 @@ mod tests {
     use fe_parser as parser;
     use fe_semantics::namespace::types::{
         Array,
-        Base,
         Type,
+        U256,
     };
     use fe_semantics::test_utils::ContextHarness;
     use fe_semantics::{
@@ -143,7 +143,7 @@ mod tests {
         harness.add_expression(
             "foo",
             ExpressionAttributes {
-                typ: Type::Base(Base::U256),
+                typ: Type::Base(U256),
                 location: Location::Value,
             },
         );
@@ -178,7 +178,7 @@ mod tests {
             ExpressionAttributes {
                 typ: Type::Array(Array {
                     dimension: 10,
-                    inner: Base::U256,
+                    inner: U256,
                 }),
                 location: Location::Memory,
             },

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -82,6 +82,7 @@ mod tests {
         Array,
         Base,
         FixedSize,
+        U256,
     };
     use fe_semantics::test_utils::ContextHarness;
     use fe_semantics::Context;
@@ -100,7 +101,7 @@ mod tests {
     #[test]
     fn decl_u256() {
         let mut harness = ContextHarness::new("foo: u256 = bar");
-        harness.add_declaration("foo: u256 = bar", FixedSize::Base(Base::U256));
+        harness.add_declaration("foo: u256 = bar", FixedSize::Base(U256));
 
         assert_eq!(map(&harness.context, &harness.src), "let foo := bar");
     }

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -303,6 +303,7 @@ mod tests {
         Base,
         Map,
         Type,
+        U256,
     };
     use fe_semantics::test_utils::ContextHarness;
     use fe_semantics::{
@@ -330,7 +331,7 @@ mod tests {
             ExpressionAttributes {
                 typ: Type::Map(Map {
                     key: Base::Address,
-                    value: Box::new(Type::Base(Base::U256)),
+                    value: Box::new(Type::Base(U256)),
                 }),
                 location: Location::Storage { index: 0 },
             },

--- a/compiler/src/yul/operations.rs
+++ b/compiler/src/yul/operations.rs
@@ -87,6 +87,7 @@ mod tests {
     use fe_semantics::namespace::types::{
         Base,
         FixedSize,
+        U256,
     };
     use yultsur::*;
 
@@ -94,7 +95,7 @@ mod tests {
     fn test_emit_event() {
         let event = Event::new(
             "MyEvent".to_string(),
-            vec![FixedSize::Base(Base::U256), FixedSize::Base(Base::Address)],
+            vec![FixedSize::Base(U256), FixedSize::Base(Base::Address)],
         );
 
         assert_eq!(

--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -1,8 +1,6 @@
 use crate::abi::utils as abi_utils;
 use crate::errors::CompileError;
 use crate::yul::abi::operations as abi_operations;
-#[cfg(test)]
-use fe_semantics::namespace::types::Base;
 use fe_semantics::namespace::types::{
     AbiDecodeLocation,
     AbiEncoding,
@@ -79,18 +77,27 @@ fn selection_as_statement(name: String, params: &[FixedSize]) -> yul::Statement 
     yul::Statement::Expression(selection(name, params))
 }
 
-#[test]
-fn test_selector_literal_basic() {
-    assert_eq!(
-        selector("foo".to_string(), &[]).to_string(),
-        String::from("0xc2985578"),
-    )
-}
+#[cfg(test)]
+mod tests {
+    use crate::yul::runtime::abi_dispatcher::selector;
+    use fe_semantics::namespace::types::{
+        FixedSize,
+        U256,
+    };
 
-#[test]
-fn test_selector_literal() {
-    assert_eq!(
-        selector("bar".to_string(), &[FixedSize::Base(Base::U256)]).to_string(),
-        String::from("0x0423a132"),
-    )
+    #[test]
+    fn test_selector_literal_basic() {
+        assert_eq!(
+            selector("foo".to_string(), &[]).to_string(),
+            String::from("0xc2985578"),
+        )
+    }
+
+    #[test]
+    fn test_selector_literal() {
+        assert_eq!(
+            selector("bar".to_string(), &[FixedSize::Base(U256)]).to_string(),
+            String::from("0x0423a132"),
+        )
+    }
 }

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -45,7 +45,12 @@ use std::fs;
     case(
         "return_call_to_fn_with_param_type_mismatch.fe",
         "[Str(\"semantic error: TypeError\")]"
-    )
+    ),
+    case(
+        "return_addition_with_mixed_types.fe",
+        "[Str(\"semantic error: TypeError\")]"
+    ),
+    case("return_lt_mixed_types.fe", "[Str(\"semantic error: TypeError\")]")
 )]
 fn test_compile_errors(fixture_file: &str, error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -178,7 +178,7 @@ fn deploy_contract(
     panic!("Failed to create contract")
 }
 
-fn u256_token(n: usize) -> ethabi::Token {
+fn uint_token(n: usize) -> ethabi::Token {
     ethabi::Token::Uint(U256::from(n))
 }
 
@@ -199,7 +199,7 @@ fn bytes_token(s: &str) -> ethabi::Token {
 }
 
 fn u256_array_token(v: Vec<usize>) -> ethabi::Token {
-    ethabi::Token::FixedArray(v.into_iter().map(|n| u256_token(n)).collect())
+    ethabi::Token::FixedArray(v.into_iter().map(|n| uint_token(n)).collect())
 }
 
 #[test]
@@ -232,14 +232,14 @@ fn test_assert() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "assert.fe", "Foo", vec![]);
 
-        let exit1 = harness.capture_call(&mut executor, "bar", &vec![u256_token(4)]);
+        let exit1 = harness.capture_call(&mut executor, "bar", &vec![uint_token(4)]);
 
         assert!(matches!(
             exit1,
             evm::Capture::Exit((evm::ExitReason::Revert(_), _))
         ));
 
-        let exit2 = harness.capture_call(&mut executor, "bar", &vec![u256_token(42)]);
+        let exit2 = harness.capture_call(&mut executor, "bar", &vec![uint_token(42)]);
 
         assert!(matches!(
             exit2,
@@ -249,43 +249,43 @@ fn test_assert() {
 }
 
 #[rstest(fixture_file, input, expected,
-    case("while_loop_with_continue.fe", vec![], Some(u256_token(1))),
-    case("while_loop.fe", vec![], Some(u256_token(3))),
-    case("while_loop_with_break.fe", vec![], Some(u256_token(1))),
-    case("while_loop_with_break_2.fe", vec![], Some(u256_token(1))),
-    case("if_statement.fe", vec![6], Some(u256_token(1))),
-    case("if_statement.fe", vec![4], Some(u256_token(0))),
-    case("if_statement_2.fe", vec![6], Some(u256_token(1))),
-    case("if_statement_with_block_declaration.fe", vec![], Some(u256_token(1))),
+    case("while_loop_with_continue.fe", vec![], Some(uint_token(1))),
+    case("while_loop.fe", vec![], Some(uint_token(3))),
+    case("while_loop_with_break.fe", vec![], Some(uint_token(1))),
+    case("while_loop_with_break_2.fe", vec![], Some(uint_token(1))),
+    case("if_statement.fe", vec![6], Some(uint_token(1))),
+    case("if_statement.fe", vec![4], Some(uint_token(0))),
+    case("if_statement_2.fe", vec![6], Some(uint_token(1))),
+    case("if_statement_with_block_declaration.fe", vec![], Some(uint_token(1))),
     case("ternary_expression.fe", vec![6], Some(u256_token(1))),
     case("ternary_expression.fe", vec![4], Some(u256_token(0))),
-    case("call_statement_without_args.fe", vec![], Some(u256_token(100))),
-    case("call_statement_with_args.fe", vec![], Some(u256_token(100))),
-    case("call_statement_with_args_2.fe", vec![], Some(u256_token(100))),
+    case("call_statement_without_args.fe", vec![], Some(uint_token(100))),
+    case("call_statement_with_args.fe", vec![], Some(uint_token(100))),
+    case("call_statement_with_args_2.fe", vec![], Some(uint_token(100))),
     case("return_bool_true.fe", vec![], Some(bool_token(true))),
     case("return_bool_false.fe", vec![], Some(bool_token(false))),
-    case("return_u256_from_called_fn_with_args.fe", vec![], Some(u256_token(200))),
-    case("return_u256_from_called_fn.fe", vec![], Some(u256_token(42))),
-    case("return_u256.fe", vec![], Some(u256_token(42))),
-    case("return_identity_u256.fe", vec![42], Some(u256_token(42))),
+    case("return_u256_from_called_fn_with_args.fe", vec![], Some(uint_token(200))),
+    case("return_u256_from_called_fn.fe", vec![], Some(uint_token(42))),
+    case("return_u256.fe", vec![], Some(uint_token(42))),
+    case("return_identity_u256.fe", vec![42], Some(uint_token(42))),
     // binary operators
-    case("return_addition_u256.fe", vec![42, 42], Some(u256_token(84))),
-    case("return_subtraction_u256.fe", vec![42, 42], Some(u256_token(0))),
-    case("return_multiplication_u256.fe", vec![42, 42], Some(u256_token(1764))),
-    case("return_division_u256.fe", vec![42, 42], Some(u256_token(1))),
-    case("return_pow_u256.fe", vec![2, 0], Some(u256_token(1))),
-    case("return_pow_u256.fe", vec![2, 4], Some(u256_token(16))),
-    case("return_mod_u256.fe", vec![5, 0], Some(u256_token(0))),
-    case("return_mod_u256.fe", vec![5, 2], Some(u256_token(1))),
-    case("return_mod_u256.fe", vec![5, 3], Some(u256_token(2))),
-    case("return_mod_u256.fe", vec![5, 5], Some(u256_token(0))),
-    case("return_bitwiseand_u256.fe", vec![12, 25], Some(u256_token(8))),
-    case("return_bitwiseor_u256.fe", vec![12, 25], Some(u256_token(29))),
-    case("return_bitwisexor_u256.fe", vec![12, 25], Some(u256_token(21))),
-    case("return_bitwiseshl_u256.fe", vec![212, 0], Some(u256_token(212))),
-    case("return_bitwiseshl_u256.fe", vec![212, 1], Some(u256_token(424))),
-    case("return_bitwiseshr_u256.fe", vec![212, 0], Some(u256_token(212))),
-    case("return_bitwiseshr_u256.fe", vec![212, 1], Some(u256_token(106))),
+    case("return_addition_u256.fe", vec![42, 42], Some(uint_token(84))),
+    case("return_subtraction_u256.fe", vec![42, 42], Some(uint_token(0))),
+    case("return_multiplication_u256.fe", vec![42, 42], Some(uint_token(1764))),
+    case("return_division_u256.fe", vec![42, 42], Some(uint_token(1))),
+    case("return_pow_u256.fe", vec![2, 0], Some(uint_token(1))),
+    case("return_pow_u256.fe", vec![2, 4], Some(uint_token(16))),
+    case("return_mod_u256.fe", vec![5, 0], Some(uint_token(0))),
+    case("return_mod_u256.fe", vec![5, 2], Some(uint_token(1))),
+    case("return_mod_u256.fe", vec![5, 3], Some(uint_token(2))),
+    case("return_mod_u256.fe", vec![5, 5], Some(uint_token(0))),
+    case("return_bitwiseand_u256.fe", vec![12, 25], Some(uint_token(8))),
+    case("return_bitwiseor_u256.fe", vec![12, 25], Some(uint_token(29))),
+    case("return_bitwisexor_u256.fe", vec![12, 25], Some(uint_token(21))),
+    case("return_bitwiseshl_u256.fe", vec![212, 0], Some(uint_token(212))),
+    case("return_bitwiseshl_u256.fe", vec![212, 1], Some(uint_token(424))),
+    case("return_bitwiseshr_u256.fe", vec![212, 0], Some(uint_token(212))),
+    case("return_bitwiseshr_u256.fe", vec![212, 1], Some(uint_token(106))),
     // comparision operators
     case("return_eq_u256.fe", vec![1, 1], Some(bool_token(true))),
     case("return_eq_u256.fe", vec![1, 2], Some(bool_token(false))),
@@ -313,7 +313,7 @@ fn test_method_return(fixture_file: &str, input: Vec<usize>, expected: Option<et
             input
                 .clone()
                 .into_iter()
-                .map(|val| u256_token(val))
+                .map(|val| uint_token(val))
                 .collect(),
             expected.clone(),
         )
@@ -328,7 +328,7 @@ fn return_array() {
         harness.test_function(
             &mut executor,
             "bar",
-            vec![u256_token(42)],
+            vec![uint_token(42)],
             Some(u256_array_token(vec![0, 0, 0, 42, 0])),
         )
     })
@@ -342,7 +342,7 @@ fn multi_param() {
         harness.test_function(
             &mut executor,
             "bar",
-            vec![u256_token(4), u256_token(42), u256_token(420)],
+            vec![uint_token(4), uint_token(42), uint_token(420)],
             Some(u256_array_token(vec![4, 42, 420])),
         )
     })
@@ -356,29 +356,29 @@ fn u256_u256_map() {
         harness.test_function(
             &mut executor,
             "write_bar",
-            vec![u256_token(4), u256_token(42)],
+            vec![uint_token(4), uint_token(42)],
             None,
         );
 
         harness.test_function(
             &mut executor,
             "write_bar",
-            vec![u256_token(420), u256_token(12)],
+            vec![uint_token(420), uint_token(12)],
             None,
         );
 
         harness.test_function(
             &mut executor,
             "read_bar",
-            vec![u256_token(4)],
-            Some(u256_token(42)),
+            vec![uint_token(4)],
+            Some(uint_token(42)),
         );
 
         harness.test_function(
             &mut executor,
             "read_bar",
-            vec![u256_token(420)],
-            Some(u256_token(12)),
+            vec![uint_token(420)],
+            Some(uint_token(12)),
         );
     })
 }
@@ -463,19 +463,19 @@ fn nested_map() {
         harness.test_function(
             &mut executor,
             "write_bar",
-            vec![address1.clone(), address2.clone(), u256_token(12)],
+            vec![address1.clone(), address2.clone(), uint_token(12)],
             None,
         );
         harness.test_function(
             &mut executor,
             "write_bar",
-            vec![address1.clone(), address3.clone(), u256_token(13)],
+            vec![address1.clone(), address3.clone(), uint_token(13)],
             None,
         );
         harness.test_function(
             &mut executor,
             "write_bar",
-            vec![address2.clone(), address1.clone(), u256_token(21)],
+            vec![address2.clone(), address1.clone(), uint_token(21)],
             None,
         );
 
@@ -483,19 +483,19 @@ fn nested_map() {
         harness.test_function(
             &mut executor,
             "write_baz",
-            vec![address1.clone(), u256_token(26), bool_token(true)],
+            vec![address1.clone(), uint_token(26), bool_token(true)],
             None,
         );
         harness.test_function(
             &mut executor,
             "write_baz",
-            vec![address2.clone(), u256_token(42), bool_token(true)],
+            vec![address2.clone(), uint_token(42), bool_token(true)],
             None,
         );
         harness.test_function(
             &mut executor,
             "write_baz",
-            vec![address2.clone(), u256_token(100), bool_token(false)],
+            vec![address2.clone(), uint_token(100), bool_token(false)],
             None,
         );
 
@@ -504,38 +504,38 @@ fn nested_map() {
             &mut executor,
             "read_bar",
             vec![address1.clone(), address2.clone()],
-            Some(u256_token(12)),
+            Some(uint_token(12)),
         );
         harness.test_function(
             &mut executor,
             "read_bar",
             vec![address1.clone(), address3.clone()],
-            Some(u256_token(13)),
+            Some(uint_token(13)),
         );
         harness.test_function(
             &mut executor,
             "read_bar",
             vec![address2.clone(), address1.clone()],
-            Some(u256_token(21)),
+            Some(uint_token(21)),
         );
 
         // read baz
         harness.test_function(
             &mut executor,
             "read_baz",
-            vec![address1.clone(), u256_token(26)],
+            vec![address1.clone(), uint_token(26)],
             Some(bool_token(true)),
         );
         harness.test_function(
             &mut executor,
             "read_baz",
-            vec![address2.clone(), u256_token(42)],
+            vec![address2.clone(), uint_token(42)],
             Some(bool_token(true)),
         );
         harness.test_function(
             &mut executor,
             "read_baz",
-            vec![address2.clone(), u256_token(100)],
+            vec![address2.clone(), uint_token(100)],
             Some(bool_token(false)),
         );
     })
@@ -574,11 +574,11 @@ fn events() {
         harness.events_emitted(
             executor,
             vec![
-                ("Nums", vec![u256_token(26), u256_token(42)]),
-                ("Bases", vec![u256_token(26), addr1.clone()]),
+                ("Nums", vec![uint_token(26), uint_token(42)]),
+                ("Bases", vec![uint_token(26), addr1.clone()]),
                 (
                     "Mix",
-                    vec![u256_token(26), addr1.clone(), u256_token(42), bytes],
+                    vec![uint_token(26), addr1.clone(), uint_token(42), bytes],
                 ),
                 ("Addresses", vec![addr_array]),
             ],
@@ -593,10 +593,10 @@ fn constructor() {
             &mut executor,
             "constructor.fe",
             "Foo",
-            vec![u256_token(26), u256_token(42)],
+            vec![uint_token(26), uint_token(42)],
         );
 
-        harness.test_function(&mut executor, "read_bar", vec![], Some(u256_token(68)));
+        harness.test_function(&mut executor, "read_bar", vec![], Some(uint_token(68)));
     })
 }
 
@@ -611,7 +611,7 @@ fn strings() {
                 string_token("string 1"),
                 address_token("1000000000000000000000000000000000000001"),
                 string_token("string 2"),
-                u256_token(42),
+                uint_token(42),
                 string_token("string 3"),
             ],
         );
@@ -629,7 +629,7 @@ fn strings() {
                 "MyEvent",
                 vec![
                     string_token("string 2"),
-                    u256_token(42),
+                    uint_token(42),
                     string_token("string 1"),
                     string_token("string 3"),
                     address_token("1000000000000000000000000000000000000001"),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -257,8 +257,8 @@ fn test_assert() {
     case("if_statement.fe", vec![4], Some(uint_token(0))),
     case("if_statement_2.fe", vec![6], Some(uint_token(1))),
     case("if_statement_with_block_declaration.fe", vec![], Some(uint_token(1))),
-    case("ternary_expression.fe", vec![6], Some(u256_token(1))),
-    case("ternary_expression.fe", vec![4], Some(u256_token(0))),
+    case("ternary_expression.fe", vec![6], Some(uint_token(1))),
+    case("ternary_expression.fe", vec![4], Some(uint_token(0))),
     case("call_statement_without_args.fe", vec![], Some(uint_token(100))),
     case("call_statement_with_args.fe", vec![], Some(uint_token(100))),
     case("call_statement_with_args_2.fe", vec![], Some(uint_token(100))),
@@ -268,8 +268,14 @@ fn test_assert() {
     case("return_u256_from_called_fn.fe", vec![], Some(uint_token(42))),
     case("return_u256.fe", vec![], Some(uint_token(42))),
     case("return_identity_u256.fe", vec![42], Some(uint_token(42))),
+    case("return_identity_u128.fe", vec![42], Some(uint_token(42))),
+    case("return_identity_u64.fe", vec![42], Some(uint_token(42))),
+    case("return_identity_u32.fe", vec![42], Some(uint_token(42))),
+    case("return_identity_u16.fe", vec![42], Some(uint_token(42))),
+    case("return_identity_u8.fe", vec![42], Some(uint_token(42))),
     // binary operators
     case("return_addition_u256.fe", vec![42, 42], Some(uint_token(84))),
+    case("return_addition_u128.fe", vec![42, 42], Some(uint_token(84))),
     case("return_subtraction_u256.fe", vec![42, 42], Some(uint_token(0))),
     case("return_multiplication_u256.fe", vec![42, 42], Some(uint_token(1764))),
     case("return_division_u256.fe", vec![42, 42], Some(uint_token(1))),
@@ -280,6 +286,7 @@ fn test_assert() {
     case("return_mod_u256.fe", vec![5, 3], Some(uint_token(2))),
     case("return_mod_u256.fe", vec![5, 5], Some(uint_token(0))),
     case("return_bitwiseand_u256.fe", vec![12, 25], Some(uint_token(8))),
+    case("return_bitwiseand_u128.fe", vec![12, 25], Some(uint_token(8))),
     case("return_bitwiseor_u256.fe", vec![12, 25], Some(uint_token(29))),
     case("return_bitwisexor_u256.fe", vec![12, 25], Some(uint_token(21))),
     case("return_bitwiseshl_u256.fe", vec![212, 0], Some(uint_token(212))),
@@ -294,6 +301,7 @@ fn test_assert() {
     case("return_lt_u256.fe", vec![1, 2], Some(bool_token(true))),
     case("return_lt_u256.fe", vec![1, 1], Some(bool_token(false))),
     case("return_lt_u256.fe", vec![2, 1], Some(bool_token(false))),
+    case("return_lt_u128.fe", vec![1, 2], Some(bool_token(true))),
     case("return_lte_u256.fe", vec![1, 2], Some(bool_token(true))),
     case("return_lte_u256.fe", vec![1, 1], Some(bool_token(true))),
     case("return_lte_u256.fe", vec![2, 1], Some(bool_token(false))),
@@ -348,10 +356,18 @@ fn multi_param() {
     })
 }
 
-#[test]
-fn u256_u256_map() {
+#[rstest(
+    fixture_file,
+    case("u256_u256_map.fe"),
+    case("u128_u128_map.fe"),
+    case("u64_u64_map.fe"),
+    case("u32_u32_map.fe"),
+    case("u16_u16_map.fe"),
+    case("u8_u8_map.fe")
+)]
+fn test_map(fixture_file: &str) {
     with_executor(&|mut executor| {
-        let harness = deploy_contract(&mut executor, "u256_u256_map.fe", "Foo", vec![]);
+        let harness = deploy_contract(&mut executor, fixture_file, "Foo", vec![]);
 
         harness.test_function(
             &mut executor,

--- a/compiler/tests/fixtures/compile_errors/return_addition_with_mixed_types.fe
+++ b/compiler/tests/fixtures/compile_errors/return_addition_with_mixed_types.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u256, y: u128) -> u128:
+        return x + y

--- a/compiler/tests/fixtures/compile_errors/return_lt_mixed_types.fe
+++ b/compiler/tests/fixtures/compile_errors/return_lt_mixed_types.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u128, y: u256) -> bool:
+        return x < y

--- a/compiler/tests/fixtures/return_addition_u128.fe
+++ b/compiler/tests/fixtures/return_addition_u128.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u128, y: u128) -> u128:
+        return x + y

--- a/compiler/tests/fixtures/return_bitwiseand_u128.fe
+++ b/compiler/tests/fixtures/return_bitwiseand_u128.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u128, y: u128) -> u128:
+        return x & y

--- a/compiler/tests/fixtures/return_identity_u128.fe
+++ b/compiler/tests/fixtures/return_identity_u128.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u128) -> u128:
+        return x

--- a/compiler/tests/fixtures/return_identity_u16.fe
+++ b/compiler/tests/fixtures/return_identity_u16.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u16) -> u16:
+        return x

--- a/compiler/tests/fixtures/return_identity_u32.fe
+++ b/compiler/tests/fixtures/return_identity_u32.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u32) -> u32:
+        return x

--- a/compiler/tests/fixtures/return_identity_u64.fe
+++ b/compiler/tests/fixtures/return_identity_u64.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u64) -> u64:
+        return x

--- a/compiler/tests/fixtures/return_identity_u8.fe
+++ b/compiler/tests/fixtures/return_identity_u8.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u8) -> u8:
+        return x

--- a/compiler/tests/fixtures/return_lt_u128.fe
+++ b/compiler/tests/fixtures/return_lt_u128.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: u128, y: u128) -> bool:
+        return x < y

--- a/compiler/tests/fixtures/u128_u128_map.fe
+++ b/compiler/tests/fixtures/u128_u128_map.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub bar: map<u128, u128>
+
+    pub def read_bar(key: u128) -> u128:
+        return self.bar[key]
+
+    pub def write_bar(key: u128, value: u128):
+        self.bar[key] = value

--- a/compiler/tests/fixtures/u16_u16_map.fe
+++ b/compiler/tests/fixtures/u16_u16_map.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub bar: map<u16, u16>
+
+    pub def read_bar(key: u16) -> u16:
+        return self.bar[key]
+
+    pub def write_bar(key: u16, value: u16):
+        self.bar[key] = value

--- a/compiler/tests/fixtures/u32_u32_map.fe
+++ b/compiler/tests/fixtures/u32_u32_map.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub bar: map<u32, u32>
+
+    pub def read_bar(key: u32) -> u32:
+        return self.bar[key]
+
+    pub def write_bar(key: u32, value: u32):
+        self.bar[key] = value

--- a/compiler/tests/fixtures/u64_u64_map.fe
+++ b/compiler/tests/fixtures/u64_u64_map.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub bar: map<u64, u64>
+
+    pub def read_bar(key: u64) -> u64:
+        return self.bar[key]
+
+    pub def write_bar(key: u64, value: u64):
+        self.bar[key] = value

--- a/compiler/tests/fixtures/u8_u8_map.fe
+++ b/compiler/tests/fixtures/u8_u8_map.fe
@@ -1,0 +1,8 @@
+contract Foo:
+    pub bar: map<u8, u8>
+
+    pub def read_bar(key: u8) -> u8:
+        return self.bar[key]
+
+    pub def write_bar(key: u8, value: u8):
+        self.bar[key] = value

--- a/semantics/src/namespace/operations.rs
+++ b/semantics/src/namespace/operations.rs
@@ -1,9 +1,9 @@
 use crate::errors::SemanticError;
 use crate::namespace::types::{
     Array,
-    Base,
     Map,
     Type,
+    U256,
 };
 
 /// Finds the type of an indexed expression.
@@ -20,7 +20,7 @@ pub fn index(value: Type, index: Type) -> Result<Type, SemanticError> {
 }
 
 fn index_array(array: Array, index: Type) -> Result<Type, SemanticError> {
-    if index != Type::Base(Base::U256) {
+    if index != Type::Base(U256) {
         return Err(SemanticError::TypeError);
     }
 
@@ -44,19 +44,20 @@ mod tests {
         Base,
         Map,
         Type,
+        U256,
     };
     use rstest::rstest;
 
-    const U256_ARRAY: Type = Type::Array(Array {
-        inner: Base::U256,
+    const U256_ARRAY_TYPE: Type = Type::Array(Array {
+        inner: U256,
         dimension: 100,
     });
-    const U256: Type = Type::Base(Base::U256);
-    const BOOL: Type = Type::Base(Base::Bool);
+    const U256_TYPE: Type = Type::Base(U256);
+    const BOOL_TYPE: Type = Type::Base(Base::Bool);
 
     fn u256_bool_map() -> Type {
         Type::Map(Map {
-            key: Base::U256,
+            key: U256,
             value: Box::new(Type::Base(Base::Bool)),
         })
     }
@@ -65,8 +66,8 @@ mod tests {
         value,
         index,
         expected,
-        case(U256_ARRAY, U256, U256),
-        case(u256_bool_map(), U256, BOOL)
+        case(U256_ARRAY_TYPE, U256_TYPE, U256_TYPE),
+        case(u256_bool_map(), U256_TYPE, BOOL_TYPE)
     )]
     fn basic_index(value: Type, index: Type, expected: Type) {
         let actual = operations::index(value, index).expect("failed to get expected type");
@@ -76,9 +77,9 @@ mod tests {
     #[rstest(
         value,
         index,
-        case(U256_ARRAY, BOOL),
-        case(u256_bool_map(), BOOL),
-        case(u256_bool_map(), U256_ARRAY)
+        case(U256_ARRAY_TYPE, BOOL_TYPE),
+        case(u256_bool_map(), BOOL_TYPE),
+        case(u256_bool_map(), U256_ARRAY_TYPE)
     )]
     fn type_error_index(value: Type, index: Type) {
         let actual = operations::index(value, index).expect_err("didn't fail");

--- a/semantics/src/traversal/assignments.rs
+++ b/semantics/src/traversal/assignments.rs
@@ -100,9 +100,9 @@ mod tests {
     };
     use crate::namespace::types::{
         Array,
-        Base,
         Map,
         Type,
+        U256,
     };
     use crate::traversal::assignments::assign;
     use crate::Context;
@@ -121,18 +121,18 @@ mod tests {
         contract_scope.borrow_mut().add_map(
             "foobar".to_string(),
             Map {
-                key: Base::U256,
-                value: Box::new(Type::Base(Base::U256)),
+                key: U256,
+                value: Box::new(Type::Base(U256)),
             },
         );
         let function_scope = BlockScope::from_contract_scope(Span::new(0, 0), contract_scope);
         function_scope
             .borrow_mut()
-            .add_var("foo".to_string(), Type::Base(Base::U256));
+            .add_var("foo".to_string(), Type::Base(U256));
         function_scope.borrow_mut().add_var(
             "bar".to_string(),
             Type::Array(Array {
-                inner: Base::U256,
+                inner: U256,
                 dimension: 100,
             }),
         );

--- a/semantics/src/traversal/declarations.rs
+++ b/semantics/src/traversal/declarations.rs
@@ -52,8 +52,8 @@ mod tests {
         Shared,
     };
     use crate::namespace::types::{
-        Base,
         Type,
+        U256,
     };
     use crate::traversal::declarations::var_decl;
     use crate::Context;
@@ -89,7 +89,7 @@ mod tests {
         assert_eq!(context.expressions.len(), 3);
         assert_eq!(
             scope.borrow().def("foo".to_string()),
-            Some(BlockDef::Variable(Type::Base(Base::U256)))
+            Some(BlockDef::Variable(Type::Base(U256)))
         );
     }
 

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -372,8 +372,8 @@ mod tests {
         Shared,
     };
     use crate::namespace::types::{
-        Base,
         FixedSize,
+        U256,
     };
     use crate::traversal::functions::func_def;
     use crate::Context;
@@ -412,8 +412,8 @@ mod tests {
             scope.borrow().def("foo".to_string()),
             Some(ContractDef::Function {
                 is_public: false,
-                params: vec![FixedSize::Base(Base::U256)],
-                returns: FixedSize::Base(Base::U256)
+                params: vec![FixedSize::Base(U256)],
+                returns: FixedSize::Base(U256)
             })
         );
     }


### PR DESCRIPTION
### What was wrong?

We did not support other numeric types as `u256`.

### How was it fixed?

Added support for `u8`, `u16`, `u32`, `u64` and `u128`

### To-Do

[//]: # (Stay ahead of things, add list items here!)

- [x] use in storage
- [x] use as value
- [x] basic arithmetic
- [x] abi encoding

