### PR TITLE
Run CI tests on Mac too and create Mac binaries on releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,8 +86,7 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-        # Ignoring Mac until we find a solution to: https://github.com/ethereum/fe/pull/106/checks?check_run_id=1322145918
-        # - os: macOS-latest
+        - os: macOS-latest
     steps:
     - uses: actions/checkout@v2
     - name: Cache Rust dependencies
@@ -141,7 +140,11 @@ jobs:
       needs: [lint, test, wasm-test]
       strategy:
         matrix:
-          os: [ubuntu-latest]
+          include:
+          - os: ubuntu-latest
+            BIN_FILE: fe_amd64
+          - os: macOS-latest
+            BIN_FILE: fe_mac
 
       steps:
         - uses: actions/checkout@v2
@@ -151,6 +154,10 @@ jobs:
             sudo apt-get install -y libboost-all-dev
             sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
             sudo update-alternatives --set g++ "/usr/bin/g++-8"
+        - name: Install Mac System dependencies
+          if: startsWith(matrix.os,'macOS')
+          run: |
+            brew install boost
         - name: Install latest nightly
           uses: actions-rs/toolchain@v1
           with:
@@ -158,11 +165,11 @@ jobs:
             toolchain: nightly
             override: true
         - name: Build
-          run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/fe_amd64
+          run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}
         - name: Release
           uses: softprops/action-gh-release@v1
           with:
-            files: target/release/fe_amd64
+            files: target/release/${{ matrix.BIN_FILE }}
             prerelease: true
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/newsfragments/178.internal.md
+++ b/newsfragments/178.internal.md
@@ -1,0 +1,1 @@
+Run CI tests on Mac and support creating Mac binaries for releases.


### PR DESCRIPTION
### What was wrong?

We currently do not test on Mac and don't produce Mac binaries on releases.

### How was it fixed?

- Re-enabled running tests on Mac
- Changed release job to also build and upload Mac binary

### To-Do

- [x] I have a [Mac binary created for a test release](https://github.com/cburgdorf/fe/releases/tag/v_test_2) but I still need to verify that it's actually working

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
