### PR TITLE
Christoph/feat/static strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,12 +611,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fe-common"
+version = "0.1.0-alpha"
+dependencies = [
+ "hex",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
 name = "fe-compiler"
 version = "0.1.0-alpha"
 dependencies = [
  "ethabi",
  "evm",
  "evm-runtime",
+ "fe-common",
  "fe-parser",
  "fe-semantics",
  "hex",
@@ -627,7 +636,6 @@ dependencies = [
  "serde_json",
  "solc",
  "stringreader",
- "tiny-keccak 2.0.2",
  "yultsur",
 ]
 
@@ -649,6 +657,7 @@ name = "fe-semantics"
 version = "0.1.0-alpha"
 dependencies = [
  "ansi_term 0.12.1",
+ "fe-common",
  "fe-parser",
  "hex",
  "num-bigint",
@@ -1927,4 +1936,4 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "yultsur"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/yultsur#ab0c49099d06722e09bd1003a95ae56f1ffe3757"
+source = "git+https://github.com/g-r-a-n-t/yultsur#4db24c750ebfd5890c59ff111b4c6af3d4fefa56"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fe-semantics"
+name = "fe-common"
 version = "0.1.0-alpha"
 authors = ["Ethereum Foundation <snakecharmers@ethereum.org>"]
 edition = "2018"
@@ -7,10 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe-common = {path = "../common", version = "^0.1.0-alpha"}
-fe-parser = {path = "../parser", version = "^0.1.0-alpha"}
-rstest = "0.6.4"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 hex = "0.4"
-ansi_term = "0.12.1"
-num-bigint = "0.3.1"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod utils;

--- a/common/src/utils/keccak.rs
+++ b/common/src/utils/keccak.rs
@@ -1,0 +1,18 @@
+use tiny_keccak::{
+    Hasher,
+    Keccak,
+};
+
+pub fn get_full_signature(content: &[u8]) -> String {
+    get_partial_signature(content, 32)
+}
+
+pub fn get_partial_signature(content: &[u8], size: usize) -> String {
+    let mut keccak = Keccak::v256();
+    let mut selector = [0u8; 32];
+
+    keccak.update(content);
+    keccak.finalize(&mut selector);
+
+    format!("0x{}", hex::encode(&selector[0..size]))
+}

--- a/common/src/utils/mod.rs
+++ b/common/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod keccak;

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -12,15 +12,15 @@ description = "Compiler lib for the Fe language."
 solc-backend = ["solc"]
 
 [dependencies]
+fe-common = {path = "../common", version = "^0.1.0-alpha"}
 fe-parser = {path = "../parser", version = "^0.1.0-alpha"}
 fe-semantics = {path = "../semantics", version = "^0.1.0-alpha"}
 serde_json = "1.0"
 serde = "1.0"
 hex = "0.4"
 # This fork contains the shorthand macros and some other necessary updates.
-yultsur = { git = "https://github.com/g-r-a-n-t/yultsur" }
+yultsur = { git = "https://github.com/g-r-a-n-t/yultsur"}
 ethabi = "12.0"
-tiny-keccak = { version = "2.0", features = ["keccak"] }
 stringreader = "0.1"
 # Optional
 # This fork supports concurrent compilation, which is required for Rust tests.

--- a/compiler/src/abi/utils.rs
+++ b/compiler/src/abi/utils.rs
@@ -1,27 +1,17 @@
-use tiny_keccak::{
-    Hasher,
-    Keccak,
-};
+use fe_common::utils::keccak::get_partial_signature;
 
 /// Formats the name and fields and calculates the 32 byte keccak256 value of
 /// the signature.
 pub fn event_topic(name: String, fields: Vec<String>) -> String {
-    sig_keccak256(name, fields, 32)
+    sign_event_or_func(name, fields, 32)
 }
 /// Formats the name and params and calculates the 4 byte keccak256 value of the
 /// signature.
 pub fn func_selector(name: String, params: Vec<String>) -> String {
-    sig_keccak256(name, params, 4)
+    sign_event_or_func(name, params, 4)
 }
 
-fn sig_keccak256(name: String, params: Vec<String>, size: usize) -> String {
+fn sign_event_or_func(name: String, params: Vec<String>, size: usize) -> String {
     let signature = format!("{}({})", name, params.join(","));
-
-    let mut keccak = Keccak::v256();
-    let mut selector = [0u8; 32];
-
-    keccak.update(signature.as_bytes());
-    keccak.finalize(&mut selector);
-
-    format!("0x{}", hex::encode(&selector[0..size]))
+    get_partial_signature(signature.as_bytes(), size)
 }

--- a/compiler/src/yul/runtime/functions/data.rs
+++ b/compiler/src/yul/runtime/functions/data.rs
@@ -50,6 +50,18 @@ pub fn ccopym() -> yul::Statement {
     }
 }
 
+/// Load a static string from data into a newly allocated segment of memory.
+pub fn load_data_string() -> yul::Statement {
+    function_definition! {
+        function load_data_string(code_ptr, size) -> mptr {
+            (mptr := alloc(32))
+            (mstore(mptr, size))
+            (let content_ptr := alloc(size))
+            (datacopy(content_ptr, code_ptr, size))
+        }
+    }
+}
+
 /// Copy memory to a given segment of storage.
 pub fn mcopys() -> yul::Statement {
     function_definition! {

--- a/compiler/src/yul/runtime/functions/mod.rs
+++ b/compiler/src/yul/runtime/functions/mod.rs
@@ -12,6 +12,7 @@ pub fn std() -> Vec<yul::Statement> {
         data::alloc_mstoren(),
         data::free(),
         data::ccopym(),
+        data::load_data_string(),
         data::mcopys(),
         data::scopym(),
         data::mcopym(),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -749,6 +749,13 @@ fn strings() {
             Some(string_token("string 5")),
         );
 
+        harness.test_function(
+            &mut executor,
+            "return_static_string",
+            vec![],
+            Some(string_token("The quick brown fox jumps over the lazy dog")),
+        );
+
         harness.events_emitted(
             executor,
             vec![(
@@ -759,6 +766,7 @@ fn strings() {
                     string_token("string 1"),
                     string_token("string 3"),
                     address_token("1000000000000000000000000000000000000001"),
+                    string_token("static string"),
                 ],
             )],
         );

--- a/compiler/tests/fixtures/strings.fe
+++ b/compiler/tests/fixtures/strings.fe
@@ -5,9 +5,13 @@ contract Foo:
         s1: string42
         s3: string100
         a: address
+        s4: string13
 
     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-        emit MyEvent(s2, u, s1, s3, a)
+        emit MyEvent(s2, u, s1, s3, a, "static string")
 
     pub def bar(s1: string100, s2: string100) -> string100:
         return s2
+
+    pub def return_static_string() -> string43:
+        return "The quick brown fox jumps over the lazy dog"

--- a/newsfragments/186.feature.md
+++ b/newsfragments/186.feature.md
@@ -1,0 +1,11 @@
+Add support for string literals.
+
+Example:
+
+```
+def get_ticker_symbol() -> string3:
+    return "ETH"
+```
+
+String literals are stored in and loaded from the compiled bytecode.
+

--- a/parser/src/parsers.rs
+++ b/parser/src/parsers.rs
@@ -1449,7 +1449,13 @@ pub fn atom(input: Cursor) -> ParseResult<Spanned<Expr>> {
             span: tok.span,
         }),
         map(many1(string_token), |toks| {
-            let tok_strings: Vec<_> = toks.iter().map(|t| t.string).collect();
+            let tok_strings: Vec<_> = toks
+                .iter()
+                .map(|t| {
+                    // We don't want to carry quotes around strings past the parsing stage
+                    &t.string[1..t.string.len() - 1]
+                })
+                .collect();
 
             let fst = toks.first().unwrap();
             let snd = toks.last().unwrap();

--- a/parser/tests/fixtures/parsers/atom.ron
+++ b/parser/tests/fixtures/parsers/atom.ron
@@ -48,8 +48,8 @@ x
   ),
   Spanned(
     node: Str([
-      "\"asdf\"",
-      "\"foo\"",
+      "asdf",
+      "foo",
     ]),
     span: Span(
       start: 14,

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -67,6 +67,8 @@ pub struct ContractAttributes {
     pub init_function: Option<FunctionAttributes>,
     /// Events that have been defined by the user.
     pub events: Vec<Event>,
+    /// Static strings that the contract defines
+    pub string_literals: Vec<String>,
 }
 
 impl From<Ref<'_, ContractScope>> for ContractAttributes {
@@ -102,6 +104,7 @@ impl From<Ref<'_, ContractScope>> for ContractAttributes {
                 .values()
                 .map(|event| event.to_owned())
                 .collect::<Vec<Event>>(),
+            string_literals: scope.string_defs.clone(),
         }
     }
 }

--- a/semantics/src/namespace/events.rs
+++ b/semantics/src/namespace/events.rs
@@ -2,10 +2,7 @@ use crate::namespace::types::{
     AbiEncoding,
     FixedSize,
 };
-use tiny_keccak::{
-    Hasher,
-    Keccak,
-};
+use fe_common::utils::keccak::get_full_signature;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Event {
@@ -59,19 +56,8 @@ impl Event {
 }
 
 fn build_event_topic(name: String, fields: Vec<String>) -> String {
-    sig_keccak256(name, fields, 32)
-}
-
-fn sig_keccak256(name: String, params: Vec<String>, size: usize) -> String {
-    let signature = format!("{}({})", name, params.join(","));
-
-    let mut keccak = Keccak::v256();
-    let mut selector = [0u8; 32];
-
-    keccak.update(signature.as_bytes());
-    keccak.finalize(&mut selector);
-
-    format!("0x{}", hex::encode(&selector[0..size]))
+    let signature = format!("{}({})", name, fields.join(","));
+    get_full_signature(signature.as_bytes())
 }
 
 #[cfg(test)]

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -35,6 +35,7 @@ pub struct ContractScope {
     pub event_defs: HashMap<String, Event>,
     pub field_defs: HashMap<String, ContractFieldDef>,
     pub function_defs: HashMap<String, ContractFunctionDef>,
+    pub string_defs: Vec<String>,
     num_fields: usize,
 }
 
@@ -96,6 +97,7 @@ impl ContractScope {
             function_defs: HashMap::new(),
             event_defs: HashMap::new(),
             field_defs: HashMap::new(),
+            string_defs: vec![],
             interface: vec![],
             num_fields: 0,
         }))
@@ -153,6 +155,11 @@ impl ContractScope {
     /// Add an event definition to the scope.
     pub fn add_event(&mut self, name: String, event: Event) {
         self.event_defs.insert(name, event);
+    }
+
+    /// Add a static string definition to the scope.
+    pub fn add_string(&mut self, value: String) {
+        self.string_defs.push(value);
     }
 }
 


### PR DESCRIPTION
### What was wrong?

As described in #186 we need to support string literals.

### How was it fixed?

1. The parser was changed to not carry the quotes into the `Str` object (e.g. `Str(["foo", "bar"])` instead of `Str(["\"foo\"", "\"bar\""])`
2. Traversal path turns string literals into the string type that has the same max size as the length of the string (e.g. "foo" becomes `string3`)
3. Similar to how bookmarking for events happens, strings are then added to the contract scope to be carried forward to the `ContractAttributes` to be later mapped into YUL `data` objects.
4. Added a new runtime function `load_data_string` that deals with pulling these strings out of the `data` section of the YUL.
5. Mapper calls `load_data_string` using the keccak of the string content as identifier
6. Did a bit of refactoring / DRYing by introducing a `fe-common` library that is meant to hold very generic code that can be cross used from all other parts of the code base (such as getting keccak hashes over some bytes)

## Known issues

1. Going through the scope feels like an unpleasant indirection. We might want to explore other options.

2. Something like `val: string100 = "foo"` isn't yet allowed because `"foo"` is treated as a `string3`. Haven't yet thought much about how to handle that.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
