### PR TITLE
Add support for value assignment in declaration

### DIFF
--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -52,7 +52,7 @@ fn var_decl_base(
 }
 
 fn var_decl_array(
-    _context: &Context,
+    context: &Context,
     decl: &Spanned<fe::FuncStmt>,
     array: Array,
 ) -> Result<yul::Statement, CompileError> {
@@ -65,10 +65,12 @@ fn var_decl_array(
         let target = utils::var_name(expressions::expr_name_str(target)?);
         let size = literal_expression! { (array.size()) };
 
-        return Ok(if value.is_some() {
-            unimplemented!()
-        } else {
-            statement! { let [target] := alloc([size]) }
+        return Ok(match value {
+            Some(val) => {
+                let value_yul = expressions::expr(&context, val)?;
+                statement! { let [target] := [value_yul] }
+            }
+            None => statement! { let [target] := alloc([size]) },
         });
     }
 

--- a/compiler/tests/fixtures/data_copying_stress.fe
+++ b/compiler/tests/fixtures/data_copying_stress.fe
@@ -27,10 +27,8 @@ contract Foo:
         self.my_u256 = self.my_other_u256
 
     pub def multiple_references_shared_memory(my_array: u256[10]):
-        my_2nd_array: u256[10]
-        my_3rd_array: u256[10]
-        my_2nd_array = my_array
-        my_3rd_array = my_2nd_array
+        my_2nd_array: u256[10] = my_array
+        my_3rd_array: u256[10] = my_2nd_array
 
         assert my_array[3] != 5
         my_array[3] = 5

--- a/newsfragments/173.feature.md
+++ b/newsfragments/173.feature.md
@@ -1,0 +1,16 @@
+Support for value assignments in declaration.
+
+Previously, this code would fail:
+
+```
+another_reference: u256[10] = my_array
+```
+
+As a workaround declaration and assignment could be split apart.
+
+```
+another_reference: u256[10]
+another_reference =  = my_array
+```
+
+With this change, the shorter declaration with assignment syntax is supported.


### PR DESCRIPTION
### What was wrong?

Previously, this code would fail:

```
another_reference: u256[10] = my_array
```

As a workaround declaration and assignment could be split apart.

```
another_reference: u256[10]
another_reference =  = my_array

```
With this change, the shorter declaration with assignment syntax is supported.

### How was it fixed?

- Added implementation to map value assignments in declarations
- Rewrote test code that used workaround


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
