### PR TITLE
Safe user-defined identifier mapping. 

### DIFF
--- a/compiler/src/yul/constructor.rs
+++ b/compiler/src/yul/constructor.rs
@@ -36,6 +36,7 @@ pub fn build(
         // The parameters are immediately copied from this location into memory at
         // `mem_start`. From there, parameters are decoded and passed into the
         // init function.
+        let init_func = identifier! { ("$$__init__") };
         block! {
             // copy params to memory where they can be decoded
             (let params_start_code := datasize("Contract"))
@@ -44,9 +45,9 @@ pub fn build(
             (let params_start_mem := alloc(params_size))
             (codecopy(params_start_mem, params_start_code, params_size))
 
-            // add init function amd run it
+            // add init function amd call it
             [init]
-            (__init__([decoded_params...]))
+            ([init_func]([decoded_params...]))
 
             // add the runtime functions
             [runtime...]

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -121,23 +121,23 @@ mod tests {
             ExpressionAttributes::new(Type::Base(U256), Location::Value),
         );
 
-        assert_eq!(map(&harness.context, &harness.src), "foo := bar")
+        assert_eq!(map(&harness.context, &harness.src), "$foo := $bar")
     }
 
     #[rstest(
         assignment,
         expected_yul,
-        case("foo = 1 + 2", "foo := add(1, 2)"),
-        case("foo = 1 - 2", "foo := sub(1, 2)"),
-        case("foo = 1 * 2", "foo := mul(1, 2)"),
-        case("foo = 1 / 2", "foo := div(1, 2)"),
-        case("foo = 1 ** 2", "foo := exp(1, 2)"),
-        case("foo = 1 % 2", "foo := mod(1, 2)"),
-        case("foo = 1 & 2", "foo := and(1, 2)"),
-        case("foo = 1 | 2", "foo := or(1, 2)"),
-        case("foo = 1 ^ 2", "foo := xor(1, 2)"),
-        case("foo = 1 << 2", "foo := shl(2, 1)"),
-        case("foo = 1 >> 2", "foo := shr(2, 1)")
+        case("foo = 1 + 2", "$foo := add(1, 2)"),
+        case("foo = 1 - 2", "$foo := sub(1, 2)"),
+        case("foo = 1 * 2", "$foo := mul(1, 2)"),
+        case("foo = 1 / 2", "$foo := div(1, 2)"),
+        case("foo = 1 ** 2", "$foo := exp(1, 2)"),
+        case("foo = 1 % 2", "$foo := mod(1, 2)"),
+        case("foo = 1 & 2", "$foo := and(1, 2)"),
+        case("foo = 1 | 2", "$foo := or(1, 2)"),
+        case("foo = 1 ^ 2", "$foo := xor(1, 2)"),
+        case("foo = 1 << 2", "$foo := shl(2, 1)"),
+        case("foo = 1 >> 2", "$foo := shr(2, 1)")
     )]
     fn assign_arithmetic_expression(assignment: &str, expected_yul: &str) {
         let mut harness = ContextHarness::new(assignment);
@@ -176,7 +176,7 @@ mod tests {
 
         assert_eq!(
             map(&harness.context, &harness.src),
-            "mstoren(add(foo, mul(4, 32)), 2, 32)"
+            "mstoren(add($foo, mul(4, 32)), 2, 32)"
         )
     }
 }

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -1,5 +1,6 @@
 use crate::errors::CompileError;
 use crate::yul::mappers::expressions;
+use crate::yul::utils;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use fe_semantics::namespace::types::{
@@ -37,7 +38,7 @@ fn var_decl_base(
         value,
     } = &decl.node
     {
-        let target = identifier! { (expressions::expr_name_string(target)?) };
+        let target = utils::var_name(expressions::expr_name_str(target)?);
 
         return Ok(if let Some(value) = value {
             let value = expressions::expr(context, &value)?;
@@ -61,7 +62,7 @@ fn var_decl_array(
         value,
     } = &decl.node
     {
-        let target = identifier! { (expressions::expr_name_string(target)?) };
+        let target = utils::var_name(expressions::expr_name_str(target)?);
         let size = literal_expression! { (array.size()) };
 
         return Ok(if value.is_some() {
@@ -112,7 +113,7 @@ mod tests {
             ExpressionAttributes::new(Type::Base(U256), Location::Value),
         );
 
-        assert_eq!(map(&harness.context, &harness.src), "let foo := bar");
+        assert_eq!(map(&harness.context, &harness.src), "let $foo := $bar");
     }
 
     #[test]
@@ -126,6 +127,9 @@ mod tests {
             }),
         );
 
-        assert_eq!(map(&harness.context, &harness.src), "let foo := alloc(200)");
+        assert_eq!(
+            map(&harness.context, &harness.src),
+            "let $foo := alloc(200)"
+        );
     }
 }

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -1,6 +1,6 @@
 use crate::errors::CompileError;
-use crate::yul::mappers::_utils::spanned_expression;
 use crate::yul::operations;
+use crate::yul::utils;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use fe_semantics::namespace::types::{
@@ -23,7 +23,7 @@ use yultsur::*;
 pub fn expr(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
     if let Some(attributes) = context.get_expression(exp) {
         let expression = match &exp.node {
-            fe::Expr::Name(_) => expr_name(context, exp),
+            fe::Expr::Name(_) => expr_name(exp),
             fe::Expr::Num(_) => expr_num(exp),
             fe::Expr::Bool(_) => expr_bool(exp),
             fe::Expr::Subscript { .. } => expr_subscript(context, exp),
@@ -79,7 +79,7 @@ pub fn call_arg(
 ) -> Result<yul::Expression, CompileError> {
     match &arg.node {
         fe::CallArg::Arg(value) => {
-            let spanned = spanned_expression(&arg.span, value);
+            let spanned = utils::spanned_expression(&arg.span, value);
             expr(context, &spanned)
         }
         fe::CallArg::Kwarg(fe::Kwarg { name: _, value }) => expr(context, value),
@@ -99,7 +99,7 @@ pub fn expr_call(
 
         return match call_type {
             CallType::SelfFunction { name } => {
-                let func_name = identifier! { (name) };
+                let func_name = utils::func_name(name);
 
                 Ok(expression! { [func_name]([yul_args...]) })
             }
@@ -176,11 +176,6 @@ pub fn expr_name_str<'a>(exp: &Spanned<fe::Expr<'a>>) -> Result<&'a str, Compile
     unreachable!()
 }
 
-/// Retrieves the &str value of a name expression and converts it to a String.
-pub fn expr_name_string(exp: &Spanned<fe::Expr>) -> Result<String, CompileError> {
-    expr_name_str(exp).map(|name| name.to_string())
-}
-
 /// Builds a Yul expression from the first slice, if it is an index.
 pub fn slices_index(
     context: &Context,
@@ -198,19 +193,17 @@ pub fn slice_index(
     slice: &Spanned<fe::Slice>,
 ) -> Result<yul::Expression, CompileError> {
     if let fe::Slice::Index(index) = &slice.node {
-        let spanned = spanned_expression(&slice.span, index.as_ref());
+        let spanned = utils::spanned_expression(&slice.span, index.as_ref());
         return expr(context, &spanned);
     }
 
     unreachable!()
 }
 
-fn expr_name(_context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
-    if let fe::Expr::Name(name) = exp.node {
-        return Ok(identifier_expression! {(name)});
-    }
+fn expr_name(exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
+    let name = expr_name_str(exp)?;
 
-    unreachable!()
+    Ok(identifier_expression! { [utils::var_name(name)] })
 }
 
 fn expr_num(exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
@@ -387,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn map_sload_w_array_elem() {
+    fn map_sload_with_array_elem() {
         let mut harness = ContextHarness::new("self.foo_map[bar_array[index]]");
 
         let foo_key = Base::Address;
@@ -437,7 +430,7 @@ mod tests {
 
         assert_eq!(
             result,
-            "scopy(dualkeccak256(0, mloadn(add(bar_array, mul(index, 20)), 20)), 160)"
+            "scopy(dualkeccak256(0, mloadn(add($bar_array, mul($index, 20)), 20)), 160)"
         );
     }
 

--- a/compiler/src/yul/mappers/mod.rs
+++ b/compiler/src/yul/mappers/mod.rs
@@ -1,4 +1,3 @@
-mod _utils;
 mod assignments;
 mod contracts;
 mod declarations;

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -7,6 +7,7 @@ mod constructor;
 mod mappers;
 mod operations;
 mod runtime;
+mod utils;
 
 pub struct CompilerOutput {
     pub tokens: String,

--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -1,6 +1,7 @@
 use crate::abi::utils as abi_utils;
 use crate::errors::CompileError;
 use crate::yul::abi::operations as abi_operations;
+use crate::yul::utils;
 use fe_semantics::namespace::types::{
     AbiDecodeLocation,
     AbiEncoding,
@@ -68,7 +69,7 @@ fn selection(name: String, params: &[FixedSize]) -> yul::Expression {
         AbiDecodeLocation::Calldata,
     );
 
-    let name = identifier! { (name) };
+    let name = utils::func_name(&name);
 
     expression! { [name]([decoded_params...]) }
 }

--- a/compiler/src/yul/utils.rs
+++ b/compiler/src/yul/utils.rs
@@ -3,6 +3,7 @@ use fe_parser::span::{
     Span,
     Spanned,
 };
+use yultsur::*;
 
 /// Creates a new spanned expression. Useful in cases where an `Expr` is nested
 /// within the node of a `Spanned` object.
@@ -11,4 +12,12 @@ pub fn spanned_expression<'a>(span: &Span, exp: &fe::Expr<'a>) -> Spanned<fe::Ex
         node: (*exp).clone(),
         span: (*span).to_owned(),
     }
+}
+
+pub fn func_name(name: &str) -> yul::Identifier {
+    identifier! { (format!("$${}", name)) }
+}
+
+pub fn var_name(name: &str) -> yul::Identifier {
+    identifier! { (format!("${}", name)) }
 }

--- a/compiler/tests/fixtures/erc20_token.fe
+++ b/compiler/tests/fixtures/erc20_token.fe
@@ -2,7 +2,7 @@ contract ERC20:
     _balances: map<address, u256>
     _allowances: map<address, map<address, u256>>
 
-    _totalSupply: u256
+    _total_supply: u256
 
     _name: string100
     _symbol: string100
@@ -18,9 +18,9 @@ contract ERC20:
         idx to: address
         value: u256
 
-    pub def __init__(_name: string100, _symbol: string100):
-        self._name = _name
-        self._symbol = _symbol
+    pub def __init__(name: string100, symbol: string100):
+        self._name = name
+        self._symbol = symbol
         self._decimals = u8(18)
         self._mint(msg.sender, 2600)
 
@@ -34,7 +34,7 @@ contract ERC20:
         return self._decimals
 
     pub def totalSupply() -> u256:
-        return self._totalSupply
+        return self._total_supply
 
     pub def balanceOf(account: address) -> u256:
         return self._balances[account]
@@ -69,7 +69,7 @@ contract ERC20:
         assert sender != address(0)
         assert recipient != address(0)
 
-        self._beforeTokenTransfer(sender, recipient, amount)
+        self._before_token_transfer(sender, recipient, amount)
 
         self._balances[sender] = self._balances[sender] - amount
         self._balances[recipient] = self._balances[recipient] + amount
@@ -78,19 +78,19 @@ contract ERC20:
     def _mint(account: address, amount: u256):
         assert account != address(0)
 
-        self._beforeTokenTransfer(address(0), account, amount)
+        self._before_token_transfer(address(0), account, amount)
 
-        self._totalSupply = self._totalSupply + amount
+        self._total_supply = self._total_supply + amount
         self._balances[account] = self._balances[account] + amount
         emit Transfer(address(0), account, amount)
 
     def _burn(account: address, amount: u256):
         assert account != address(0)
 
-        self._beforeTokenTransfer(account, address(0), amount)
+        self._before_token_transfer(account, address(0), amount)
 
         self._balances[account] = self._balances[account] - amount
-        self._totalSupply = self._totalSupply - amount
+        self._total_supply = self._total_supply - amount
         emit Transfer(account, address(0), amount)
 
     def _approve(owner: address, spender: address, amount: u256):
@@ -100,8 +100,8 @@ contract ERC20:
         self._allowances[owner][spender] = amount
         emit Approval(owner, spender, amount)
 
-    def _setupDecimals(decimals_: u8):
+    def _setup_decimals(decimals_: u8):
         self._decimals = decimals_
 
-    def _beforeTokenTransfer(from: address, to: address, amount: u256):
+    def _before_token_transfer(from: address, to: address, amount: u256):
         pass


### PR DESCRIPTION
### What was wrong?

closes #102 

Identifiers chosen by users could conflict with identifiers introduced by the compiler.

### How was it fixed?

User-defined variable names now have `$` added to the front and user defined function names now have `$$` added to the front.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
