### PR TITLE
Ensure integer type constructor reject anything but numeric literals

### DIFF
--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -24,7 +24,8 @@ use std::fs;
     case("return_addition_with_mixed_types.fe", "TypeError"),
     case("return_lt_mixed_types.fe", "TypeError"),
     case("indexed_event.fe", "MoreThanThreeIndexedParams"),
-    case("unary_minus_on_bool.fe", "TypeError")
+    case("unary_minus_on_bool.fe", "TypeError"),
+    case("type_constructor_from_variable.fe", "NumericLiteralExpected")
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -31,7 +31,10 @@ fn test_compile_errors(fixture_file: &str, expected_error: &str) {
         .expect("Unable to read fixture file");
 
     match fe_compiler::evm::compile(&src, CompileStage::AllUpToBytecode) {
-        Err(compile_error) => assert!(format!("{}", compile_error).contains(expected_error)),
+        Err(compile_error) => assert!(
+            format!("{}", compile_error).contains(expected_error),
+            format!("{} did not contain {}", compile_error, expected_error)
+        ),
         _ => panic!(
             "Compiling succeeded when it was expected to fail with: {}",
             expected_error

--- a/compiler/tests/fixtures/compile_errors/type_constructor_from_variable.fe
+++ b/compiler/tests/fixtures/compile_errors/type_constructor_from_variable.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar(val: u8) -> u16:
+        return u16(val)

--- a/newsfragments/163.feature.md
+++ b/newsfragments/163.feature.md
@@ -1,0 +1,9 @@
+Ensure integer type constructor reject all expressions that aren't a numeric literal.
+For instance, previously the compiler would not reject the following code even though it could not be guaranteed that `val` would fit into an `u16`.
+
+```
+pub def bar(val: u8) -> u16:
+        return u16(val)
+```
+
+Now such code is rejected and integer type constructor do only work with numeric literals such as `1` or `-3`.

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -15,6 +15,7 @@ pub enum ErrorKind {
     TypeError,
     CannotMove,
     NotCallable,
+    NumericLiteralExpected,
     MoreThanThreeIndexedParams,
 }
 
@@ -95,6 +96,14 @@ impl SemanticError {
     pub fn not_callable() -> Self {
         SemanticError {
             kind: ErrorKind::NotCallable,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `NumericLiteralExpected`
+    pub fn numeric_literal_expected() -> Self {
+        SemanticError {
+            kind: ErrorKind::NumericLiteralExpected,
             context: vec![],
         }
     }


### PR DESCRIPTION
### What was wrong?

Currently, our integer type constructor are too permissive. E.g. the following is allowed today even though it isn't guaranteed that `val` will fit into the `u16)`

```
    pub def bar(val: u8) -> u16:
        return u16(val)

```

I believe that our integer type constructor should simply not allow being used with anything other than a numeric literal such as `1` or `-3`.

Numeric literals can be checked on compile time whereas arbitrary variables can't. 

### How was it fixed?

- Added a function `validate_is_numeric_literal` and used it inside `expr_call` to validate
- Added a new error type `NumericLiteralExpected`
- Added a test to prove bad code is rejected.

Notice that this does not yet entail #145 but it is paving the way for it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
