### PR TITLE
Update clippy command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ docker-wasm-test:
 
 .PHONY: clippy
 clippy:
-	cargo clippy-preview -Z unstable-options --workspace
+	cargo clippy --all-targets --all-features -- -D warnings
 
 .PHONY: rustfmt
 rustfmt:


### PR DESCRIPTION
### What was wrong?

The clippy command in the make file was outdated.

### How was it fixed?

Updated so that now one can run `make lint` locally as a simple shortcut to the same checks that run in CI.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
