### PR TITLE
Add support for structs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-01-30
         override: true
     - name: coverage with tarpaulin
       run: |
@@ -66,7 +66,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-01-30
         override: true
         components: rustfmt, clippy
     - name: Validate release notes entry
@@ -116,7 +116,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-01-30
         override: true
     - name: Build
       run: cargo build --all-features --verbose
@@ -132,7 +132,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-01-30
           override: true
       - name: Run WASM tests
         run: wasm-pack test --node -- --workspace
@@ -167,7 +167,7 @@ jobs:
           uses: actions-rs/toolchain@v1
           with:
             profile: minimal
-            toolchain: nightly
+            toolchain: nightly-2021-01-30
             override: true
         - name: Build
           run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}

--- a/analyzer/src/namespace/operations.rs
+++ b/analyzer/src/namespace/operations.rs
@@ -17,6 +17,7 @@ pub fn index(value: Type, index: Type) -> Result<Type, SemanticError> {
         Type::Tuple(_) => Err(SemanticError::not_subscriptable()),
         Type::String(_) => Err(SemanticError::not_subscriptable()),
         Type::Contract(_) => Err(SemanticError::not_subscriptable()),
+        Type::Struct(_) => Err(SemanticError::not_subscriptable()),
     }
 }
 

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -1,6 +1,9 @@
 use crate::errors::SemanticError;
 use fe_parser::ast as fe;
-use std::collections::HashMap;
+use std::collections::{
+    BTreeMap,
+    HashMap,
+};
 use std::convert::TryFrom;
 use std::num::{
     IntErrorKind,
@@ -103,6 +106,7 @@ pub enum Type {
     Tuple(Tuple),
     String(FeString),
     Contract(Contract),
+    Struct(Struct),
 }
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -112,6 +116,7 @@ pub enum FixedSize {
     Tuple(Tuple),
     String(FeString),
     Contract(Contract),
+    Struct(Struct),
 }
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -158,6 +163,12 @@ pub struct Tuple {
 }
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
+pub struct Struct {
+    pub name: String,
+    fields: BTreeMap<String, Base>,
+}
+
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct FeString {
     pub max_size: usize,
 }
@@ -166,6 +177,40 @@ pub struct FeString {
 pub struct Contract {
     pub name: String,
     pub functions: Vec<FunctionAttributes>,
+}
+
+impl Struct {
+    pub fn new(name: &str) -> Struct {
+        Struct {
+            name: name.to_string(),
+            fields: BTreeMap::new(),
+        }
+    }
+
+    // Return `true` if the struct has any fields, otherwise return `false`
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Add a field to the struct
+    pub fn add_field(&mut self, name: &str, value: &Base) -> Option<Base> {
+        self.fields.insert(name.to_string(), value.clone())
+    }
+
+    // Return the type of the given field name
+    pub fn get_field_type(&self, name: &str) -> Option<&Base> {
+        self.fields.get(name)
+    }
+
+    // Return a vector of field types
+    pub fn get_field_types(&self) -> Vec<Type> {
+        self.fields.values().map(|val| val.clone().into()).collect()
+    }
+
+    //Return a vector of field names
+    pub fn get_field_names(&self) -> Vec<String> {
+        self.fields.keys().cloned().collect()
+    }
 }
 
 impl TryFrom<&str> for FeString {
@@ -258,7 +303,14 @@ impl From<FixedSize> for Type {
             FixedSize::Tuple(tuple) => Type::Tuple(tuple),
             FixedSize::String(string) => Type::String(string),
             FixedSize::Contract(contract) => Type::Contract(contract),
+            FixedSize::Struct(val) => Type::Struct(val),
         }
+    }
+}
+
+impl From<Base> for Type {
+    fn from(value: Base) -> Self {
+        Type::Base(value)
     }
 }
 
@@ -270,6 +322,7 @@ impl FeSized for FixedSize {
             FixedSize::Tuple(tuple) => tuple.size(),
             FixedSize::String(string) => string.size(),
             FixedSize::Contract(contract) => contract.size(),
+            FixedSize::Struct(val) => val.size(),
         }
     }
 }
@@ -301,6 +354,7 @@ impl AbiEncoding for FixedSize {
             FixedSize::Tuple(tuple) => tuple.abi_name(),
             FixedSize::String(string) => string.abi_name(),
             FixedSize::Contract(contract) => contract.abi_name(),
+            FixedSize::Struct(val) => val.abi_name(),
         }
     }
 
@@ -311,6 +365,7 @@ impl AbiEncoding for FixedSize {
             FixedSize::Tuple(tuple) => tuple.abi_safe_name(),
             FixedSize::String(string) => string.abi_safe_name(),
             FixedSize::Contract(contract) => contract.abi_safe_name(),
+            FixedSize::Struct(val) => val.abi_safe_name(),
         }
     }
 
@@ -321,6 +376,7 @@ impl AbiEncoding for FixedSize {
             FixedSize::Tuple(tuple) => tuple.abi_type(),
             FixedSize::String(string) => string.abi_type(),
             FixedSize::Contract(contract) => contract.abi_type(),
+            FixedSize::Struct(val) => val.abi_type(),
         }
     }
 }
@@ -348,6 +404,7 @@ impl TryFrom<Type> for FixedSize {
             Type::Base(base) => Ok(FixedSize::Base(base)),
             Type::Tuple(tuple) => Ok(FixedSize::Tuple(tuple)),
             Type::String(string) => Ok(FixedSize::String(string)),
+            Type::Struct(val) => Ok(FixedSize::Struct(val)),
             Type::Map(_) => Err(SemanticError::type_error()),
             Type::Contract(contract) => Ok(FixedSize::Contract(contract)),
         }
@@ -540,6 +597,26 @@ impl From<Tuple> for FixedSize {
 impl FeSized for Tuple {
     fn size(&self) -> usize {
         self.items.iter().map(|typ| typ.size()).sum()
+    }
+}
+
+impl FeSized for Struct {
+    fn size(&self) -> usize {
+        self.fields.len() * 32
+    }
+}
+
+impl AbiEncoding for Struct {
+    fn abi_name(&self) -> String {
+        unimplemented!();
+    }
+
+    fn abi_safe_name(&self) -> String {
+        unimplemented!();
+    }
+
+    fn abi_type(&self) -> AbiType {
+        unimplemented!();
     }
 }
 

--- a/analyzer/src/traversal/mod.rs
+++ b/analyzer/src/traversal/mod.rs
@@ -5,4 +5,5 @@ mod declarations;
 mod expressions;
 mod functions;
 pub mod module;
+mod structs;
 mod types;

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -20,6 +20,7 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
             fe::ModuleStmt::ContractDef { .. } => {
                 contracts::contract_def(Rc::clone(&scope), Rc::clone(&context), stmt)?
             }
+            fe::ModuleStmt::StructDef { .. } => unimplemented!(),
             fe::ModuleStmt::FromImport { .. } => unimplemented!(),
             fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
         }

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -4,7 +4,10 @@ use crate::namespace::scopes::{
     Shared,
 };
 use crate::namespace::types;
-use crate::traversal::contracts;
+use crate::traversal::{
+    contracts,
+    structs,
+};
 use crate::Context;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
@@ -17,10 +20,12 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
     for stmt in module.body.iter() {
         match &stmt.node {
             fe::ModuleStmt::TypeDef { .. } => type_def(Rc::clone(&scope), stmt)?,
+            fe::ModuleStmt::StructDef { name, body } => {
+                structs::struct_def(Rc::clone(&scope), name.node, body)?
+            }
             fe::ModuleStmt::ContractDef { .. } => {
                 contracts::contract_def(Rc::clone(&scope), Rc::clone(&context), stmt)?
             }
-            fe::ModuleStmt::StructDef { .. } => unimplemented!(),
             fe::ModuleStmt::FromImport { .. } => unimplemented!(),
             fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
         }

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -1,0 +1,36 @@
+use fe_parser::{
+    ast::StructStmt,
+    span::Spanned,
+};
+
+use crate::errors::SemanticError;
+use crate::namespace::scopes::{
+    ModuleScope,
+    Shared,
+};
+use crate::namespace::types::{
+    type_desc,
+    Struct,
+    Type,
+};
+
+pub fn struct_def(
+    module_scope: Shared<ModuleScope>,
+    name: &str,
+    struct_stmts: &[Spanned<StructStmt>],
+) -> Result<(), SemanticError> {
+    let mut val = Struct::new(name);
+    for stmt in struct_stmts {
+        let StructStmt::StructField { name, typ, .. } = &stmt.node;
+        let field_type = type_desc(&module_scope.borrow().type_defs, &typ.node)?;
+        if let Type::Base(base_typ) = field_type {
+            val.add_field(name.node, &base_typ);
+        } else {
+            todo!("Non-Base type fields aren't yet supported")
+        }
+    }
+    module_scope
+        .borrow_mut()
+        .add_type_def(name.to_string(), Type::Struct(val));
+    Ok(())
+}

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -22,6 +22,7 @@ pub fn module(context: &Context, module: &fe::Module) -> Result<YulContracts, Co
                         return Err(CompileError::static_str("duplicate contract def"));
                     }
                 }
+                fe::ModuleStmt::StructDef { .. } => unimplemented!(),
                 fe::ModuleStmt::FromImport { .. } => unimplemented!(),
                 fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
             }

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -22,7 +22,7 @@ pub fn module(context: &Context, module: &fe::Module) -> Result<YulContracts, Co
                         return Err(CompileError::static_str("duplicate contract def"));
                     }
                 }
-                fe::ModuleStmt::StructDef { .. } => unimplemented!(),
+                fe::ModuleStmt::StructDef { .. } => {}
                 fe::ModuleStmt::FromImport { .. } => unimplemented!(),
                 fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
             }

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -45,6 +45,23 @@ pub fn contract_call(contract_name: &str, func_name: &str) -> yul::Identifier {
     identifier! { (name) }
 }
 
+/// Generates a function name for to interact with a certain struct type
+pub fn struct_function_name(struct_name: &str, func_name: &str) -> yul::Identifier {
+    let name = format!("struct_{}_{}", struct_name, func_name);
+    identifier! { (name) }
+}
+
+/// Generates a function name for creating a certain struct type
+pub fn struct_new_call(struct_name: &str) -> yul::Identifier {
+    struct_function_name(struct_name, "new")
+}
+
+/// Generates a function name for reading a named property of a certain struct
+/// type
+pub fn struct_getter_call(struct_name: &str, field_name: &str) -> yul::Identifier {
+    struct_function_name(struct_name, &format!("get_{}_ptr", field_name))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::yul::names::{

--- a/compiler/src/yul/operations/mod.rs
+++ b/compiler/src/yul/operations/mod.rs
@@ -1,3 +1,4 @@
 pub mod abi;
 pub mod calls;
 pub mod data;
+pub mod structs;

--- a/compiler/src/yul/operations/structs.rs
+++ b/compiler/src/yul/operations/structs.rs
@@ -1,0 +1,39 @@
+use crate::yul::names;
+use fe_analyzer::namespace::types::Struct;
+use yultsur::*;
+
+pub fn new(struct_type: &Struct, params: Vec<yul::Expression>) -> yul::Expression {
+    let function_name = names::struct_new_call(&struct_type.name);
+    expression! { [function_name]([params...]) }
+}
+
+pub fn get_attribute(struct_type: &Struct, ptr_name: &str, field_name: &str) -> yul::Expression {
+    let function_name = names::struct_getter_call(&struct_type.name, field_name);
+    let ptr_name_exp = identifier_expression! {(ptr_name)};
+    expression! { [function_name]([ptr_name_exp]) }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::operations::structs;
+    use fe_analyzer::namespace::types::{
+        Base,
+        Struct,
+    };
+    use yultsur::*;
+
+    #[test]
+    fn test_new() {
+        let mut val = Struct::new("Foo");
+        val.add_field("bar", &Base::Bool);
+        val.add_field("bar2", &Base::Bool);
+        let params = vec![
+            identifier_expression! { (1) },
+            identifier_expression! { (2) },
+        ];
+        assert_eq!(
+            structs::new(&val, params).to_string(),
+            "struct_Foo_new(1, 2)"
+        )
+    }
+}

--- a/compiler/src/yul/runtime/functions/mod.rs
+++ b/compiler/src/yul/runtime/functions/mod.rs
@@ -4,6 +4,7 @@ use yultsur::*;
 pub mod abi;
 pub mod calls;
 pub mod data;
+pub mod structs;
 
 /// Returns all functions that should be available during runtime.
 pub fn std() -> Vec<yul::Statement> {

--- a/compiler/src/yul/runtime/functions/structs.rs
+++ b/compiler/src/yul/runtime/functions/structs.rs
@@ -1,0 +1,136 @@
+use crate::yul::names;
+use fe_analyzer::namespace::types::Struct;
+use yultsur::*;
+
+/// Generate a YUL function that can be used to create an instance of
+/// `struct_type`
+pub fn generate_new_fn(struct_type: &Struct) -> yul::Statement {
+    let function_name = names::struct_new_call(&struct_type.name);
+
+    if struct_type.is_empty() {
+        // We return 0 here because it is safe to assume that we never write to an empty
+        // struct. If we end up writing to an empty struct that's an actual Fe
+        // bug.
+        let body = statement! { return_val := 0 };
+        return function_definition! {
+            function [function_name]() -> return_val {
+                 [body]
+            }
+        };
+    }
+
+    let params = struct_type
+        .get_field_names()
+        .iter()
+        .map(|key| {
+            identifier! {(key)}
+        })
+        .collect::<Vec<_>>();
+
+    let body = struct_type
+        .get_field_names()
+        .iter()
+        .enumerate()
+        .map(|(index, key)| {
+            if index == 0 {
+                let param_identifier_exp = identifier_expression! {(key)};
+                statements! {
+                    (return_val := alloc(32))
+                    (mstore(return_val, [param_identifier_exp]))
+                }
+            } else {
+                let ptr_identifier = format!("{}_ptr", key);
+                let ptr_identifier = identifier! {(ptr_identifier)};
+                let ptr_identifier_exp = identifier_expression! {(ptr_identifier)};
+                let param_identifier_exp = identifier_expression! {(key)};
+                statements! {
+                    (let [ptr_identifier] := alloc(32))
+                    (mstore([ptr_identifier_exp], [param_identifier_exp]))
+                }
+            }
+        })
+        .flatten()
+        .collect::<Vec<_>>();
+
+    function_definition! {
+        function [function_name]([params...]) -> return_val {
+            [body...]
+        }
+    }
+}
+
+/// Generate a YUL function that can be used to read a property of `struct_type`
+pub fn generate_get_fn(struct_type: &Struct, field_name: &str) -> yul::Statement {
+    let function_name = names::struct_getter_call(&struct_type.name, field_name);
+    let field_index = struct_type
+        .get_field_names()
+        .iter()
+        .position(|field| field == field_name)
+        .unwrap_or_else(|| panic!("No field {} in {}", field_name, struct_type.name));
+    let field_offset = field_index * 32;
+
+    let offset = literal_expression! {(field_offset)};
+    let return_expression = expression! { add(ptr, [offset]) };
+    let body = statement! { (return_val := [return_expression]) };
+    function_definition! {
+        function [function_name](ptr) -> return_val {
+             [body]
+        }
+    }
+}
+
+/// Builds a set of functions used to interact with structs used in a contract
+pub fn struct_apis(struct_type: Struct) -> Vec<yul::Statement> {
+    [
+        vec![generate_new_fn(&struct_type)],
+        struct_type
+            .get_field_names()
+            .iter()
+            .map(|field| generate_get_fn(&struct_type, &field))
+            .collect(),
+    ]
+    .concat()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::yul::runtime::functions::structs;
+    use fe_analyzer::namespace::types::{
+        Base,
+        Struct,
+    };
+
+    #[test]
+    fn test_empty_struct() {
+        assert_eq!(
+            structs::generate_new_fn(&Struct::new("Foo")).to_string(),
+            "function struct_Foo_new() -> return_val { return_val := 0 }"
+        )
+    }
+
+    #[test]
+    fn test_struct_api_generation() {
+        let mut val = Struct::new("Foo");
+        val.add_field("bar", &Base::Bool);
+        val.add_field("bar2", &Base::Bool);
+        assert_eq!(
+            structs::generate_new_fn(&val).to_string(),
+            "function struct_Foo_new(bar, bar2) -> return_val { return_val := alloc(32) mstore(return_val, bar) let bar2_ptr := alloc(32) mstore(bar2_ptr, bar2) }"
+        )
+    }
+
+    #[test]
+    fn test_struct_getter_generation() {
+        let mut val = Struct::new("Foo");
+        val.add_field("bar", &Base::Bool);
+        val.add_field("bar2", &Base::Bool);
+        assert_eq!(
+            structs::generate_get_fn(&val, &val.get_field_names().get(0).unwrap()).to_string(),
+            "function struct_Foo_get_bar_ptr(ptr) -> return_val { return_val := add(ptr, 0) }"
+        );
+        assert_eq!(
+            structs::generate_get_fn(&val, &val.get_field_names().get(1).unwrap()).to_string(),
+            "function struct_Foo_get_bar2_ptr(ptr) -> return_val { return_val := add(ptr, 32) }"
+        );
+    }
+}

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -86,7 +86,14 @@ pub fn build(context: &Context, contract: &Spanned<fe::ModuleStmt>) -> Vec<yul::
                 .concat()
         };
 
-        return [std, encoding, decoding, contract_calls].concat();
+        let struct_apis = attributes
+            .structs
+            .iter()
+            .map(|val| functions::structs::struct_apis(val.to_owned()))
+            .collect::<Vec<_>>()
+            .concat();
+
+        return [std, encoding, decoding, contract_calls, struct_apis].concat();
     }
 
     panic!("missing contract attributes")

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -955,7 +955,8 @@ fn sized_vals_in_sto() {
 #[test]
 fn structs() {
     with_executor(&|mut executor| {
-        let harness = deploy_contract(&mut executor, "structs.fe", "Foo", vec![]);
+        let harness = deploy_contract(&mut executor, "structs.fe", "Foo", &[]);
+        harness.test_function(&mut executor, "bar", &[], Some(&uint_token(2)));
     });
 }
 

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -953,6 +953,13 @@ fn sized_vals_in_sto() {
 }
 
 #[test]
+fn structs() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "structs.fe", "Foo", vec![]);
+    });
+}
+
+#[test]
 fn erc20_token() {
     with_executor(&|mut executor| {
         let token_name = string_token("Fe Coin");

--- a/compiler/tests/fixtures/structs.fe
+++ b/compiler/tests/fixtures/structs.fe
@@ -1,0 +1,7 @@
+struct House:
+    price: u256
+    size: u256
+
+
+contract City:
+    pub house: House

--- a/compiler/tests/fixtures/structs.fe
+++ b/compiler/tests/fixtures/structs.fe
@@ -1,7 +1,21 @@
 struct House:
     price: u256
     size: u256
+    vacant: bool
 
+contract Foo:
 
-contract City:
-    pub house: House
+    pub def bar() -> u256:
+        building: House = House(300, 500, true)
+        assert building.size == 500
+        assert building.price == 300
+        assert building.vacant
+
+        building.vacant = false
+        building.price = 1
+        building.size = 2
+
+        assert building.vacant == false
+        assert building.price == 1
+        assert building.size == 2
+        return building.size

--- a/newsfragments/203.feature.md
+++ b/newsfragments/203.feature.md
@@ -1,0 +1,22 @@
+Add basic support for structs.
+
+Example:
+
+```
+struct House:
+    price: u256
+    size: u256
+    vacant: bool
+
+contract City:
+
+    pub def get_price() -> u256:
+        building: House = House(300, 500, true)
+
+        assert building.size == 500
+        assert building.price == 300
+        assert building.vacant
+
+        return building.price
+```
+

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -33,6 +33,11 @@ pub enum ModuleStmt<'a> {
         #[serde(borrow)]
         body: Vec<Spanned<ContractStmt<'a>>>,
     },
+    StructDef {
+        name: Spanned<&'a str>,
+        #[serde(borrow)]
+        body: Vec<Spanned<StructStmt<'a>>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -109,7 +114,23 @@ pub enum ContractStmt<'a> {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum StructStmt<'a> {
+    StructField {
+        //qual: Option<Spanned<ContractFieldQual>>,
+        #[serde(borrow)]
+        name: Spanned<&'a str>,
+        typ: Spanned<TypeDesc<'a>>,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum ContractFieldQual {
+    Const,
+    Pub,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum StructFieldQual {
     Const,
     Pub,
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -116,7 +116,7 @@ pub enum ContractStmt<'a> {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum StructStmt<'a> {
     StructField {
-        //qual: Option<Spanned<ContractFieldQual>>,
+        qual: Option<Spanned<StructFieldQual>>,
         #[serde(borrow)]
         name: Spanned<&'a str>,
         typ: Spanned<TypeDesc<'a>>,

--- a/parser/src/ast_traits.rs
+++ b/parser/src/ast_traits.rs
@@ -24,6 +24,23 @@ impl TryFrom<&Token<'_>> for Spanned<ContractFieldQual> {
     }
 }
 
+impl TryFrom<&Token<'_>> for Spanned<StructFieldQual> {
+    type Error = &'static str;
+
+    #[cfg_attr(tarpaulin, rustfmt::skip)]
+    fn try_from(tok: &Token) -> Result<Self, Self::Error> {
+        use StructFieldQual::*;
+
+        let span = tok.span;
+
+        Ok(match tok.string {
+            "const" => Spanned { node: Const, span },
+            "pub" => Spanned { node: Pub, span },
+            _ => return Err("unrecognized string"),
+        })
+    }
+}
+
 impl TryFrom<&Token<'_>> for Spanned<EventFieldQual> {
     type Error = &'static str;
 

--- a/parser/src/parsers.rs
+++ b/parser/src/parsers.rs
@@ -523,7 +523,7 @@ pub fn struct_field(input: Cursor) -> ParseResult<Spanned<StructStmt>> {
         input,
         Spanned {
             node: StructStmt::StructField {
-                //qual,
+                qual,
                 name: name_tok.into(),
                 typ,
             },

--- a/parser/tests/fixtures/parsers/struct_def.ron
+++ b/parser/tests/fixtures/parsers/struct_def.ron
@@ -14,6 +14,7 @@ struct Foo:
       body: [
         Spanned(
           node: StructField(
+            qual: None,
             name: Spanned(
               node: "x",
               span: Span(

--- a/parser/tests/fixtures/parsers/struct_def.ron
+++ b/parser/tests/fixtures/parsers/struct_def.ron
@@ -1,0 +1,46 @@
+struct Foo:
+    x: address
+---
+[
+  Spanned(
+    node: StructDef(
+      name: Spanned(
+        node: "Foo",
+        span: Span(
+          start: 7,
+          end: 10,
+        ),
+      ),
+      body: [
+        Spanned(
+          node: StructField(
+            name: Spanned(
+              node: "x",
+              span: Span(
+                start: 16,
+                end: 17,
+              ),
+            ),
+            typ: Spanned(
+              node: Base(
+                base: "address",
+              ),
+              span: Span(
+                start: 19,
+                end: 26,
+              ),
+            ),
+          ),
+          span: Span(
+            start: 16,
+            end: 26,
+          ),
+        ),
+      ],
+    ),
+    span: Span(
+      start: 0,
+      end: 26,
+    ),
+  ),
+]

--- a/parser/tests/test_parsers.rs
+++ b/parser/tests/test_parsers.rs
@@ -367,6 +367,12 @@ parser_fixture_tests! {
         "fixtures/parsers/contract_def.ron",
     ),
     (
+        repeat(struct_def),
+        test_struct_def,
+        write_struct_def,
+        "fixtures/parsers/struct_def.ron",
+    ),
+    (
         repeat(contract_stmt),
         test_contract_stmt,
         write_contract_stmt,


### PR DESCRIPTION
### What was wrong?

Fe should support structs to allow better user defined abstractions.

### How was it fixed?

This PR lays the ground work for struct support as demonstrated with the following test.

```
struct House:
    price: u256
    size: u256
    vacant: bool

contract Foo:

    pub def bar() -> u256:
        building: House = House(300, 500, true)
        assert building.size == 500
        assert building.price == 300
        assert building.vacant

        building.vacant = false
        building.price = 1
        building.size = 2

        assert building.vacant == false
        assert building.price == 1
        assert building.size == 2
        return building.size

```

There are still a few open todos which were moved into dedicated issues (see todos)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
- [x] Create issue for `pub` field support (it parses but isn't respected) -> #236
- [x] Create issue for storage assignment support -> #235 
- [x] Create issue for enforcing KW syntax for structs -> #234 