### PR TITLE
Compile multiple contracts in single module.

### DIFF
--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -9,32 +9,8 @@ use serde::{
 };
 use std::collections::HashMap;
 
-/// Wrapper around a map of contract names to their ABIs.
-#[derive(Serialize, Debug, PartialEq, Clone)]
-pub struct ModuleABIs {
-    #[serde(flatten)]
-    pub contracts: HashMap<String, Contract>,
-}
-
-impl Default for ModuleABIs {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ModuleABIs {
-    pub fn new() -> Self {
-        Self {
-            contracts: HashMap::new(),
-        }
-    }
-
-    /// Serialize the module into a JSON object that maps each contract in the
-    /// module to its ABI.
-    pub fn json(&self) -> Result<String, CompileError> {
-        Ok(serde_json::to_string(self)?)
-    }
-}
+/// The ABIs for each contract in a Fe module.
+pub type ModuleAbis = HashMap<String, Contract>;
 
 /// All public interfaces of a Fe contract.
 #[derive(Debug, PartialEq, Clone)]
@@ -243,36 +219,8 @@ mod tests {
         FuncOutput,
         FuncType,
         Function,
-        ModuleABIs,
         VarType,
     };
-    use std::collections::HashMap;
-
-    #[test]
-    fn module_abis_json() {
-        let mut contracts = HashMap::new();
-        contracts.insert(
-            "contract1".to_string(),
-            Contract {
-                functions: vec![],
-                events: vec![],
-            },
-        );
-        contracts.insert(
-            "contract2".to_string(),
-            Contract {
-                functions: vec![],
-                events: vec![],
-            },
-        );
-
-        let json = ModuleABIs { contracts }.json().unwrap();
-
-        assert!(
-            json == r#"{"contract1":[],"contract2":[]}"#
-                || json == r#"{"contract2":[],"contract1":[]}"#
-        )
-    }
 
     #[test]
     fn contract_json() {

--- a/compiler/src/types.rs
+++ b/compiler/src/types.rs
@@ -1,0 +1,40 @@
+use fe_parser::ast as fe;
+use std::collections::HashMap;
+
+/// The name of a Fe contract.
+pub type ContractName = String;
+/// The AST of a Fe module.
+pub type FeModuleAst<'a> = fe::Module<'a>;
+/// The ABI of a contract as a string.
+pub type JsonAbi = String;
+/// The source of a Fe module as a static string.
+pub type FeSrc<'a> = &'a str;
+/// The intermediate representation of a contract as a string object.
+pub type YulIr = String;
+/// The bytecode of a contract as string object.
+pub type Bytecode = String;
+
+/// A mapping of contract names and their ABIs.
+pub type NamedAbis = HashMap<ContractName, JsonAbi>;
+/// A mapping of contract names and their Yul IR.
+pub type NamedYulContracts = HashMap<ContractName, YulIr>;
+/// A mapping of contract names and their bytecode.
+pub type NamedBytecodeContracts = HashMap<ContractName, Bytecode>;
+
+/// The artifacts of a compiled contract.
+pub struct CompiledContract {
+    pub json_abi: JsonAbi,
+    pub yul: YulIr,
+    #[cfg(feature = "solc-backend")]
+    pub bytecode: Bytecode,
+}
+
+/// A mapping of contract names and their artifacts.
+pub type NamedContracts = HashMap<ContractName, CompiledContract>;
+
+/// The artifacts of a compiled module.
+pub struct CompiledModule {
+    pub fe_tokens: String,
+    pub fe_ast: String,
+    pub contracts: NamedContracts,
+}

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,6 +1,11 @@
 //! Fe to Yul compiler.
 
 use crate::errors::CompileError;
+use crate::types::{
+    FeModuleAst,
+    NamedYulContracts,
+};
+use fe_semantics::Context;
 
 mod constructor;
 mod mappers;
@@ -9,33 +14,10 @@ mod operations;
 mod runtime;
 mod utils;
 
-pub struct CompilerOutput {
-    pub tokens: String,
-    pub ast: String,
-    pub yul: String,
-}
-
 /// Compiles Fe source code to Yul.
-pub fn compile(src: &str) -> Result<CompilerOutput, CompileError> {
-    let tokens = fe_parser::get_parse_tokens(src)?;
-    let fe_module = fe_parser::parsers::file_input(&tokens[..])
-        .map_err(|error| CompileError::str(error.format_user(src)))?
-        .1
-        .node;
-    let context = fe_semantics::analysis(&fe_module)
-        .map_err(|error| CompileError::str(error.format_with_src(src)))?;
-
-    // TODO: Handle multiple contracts in one Fe module cleanly.
-    if let Some(first_contract) = mappers::module::module(&context, &fe_module)?
-        .values()
-        .next()
-    {
-        return Ok(CompilerOutput {
-            tokens: format!("{:#?}", tokens),
-            ast: format!("{:#?}", fe_module),
-            yul: first_contract.to_string(),
-        });
-    }
-
-    Err(CompileError::static_str("unable to parse tokens."))
+pub fn compile(module: &FeModuleAst, context: Context) -> Result<NamedYulContracts, CompileError> {
+    Ok(mappers::module::module(&context, module)?
+        .drain()
+        .map(|(name, object)| (name, object.to_string().replace("\"", "\\\"")))
+        .collect::<NamedYulContracts>())
 }

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "solc-backend")]
 
-use fe_compiler::evm::CompileStage;
-
 use rstest::rstest;
 use std::fs;
 
@@ -56,7 +54,7 @@ fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))
         .expect("Unable to read fixture file");
 
-    match fe_compiler::evm::compile(&src, CompileStage::AllUpToBytecode) {
+    match fe_compiler::compile(&src, true) {
         Err(compile_error) => assert!(
             format!("{}", compile_error).contains(expected_error),
             format!("{} did not contain {}", compile_error, expected_error)

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -2,7 +2,6 @@
 use ethabi;
 use evm;
 
-use compiler::evm::CompileStage;
 use evm_runtime::{
     ExitReason,
     Handler,
@@ -163,24 +162,22 @@ fn with_executor(test: &dyn Fn(Executor)) {
 fn deploy_contract(
     executor: &mut Executor,
     fixture: &str,
-    name: &str,
+    contract_name: &str,
     init_params: Vec<ethabi::Token>,
 ) -> ContractHarness {
     let src = fs::read_to_string(format!("tests/fixtures/{}", fixture))
-        .expect("Unable to read fixture file");
+        .expect("unable to read fixture file");
+    let compiled_module = compiler::compile(&src, true).expect("failed to compile module");
+    let compiled_contract = compiled_module
+        .contracts
+        .get(contract_name)
+        .expect("could not find contract in fixture");
+    let abi = ethabi::Contract::load(StringReader::new(&compiled_contract.json_abi))
+        .expect("unable to load the ABI");
+    let mut bytecode = hex::decode(&compiled_contract.bytecode).expect("failed to decode bytecode");
 
-    let output = compiler::evm::compile(&src, CompileStage::AllUpToBytecode)
-        .expect("Unable to compile to bytecode");
-    let json_abi = compiler::abi::build(&src)
-        .expect("Unable to build the module ABIs")
-        .contracts[name]
-        .json(false)
-        .expect("Unable to serialize the contract ABI.");
-
-    let abi = ethabi::Contract::load(StringReader::new(&json_abi)).expect("Unable to load the ABI");
-    let mut init_code = hex::decode(output.bytecode).unwrap();
     if let Some(constructor) = &abi.constructor {
-        init_code = constructor.encode_input(init_code, &init_params).unwrap()
+        bytecode = constructor.encode_input(bytecode, &init_params).unwrap()
     }
 
     if let evm::Capture::Exit(exit) = executor.create(
@@ -189,7 +186,7 @@ fn deploy_contract(
             caller: address(DEFAULT_CALLER),
         },
         U256::zero(),
-        init_code,
+        bytecode,
         None,
     ) {
         return ContractHarness::new(exit.1.expect("Unable to retrieve contract address"), abi);
@@ -1172,4 +1169,16 @@ fn abi_encoding_stress() {
             )],
         );
     });
+}
+
+#[test]
+fn two_contracts() {
+    with_executor(&|mut executor| {
+        let foo_harness = deploy_contract(&mut executor, "two_contracts.fe", "Foo", vec![]);
+        let bar_harness = deploy_contract(&mut executor, "two_contracts.fe", "Bar", vec![]);
+
+        foo_harness.test_function(&mut executor, "foo", vec![], Some(uint_token(42)));
+
+        bar_harness.test_function(&mut executor, "bar", vec![], Some(uint_token(26)));
+    })
 }

--- a/compiler/tests/fixtures/two_contracts.fe
+++ b/compiler/tests/fixtures/two_contracts.fe
@@ -1,0 +1,7 @@
+contract Foo:
+    pub def foo() -> u256:
+        return 42
+
+contract Bar:
+    pub def bar() -> u256:
+        return 26

--- a/newsfragments/197.feature.md
+++ b/newsfragments/197.feature.md
@@ -1,0 +1,17 @@
+The CLI now compiles every contract in a module, not just the first one.
+
+Sample compiler output with all targets enabled:
+
+```
+output
+|-- Bar
+|   |-- Bar.bin
+|   |-- Bar_abi.json
+|   `-- Bar_ir.yul
+|-- Foo
+|   |-- Foo.bin
+|   |-- Foo_abi.json
+|   `-- Foo_ir.yul
+|-- module.ast
+`-- module.tokens
+```

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -145,7 +145,7 @@ impl SemanticError {
     ///
     /// The string will contain the error kind, line number, and surrounding
     /// code.
-    pub fn format_with_src(&self, src: &str) -> String {
+    pub fn format_user(&self, src: &str) -> String {
         let line = if let Some(span) = self.context.first() {
             src[..span.start].lines().count()
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod main_full;
 
 #[cfg(not(feature = "solc-backend"))]
 fn main() {
-    println!("Using the CLI requires passing `--features solc-backend`");
+    println!("The CLI must be built with the solc-backend feature (i.e. `cargo build --release --features solc-backend`).");
 }
 
 // This is moved to its own file so that we don't have to sprinkle the code with


### PR DESCRIPTION
### What was wrong?

We were only able to compile the first contract in a module.

### How was it fixed?

- Updated the compiler module internals and API to handle multiple contracts.
- Updated the contract testing harness and added a test for a module with two separate contracts.
- Updated the CLI. We now write the following to the output directory:

```
output
|-- Bar
|   |-- Bar.bin
|   |-- Bar_abi.json
|   `-- Bar_ir.yul
|-- Foo
|   |-- Foo.bin
|   |-- Foo_abi.json
|   `-- Foo_ir.yul
|-- module.ast
`-- module.tokens
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
