### PR TITLE
Add descriptions of to_mem and clone to spec.

### DIFF
--- a/newsfragments/195.doc.md
+++ b/newsfragments/195.doc.md
@@ -1,0 +1,1 @@
+Added descriptions of the `to_mem` and `clone` functions to the spec.


### PR DESCRIPTION
### What was wrong?

We were missing descriptions of these two builtin functions in the spec.

### How was it fixed?

Added descriptions in the data layout section.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
