### PR TITLE
Fix assignments

### DIFF
--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -47,8 +47,7 @@ pub fn assign(
                         }
                         (Location::Memory, Location::Memory) => {
                             let target = expr_as_ident(target)?;
-                            let ptr = operations::mcopym(typ, value);
-                            statement! { [target] := [ptr] }
+                            statement! { [target] := [value] }
                         }
                         (Location::Storage { .. }, Location::Storage { .. }) => {
                             operations::scopys(typ, target, value)

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -1054,6 +1054,13 @@ fn data_copying_stress() {
 
         harness.test_function(
             &mut executor,
+            "multiple_references_shared_memory",
+            vec![my_array.clone()],
+            None,
+        );
+
+        harness.test_function(
+            &mut executor,
             "clone_and_return",
             vec![my_array.clone()],
             Some(my_array.clone()),

--- a/compiler/tests/fixtures/data_copying_stress.fe
+++ b/compiler/tests/fixtures/data_copying_stress.fe
@@ -26,6 +26,23 @@ contract Foo:
         self.my_string = self.my_other_string
         self.my_u256 = self.my_other_u256
 
+    pub def multiple_references_shared_memory(my_array: u256[10]):
+        my_2nd_array: u256[10]
+        my_3rd_array: u256[10]
+        my_2nd_array = my_array
+        my_3rd_array = my_2nd_array
+
+        assert my_array[3] != 5
+        my_array[3] = 5
+        assert my_array[3] == 5
+        assert my_2nd_array[3] == 5
+        assert my_3rd_array[3] == 5
+
+        my_3rd_array[3] = 50
+        assert my_array[3] == 50
+        assert my_2nd_array[3] == 50
+        assert my_3rd_array[3] == 50
+
     pub def mutate_and_return(my_array: u256[10]) -> u256[10]:
         my_array[3] = 5
         return my_array


### PR DESCRIPTION
### What was wrong?

Reference type assignments were being copied, when they should be assigning a shared reference.

### How was it fixed?

Removed the copy.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
