### PR TITLE
Ensure event emits are type checked

### DIFF
--- a/compiler/src/yul/operations/data.rs
+++ b/compiler/src/yul/operations/data.rs
@@ -70,7 +70,7 @@ pub fn emit_event(event: Event, vals: Vec<yul::Expression>) -> yul::Statement {
     let mut topics = vec![literal_expression! { (event.topic) }];
 
     let (field_vals, field_types): (Vec<yul::Expression>, Vec<FixedSize>) = event
-        .fields()
+        .non_indexed_fields()
         .into_iter()
         .map(|(index, typ)| (vals[index].to_owned(), typ))
         .unzip();

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -25,7 +25,7 @@ pub fn build(context: &Context, contract: &Spanned<fe::ModuleStmt>) -> Vec<yul::
             let events_batch = attributes
                 .events
                 .iter()
-                .map(|event| event.field_types())
+                .map(|event| event.non_indexed_field_types())
                 .collect::<Vec<_>>();
 
             let batch = [public_functions_batch, events_batch].concat();

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -8,6 +8,7 @@ use std::fs;
 #[rstest(
     fixture_file,
     expected_error,
+    case("call_event_with_wrong_types.fe", "TypeError"),
     case("continue_without_loop.fe", "ContinueWithoutLoop"),
     case("continue_without_loop_2.fe", "ContinueWithoutLoop"),
     case("break_without_loop.fe", "BreakWithoutLoop"),

--- a/compiler/tests/fixtures/compile_errors/call_event_with_wrong_types.fe
+++ b/compiler/tests/fixtures/compile_errors/call_event_with_wrong_types.fe
@@ -1,0 +1,7 @@
+contract Foo:
+    event MyEvent:
+        val_1: string100
+        idx val_2: u8
+
+    pub def foo():
+        emit MyEvent("foo", 1000)

--- a/compiler/tests/fixtures/strings.fe
+++ b/compiler/tests/fixtures/strings.fe
@@ -9,7 +9,7 @@ contract Foo:
         s5: string100
 
     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-        emit MyEvent(s2, u, s1, s3, a, "static string", "foo")
+        emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
 
     pub def bar(s1: string100, s2: string100) -> string100:
         return s2

--- a/newsfragments/202.bugfix.md
+++ b/newsfragments/202.bugfix.md
@@ -1,0 +1,16 @@
+Perform type checking when calling event constructors
+
+Previously, the following would not raise an error even though it should:
+
+```
+contract Foo:
+    event MyEvent:
+        val_1: string100
+        val_2: u8
+
+    pub def foo():
+        emit MyEvent("foo", 1000)
+
+```
+
+Wit this change, the code fails with a type error as expected.

--- a/semantics/src/namespace/events.rs
+++ b/semantics/src/namespace/events.rs
@@ -40,7 +40,7 @@ impl Event {
     /// The event's non-indexed fields.
     ///
     /// These should be logged in the data section.
-    pub fn fields(&self) -> Vec<(usize, FixedSize)> {
+    pub fn non_indexed_fields(&self) -> Vec<(usize, FixedSize)> {
         self.fields
             .to_owned()
             .into_iter()
@@ -50,8 +50,15 @@ impl Event {
     }
 
     /// The event's non-indexed field types.
+    pub fn non_indexed_field_types(&self) -> Vec<FixedSize> {
+        self.non_indexed_fields()
+            .into_iter()
+            .map(|(_, typ)| typ)
+            .collect()
+    }
+    /// The event's field types.
     pub fn field_types(&self) -> Vec<FixedSize> {
-        self.fields().into_iter().map(|(_, typ)| typ).collect()
+        self.fields.clone()
     }
 }
 
@@ -81,7 +88,16 @@ mod tests {
         );
 
         assert_eq!(
-            event.fields(),
+            event.field_types(),
+            vec![
+                FixedSize::Base(Base::Address),
+                FixedSize::Base(Base::Address),
+                FixedSize::Base(Base::Bool),
+            ],
+        );
+
+        assert_eq!(
+            event.non_indexed_fields(),
             vec![
                 (0, FixedSize::Base(Base::Address)),
                 (2, FixedSize::Base(Base::Bool))

--- a/semantics/src/traversal/expressions.rs
+++ b/semantics/src/traversal/expressions.rs
@@ -209,7 +209,7 @@ fn expr_str(
         let string_length = string_val.len();
 
         scope
-            .borrow_mut()
+            .borrow()
             .contract_scope()
             .borrow_mut()
             .add_string(string_val);


### PR DESCRIPTION
### What was wrong?

On master, the following would not raise an error even though it should:

```
contract Foo:
    event MyEvent:
        val_1: string100
        val_2: u8

    pub def foo():
        emit MyEvent("foo", 1000)

```

### How was it fixed?

Basically reuse the `call_arg` that is defined in `expression` and a little bit of refactoring the event to expose all field types.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
