### PR TITLE
Refactor away to_fixed_size method

### DIFF
--- a/semantics/src/namespace/types.rs
+++ b/semantics/src/namespace/types.rs
@@ -490,12 +490,6 @@ impl AbiEncoding for Array {
     }
 }
 
-impl Array {
-    pub fn to_fixed_size(&self) -> FixedSize {
-        FixedSize::Array(self.clone())
-    }
-}
-
 impl Tuple {
     pub fn empty() -> Tuple {
         Tuple { items: vec![] }
@@ -504,9 +498,11 @@ impl Tuple {
     pub fn is_empty(&self) -> bool {
         self.size() == 0
     }
+}
 
-    pub fn to_fixed_size(&self) -> FixedSize {
-        FixedSize::Tuple(self.clone())
+impl From<Tuple> for FixedSize {
+    fn from(value: Tuple) -> Self {
+        FixedSize::Tuple(value)
     }
 }
 

--- a/semantics/src/traversal/functions.rs
+++ b/semantics/src/traversal/functions.rs
@@ -55,7 +55,7 @@ pub fn func_def(
             .as_ref()
             .map(|typ| types::type_desc_fixed_size(Scope::Block(Rc::clone(&function_scope)), &typ))
             .transpose()?
-            .unwrap_or_else(|| Tuple::empty().to_fixed_size());
+            .unwrap_or_else(|| Tuple::empty().into());
 
         let is_public = qual.is_some();
         contract_scope.borrow_mut().add_function(


### PR DESCRIPTION
Tiny refeactoring to get rid of `to_fixed_size` and implement the more common `From<T>` trait instead.
