### PR TITLE
Support emitting ABI via --emit abi

### DIFF
--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -62,9 +62,12 @@ impl Contract {
 
 impl Contract {
     /// Serialize the contract into a valid JSON ABI.
-    pub fn json(&self) -> Result<String, CompileError> {
-        serde_json::to_string(self)
-            .map_err(|_| CompileError::static_str("unable to serialize contract to json"))
+    pub fn json(&self, prettify: bool) -> Result<String, CompileError> {
+        match prettify {
+            true => serde_json::to_string_pretty(self),
+            false => serde_json::to_string(self),
+        }
+        .map_err(|_| CompileError::static_str("unable to serialize contract to json"))
     }
 }
 
@@ -299,7 +302,7 @@ mod tests {
         };
 
         assert_eq!(
-            contract.json().unwrap(),
+            contract.json(false).unwrap(),
             r#"[
                 {
                     "name":"event_name",

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -174,7 +174,7 @@ fn deploy_contract(
     let json_abi = compiler::abi::build(&src)
         .expect("Unable to build the module ABIs")
         .contracts[name]
-        .json()
+        .json(false)
         .expect("Unable to serialize the contract ABI.");
 
     let abi = ethabi::Contract::load(StringReader::new(&json_abi)).expect("Unable to load the ABI");

--- a/newsfragments/160.feature.md
+++ b/newsfragments/160.feature.md
@@ -1,0 +1,1 @@
+Support emitting JSON ABI via `--emit abi`.

--- a/newsfragments/160.feature.md
+++ b/newsfragments/160.feature.md
@@ -1,1 +1,2 @@
 Support emitting JSON ABI via `--emit abi`.
+The default value of `--emit` is now `abi,bytecode`.

--- a/src/main_full.rs
+++ b/src/main_full.rs
@@ -1,8 +1,6 @@
 use std::fs;
 use std::io::{
     Error,
-    ErrorKind,
-    Result,
     Write,
 };
 use std::path::Path;
@@ -74,69 +72,82 @@ pub fn main() {
     }
 }
 
-fn verify_nonexistent_or_empty(dir: &Path) -> Result<()> {
-    if !dir.exists() || dir.read_dir()?.next().is_none() {
+fn verify_nonexistent_or_empty(dir: &Path) -> Result<(), String> {
+    if !dir.exists() || dir.read_dir().map_err(ioerr_to_string)?.next().is_none() {
         Ok(())
     } else {
-        Err(Error::new(
-            ErrorKind::Other,
-            format!("Directory '{}' is not empty", dir.display()),
-        ))
+        Err(format!("Directory '{}' is not empty", dir.display()))
     }
 }
 
-fn compile(src_file: &str, output_dir: &str, targets: Vec<CompilationTarget>) -> Result<()> {
+fn compile(
+    src_file: &str,
+    output_dir: &str,
+    targets: Vec<CompilationTarget>,
+) -> Result<(), String> {
     let output_dir = Path::new(output_dir);
 
     verify_nonexistent_or_empty(output_dir)?;
-    std::fs::create_dir_all(output_dir)?;
+    std::fs::create_dir_all(output_dir).map_err(ioerr_to_string)?;
 
-    let contents = fs::read_to_string(src_file)?;
+    let contents = fs::read_to_string(src_file).map_err(ioerr_to_string)?;
 
     let output = fe_compiler::evm::compile(&contents, to_compile_stage(&targets))
-        .map_err(|e| Error::new(ErrorKind::Other, format!("{}", e)))?;
+        .map_err(|e| e.to_string())?;
 
     for target in targets {
         match target {
             CompilationTarget::Abi => {
-                let module_abi = fe_compiler::abi::build(&contents).map_err(|e| {
-                    Error::new(
-                        ErrorKind::Other,
-                        format!("Unable to build the module ABIs: {}", e),
-                    )
-                })?;
+                let module_abi = fe_compiler::abi::build(&contents)
+                    .map_err(|e| format!("Unable to build the module ABIs: {}", e))?;
                 for (contract_name, contract_abi) in module_abi.contracts.iter() {
-                    let json = contract_abi.json(true).map_err(|e| {
-                        Error::new(
-                            ErrorKind::Other,
-                            format!("Unable to serialize the contract ABI: {}", e),
-                        )
-                    })?;
+                    let json = contract_abi
+                        .json(true)
+                        .map_err(|e| format!("Unable to serialize the contract ABI: {}", e))?;
                     let file_name = format!("out.{}.abi", contract_name).to_lowercase();
-                    let mut file_abi = fs::File::create(output_dir.join(file_name))?;
-                    file_abi.write_all(json.as_bytes())?;
+                    let mut file_abi =
+                        fs::File::create(output_dir.join(file_name)).map_err(ioerr_to_string)?;
+                    file_abi
+                        .write_all(json.as_bytes())
+                        .map_err(ioerr_to_string)?;
                 }
             }
             CompilationTarget::Ast => {
-                let mut file_ast = fs::File::create(output_dir.join("out.ast"))?;
-                file_ast.write_all(output.ast.as_bytes())?;
+                let mut file_ast =
+                    fs::File::create(output_dir.join("out.ast")).map_err(ioerr_to_string)?;
+                file_ast
+                    .write_all(output.ast.as_bytes())
+                    .map_err(ioerr_to_string)?;
             }
             CompilationTarget::Bytecode => {
-                let mut file_bytecode = fs::File::create(output_dir.join("out.bin"))?;
-                file_bytecode.write_all(output.bytecode.as_bytes())?;
+                let mut file_bytecode =
+                    fs::File::create(output_dir.join("out.bin")).map_err(ioerr_to_string)?;
+                file_bytecode
+                    .write_all(output.bytecode.as_bytes())
+                    .map_err(ioerr_to_string)?;
             }
             CompilationTarget::Tokens => {
-                let mut file_tokens = fs::File::create(output_dir.join("out.tokens"))?;
-                file_tokens.write_all(output.tokens.as_bytes())?;
+                let mut file_tokens =
+                    fs::File::create(output_dir.join("out.tokens")).map_err(ioerr_to_string)?;
+                file_tokens
+                    .write_all(output.tokens.as_bytes())
+                    .map_err(ioerr_to_string)?;
             }
             CompilationTarget::Yul => {
-                let mut file_yul = fs::File::create(output_dir.join("out.yul"))?;
-                file_yul.write_all(pretty_curly_print(&output.yul, 4).as_bytes())?;
+                let mut file_yul =
+                    fs::File::create(output_dir.join("out.yul")).map_err(ioerr_to_string)?;
+                file_yul
+                    .write_all(pretty_curly_print(&output.yul, 4).as_bytes())
+                    .map_err(ioerr_to_string)?;
             }
         }
     }
 
     Ok(())
+}
+
+fn ioerr_to_string(error: Error) -> String {
+    format!("{}", error)
 }
 
 fn to_compile_stage(targets: &[CompilationTarget]) -> CompileStage {

--- a/src/main_full.rs
+++ b/src/main_full.rs
@@ -51,7 +51,7 @@ pub fn main() {
                 .short("e")
                 .long("emit")
                 .help("Comma seperated compile targets e.g. -e=bytecode,yul")
-                .default_value("bytecode")
+                .default_value("abi,bytecode")
                 .use_delimiter(true)
                 .takes_value(true),
         )


### PR DESCRIPTION
### What was wrong?

We do currently not support emitting the contract ABI. Emitting the contract ABI is crucial in order to interact with a contract.

### How was it fixed?

- Added support to emit the ABI via `--emit abi`
- Changed ABI API to allow prettyfying
- Cleaned up error handling
- Made `abi,bytecode` the default value for `--emit`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
