### PR TITLE
Memory and storage copying

### DIFF
--- a/compiler/src/yul/abi/functions.rs
+++ b/compiler/src/yul/abi/functions.rs
@@ -195,7 +195,9 @@ fn decode_array(
                 let total_size = literal_expression! { (total_size) };
 
                 match location {
-                    AbiDecodeLocation::Calldata => expression! { ccopy(head_ptr, [total_size]) },
+                    AbiDecodeLocation::Calldata => {
+                        expression! { ccopym(head_ptr, [total_size]) }
+                    }
                     AbiDecodeLocation::Memory => expression! { head_ptr },
                 }
             }
@@ -206,7 +208,7 @@ fn decode_array(
                     let data_size = literal_expression! { (data_size) };
                     let total_size = expression! { add(32, (mul([array_size], [data_size]))) };
 
-                    expression! { ccopy([data_ptr], [total_size]) }
+                    expression! { ccopym([data_ptr], [total_size]) }
                 }
                 AbiDecodeLocation::Memory => {
                     expression! { add(start, (mload(head_ptr))) }
@@ -251,7 +253,7 @@ mod tests {
     fn test_decode_string_calldata() {
         assert_eq!(
             decode(FeString { max_size: 100 }, AbiDecodeLocation::Calldata).to_string(),
-            "function abi_decode_string100_calldata(start, head_ptr) -> val { val := ccopy(add(start, calldataload(head_ptr)), add(32, mul(calldataload(add(start, calldataload(head_ptr))), 1))) }"
+            "function abi_decode_string100_calldata(start, head_ptr) -> val { val := ccopym(add(start, calldataload(head_ptr)), add(32, mul(calldataload(add(start, calldataload(head_ptr))), 1))) }"
         )
     }
 

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -38,32 +38,34 @@ pub fn assign(
                         target_attributes.final_location(),
                     ) {
                         (Location::Memory, Location::Storage { .. }) => {
-                            operations::mem_to_sto(typ, target, value)
+                            operations::mcopys(typ, target, value)
                         }
                         (Location::Memory, Location::Value) => {
                             let target = expr_as_ident(target)?;
-                            let value = operations::mem_to_val(typ, value);
+                            let value = operations::mload(typ, value);
                             statement! { [target] := [value] }
                         }
-                        (Location::Memory, Location::Memory) => unimplemented!("memory copying"),
+                        (Location::Memory, Location::Memory) => {
+                            let target = expr_as_ident(target)?;
+                            let ptr = operations::mcopym(typ, value);
+                            statement! { [target] := [ptr] }
+                        }
                         (Location::Storage { .. }, Location::Storage { .. }) => {
-                            unimplemented!("storage copying")
+                            operations::scopys(typ, target, value)
                         }
                         (Location::Storage { .. }, Location::Value) => {
                             let target = expr_as_ident(target)?;
-                            let value = operations::sto_to_val(typ, value);
+                            let value = operations::sload(typ, value);
                             statement! { [target] := [value] }
                         }
                         (Location::Storage { .. }, Location::Memory) => {
-                            let target = expr_as_ident(target)?;
-                            let mptr = operations::sto_to_mem(typ, value);
-                            statement! { [target] := [mptr] }
+                            unreachable!("raw sto to mem assign")
                         }
                         (Location::Value, Location::Memory) => {
-                            operations::val_to_mem(typ, target, value)
+                            operations::mstore(typ, target, value)
                         }
                         (Location::Value, Location::Storage { .. }) => {
-                            operations::val_to_sto(typ, target, value)
+                            operations::sstore(typ, target, value)
                         }
                         (Location::Value, Location::Value) => {
                             let target = expr_as_ident(target)?;

--- a/compiler/src/yul/operations.rs
+++ b/compiler/src/yul/operations.rs
@@ -10,53 +10,57 @@ use yultsur::*;
 /// Loads a value from storage.
 ///
 /// The returned expression evaluates to a 256 bit value.
-pub fn sto_to_val<T: FeSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
+pub fn sload<T: FeSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
     let size = literal_expression! { (typ.size()) };
     expression! { sloadn([sptr], [size]) }
 }
 
-/// Copies a segment of storage into memory.
-///
-/// The returned expression evaluates to a memory pointer.
-pub fn sto_to_mem<T: FeSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
-    let size = literal_expression! { (typ.size()) };
-    expression! { scopy([sptr], [size]) }
-}
-
 /// Stores a 256 bit value in storage.
-pub fn val_to_sto<T: FeSized>(
-    typ: T,
-    sptr: yul::Expression,
-    value: yul::Expression,
-) -> yul::Statement {
+pub fn sstore<T: FeSized>(typ: T, sptr: yul::Expression, value: yul::Expression) -> yul::Statement {
     let size = literal_expression! { (typ.size()) };
     statement! { sstoren([sptr], [value], [size]) }
 }
 
 /// Stores a 256 bit value in memory.
-pub fn val_to_mem<T: FeSized>(
-    typ: T,
-    mptr: yul::Expression,
-    value: yul::Expression,
-) -> yul::Statement {
+pub fn mstore<T: FeSized>(typ: T, mptr: yul::Expression, value: yul::Expression) -> yul::Statement {
     let size = literal_expression! { (typ.size()) };
     statement! { mstoren([mptr], [value], [size]) }
 }
 
 /// Copies a segment of memory into storage.
-pub fn mem_to_sto<T: FeSized>(
+pub fn mcopys<T: FeSized>(typ: T, sptr: yul::Expression, mptr: yul::Expression) -> yul::Statement {
+    let size = literal_expression! { (typ.size()) };
+    statement! { mcopys([mptr], [sptr], [size]) }
+}
+
+/// Copies a segment of storage into memory.
+///
+/// The returned expression evaluates to a memory pointer.
+pub fn scopym<T: FeSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (typ.size()) };
+    expression! { scopym([sptr], [size]) }
+}
+
+/// Copies a segment of storage to another segment of storage.
+pub fn scopys<T: FeSized>(
     typ: T,
-    sptr: yul::Expression,
-    mptr: yul::Expression,
+    dest_ptr: yul::Expression,
+    origin_ptr: yul::Expression,
 ) -> yul::Statement {
     let size = literal_expression! { (typ.size()) };
-    statement! { mcopy([mptr], [sptr], [size]) }
+    statement! { scopys([origin_ptr], [dest_ptr], [size]) }
+}
+
+/// Copies a segment of memory to another segment of memory.
+pub fn mcopym<T: FeSized>(typ: T, ptr: yul::Expression) -> yul::Expression {
+    let size = literal_expression! { (typ.size()) };
+    expression! { mcopym([ptr], [size]) }
 }
 
 /// Loads a value in memory.
 ///
 /// The returned expression evaluates to a 256 bit value.
-pub fn mem_to_val<T: FeSized>(typ: T, mptr: yul::Expression) -> yul::Expression {
+pub fn mload<T: FeSized>(typ: T, mptr: yul::Expression) -> yul::Expression {
     let size = literal_expression! { (typ.size()) };
     expression! { mloadn([mptr], [size]) }
 }

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -25,7 +25,8 @@ use std::fs;
     case("return_lt_mixed_types.fe", "TypeError"),
     case("indexed_event.fe", "MoreThanThreeIndexedParams"),
     case("unary_minus_on_bool.fe", "TypeError"),
-    case("type_constructor_from_variable.fe", "NumericLiteralExpected")
+    case("type_constructor_from_variable.fe", "NumericLiteralExpected"),
+    case("needs_mem_copy.fe", "CannotMove")
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/fixtures/address_bytes10_map.fe
+++ b/compiler/tests/fixtures/address_bytes10_map.fe
@@ -2,7 +2,7 @@ contract Foo:
     pub bar: map<address, bytes[10]>
 
     pub def read_bar(key: address) -> bytes[10]:
-        return self.bar[key]
+        return self.bar[key].to_mem()
 
     pub def write_bar(key: address, value: bytes[10]):
         self.bar[key] = value

--- a/compiler/tests/fixtures/compile_errors/needs_mem_copy.fe
+++ b/compiler/tests/fixtures/compile_errors/needs_mem_copy.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    my_sto_array: u256[10]
+
+    pub def bar(my_array: u256[10]):
+        my_array = self.my_sto_array

--- a/compiler/tests/fixtures/data_copying_stress.fe
+++ b/compiler/tests/fixtures/data_copying_stress.fe
@@ -1,0 +1,57 @@
+contract Foo:
+    my_string: string42
+    my_other_string: string42
+
+    my_u256: u256
+    my_other_u256: u256
+
+    my_nums: u256[5]
+
+    event MyEvent:
+        my_string: string42
+        my_u256: u256
+
+    pub def set_my_vals(
+        my_string: string42,
+        my_other_string: string42,
+        my_u256: u256,
+        my_other_u256: u256
+    ):
+        self.my_string = my_string
+        self.my_other_string = my_other_string
+        self.my_u256 = my_u256
+        self.my_other_u256 = my_other_u256
+
+    pub def set_to_my_other_vals():
+        self.my_string = self.my_other_string
+        self.my_u256 = self.my_other_u256
+
+    pub def mutate_and_return(my_array: u256[10]) -> u256[10]:
+        my_array[3] = 5
+        return my_array
+
+    pub def clone_and_return(my_array: u256[10]) -> u256[10]:
+        return my_array.clone()
+
+    pub def clone_mutate_and_return(my_array: u256[10]) -> u256[10]:
+        my_array.clone()[3] = 5
+        return my_array
+
+    pub def assign_my_nums_and_return() -> u256[5]:
+        my_nums_mem: u256[5]
+        self.my_nums[0] = 42
+        self.my_nums[1] = 26
+        self.my_nums[2] = 0
+        self.my_nums[3] = 1
+        self.my_nums[4] = 255
+        my_nums_mem = self.my_nums.to_mem()
+        return my_nums_mem
+
+    pub def emit_my_event():
+        self.emit_my_event_internal(
+            self.my_string.to_mem(),
+            self.my_u256.to_mem()
+        )
+
+    def emit_my_event_internal(some_string: string42, some_u256: u256):
+        emit MyEvent(some_string, some_u256)

--- a/compiler/tests/fixtures/erc20_token.fe
+++ b/compiler/tests/fixtures/erc20_token.fe
@@ -25,10 +25,10 @@ contract ERC20:
         self._mint(msg.sender, 2600)
 
     pub def name() -> string100:
-        return self._name
+        return self._name.to_mem()
 
     pub def symbol() -> string100:
-        return self._symbol
+        return self._symbol.to_mem()
 
     pub def decimals() -> u8:
         return self._decimals

--- a/compiler/tests/fixtures/guest_book.fe
+++ b/compiler/tests/fixtures/guest_book.fe
@@ -12,4 +12,4 @@ contract GuestBook:
         emit Signed(book_msg=book_msg)
 
     pub def get_msg(addr: address) -> BookMsg:
-        return self.guest_book[addr]
+        return self.guest_book[addr].to_mem()

--- a/compiler/tests/fixtures/sized_vals_in_sto.fe
+++ b/compiler/tests/fixtures/sized_vals_in_sto.fe
@@ -18,13 +18,17 @@ contract Foo:
         self.nums = x
 
     pub def read_nums() -> u256[42]:
-        return self.nums
+        return self.nums.to_mem()
 
     pub def write_str(x: string26):
         self.str = x
 
     pub def read_str() -> string26:
-        return self.str
+        return self.str.to_mem()
 
     pub def emit_event():
-        emit MyEvent(self.num, self.nums, self.str)
+        emit MyEvent(
+            self.num,
+            self.nums.to_mem(),
+            self.str.to_mem()
+        )

--- a/newsfragments/155.feature.md
+++ b/newsfragments/155.feature.md
@@ -1,0 +1,12 @@
+Added builtin copying methods `clone()` and `to_mem()` to reference types.
+
+
+usage:
+
+```
+# copy a segment of storage into memory and assign the new pointer
+my_mem_array = self.my_sto_array.to_mem()
+
+# copy a segment of memory into another segment of memory and assign the new pointer
+my_other_mem_array = my_mem_array.clone()
+```

--- a/semantics/src/builtins.rs
+++ b/semantics/src/builtins.rs
@@ -1,0 +1,5 @@
+pub const SELF: &str = "self";
+pub const SENDER: &str = "sender";
+pub const MSG: &str = "msg";
+pub const CLONE: &str = "clone";
+pub const TO_MEM: &str = "to_mem";

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -17,6 +17,7 @@ pub enum ErrorKind {
     NotCallable,
     NumericLiteralExpected,
     MoreThanThreeIndexedParams,
+    WrongNumberOfParams,
 }
 
 #[derive(Debug, PartialEq)]
@@ -112,6 +113,14 @@ impl SemanticError {
     pub fn more_than_three_indexed_params() -> Self {
         SemanticError {
             kind: ErrorKind::MoreThanThreeIndexedParams,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `WrongNumberOfParams`
+    pub fn wrong_number_of_params() -> Self {
+        SemanticError {
+            kind: ErrorKind::WrongNumberOfParams,
             context: vec![],
         }
     }

--- a/semantics/src/namespace/types.rs
+++ b/semantics/src/namespace/types.rs
@@ -154,6 +154,7 @@ impl Integer {
 }
 
 impl Type {
+    /// Returns true if the type is a tuple with 0 elements.
     pub fn is_empty_tuple(&self) -> bool {
         if let Type::Tuple(tuple) = &self {
             return tuple.is_empty();

--- a/semantics/src/traversal/assignments.rs
+++ b/semantics/src/traversal/assignments.rs
@@ -5,6 +5,7 @@ use crate::namespace::scopes::{
 };
 use crate::traversal::expressions;
 use crate::Context;
+use crate::Location;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use std::rc::Rc;
@@ -30,6 +31,16 @@ pub fn assign(
 
             if target_attributes.typ != value_attributes.typ {
                 return Err(SemanticError::type_error());
+            }
+
+            if matches!(
+                (
+                    value_attributes.final_location(),
+                    target_attributes.location
+                ),
+                (Location::Storage { .. }, Location::Memory)
+            ) {
+                return Err(SemanticError::cannot_move());
             }
 
             return Ok(());

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -5,6 +5,7 @@ use crate::namespace::scopes::{
     Shared,
 };
 
+use crate::builtins;
 use crate::namespace::operations;
 use crate::namespace::types::{
     Base,
@@ -27,8 +28,6 @@ use crate::{
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use std::rc::Rc;
-
-const SELF: &str = "self";
 
 /// Gather context information for expressions and check for type errors.
 pub fn expr(
@@ -63,13 +62,13 @@ pub fn expr(
 
 /// Gather context information for expressions and check for type errors.
 ///
-/// Attributes a value move to the expression.
-pub fn expr_with_value_move(
+/// Also ensures that the expression is on the stack.
+pub fn value_expr(
     scope: Shared<BlockScope>,
     context: Shared<Context>,
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.with_value_move()?;
+    let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.into_loaded()?;
 
     context.borrow_mut().add_expression(exp, attributes.clone());
 
@@ -78,13 +77,13 @@ pub fn expr_with_value_move(
 
 /// Gather context information for expressions and check for type errors.
 ///
-/// Attributes the default move to the expression.
-pub fn expr_with_default_move(
+/// Also ensures that the expression is in the type's assigment location.
+pub fn assignable_expr(
     scope: Shared<BlockScope>,
     context: Shared<Context>,
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.with_default_move()?;
+    let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.into_assignable()?;
 
     context.borrow_mut().add_expression(exp, attributes.clone());
 
@@ -126,7 +125,7 @@ pub fn slice_index(
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Slice::Index(index) = &slice.node {
         let spanned = spanned_expression(&slice.span, index.as_ref());
-        let attributes = expr_with_value_move(scope, Rc::clone(&context), &spanned)?;
+        let attributes = value_expr(scope, Rc::clone(&context), &spanned)?;
 
         return Ok(attributes);
     }
@@ -208,8 +207,8 @@ fn expr_attribute(
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Attribute { value, attr } = &exp.node {
         return match expr_name_str(value)? {
-            "msg" => expr_attribute_msg(attr),
-            "self" => expr_attribute_self(scope, attr),
+            builtins::MSG => expr_attribute_msg(attr),
+            builtins::SELF => expr_attribute_self(scope, attr),
             _ => Err(SemanticError::undefined_value()),
         };
     }
@@ -219,7 +218,7 @@ fn expr_attribute(
 
 fn expr_attribute_msg(attr: &Spanned<&str>) -> Result<ExpressionAttributes, SemanticError> {
     match attr.node {
-        "sender" => Ok(ExpressionAttributes::new(
+        builtins::SENDER => Ok(ExpressionAttributes::new(
             Type::Base(Base::Address),
             Location::Value,
         )),
@@ -248,8 +247,8 @@ fn expr_bin_operation(
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::BinOperation { left, op: _, right } = &exp.node {
-        let left_attributes = expr_with_value_move(Rc::clone(&scope), Rc::clone(&context), left)?;
-        let right_attributes = expr_with_value_move(Rc::clone(&scope), Rc::clone(&context), right)?;
+        let left_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), left)?;
+        let right_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), right)?;
 
         validate_types_equal(&left_attributes, &right_attributes)?;
 
@@ -270,8 +269,7 @@ fn expr_unary_operation(
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::UnaryOperation { op, operand } = &exp.node {
         if let fe::UnaryOperator::USub = &op.node {
-            let operand_attributes =
-                expr_with_value_move(Rc::clone(&scope), Rc::clone(&context), operand)?;
+            let operand_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), operand)?;
 
             if !matches!(operand_attributes.typ, Type::Base(Base::Numeric(_))) {
                 return Err(SemanticError::type_error());
@@ -309,7 +307,7 @@ pub fn call_arg(
     match &arg.node {
         fe::CallArg::Arg(value) => {
             let spanned = spanned_expression(&arg.span, value);
-            let attributes = expr_with_default_move(scope, Rc::clone(&context), &spanned)?;
+            let attributes = assignable_expr(scope, Rc::clone(&context), &spanned)?;
 
             Ok(attributes)
         }
@@ -323,48 +321,33 @@ fn expr_call(
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Call { args, func } = &exp.node {
-        let argument_attributes: Vec<ExpressionAttributes> = args
-            .node
-            .iter()
-            // Side effect: Performs semantic analysis on each call arg and adds its attributes to
-            // the context
-            .map(|argument| call_arg(Rc::clone(&scope), Rc::clone(&context), argument))
-            .collect::<Result<_, _>>()?;
-
-        return match &func.node {
-            fe::Expr::Attribute { value, attr } => {
-                let value = expr_name_string(value)?;
-
-                if value == SELF {
-                    context.borrow_mut().add_call(
-                        exp,
-                        CallType::SelfFunction {
-                            name: attr.node.to_string(),
-                        },
-                    );
-                    expr_call_self(scope, context, attr, argument_attributes)
-                } else {
-                    Err(SemanticError::undefined_value())
-                }
+        return match expr_call_type(Rc::clone(&scope), Rc::clone(&context), func)? {
+            CallType::TypeConstructor { typ } => {
+                expr_call_type_constructor(scope, context, typ, args)
             }
-            fe::Expr::Name(name) => {
-                if argument_attributes.len() != 1 {
-                    return Err(SemanticError::type_error());
-                }
-
-                // Ensure something like u8(x) fails, only literals allowed e.g u8(1)
-                validate_is_numeric_literal(&args.node[0].node)?;
-
-                context
-                    .borrow_mut()
-                    .add_call(exp, CallType::TypeConstructor);
-                expr_type_constructor(scope, context, *name)
+            CallType::SelfAttribute { func_name } => {
+                expr_call_self_attribute(scope, context, func_name, args)
             }
-            _ => Err(SemanticError::not_callable()),
+            CallType::ValueAttribute => expr_call_value_attribute(scope, context, func, args),
         };
     }
 
     unreachable!()
+}
+
+fn expr_call_type_constructor(
+    scope: Shared<BlockScope>,
+    context: Shared<Context>,
+    typ: Type,
+    args: &Spanned<Vec<Spanned<fe::CallArg>>>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    if args.node.len() != 1 {
+        return Err(SemanticError::wrong_number_of_params());
+    }
+
+    validate_is_numeric_literal(&args.node[0].node)?;
+    call_arg(scope, context, &args.node[0])?;
+    Ok(ExpressionAttributes::new(typ, Location::Value))
 }
 
 fn validate_is_numeric_literal(call_arg: &fe::CallArg) -> Result<(), SemanticError> {
@@ -382,62 +365,150 @@ fn validate_is_numeric_literal(call_arg: &fe::CallArg) -> Result<(), SemanticErr
     }
 }
 
-fn expr_call_self(
+fn expr_call_self_attribute(
     scope: Shared<BlockScope>,
-    _context: Shared<Context>,
-    func_name: &Spanned<&str>,
-    argument_attributes: Vec<ExpressionAttributes>,
+    context: Shared<Context>,
+    func_name: String,
+    args: &Spanned<Vec<Spanned<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    let contract_scope = &scope.borrow().contract_scope();
-    let called_func = contract_scope
+    if let Some(ContractFunctionDef {
+        is_public: _,
+        param_types,
+        return_type,
+        scope: _,
+    }) = scope
         .borrow()
-        .function_def(func_name.node.to_string());
+        .contract_scope()
+        .borrow()
+        .function_def(func_name)
+    {
+        let argument_attributes = args
+            .node
+            .iter()
+            .map(|arg| call_arg(Rc::clone(&scope), Rc::clone(&context), arg))
+            .collect::<Result<Vec<_>, _>>()?;
 
-    match called_func {
-        Some(ContractFunctionDef {
-            is_public: _,
-            param_types,
-            return_type,
-            scope: _,
-        }) => {
-            if fixed_sizes_to_types(param_types)
-                != expression_attributes_to_types(argument_attributes)
-            {
-                return Err(SemanticError::type_error());
-            }
-
-            Ok(ExpressionAttributes::new(
-                return_type.into(),
-                Location::Value,
-            ))
+        if fixed_sizes_to_types(param_types) != expression_attributes_to_types(argument_attributes)
+        {
+            return Err(SemanticError::type_error());
         }
-        None => Err(SemanticError::undefined_value()),
+
+        let return_location = match &return_type {
+            FixedSize::Base(_) => Location::Value,
+            _ => Location::Memory,
+        };
+        Ok(ExpressionAttributes::new(
+            return_type.into(),
+            return_location,
+        ))
+    } else {
+        Err(SemanticError::undefined_value())
     }
 }
 
-fn expr_type_constructor(
+fn expr_call_value_attribute(
+    scope: Shared<BlockScope>,
+    context: Shared<Context>,
+    func: &Spanned<fe::Expr>,
+    args: &Spanned<Vec<Spanned<fe::CallArg>>>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    if let fe::Expr::Attribute { value, attr } = &func.node {
+        let value_attributes = expr(scope, context, value)?;
+
+        // for now all of these function expect 0 arguments
+        if !args.node.is_empty() {
+            return Err(SemanticError::wrong_number_of_params());
+        }
+
+        return match attr.node {
+            builtins::CLONE => value_attributes.into_cloned(),
+            builtins::TO_MEM => value_attributes.into_cloned_from_sto(),
+            _ => Err(SemanticError::undefined_value()),
+        };
+    }
+
+    unreachable!()
+}
+
+fn expr_call_type(
+    scope: Shared<BlockScope>,
+    context: Shared<Context>,
+    func: &Spanned<fe::Expr>,
+) -> Result<CallType, SemanticError> {
+    let call_type = match &func.node {
+        fe::Expr::Name(name) => expr_name_call_type(scope, Rc::clone(&context), name),
+        fe::Expr::Attribute { .. } => expr_attribute_call_type(scope, Rc::clone(&context), func),
+        _ => Err(SemanticError::not_callable()),
+    }?;
+
+    context.borrow_mut().add_call(func, call_type.clone());
+    Ok(call_type)
+}
+
+fn expr_name_call_type(
     _scope: Shared<BlockScope>,
     _context: Shared<Context>,
-    func_name: &str,
-) -> Result<ExpressionAttributes, SemanticError> {
-    let typ = match func_name {
-        "address" => Type::Base(Base::Address),
-        "u256" => Type::Base(Base::Numeric(Integer::U256)),
-        "u128" => Type::Base(Base::Numeric(Integer::U128)),
-        "u64" => Type::Base(Base::Numeric(Integer::U64)),
-        "u32" => Type::Base(Base::Numeric(Integer::U32)),
-        "u16" => Type::Base(Base::Numeric(Integer::U16)),
-        "u8" => Type::Base(Base::Numeric(Integer::U8)),
-        "i256" => Type::Base(Base::Numeric(Integer::I256)),
-        "i128" => Type::Base(Base::Numeric(Integer::I128)),
-        "i64" => Type::Base(Base::Numeric(Integer::I64)),
-        "i32" => Type::Base(Base::Numeric(Integer::I32)),
-        "i16" => Type::Base(Base::Numeric(Integer::I16)),
-        "i8" => Type::Base(Base::Numeric(Integer::I8)),
-        _ => return Err(SemanticError::undefined_value()),
-    };
+    name: &str,
+) -> Result<CallType, SemanticError> {
+    match name {
+        "address" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Address),
+        }),
+        "u256" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::U256)),
+        }),
+        "u128" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::U128)),
+        }),
+        "u64" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::U64)),
+        }),
+        "u32" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::U32)),
+        }),
+        "u16" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::U16)),
+        }),
+        "u8" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::U8)),
+        }),
+        "i256" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::I256)),
+        }),
+        "i128" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::I128)),
+        }),
+        "i64" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::I64)),
+        }),
+        "i32" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::I32)),
+        }),
+        "i16" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::I16)),
+        }),
+        "i8" => Ok(CallType::TypeConstructor {
+            typ: Type::Base(Base::Numeric(Integer::I8)),
+        }),
+        _ => Err(SemanticError::undefined_value()),
+    }
+}
 
-    Ok(ExpressionAttributes::new(typ, Location::Value))
+fn expr_attribute_call_type(
+    _scope: Shared<BlockScope>,
+    _context: Shared<Context>,
+    exp: &Spanned<fe::Expr>,
+) -> Result<CallType, SemanticError> {
+    if let fe::Expr::Attribute { value, attr } = &exp.node {
+        return match value.node {
+            fe::Expr::Name(builtins::SELF) => Ok(CallType::SelfAttribute {
+                func_name: attr.node.to_string(),
+            }),
+            _ => Ok(CallType::ValueAttribute),
+        };
+    }
+
+    unreachable!()
 }
 
 fn expr_comp_operation(
@@ -447,8 +518,8 @@ fn expr_comp_operation(
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::CompOperation { left, op: _, right } = &exp.node {
         // comparison operands should be moved to the stack
-        let left_attributes = expr_with_value_move(Rc::clone(&scope), Rc::clone(&context), left)?;
-        let right_attributes = expr_with_value_move(Rc::clone(&scope), Rc::clone(&context), right)?;
+        let left_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), left)?;
+        let right_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), right)?;
 
         validate_types_equal(&left_attributes, &right_attributes)?;
 
@@ -474,16 +545,15 @@ fn expr_ternary(
     } = &exp.node
     {
         // test attributes should be stored as a value
-        let test_attributes = expr_with_value_move(Rc::clone(&scope), Rc::clone(&context), test)?;
+        let test_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), test)?;
         // the return expressions should be stored in their default locations
         //
         // If, for example, one of the expressions is stored in memory and the other is
         // stored in storage, it's necessary that we move them to the same location.
         // This could be memory or the stack, depending on the type.
-        let if_expr_attributes =
-            expr_with_default_move(Rc::clone(&scope), Rc::clone(&context), if_expr)?;
+        let if_expr_attributes = assignable_expr(Rc::clone(&scope), Rc::clone(&context), if_expr)?;
         let else_expr_attributes =
-            expr_with_default_move(Rc::clone(&scope), Rc::clone(&context), else_expr)?;
+            assignable_expr(Rc::clone(&scope), Rc::clone(&context), else_expr)?;
 
         // Make sure the `test_attributes` is a boolean type.
         if Type::Base(Base::Bool) == test_attributes.typ {

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -352,8 +352,7 @@ fn call_arg(
     match &arg.node {
         fe::CallArg::Arg(value) => {
             let spanned = spanned_expression(&arg.span, value);
-            let _attributes =
-                expressions::expr_with_default_move(scope, Rc::clone(&context), &spanned)?;
+            let _attributes = expressions::assignable_expr(scope, Rc::clone(&context), &spanned)?;
 
             // TODO: Perform type checking
         }
@@ -373,7 +372,7 @@ fn func_return(
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Return { value: Some(value) } = &stmt.node {
         let attributes =
-            expressions::expr_with_default_move(Rc::clone(&scope), Rc::clone(&context), value)?;
+            expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), value)?;
 
         let host_func_def = scope
             .borrow()

--- a/semantics/tests/analysis.rs
+++ b/semantics/tests/analysis.rs
@@ -21,6 +21,16 @@ fn addr_val() -> ExpressionAttributes {
     ExpressionAttributes::new(Type::Base(Base::Address), Location::Value)
 }
 
+fn bytes_sto() -> ExpressionAttributes {
+    ExpressionAttributes::new(
+        Type::Array(Array {
+            dimension: 100,
+            inner: Base::Byte,
+        }),
+        Location::Storage { nonce: None },
+    )
+}
+
 fn bytes_sto_moved() -> ExpressionAttributes {
     let mut expression = ExpressionAttributes::new(
         Type::Array(Array {
@@ -88,7 +98,8 @@ fn guest_book_analysis() {
         (210, 218, &bytes_mem()),
         (249, 257, &bytes_mem()),
         (322, 337, &addr_bytes_map_sto()),
-        (322, 343, &bytes_sto_moved()),
+        (322, 343, &bytes_sto()),
+        (322, 352, &bytes_sto_moved()),
         (338, 342, &addr_val()),
     ] {
         assert_eq!(

--- a/semantics/tests/fixtures/guest_book.fe
+++ b/semantics/tests/fixtures/guest_book.fe
@@ -12,4 +12,4 @@ contract GuestBook:
         emit Signed(book_msg=book_msg)
 
     pub def get_msg(addr: address) -> BookMsg:
-        return self.guest_book[addr]
+        return self.guest_book[addr].to_mem()


### PR DESCRIPTION
### What was wrong?

closes #152 

- we didn't have operations for copying storage -> storage or memory -> memory
- the existing naming scheme for these operations was a bit confusing (e.g. `scopy` for storage -> memory copying)
- copy operations were going byte-by-byte, which is extremely inefficient

### How was it fixed?

- implemented said copying operations and used them in the relevant places (assignments and expression moves)
- updated the existing operations with a cleaner naming scheme
- copying now happens word-by-word

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Clean up commit history
