### PR TITLE
Type constructors

### DIFF
--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -273,6 +273,7 @@ fn test_assert() {
     case("return_identity_u32.fe", vec![42], Some(uint_token(42))),
     case("return_identity_u16.fe", vec![42], Some(uint_token(42))),
     case("return_identity_u8.fe", vec![42], Some(uint_token(42))),
+    case("return_u128_cast.fe", vec![], Some(uint_token(42))),
     // binary operators
     case("return_addition_u256.fe", vec![42, 42], Some(uint_token(84))),
     case("return_addition_u128.fe", vec![42, 42], Some(uint_token(84))),

--- a/compiler/tests/fixtures/return_u128_cast.fe
+++ b/compiler/tests/fixtures/return_u128_cast.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> u128:
+        return u128(42)

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -12,4 +12,5 @@ pub enum SemanticError {
     UnexpectedReturn,
     TypeError,
     CannotMove,
+    NotCallable,
 }

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -121,6 +121,13 @@ impl ExpressionAttributes {
     }
 }
 
+/// The type of a function call.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CallType {
+    TypeConstructor,
+    SelfFunction { name: String },
+}
+
 /// Contains contextual information relating to a function definition AST node.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionAttributes {
@@ -138,6 +145,7 @@ pub struct Context {
     functions: HashMap<Span, FunctionAttributes>,
     declarations: HashMap<Span, FixedSize>,
     contracts: HashMap<Span, ContractAttributes>,
+    calls: HashMap<Span, CallType>,
 }
 
 impl Context {
@@ -152,6 +160,7 @@ impl Context {
             functions: HashMap::new(),
             declarations: HashMap::new(),
             contracts: HashMap::new(),
+            calls: HashMap::new(),
         }
     }
 
@@ -215,6 +224,16 @@ impl Context {
     /// Get information that has been attributed to a contract definition node.
     pub fn get_contract<T: Into<Span>>(&self, span: T) -> Option<&ContractAttributes> {
         self.contracts.get(&span.into())
+    }
+
+    /// Attribute contextual information to a call expression node.
+    pub fn add_call(&mut self, spanned: &Spanned<fe::Expr>, call_type: CallType) {
+        self.calls.insert(spanned.span, call_type);
+    }
+
+    /// Get information that has been attributed to a call expression node.
+    pub fn get_call<T: Into<Span>>(&self, span: T) -> Option<&CallType> {
+        self.calls.get(&span.into())
     }
 }
 


### PR DESCRIPTION
### What was wrong?

closes #136 

We did not support type constructors for addresses and integers.

### How was it fixed?

Expressions wrapped within a type constructor are given the type defined by the constructor.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
