### PR TITLE
Indexed event params for base types

### DIFF
--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -102,7 +102,7 @@ fn event_field<'a>(
     Ok(EventField {
         name: String::from(field.name.node),
         typ: type_desc(&type_defs, &field.typ.node)?,
-        indexed: false,
+        indexed: field.qual.is_some(),
     })
 }
 

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -22,7 +22,8 @@ use std::fs;
     case("return_call_to_fn_without_return.fe", "TypeError"),
     case("return_call_to_fn_with_param_type_mismatch.fe", "TypeError"),
     case("return_addition_with_mixed_types.fe", "TypeError"),
-    case("return_lt_mixed_types.fe", "TypeError")
+    case("return_lt_mixed_types.fe", "TypeError"),
+    case("indexed_event.fe", "MoreThanThreeIndexedParams")
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/fixtures/compile_errors/indexed_event.fe
+++ b/compiler/tests/fixtures/compile_errors/indexed_event.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    event MyEvent:
+        idx addr1: address
+        idx addr2: address
+        idx addr3: address
+        idx addr4: address

--- a/compiler/tests/fixtures/events.fe
+++ b/compiler/tests/fixtures/events.fe
@@ -1,20 +1,20 @@
 contract Foo:
     event Nums:
         idx num1: u256
-        idx num2: u256
+        num2: u256
 
     event Bases:
-        idx num: u256
-        idx addr: address
+        num: u256
+        addr: address
 
     event Mix:
-        idx num1: u256
+        num1: u256
         idx addr: address
-        idx num2: u256
-        idx my_bytes: bytes[100]
+        num2: u256
+        my_bytes: bytes[100]
 
     event Addresses:
-        idx addrs: address[2]
+        addrs: address[2]
 
     pub def emit_nums():
         emit Nums(26, 42)

--- a/compiler/tests/fixtures/guest_book.fe
+++ b/compiler/tests/fixtures/guest_book.fe
@@ -4,7 +4,7 @@ contract GuestBook:
     pub guest_book: map<address, BookMsg>
 
     event Signed:
-        idx book_msg: BookMsg
+        book_msg: BookMsg
 
     pub def sign(book_msg: BookMsg):
         self.guest_book[msg.sender] = book_msg

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -15,12 +15,14 @@ pub enum ErrorKind {
     TypeError,
     CannotMove,
     NotCallable,
+    MoreThanThreeIndexedParams,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct SemanticError {
     pub kind: ErrorKind,
-    /// A sequence of nested spans containing the error.
+    /// A sequence of nested spans containing the error's origin in the source
+    /// code.
     pub context: Vec<Span>,
 }
 
@@ -93,6 +95,14 @@ impl SemanticError {
     pub fn not_callable() -> Self {
         SemanticError {
             kind: ErrorKind::NotCallable,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `MoreThanThreeIndexedParams`
+    pub fn more_than_three_indexed_params() -> Self {
+        SemanticError {
+            kind: ErrorKind::MoreThanThreeIndexedParams,
             context: vec![],
         }
     }

--- a/semantics/src/namespace/events.rs
+++ b/semantics/src/namespace/events.rs
@@ -10,24 +10,55 @@ use tiny_keccak::{
 #[derive(Clone, Debug, PartialEq)]
 pub struct Event {
     pub topic: String,
-    pub fields: Vec<FixedSize>,
+    fields: Vec<FixedSize>,
+    indexed_fields: Vec<usize>,
 }
 
 impl Event {
-    pub fn new(name: String, fields: Vec<FixedSize>) -> Self {
+    pub fn new(name: String, fields: Vec<FixedSize>, indexed_fields: Vec<usize>) -> Self {
         let abi_fields = fields
             .iter()
             .map(|field| field.abi_name())
             .collect::<Vec<String>>();
-        let topic = event_topic(name, abi_fields);
+        let topic = build_event_topic(name, abi_fields);
 
-        Self { topic, fields }
+        Self {
+            topic,
+            fields,
+            indexed_fields,
+        }
+    }
+
+    /// The event's indexed fields.
+    ///
+    /// These should be logged as additional topics.
+    pub fn indexed_fields(&self) -> Vec<(usize, FixedSize)> {
+        self.indexed_fields
+            .to_owned()
+            .into_iter()
+            .map(|index| (index, self.fields[index].to_owned()))
+            .collect()
+    }
+
+    /// The event's non-indexed fields.
+    ///
+    /// These should be logged in the data section.
+    pub fn fields(&self) -> Vec<(usize, FixedSize)> {
+        self.fields
+            .to_owned()
+            .into_iter()
+            .enumerate()
+            .filter(|(index, _)| !self.indexed_fields.contains(index))
+            .collect()
+    }
+
+    /// The event's non-indexed field types.
+    pub fn field_types(&self) -> Vec<FixedSize> {
+        self.fields().into_iter().map(|(_, typ)| typ).collect()
     }
 }
 
-/// Formats the name and fields and calculates the 32 byte keccak256 value of
-/// the signature.
-pub fn event_topic(name: String, fields: Vec<String>) -> String {
+fn build_event_topic(name: String, fields: Vec<String>) -> String {
     sig_keccak256(name, fields, 32)
 }
 
@@ -41,4 +72,39 @@ fn sig_keccak256(name: String, params: Vec<String>, size: usize) -> String {
     keccak.finalize(&mut selector);
 
     format!("0x{}", hex::encode(&selector[0..size]))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::namespace::events::Event;
+    use crate::namespace::types::{
+        Base,
+        FixedSize,
+    };
+
+    #[test]
+    fn test_new_event() {
+        let event = Event::new(
+            "MyEvent".to_string(),
+            vec![
+                FixedSize::Base(Base::Address),
+                FixedSize::Base(Base::Address),
+                FixedSize::Base(Base::Bool),
+            ],
+            vec![1],
+        );
+
+        assert_eq!(
+            event.fields(),
+            vec![
+                (0, FixedSize::Base(Base::Address)),
+                (2, FixedSize::Base(Base::Bool))
+            ]
+        );
+
+        assert_eq!(
+            event.indexed_fields(),
+            vec![(1, FixedSize::Base(Base::Address))]
+        );
+    }
 }

--- a/semantics/tests/analysis.rs
+++ b/semantics/tests/analysis.rs
@@ -84,12 +84,12 @@ fn guest_book_analysis() {
     let context = fe_semantics::analysis(&fe_module).expect("failed to perform semantic analysis");
 
     for (start, end, expected) in &[
-        (200, 210, &addr_val()),
-        (214, 222, &bytes_mem()),
-        (253, 261, &bytes_mem()),
-        (326, 341, &addr_bytes_map_sto()),
-        (326, 347, &bytes_sto_moved()),
-        (342, 346, &addr_val()),
+        (196, 206, &addr_val()),
+        (210, 218, &bytes_mem()),
+        (249, 257, &bytes_mem()),
+        (322, 337, &addr_bytes_map_sto()),
+        (322, 343, &bytes_sto_moved()),
+        (338, 342, &addr_val()),
     ] {
         assert_eq!(
             context.get_expression(&mock_spanned_expr(*start, *end)),
@@ -98,7 +98,7 @@ fn guest_book_analysis() {
     }
 
     let actual_event = context
-        .get_emit(&mock_spanned_func_stmt(232, 262))
+        .get_emit(&mock_spanned_func_stmt(228, 258))
         .expect("couldn't find event for emit");
     assert_eq!(
         actual_event.topic,

--- a/semantics/tests/fixtures/guest_book.fe
+++ b/semantics/tests/fixtures/guest_book.fe
@@ -4,7 +4,7 @@ contract GuestBook:
     pub guest_book: map<address, BookMsg>
 
     event Signed:
-        idx book_msg: BookMsg
+        book_msg: BookMsg
 
     pub def sign(book_msg: BookMsg):
         self.guest_book[msg.sender] = book_msg


### PR DESCRIPTION
### What was wrong?

closes #138 

We were not handling indexed event parameters correctly. They were being included inside of the log data, when they should have been included as extra log topics.

This PR does not include support for indexed non-base type params.

### How was it fixed?

- added indexed fields to the ABI builder
- the `idx` qualifier now affects the way events are logged
- we return an error if there are more than 3 indexed event params (no `log5` operation available)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
