### PR TITLE
Split analysis of function definition and function body to ensure order of function definitions doesn't matter

### DIFF
--- a/compiler/tests/fixtures/return_u256_from_called_fn.fe
+++ b/compiler/tests/fixtures/return_u256_from_called_fn.fe
@@ -1,7 +1,8 @@
 contract Foo:
 
-    pub def foo() -> u256:
-        return 42
-
+    # We intentionally define `bar` before `foo` to test that order isn't important
     pub def bar() -> u256:
         return self.foo()
+
+    pub def foo() -> u256:
+        return 42

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -20,6 +20,7 @@ pub enum ContractDef {
         is_public: bool,
         param_types: Vec<FixedSize>,
         return_type: FixedSize,
+        scope: Shared<BlockScope>,
     },
     Field {
         nonce: usize,
@@ -131,6 +132,7 @@ impl ContractScope {
         is_public: bool,
         param_types: Vec<FixedSize>,
         return_type: FixedSize,
+        scope: Shared<BlockScope>,
     ) {
         self.interface.push(name.clone());
         self.defs.insert(
@@ -139,6 +141,7 @@ impl ContractScope {
                 is_public,
                 param_types,
                 return_type,
+                scope,
             },
         );
     }

--- a/semantics/src/traversal/contracts.rs
+++ b/semantics/src/traversal/contracts.rs
@@ -49,6 +49,12 @@ pub fn contract_def(
             };
         }
 
+        for stmt in body.iter() {
+            if let fe::ContractStmt::FuncDef { .. } = &stmt.node {
+                functions::func_body(Rc::clone(&contract_scope), Rc::clone(&context), stmt)?;
+            };
+        }
+
         let mut runtime_operations = vec![];
         let mut public_functions = vec![];
 
@@ -63,6 +69,7 @@ pub fn contract_def(
                     is_public: true,
                     param_types,
                     return_type,
+                    scope: _,
                 } => {
                     if name != "__init__" {
                         public_functions.push(FunctionAttributes {

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -315,6 +315,7 @@ fn expr_call(
                     is_public: _,
                     param_types,
                     return_type,
+                    scope: _,
                 }) => {
                     if fixed_sizes_to_types(param_types)
                         != expression_attributes_to_types(argument_attributes)


### PR DESCRIPTION
### What was wrong?

As explained in #90 we do currently have a bug that causes us to fail to compile contracts with functions that call other functions if the called function isn't defined above the calling function. In plain english: The order of function definitions matters but it should not matter.

### How was it fixed?

1. `func_def` was split into two functions: `func_def` and `func_body`. The former is only concerned about checking the types of the function definition and creating a scope for the function. It does not perform any tasks on the `body`  of the function.

2. The `scope` of the function is now also preserved when calling `add_function` on the contract scope. This is to give `function_body` a clean way to resolve the (already existing) scope.

3. In `contract_def`, we add a second pass that iterates over all functions again (after they have been iterated to call `func_def`) to call `func_body`. This is effectively what causes the order of the function definitions to become insignificant.

4. `func_body` retrieves the function scope by looking up the function definition in the contract scope and performs all checks on the function body.

