### PR TITLE
Fix bug with string literals and add support for string casts

### DIFF
--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -27,6 +27,7 @@ use std::fs;
     case("unary_minus_on_bool.fe", "TypeError"),
     case("type_constructor_from_variable.fe", "NumericLiteralExpected"),
     case("needs_mem_copy.fe", "CannotMove"),
+    case("string_capacity_mismatch.fe", "StringCapacityMismatch"),
     case("numeric_capacity_mismatch/u8_neg.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u8_pos.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u16_neg.fe", "NumericCapacityMismatch"),

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -756,6 +756,13 @@ fn strings() {
             Some(string_token("The quick brown fox jumps over the lazy dog")),
         );
 
+        harness.test_function(
+            &mut executor,
+            "return_casted_static_string",
+            vec![],
+            Some(string_token("foo")),
+        );
+
         harness.events_emitted(
             executor,
             vec![(
@@ -767,6 +774,7 @@ fn strings() {
                     string_token("string 3"),
                     address_token("1000000000000000000000000000000000000001"),
                     string_token("static string"),
+                    string_token("foo"),
                 ],
             )],
         );

--- a/compiler/tests/fixtures/compile_errors/string_capacity_mismatch.fe
+++ b/compiler/tests/fixtures/compile_errors/string_capacity_mismatch.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> string3:
+        return string3("too long")

--- a/compiler/tests/fixtures/strings.fe
+++ b/compiler/tests/fixtures/strings.fe
@@ -6,12 +6,16 @@ contract Foo:
         s3: string100
         a: address
         s4: string13
+        s5: string100
 
     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-        emit MyEvent(s2, u, s1, s3, a, "static string")
+        emit MyEvent(s2, u, s1, s3, a, "static string", "foo")
 
     pub def bar(s1: string100, s2: string100) -> string100:
         return s2
 
     pub def return_static_string() -> string43:
         return "The quick brown fox jumps over the lazy dog"
+
+    pub def return_casted_static_string() -> string100:
+        return string100("foo")

--- a/newsfragments/201.feature.md
+++ b/newsfragments/201.feature.md
@@ -1,0 +1,7 @@
+Add support for string type casts
+
+Example:
+
+```
+val: string100 = string100("foo")
+```

--- a/semantics/src/errors.rs
+++ b/semantics/src/errors.rs
@@ -11,6 +11,7 @@ pub enum ErrorKind {
     MissingReturn,
     NotSubscriptable,
     NumericCapacityMismatch,
+    StringCapacityMismatch,
     UndefinedValue,
     UnexpectedReturn,
     TypeError,
@@ -66,6 +67,14 @@ impl SemanticError {
     pub fn numeric_capacity_mismatch() -> Self {
         SemanticError {
             kind: ErrorKind::NumericCapacityMismatch,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `NumericCapacityMismatch`
+    pub fn string_capacity_mismatch() -> Self {
+        SemanticError {
+            kind: ErrorKind::StringCapacityMismatch,
             context: vec![],
         }
     }

--- a/semantics/src/lib.rs
+++ b/semantics/src/lib.rs
@@ -29,7 +29,10 @@ use std::cell::{
     Ref,
     RefCell,
 };
-use std::collections::HashMap;
+use std::collections::{
+    HashMap,
+    HashSet,
+};
 use std::rc::Rc;
 
 /// Indicates where an expression is stored.
@@ -68,7 +71,7 @@ pub struct ContractAttributes {
     /// Events that have been defined by the user.
     pub events: Vec<Event>,
     /// Static strings that the contract defines
-    pub string_literals: Vec<String>,
+    pub string_literals: HashSet<String>,
 }
 
 impl From<Ref<'_, ContractScope>> for ContractAttributes {

--- a/semantics/src/namespace/scopes.rs
+++ b/semantics/src/namespace/scopes.rs
@@ -4,7 +4,10 @@ use crate::namespace::types::{
     Type,
 };
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{
+    HashMap,
+    HashSet,
+};
 use std::rc::Rc;
 
 pub type Shared<T> = Rc<RefCell<T>>;
@@ -35,7 +38,7 @@ pub struct ContractScope {
     pub event_defs: HashMap<String, Event>,
     pub field_defs: HashMap<String, ContractFieldDef>,
     pub function_defs: HashMap<String, ContractFunctionDef>,
-    pub string_defs: Vec<String>,
+    pub string_defs: HashSet<String>,
     num_fields: usize,
 }
 
@@ -97,7 +100,7 @@ impl ContractScope {
             function_defs: HashMap::new(),
             event_defs: HashMap::new(),
             field_defs: HashMap::new(),
-            string_defs: vec![],
+            string_defs: HashSet::new(),
             interface: vec![],
             num_fields: 0,
         }))
@@ -159,7 +162,7 @@ impl ContractScope {
 
     /// Add a static string definition to the scope.
     pub fn add_string(&mut self, value: String) {
-        self.string_defs.push(value);
+        self.string_defs.insert(value);
     }
 }
 


### PR DESCRIPTION
### What was wrong?

1. There was a bug if the same string literal was used multiple times
2. We did not have support for string casts yet (e.g. `string100("foo")`

### How was it fixed?

1. Converted `Vec<String>` to `HashSet<String>`
2. Refactored part that recognize string types into a reusable `TryFrom`
3. Recognize `stringxxx` type constructors based on the `TryFrom`
4. Map string type casts to the altered expression.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
