### PR TITLE
Add support for ternary expression

### DIFF
--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -277,18 +277,16 @@ fn expr_ternary(
     exp: &Spanned<fe::Expr>,
 ) -> Result<yul::Expression, CompileError> {
     if let fe::Expr::Ternary {
-        test,
         if_expr,
+        test,
         else_expr,
     } = &exp.node
     {
-        let yul_test_expr = expr(context, test)?;
-        let yul_if_expr = expr_comp_operation(context, if_expr)?;
-        let yul_else_exp = expr(context, else_expr)?;
+        let yul_test_expr = expr_comp_operation(context, test)?;
+        let yul_if_expr = expr(context, if_expr)?;
+        let yul_else_expr = expr(context, else_expr)?;
 
-        // TODO: Need to find a way to return an expression that comprises all 3 of
-        // above. Dummy return to make it compile.
-        return Ok(literal_expression! {(1)});
+        return Ok(expression! {ternary([yul_test_expr], [yul_if_expr], [yul_else_expr])});
     }
     unreachable!()
 }

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -282,7 +282,7 @@ fn expr_ternary(
         else_expr,
     } = &exp.node
     {
-        let yul_test_expr = expr_comp_operation(context, test)?;
+        let yul_test_expr = expr(context, test)?;
         let yul_if_expr = expr(context, if_expr)?;
         let yul_else_expr = expr(context, else_expr)?;
 

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -276,13 +276,18 @@ fn expr_ternary(
     context: &Context,
     exp: &Spanned<fe::Expr>,
 ) -> Result<yul::Expression, CompileError> {
-    if let fe::Expr::Ternary {test, if_expr, else_expr} = &exp.node {
+    if let fe::Expr::Ternary {
+        test,
+        if_expr,
+        else_expr,
+    } = &exp.node
+    {
         let yul_test_expr = expr(context, test)?;
         let yul_if_expr = expr_comp_operation(context, if_expr)?;
         let yul_else_exp = expr(context, else_expr)?;
 
-        // TODO: Need to find a way to return an expression that comprises all 3 of above.
-        // Dummy return to make it compile.
+        // TODO: Need to find a way to return an expression that comprises all 3 of
+        // above. Dummy return to make it compile.
         return Ok(literal_expression! {(1)});
     }
     unreachable!()

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -24,7 +24,7 @@ pub fn expr(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expressio
         fe::Expr::Bool(_) => expr_bool(exp),
         fe::Expr::Subscript { .. } => expr_subscript(context, exp),
         fe::Expr::Attribute { .. } => expr_attribute(context, exp),
-        fe::Expr::Ternary { .. } => unimplemented!(),
+        fe::Expr::Ternary { .. } => expr_ternary(context, exp),
         fe::Expr::BoolOperation { .. } => unimplemented!(),
         fe::Expr::BinOperation { .. } => expr_bin_operation(context, exp),
         fe::Expr::UnaryOperation { .. } => unimplemented!(),
@@ -270,6 +270,22 @@ fn expr_attribute_self(
         }) => Ok(literal_expression! { (index) }),
         _ => unimplemented!(),
     }
+}
+
+fn expr_ternary(
+    context: &Context,
+    exp: &Spanned<fe::Expr>,
+) -> Result<yul::Expression, CompileError> {
+    if let fe::Expr::Ternary {test, if_expr, else_expr} = &exp.node {
+        let yul_test_expr = expr(context, test)?;
+        let yul_if_expr = expr_comp_operation(context, if_expr)?;
+        let yul_else_exp = expr(context, else_expr)?;
+
+        // TODO: Need to find a way to return an expression that comprises all 3 of above.
+        // Dummy return to make it compile.
+        return Ok(literal_expression! {(1)});
+    }
+    unreachable!()
 }
 
 #[cfg(test)]

--- a/compiler/src/yul/runtime/functions.rs
+++ b/compiler/src/yul/runtime/functions.rs
@@ -17,7 +17,21 @@ pub fn std() -> Vec<yul::Statement> {
         sstoren(),
         dualkeccak256(),
         ceil32(),
+        ternary(),
     ]
+}
+
+/// Evaluates the ternary expression and returns the result.
+pub fn ternary() -> yul::Statement {
+    function_definition! {
+        function ternary(test, if_expr, else_expr) -> result {
+            ([switch! {
+                switch test
+                (case 1 {(result := if_expr)})
+                (case 0 {(result := else_expr)})
+            }])
+        }
+    }
 }
 
 /// Returns the highest available pointer.
@@ -162,11 +176,27 @@ pub fn dualkeccak256() -> yul::Statement {
     }
 }
 
-/// Rounds a 256 bit value up to the naerest multiple of 32.
+/// Rounds a 256 bit value up to the nearest multiple of 32.
 pub fn ceil32() -> yul::Statement {
     function_definition! {
         function ceil32(n) -> return_val {
             (return_val := mul((div((add(n, 31)), 32)), 32))
         }
+    }
+}
+
+mod tests {
+    use yultsur::*;
+
+    #[test]
+    fn test_ternary_definition() {
+        assert_eq!(
+            function_definition! {
+                function ternary(test, if_expr, else_expr) -> result {
+                    ([switch! { switch test (case 1 {(result := if_expr)}) (case 0 {(result := else_expr)}) }])
+                }
+            }.to_string(),
+            r#"function ternary(test, if_expr, else_expr) -> result { switch test case 1 { result := if_expr } case 0 { result := else_expr }  }"#
+        );
     }
 }

--- a/compiler/src/yul/runtime/functions.rs
+++ b/compiler/src/yul/runtime/functions.rs
@@ -21,19 +21,6 @@ pub fn std() -> Vec<yul::Statement> {
     ]
 }
 
-/// Evaluates the ternary expression and returns the result.
-pub fn ternary() -> yul::Statement {
-    function_definition! {
-        function ternary(test, if_expr, else_expr) -> result {
-            ([switch! {
-                switch test
-                (case 1 {(result := if_expr)})
-                (case 0 {(result := else_expr)})
-            }])
-        }
-    }
-}
-
 /// Returns the highest available pointer.
 pub fn avail() -> yul::Statement {
     function_definition! {
@@ -185,18 +172,15 @@ pub fn ceil32() -> yul::Statement {
     }
 }
 
-mod tests {
-    use yultsur::*;
-
-    #[test]
-    fn test_ternary_definition() {
-        assert_eq!(
-            function_definition! {
-                function ternary(test, if_expr, else_expr) -> result {
-                    ([switch! { switch test (case 1 {(result := if_expr)}) (case 0 {(result := else_expr)}) }])
-                }
-            }.to_string(),
-            r#"function ternary(test, if_expr, else_expr) -> result { switch test case 1 { result := if_expr } case 0 { result := else_expr }  }"#
-        );
+/// Evaluates the ternary expression and returns the result.
+pub fn ternary() -> yul::Statement {
+    function_definition! {
+        function ternary(test, if_expr, else_expr) -> result {
+            ([switch! {
+                switch test
+                (case 1 {(result := if_expr)})
+                (case 0 {(result := else_expr)})
+            }])
+        }
     }
 }

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -256,6 +256,8 @@ fn test_assert() {
     case("if_statement.fe", vec![4], Some(u256_token(0))),
     case("if_statement_2.fe", vec![6], Some(u256_token(1))),
     case("if_statement_with_block_declaration.fe", vec![], Some(u256_token(1))),
+    case("ternary_expression.fe", vec![6], Some(u256_token(1))),
+    case("ternary_expression.fe", vec![4], Some(u256_token(0))),
     case("call_statement_without_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args.fe", vec![], Some(u256_token(100))),
     case("call_statement_with_args_2.fe", vec![], Some(u256_token(100))),

--- a/compiler/tests/fixtures/ternary_expression.fe
+++ b/compiler/tests/fixtures/ternary_expression.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar(input: u256) -> u256:
+        return 1 if input > 5 else 0

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -194,8 +194,8 @@ pub enum FuncStmt<'a> {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum Expr<'a> {
     Ternary {
-        test: Box<Spanned<Expr<'a>>>,
         if_expr: Box<Spanned<Expr<'a>>>,
+        test: Box<Spanned<Expr<'a>>>,
         else_expr: Box<Spanned<Expr<'a>>>,
     },
     BoolOperation {

--- a/parser/src/parsers.rs
+++ b/parser/src/parsers.rs
@@ -1140,29 +1140,29 @@ pub fn exprs(input: Cursor) -> ParseResult<Spanned<Expr>> {
 }
 
 pub fn expr(input: Cursor) -> ParseResult<Spanned<Expr>> {
-    let (input, test) = disjunct(input)?;
+    let (input, if_expr) = disjunct(input)?;
     let (input, ternary) = opt(|input| {
         let (input, _) = name("if")(input)?;
-        let (input, if_expr) = disjunct(input)?;
+        let (input, test) = disjunct(input)?;
         let (input, _) = name("else")(input)?;
         let (input, else_expr) = expr(input)?;
-        Ok((input, (if_expr, else_expr)))
+        Ok((input, (test, else_expr)))
     })(input)?;
 
     let result = match ternary {
-        Some((if_expr, else_expr)) => {
-            let span = Span::from_pair(&test, &else_expr);
+        Some((test, else_expr)) => {
+            let span = Span::from_pair(&if_expr, &else_expr);
 
             Spanned {
                 node: Expr::Ternary {
-                    test: Box::new(test),
                     if_expr: Box::new(if_expr),
+                    test: Box::new(test),
                     else_expr: Box::new(else_expr),
                 },
                 span,
             }
         }
-        None => test,
+        None => if_expr,
     };
 
     Ok((input, result))

--- a/parser/tests/fixtures/parsers/expr.ron
+++ b/parser/tests/fixtures/parsers/expr.ron
@@ -11,14 +11,14 @@ x if y else z
   ),
   Spanned(
     node: Ternary(
-      test: Spanned(
+      if_expr: Spanned(
         node: Name("x"),
         span: Span(
           start: 2,
           end: 3,
         ),
       ),
-      if_expr: Spanned(
+      test: Spanned(
         node: Name("y"),
         span: Span(
           start: 7,

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -329,22 +329,24 @@ fn expr_ternary(
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Ternary {
-        test,
         if_expr,
+        test,
         else_expr,
     } = &exp.node
     {
-        let test_attributes = expr(Rc::clone(&scope), Rc::clone(&context), test);
-        let _if_expr_attributes =
-            expr_comp_operation(Rc::clone(&scope), Rc::clone(&context), if_expr);
-        let else_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), else_expr);
+        let test_attributes = expr_comp_operation(Rc::clone(&scope), Rc::clone(&context), test)?;
+        let if_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), if_expr)?;
+        let else_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), else_expr)?;
 
-        if test_attributes == else_expr_attributes {
-            // can return else_expr_attributes as well.
-            return test_attributes;
-        } else {
-            return Err(SemanticError::TypeError);
+        // Make sure the `test_attributes` is a boolean type.
+        if let Type::Base(Base::Bool) = test_attributes.typ {
+            // Should have the same return Type
+            if if_expr_attributes == else_expr_attributes {
+                // can return else_expr_attributes as well.
+                return Ok(if_expr_attributes);
+            }
         }
+        return Err(SemanticError::TypeError);
     }
     unreachable!()
 }

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -328,9 +328,15 @@ fn expr_ternary(
     context: Shared<Context>,
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    if let fe::Expr::Ternary{test, if_expr, else_expr} = &exp.node {
+    if let fe::Expr::Ternary {
+        test,
+        if_expr,
+        else_expr,
+    } = &exp.node
+    {
         let test_attributes = expr(Rc::clone(&scope), Rc::clone(&context), test);
-        let _if_expr_attributes = expr_comp_operation(Rc::clone(&scope), Rc::clone(&context), if_expr);
+        let _if_expr_attributes =
+            expr_comp_operation(Rc::clone(&scope), Rc::clone(&context), if_expr);
         let else_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), else_expr);
 
         if test_attributes == else_expr_attributes {

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -334,7 +334,7 @@ fn expr_ternary(
         else_expr,
     } = &exp.node
     {
-        let test_attributes = expr_comp_operation(Rc::clone(&scope), Rc::clone(&context), test)?;
+        let test_attributes = expr(Rc::clone(&scope), Rc::clone(&context), test)?;
         let if_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), if_expr)?;
         let else_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), else_expr)?;
 

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -37,7 +37,7 @@ pub fn expr(
         fe::Expr::Bool(_) => expr_bool(exp)?,
         fe::Expr::Subscript { .. } => expr_subscript(scope, Rc::clone(&context), exp)?,
         fe::Expr::Attribute { .. } => expr_attribute(scope, exp)?,
-        fe::Expr::Ternary { .. } => unimplemented!(),
+        fe::Expr::Ternary { .. } => expr_ternary(scope, Rc::clone(&context), exp)?,
         fe::Expr::BoolOperation { .. } => unimplemented!(),
         fe::Expr::BinOperation { .. } => expr_bin_operation(scope, Rc::clone(&context), exp)?,
         fe::Expr::UnaryOperation { .. } => unimplemented!(),
@@ -320,6 +320,26 @@ fn expr_comp_operation(
         });
     }
 
+    unreachable!()
+}
+
+fn expr_ternary(
+    scope: Shared<BlockScope>,
+    context: Shared<Context>,
+    exp: &Spanned<fe::Expr>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    if let fe::Expr::Ternary{test, if_expr, else_expr} = &exp.node {
+        let test_attributes = expr(Rc::clone(&scope), Rc::clone(&context), test);
+        let _if_expr_attributes = expr_comp_operation(Rc::clone(&scope), Rc::clone(&context), if_expr);
+        let else_expr_attributes = expr(Rc::clone(&scope), Rc::clone(&context), else_expr);
+
+        if test_attributes == else_expr_attributes {
+            // can return else_expr_attributes as well.
+            return test_attributes;
+        } else {
+            return Err(SemanticError::TypeError);
+        }
+    }
     unreachable!()
 }
 


### PR DESCRIPTION
### What was wrong?
#130 


### How was it fixed?


### To-Do

- [x] Improve  `yul::mappers::expressions::exp_ternary` so it can return the valid `yul::Expression`.

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Clean up commit history
