### PR TITLE
Refactoring of scopes

### DIFF
--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -26,7 +26,6 @@ pub enum ContractDef {
         nonce: usize,
         typ: Type,
     },
-    Event(Event),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -44,6 +43,7 @@ pub struct ContractScope {
     pub parent: Shared<ModuleScope>,
     pub defs: HashMap<String, ContractDef>,
     pub interface: Vec<String>,
+    pub event_defs: HashMap<String, Event>,
     num_fields: usize,
 }
 
@@ -102,6 +102,7 @@ impl ContractScope {
         Rc::new(RefCell::new(ContractScope {
             parent,
             defs: HashMap::new(),
+            event_defs: HashMap::new(),
             interface: vec![],
             num_fields: 0,
         }))
@@ -110,6 +111,11 @@ impl ContractScope {
     /// Lookup contract def by its name.
     pub fn def(&self, name: String) -> Option<ContractDef> {
         self.defs.get(&name).map(|def| (*def).clone())
+    }
+
+    /// Lookup contract event def by its name.
+    pub fn event_def(&self, name: String) -> Option<Event> {
+        self.event_defs.get(&name).map(|def| (*def).clone())
     }
 
     /// Add a contract field definition to the scope.
@@ -148,7 +154,7 @@ impl ContractScope {
 
     /// Add an event definition to the scope.
     pub fn add_event(&mut self, name: String, event: Event) {
-        self.defs.insert(name, ContractDef::Event(event));
+        self.event_defs.insert(name, event);
     }
 }
 
@@ -217,6 +223,11 @@ impl BlockScope {
     /// Lookup a contract definition inherited contract scope
     pub fn contract_def(&self, name: String) -> Option<ContractDef> {
         self.contract_scope().borrow().def(name)
+    }
+
+    /// Lookup a contract definition inherited contract scope
+    pub fn contract_event_def(&self, name: String) -> Option<Event> {
+        self.contract_scope().borrow().event_def(name)
     }
 
     /// Lookup definition in current or inherited block scope

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -22,10 +22,12 @@ pub enum ContractDef {
         return_type: FixedSize,
         scope: Shared<BlockScope>,
     },
-    Field {
-        nonce: usize,
-        typ: Type,
-    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ContractFieldDef {
+    pub nonce: usize,
+    pub typ: Type,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -44,6 +46,7 @@ pub struct ContractScope {
     pub defs: HashMap<String, ContractDef>,
     pub interface: Vec<String>,
     pub event_defs: HashMap<String, Event>,
+    pub field_defs: HashMap<String, ContractFieldDef>,
     num_fields: usize,
 }
 
@@ -103,6 +106,7 @@ impl ContractScope {
             parent,
             defs: HashMap::new(),
             event_defs: HashMap::new(),
+            field_defs: HashMap::new(),
             interface: vec![],
             num_fields: 0,
         }))
@@ -118,11 +122,16 @@ impl ContractScope {
         self.event_defs.get(&name).map(|def| (*def).clone())
     }
 
+    /// Lookup contract field def by its name.
+    pub fn field_def(&self, name: String) -> Option<ContractFieldDef> {
+        self.field_defs.get(&name).map(|def| (*def).clone())
+    }
+
     /// Add a contract field definition to the scope.
     pub fn add_field(&mut self, name: String, typ: Type) {
-        self.defs.insert(
+        self.field_defs.insert(
             name,
-            ContractDef::Field {
+            ContractFieldDef {
                 nonce: self.num_fields,
                 typ,
             },
@@ -225,9 +234,14 @@ impl BlockScope {
         self.contract_scope().borrow().def(name)
     }
 
-    /// Lookup a contract definition inherited contract scope
+    /// Lookup a contract event definition inherited contract scope
     pub fn contract_event_def(&self, name: String) -> Option<Event> {
         self.contract_scope().borrow().event_def(name)
+    }
+
+    /// Lookup a contract event definition inherited contract scope
+    pub fn contract_field_def(&self, name: String) -> Option<ContractFieldDef> {
+        self.contract_scope().borrow().field_def(name)
     }
 
     /// Lookup definition in current or inherited block scope

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -10,11 +10,6 @@ use std::rc::Rc;
 pub type Shared<T> = Rc<RefCell<T>>;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ModuleDef {
-    Type(Type),
-}
-
-#[derive(Clone, Debug, PartialEq)]
 pub struct ContractFunctionDef {
     pub is_public: bool,
     pub param_types: Vec<FixedSize>,
@@ -35,7 +30,7 @@ pub enum BlockDef {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModuleScope {
-    pub defs: HashMap<String, ModuleDef>,
+    pub type_defs: HashMap<String, Type>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -89,12 +84,12 @@ impl Scope {
 impl ModuleScope {
     pub fn new() -> Shared<Self> {
         Rc::new(RefCell::new(ModuleScope {
-            defs: HashMap::new(),
+            type_defs: HashMap::new(),
         }))
     }
 
     pub fn add_type_def(&mut self, name: String, typ: Type) {
-        self.defs.insert(name, ModuleDef::Type(typ));
+        self.type_defs.insert(name, typ);
     }
 }
 

--- a/semantics/src/namespace/types.rs
+++ b/semantics/src/namespace/types.rs
@@ -1,5 +1,4 @@
 use crate::errors::SemanticError;
-use crate::namespace::scopes::*;
 use fe_parser::ast as fe;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -429,7 +428,7 @@ impl AbiEncoding for FeString {
 }
 
 pub fn type_desc_fixed_size(
-    defs: &HashMap<String, ModuleDef>,
+    defs: &HashMap<String, Type>,
     typ: &fe::TypeDesc,
 ) -> Result<FixedSize, SemanticError> {
     match type_desc(defs, typ)? {
@@ -442,7 +441,7 @@ pub fn type_desc_fixed_size(
 }
 
 pub fn type_desc_base(
-    defs: &HashMap<String, ModuleDef>,
+    defs: &HashMap<String, Type>,
     typ: &fe::TypeDesc,
 ) -> Result<Base, SemanticError> {
     match type_desc(defs, typ)? {
@@ -454,10 +453,7 @@ pub fn type_desc_base(
     }
 }
 
-pub fn type_desc(
-    defs: &HashMap<String, ModuleDef>,
-    typ: &fe::TypeDesc,
-) -> Result<Type, SemanticError> {
+pub fn type_desc(defs: &HashMap<String, Type>, typ: &fe::TypeDesc) -> Result<Type, SemanticError> {
     match typ {
         fe::TypeDesc::Base { base: "u256" } => Ok(Type::Base(U256)),
         fe::TypeDesc::Base { base: "u128" } => Ok(Type::Base(Base::Numeric(Integer::U128))),
@@ -475,7 +471,7 @@ pub fn type_desc(
             Ok(Type::String(FeString { max_size }))
         }
         fe::TypeDesc::Base { base } => {
-            if let Some(ModuleDef::Type(typ)) = defs.get(base.to_owned()) {
+            if let Some(typ) = defs.get(base.to_owned()) {
                 return Ok(typ.clone());
             }
 

--- a/semantics/src/traversal/assignments.rs
+++ b/semantics/src/traversal/assignments.rs
@@ -75,7 +75,7 @@ mod tests {
                 value: Box::new(Type::Base(U256)),
             }),
         );
-        let function_scope = BlockScope::from_contract_scope(contract_scope);
+        let function_scope = BlockScope::from_contract_scope("".to_string(), contract_scope);
         function_scope
             .borrow_mut()
             .add_var("foo".to_string(), FixedSize::Base(U256));

--- a/semantics/src/traversal/contracts.rs
+++ b/semantics/src/traversal/contracts.rs
@@ -58,13 +58,14 @@ pub fn contract_def(
         let mut runtime_operations = vec![];
         let mut public_functions = vec![];
 
+        for (_, event) in contract_scope.borrow().event_defs.iter() {
+            runtime_operations.push(RuntimeOperations::AbiEncode {
+                params: event.fields.clone(),
+            })
+        }
+
         for (name, def) in contract_scope.borrow().defs.iter() {
             match def {
-                ContractDef::Event(event) => {
-                    runtime_operations.push(RuntimeOperations::AbiEncode {
-                        params: event.fields.clone(),
-                    })
-                }
                 ContractDef::Function {
                     is_public: true,
                     param_types,

--- a/semantics/src/traversal/declarations.rs
+++ b/semantics/src/traversal/declarations.rs
@@ -62,7 +62,7 @@ mod tests {
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
-        BlockScope::from_contract_scope(contract_scope)
+        BlockScope::from_contract_scope("".to_string(), contract_scope)
     }
 
     fn analyze(scope: Shared<BlockScope>, src: &str) -> Result<Context, SemanticError> {

--- a/semantics/src/traversal/declarations.rs
+++ b/semantics/src/traversal/declarations.rs
@@ -44,7 +44,6 @@ pub fn var_decl(
 mod tests {
     use crate::errors::SemanticError;
     use crate::namespace::scopes::{
-        BlockDef,
         BlockScope,
         ContractScope,
         ModuleScope,
@@ -86,8 +85,8 @@ mod tests {
         let context = analyze(Rc::clone(&scope), statement).expect("analysis failed");
         assert_eq!(context.expressions.len(), 3);
         assert_eq!(
-            scope.borrow().def("foo".to_string()),
-            Some(BlockDef::Variable(FixedSize::Base(U256)))
+            scope.borrow().variable_def("foo".to_string()),
+            Some(FixedSize::Base(U256))
         );
     }
 

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -1,8 +1,8 @@
 use crate::errors::SemanticError;
 use crate::namespace::scopes::{
+    ContractFunctionDef,
     BlockDef,
     BlockScope,
-    ContractDef,
     Shared,
 };
 
@@ -352,10 +352,10 @@ fn expr_call_self(
     argument_attributes: Vec<ExpressionAttributes>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     let contract_scope = &scope.borrow().contract_scope();
-    let called_func = contract_scope.borrow().def(func_name.node.to_string());
+    let called_func = contract_scope.borrow().function_def(func_name.node.to_string());
 
     match called_func {
-        Some(ContractDef::Function {
+        Some(ContractFunctionDef {
             is_public: _,
             param_types,
             return_type,
@@ -372,7 +372,6 @@ fn expr_call_self(
                 Location::Value,
             ))
         }
-        Some(_) => Err(SemanticError::NotCallable),
         None => Err(SemanticError::UndefinedValue {
             value: func_name.node.to_string(),
         }),

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -542,7 +542,7 @@ mod tests {
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
-        BlockScope::from_contract_scope(contract_scope)
+        BlockScope::from_contract_scope("".to_string(), contract_scope)
     }
 
     fn analyze(scope: Shared<BlockScope>, src: &str) -> Context {

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -237,15 +237,16 @@ fn expr_attribute_self(
     scope: Shared<BlockScope>,
     attr: &Spanned<&str>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    match scope.borrow().contract_def(attr.node.to_string()) {
-        Some(ContractDef::Field { nonce, typ }) => Ok(ExpressionAttributes::new(
-            typ,
-            Location::Storage { nonce: Some(nonce) },
+    match scope.borrow().contract_field_def(attr.node.to_string()) {
+        Some(field) => Ok(ExpressionAttributes::new(
+            field.typ,
+            Location::Storage {
+                nonce: Some(field.nonce),
+            },
         )),
         None => Err(SemanticError::UndefinedValue {
             value: attr.node.to_string(),
         }),
-        _ => Err(SemanticError::TypeError),
     }
 }
 

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -1,8 +1,7 @@
 use crate::errors::SemanticError;
 use crate::namespace::scopes::{
-    ContractFunctionDef,
-    BlockDef,
     BlockScope,
+    ContractFunctionDef,
     Shared,
 };
 
@@ -139,19 +138,19 @@ fn expr_name(
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Name(name) = exp.node {
-        return match scope.borrow().def(name.to_string()) {
-            Some(BlockDef::Variable(FixedSize::Base(base))) => {
+        return match scope.borrow().variable_def(name.to_string()) {
+            Some(FixedSize::Base(base)) => {
                 Ok(ExpressionAttributes::new(Type::Base(base), Location::Value))
             }
-            Some(BlockDef::Variable(FixedSize::Array(array))) => Ok(ExpressionAttributes::new(
+            Some(FixedSize::Array(array)) => Ok(ExpressionAttributes::new(
                 Type::Array(array),
                 Location::Memory,
             )),
-            Some(BlockDef::Variable(FixedSize::String(string))) => Ok(ExpressionAttributes::new(
+            Some(FixedSize::String(string)) => Ok(ExpressionAttributes::new(
                 Type::String(string),
                 Location::Memory,
             )),
-            Some(BlockDef::Variable(FixedSize::Tuple(_))) => unimplemented!(),
+            Some(FixedSize::Tuple(_)) => unimplemented!(),
             None => Err(SemanticError::UndefinedValue {
                 value: name.to_string(),
             }),
@@ -352,7 +351,9 @@ fn expr_call_self(
     argument_attributes: Vec<ExpressionAttributes>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     let contract_scope = &scope.borrow().contract_scope();
-    let called_func = contract_scope.borrow().function_def(func_name.node.to_string());
+    let called_func = contract_scope
+        .borrow()
+        .function_def(func_name.node.to_string());
 
     match called_func {
         Some(ContractFunctionDef {

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -43,9 +43,10 @@ pub fn func_def(
         body: _,
     } = &def.node
     {
-        let function_scope = BlockScope::from_contract_scope(Rc::clone(&contract_scope));
-
         let name = name.node.to_string();
+        let function_scope =
+            BlockScope::from_contract_scope(name.clone(), Rc::clone(&contract_scope));
+
         let param_types = args
             .iter()
             .map(|arg| func_def_arg(Rc::clone(&function_scope), arg))
@@ -56,8 +57,6 @@ pub fn func_def(
             .map(|typ| types::type_desc_fixed_size(Scope::Block(Rc::clone(&function_scope)), &typ))
             .transpose()?
             .unwrap_or_else(|| Tuple::empty().to_fixed_size());
-
-        function_scope.borrow_mut().return_type = return_type.clone();
 
         let is_public = qual.is_some();
         contract_scope.borrow_mut().add_function(

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -315,7 +315,7 @@ fn emit(
     {
         let event_name = expressions::expr_name_string(func)?;
 
-        if let Some(ContractDef::Event(event)) = scope.borrow().contract_def(event_name) {
+        if let Some(event) = scope.borrow().contract_event_def(event_name) {
             context.borrow_mut().add_emit(stmt, event);
         }
 

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -98,10 +98,7 @@ pub fn func_body(
         let host_func_def = contract_scope
             .borrow()
             .function_def(func_name)
-            .expect(&format!(
-                "Failed to lookup function definition for {}",
-                &name.node
-            ));
+            .unwrap_or_else(|| panic!("Failed to lookup function definition for {}", &name.node));
 
         // If the return type is an empty tuple we do not have to validate any further
         // at this point because both returning (explicit) or not returning (implicit

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -95,10 +95,13 @@ pub fn func_body(
     } = &def.node
     {
         let func_name = name.node.to_string();
-        let host_func_def = contract_scope.borrow().function_def(func_name).expect(&format!(
-            "Failed to lookup function definition for {}",
-            &name.node
-        ));
+        let host_func_def = contract_scope
+            .borrow()
+            .function_def(func_name)
+            .expect(&format!(
+                "Failed to lookup function definition for {}",
+                &name.node
+            ));
 
         // If the return type is an empty tuple we do not have to validate any further
         // at this point because both returning (explicit) or not returning (implicit
@@ -440,7 +443,10 @@ mod tests {
         let context = analyze(Rc::clone(&scope), func_def);
         assert_eq!(context.expressions.len(), 3);
 
-        let def = scope.borrow().function_def("foo".to_string()).expect("No definiton for foo exists");
+        let def = scope
+            .borrow()
+            .function_def("foo".to_string())
+            .expect("No definiton for foo exists");
 
         assert_eq!(def.is_public, false);
         assert_eq!(def.param_types, vec![FixedSize::Base(U256)]);

--- a/semantics/src/traversal/module.rs
+++ b/semantics/src/traversal/module.rs
@@ -33,7 +33,7 @@ fn type_def(
     def: &Spanned<fe::ModuleStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::ModuleStmt::TypeDef { name, typ } = &def.node {
-        let typ = types::type_desc(&scope.borrow().defs, &typ.node)?;
+        let typ = types::type_desc(&scope.borrow().type_defs, &typ.node)?;
         scope.borrow_mut().add_type_def(name.node.to_string(), typ);
         return Ok(());
     }

--- a/semantics/src/traversal/types.rs
+++ b/semantics/src/traversal/types.rs
@@ -10,7 +10,7 @@ use fe_parser::span::Spanned;
 
 /// Maps a type description node to an enum type.
 pub fn type_desc(scope: Scope, typ: &Spanned<fe::TypeDesc>) -> Result<Type, SemanticError> {
-    types::type_desc(&scope.module_scope().borrow().defs, &typ.node)
+    types::type_desc(&scope.module_scope().borrow().type_defs, &typ.node)
 }
 
 /// Maps a type description node to a fixed size enum type.
@@ -18,5 +18,5 @@ pub fn type_desc_fixed_size(
     scope: Scope,
     typ: &Spanned<fe::TypeDesc>,
 ) -> Result<FixedSize, SemanticError> {
-    types::type_desc_fixed_size(&scope.module_scope().borrow().defs, &typ.node)
+    types::type_desc_fixed_size(&scope.module_scope().borrow().type_defs, &typ.node)
 }


### PR DESCRIPTION
### What was wrong?

Multiple things:

1. `return_type` on `BlockScope` didn't feel right (because it carries no meaning for block scopes that originate in loops or if/else)

2. Using enums for `ContractDef`, `BlockDef` and `ModuleDef` made usage less ergonomic because one always had to match arms that would not make sense leaving to excessive use of `unreachable!()` or other anti patterns.

### How was it fixed?

1. Instead of putting `return_type` on `BlockScope` there's now a `name` on `BlockScope` that can tie a `BlockScope` to a function name. Frankly one can argue that `name` wouldn't be strictly necessary for block scopes originating from loops or if/else but one *can* think of the benefits of naming these (e.g. `block_scope_foo_1` -> `blockscope_foo_2`) e.g. when visualizing scopes in a hierachy.

Having the name, one can easily lookup the `ContractFunctionDef` from a `BlockScope` by calling `current_function_def`. The `ContractFunctionDef` then carries information such as the `return_type` and more.

2. Instead of using enums for `ContractDef`, `BlockDef` and `ModuleDef` we now have dedicated `struct` (where needed). In some cases, we don't use any wrapper because e.g. we store the bare `FixedType` for variables on the block scope. This also means that the generic lookup method `pub fn def(&self, name: String) -> Option<ContractDef>` was refactored into dedicated lookups that either return `Option<Event>`, `Option<ContractFieldDef>` or `Option<ContractFunctionDef>`. This makes pattern matching more straight forward simply because there are less cases that can possibly be matched. It also means that all the different components are kept in their own dedicated hashmaps. 

3. Calling code was optimized to get rid of unnecessary arms or ditch pattern matching altogether where applicable.