### PR TITLE
Updated solc to v0.8.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,8 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get install -y libboost-all-dev
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
+        sudo update-alternatives --set g++ "/usr/bin/g++-8"
     - uses: actions/checkout@v2
     - name: Cache Rust dependencies
       uses: actions/cache@v1.1.2
@@ -104,6 +106,8 @@ jobs:
       if: startsWith(matrix.os,'ubuntu')
       run: |
         sudo apt-get install -y libboost-all-dev
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
+        sudo update-alternatives --set g++ "/usr/bin/g++-8"
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
@@ -145,6 +149,8 @@ jobs:
           if: startsWith(matrix.os,'ubuntu')
           run: |
             sudo apt-get install -y libboost-all-dev
+            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
+            sudo update-alternatives --set g++ "/usr/bin/g++-8"
         - name: Install latest nightly
           uses: actions-rs/toolchain@v1
           with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,16 +79,15 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
-version = "0.52.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c85344eb535a31b62f0af37be84441ba9e7f0f4111eb0530f43d15e513fe57"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.8.2",
  "lazy_static",
  "lazycell",
  "log",
@@ -221,7 +220,7 @@ dependencies = [
  "crates-index",
  "difflib",
  "dirs",
- "env_logger",
+ "env_logger 0.7.1",
  "ignore",
  "itertools",
  "log",
@@ -261,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cexpr"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
  "nom",
 ]
@@ -295,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "0.28.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",
@@ -473,7 +472,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+dependencies = [
+ "atty",
+ "humantime 2.0.1",
  "log",
  "regex",
  "termcolor",
@@ -688,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -795,6 +807,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "idna"
@@ -925,11 +943,11 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "e9367bdfa836b7e3cf895867f7a570283444da90562980ec2263d6e1569b16bc"
 dependencies = [
- "cc",
+ "cfg-if 1.0.0",
  "winapi",
 ]
 
@@ -994,12 +1012,12 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "nom"
-version = "4.2.3"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
- "version_check 0.1.5",
+ "version_check",
 ]
 
 [[package]]
@@ -1150,7 +1168,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1161,7 +1179,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -1483,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/spalladino/solc-rust?branch=feature/solc-0.6.2#26b002047a8c5090fa755aa7c01039655b8ec1bc"
+source = "git+https://github.com/g-r-a-n-t/solc-rust#6bdc0f8fee31500ead9d5cf6e4ee8b2210be9b69"
 dependencies = [
  "bindgen",
  "cmake",
@@ -1730,12 +1748,6 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -24,7 +24,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 stringreader = "0.1"
 # Optional
 # This fork supports concurrent compilation, which is required for Rust tests.
-solc = { git = "https://github.com/spalladino/solc-rust", branch = "feature/solc-0.6.2", optional = true }
+solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true }
 
 [dev-dependencies]
 evm-runtime = "0.18"

--- a/newsfragments/169.internal.md
+++ b/newsfragments/169.internal.md
@@ -1,0 +1,1 @@
+Updated the Solidity backend to v0.8.0.


### PR DESCRIPTION
### What was wrong?

We were using an older version of solc for Yul compilation.

### How was it fixed?

Went into solc-rust and updated the solidity submodule. There are still some things that I'd like to look into in solc-rust before opening a PR in that repo, so we're just using my personal fork for now.

Surprisingly, the solc-backend feature of the Fe compiler still works fine. I thought there would be atleast a couple breaking changes in libyul.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
