### PR TITLE
Contract type and external calls.

### DIFF
--- a/analyzer/src/namespace/operations.rs
+++ b/analyzer/src/namespace/operations.rs
@@ -16,6 +16,7 @@ pub fn index(value: Type, index: Type) -> Result<Type, SemanticError> {
         Type::Base(_) => Err(SemanticError::not_subscriptable()),
         Type::Tuple(_) => Err(SemanticError::not_subscriptable()),
         Type::String(_) => Err(SemanticError::not_subscriptable()),
+        Type::Contract(_) => Err(SemanticError::not_subscriptable()),
     }
 }
 

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -106,6 +106,11 @@ impl ContractScope {
         }))
     }
 
+    /// Return the module scope that the contract scope inherits from
+    pub fn module_scope(&self) -> Shared<ModuleScope> {
+        Rc::clone(&self.parent)
+    }
+
     /// Lookup contract event definition by its name.
     pub fn event_def(&self, name: String) -> Option<Event> {
         self.event_defs.get(&name).map(|def| (*def).clone())

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -25,7 +25,8 @@ pub fn var_decl(
         let declared_type = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), typ)?;
         if let Some(value) = value {
             let value_attributes =
-                expressions::expr(Rc::clone(&scope), Rc::clone(&context), value)?;
+                expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), value)?;
+
             if Type::from(declared_type.clone()) != value_attributes.typ {
                 return Err(SemanticError::type_error());
             }

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -39,6 +39,12 @@ pub fn decode_name<T: AbiEncoding>(typ: &T, location: AbiDecodeLocation) -> yul:
     identifier! { (full_name) }
 }
 
+/// Generates an external call function name for a given type and location.
+pub fn contract_call(contract_name: &str, func_name: &str) -> yul::Identifier {
+    let name = format!("{}_{}", contract_name, func_name);
+    identifier! { (name) }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::yul::names::{

--- a/compiler/src/yul/operations/abi.rs
+++ b/compiler/src/yul/operations/abi.rs
@@ -53,6 +53,38 @@ pub fn encode_size<T: AbiEncoding>(types: Vec<T>, vals: Vec<yul::Expression>) ->
     return expression! { add([static_size], [data_operations::sum(dyn_size)]) };
 }
 
+/// Returns an expression that gives the max size of the encoded values.
+pub fn static_encode_size<T: AbiEncoding>(types: Vec<T>) -> Result<yul::Expression, String> {
+    let mut static_size = 0;
+
+    for typ in types {
+        match typ.abi_type() {
+            AbiType::Uint { .. } => static_size += 32,
+            AbiType::Array { inner, size } => {
+                let inner_size = match *inner {
+                    AbiType::Uint {
+                        size: AbiUintSize { padded_size, .. },
+                    } => padded_size,
+                    AbiType::Array { .. } => unimplemented!(),
+                };
+                match size {
+                    AbiArraySize::Static { size } => {
+                        static_size += utils::ceil_32(inner_size * size)
+                    }
+                    AbiArraySize::Dynamic => {
+                        return Err(
+                            "tried to get the static encoding size of dynamically sized value"
+                                .to_string(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(literal_expression! { (static_size) })
+}
+
 /// Returns a list of expressions that can be used to decode given types.
 /// `start` is where the encoding starts and `loc` indicates whether the data is
 /// in calldata or memory.
@@ -81,10 +113,14 @@ mod tests {
         decode,
         encode,
         encode_size,
+        static_encode_size,
     };
     use fe_analyzer::namespace::types::{
         AbiDecodeLocation,
+        Array,
+        Base,
         FeString,
+        FixedSize,
         U256,
     };
     use yultsur::*;
@@ -115,6 +151,22 @@ mod tests {
             )[0]
             .to_string(),
             "abi_decode_string26_calldata(42, 0)"
+        )
+    }
+
+    #[test]
+    fn test_static_encode_size() {
+        assert_eq!(
+            static_encode_size(vec![
+                FixedSize::Array(Array {
+                    inner: Base::Address,
+                    dimension: 42
+                }),
+                FixedSize::Base(Base::Bool)
+            ])
+            .expect("failed to get static size")
+            .to_string(),
+            "1376"
         )
     }
 }

--- a/compiler/src/yul/operations/calls.rs
+++ b/compiler/src/yul/operations/calls.rs
@@ -1,0 +1,15 @@
+use crate::yul::names;
+use fe_analyzer::namespace::types::Contract;
+use yultsur::*;
+
+/// Make a call to a contract of the given type and address with a set of
+/// parameters.
+pub fn contract_call(
+    contract: Contract,
+    func_name: String,
+    address: yul::Expression,
+    params: Vec<yul::Expression>,
+) -> yul::Expression {
+    let func_name = names::contract_call(&contract.name, &func_name);
+    expression! { [func_name]([address], [params...]) }
+}

--- a/compiler/src/yul/operations/mod.rs
+++ b/compiler/src/yul/operations/mod.rs
@@ -1,2 +1,3 @@
 pub mod abi;
+pub mod calls;
 pub mod data;

--- a/compiler/src/yul/runtime/functions/calls.rs
+++ b/compiler/src/yul/runtime/functions/calls.rs
@@ -1,0 +1,84 @@
+use crate::abi::utils as abi_utils;
+use crate::yul::names;
+use crate::yul::operations::abi as abi_operations;
+use fe_analyzer::namespace::types::Contract;
+use fe_analyzer::namespace::types::{
+    AbiDecodeLocation,
+    AbiEncoding,
+};
+use yultsur::*;
+
+/// Builds a set of functions used to make calls to the given contract's public
+/// functions.
+pub fn contract_calls(contract: Contract) -> Vec<yul::Statement> {
+    let contract_name = contract.name;
+    contract
+        .functions
+        .into_iter()
+        .map(|function| {
+            // get the name of the call function and its parameters
+            let function_name = names::contract_call(&contract_name, &function.name);
+            let param_names = function
+                .param_types
+                .iter()
+                .map(|typ| typ.abi_name())
+                .collect::<Vec<String>>();
+
+            // create a pair of identifiers and expressions for the parameters
+            let (param_idents, param_exprs): (Vec<yul::Identifier>, Vec<yul::Expression>) = (0
+                ..function.param_types.len())
+                .into_iter()
+                .map(|n| {
+                    let name = format!("val_{}", n);
+                    (identifier! { (name) }, identifier_expression! { (name) })
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .unzip();
+            // the function selector must be added to the first 4 bytes of the calldata
+            let selector = {
+                let selector = abi_utils::func_selector(function.name.clone(), param_names);
+                literal_expression! { (selector) }
+            };
+            // the operations used to encode the parameters
+            let encoding_operation =
+                abi_operations::encode(function.param_types.clone(), param_exprs.clone());
+            // the size of the encoded data
+            let encoding_size = abi_operations::encode_size(function.param_types, param_exprs);
+
+            if function.return_type.is_empty_tuple() {
+                // there is no return data to handle
+                function_definition! {
+                    function [function_name](addr, [param_idents...]) {
+                        (let instart := alloc_mstoren([selector], 4))
+                        (let insize := add(4, [encoding_size]))
+                        (pop([encoding_operation]))
+                        (pop((call((gas()), addr, 0, instart, insize, 0, 0))))
+                    }
+                }
+            } else {
+                let decoding_size =
+                    abi_operations::static_encode_size(vec![function.return_type.clone()])
+                        .expect("failed to get the static encoding size");
+                let decoding_operation = abi_operations::decode(
+                    vec![function.return_type],
+                    identifier_expression! { outstart },
+                    AbiDecodeLocation::Memory,
+                )[0]
+                .to_owned();
+                // return data must be captured and decoded
+                function_definition! {
+                    function [function_name](addr, [param_idents...]) -> return_val {
+                        (let instart := alloc_mstoren([selector], 4))
+                        (let insize := add(4, [encoding_size]))
+                        (pop([encoding_operation]))
+                        (let outsize := [decoding_size])
+                        (let outstart := alloc(outsize))
+                        (pop((call((gas()), addr, 0, instart, insize, outstart, outsize))))
+                        (return_val := [decoding_operation])
+                    }
+                }
+            }
+        })
+        .collect()
+}

--- a/compiler/src/yul/runtime/functions/mod.rs
+++ b/compiler/src/yul/runtime/functions/mod.rs
@@ -2,6 +2,7 @@ use fe_analyzer::namespace::types::AbiDecodeLocation;
 use yultsur::*;
 
 pub mod abi;
+pub mod calls;
 pub mod data;
 
 /// Returns all functions that should be available during runtime.

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -50,7 +50,9 @@ use std::fs;
     case("numeric_capacity_mismatch/i128_neg.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/i128_pos.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/i256_neg.fe", "NumericCapacityMismatch"),
-    case("numeric_capacity_mismatch/i256_pos.fe", "NumericCapacityMismatch")
+    case("numeric_capacity_mismatch/i256_pos.fe", "NumericCapacityMismatch"),
+    case("external_call_type_error.fe", "TypeError"),
+    case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams")
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/fixtures/compile_errors/external_call_type_error.fe
+++ b/compiler/tests/fixtures/compile_errors/external_call_type_error.fe
@@ -1,0 +1,7 @@
+contract Foo:
+    pub def bar(a: u256):
+        pass
+
+contract FooProxy:
+    pub def baz():
+        Foo(address(0)).bar("hello world")

--- a/compiler/tests/fixtures/compile_errors/external_call_wrong_number_of_params.fe
+++ b/compiler/tests/fixtures/compile_errors/external_call_wrong_number_of_params.fe
@@ -1,0 +1,7 @@
+contract Foo:
+    pub def bar(a: u256, b: u256):
+        pass
+
+contract FooProxy:
+    pub def baz():
+        Foo(address(0)).bar(42)

--- a/compiler/tests/fixtures/external_contract.fe
+++ b/compiler/tests/fixtures/external_contract.fe
@@ -1,0 +1,33 @@
+contract Foo:
+    event MyEvent:
+        my_num: u256
+        my_addrs: address[5]
+        my_string: string11
+
+    pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
+        emit MyEvent(my_num, my_addrs, my_string)
+
+    pub def build_array(a: u256, b: u256) -> u256[3]:
+        my_array: u256[3]
+        my_array[0] = a
+        my_array[1] = a * b
+        my_array[2] = b
+        return my_array
+
+contract FooProxy:
+    pub def call_emit_event(
+        foo_address: address,
+        my_num: u256,
+        my_addrs: address[5],
+        my_string: string11
+    ):
+        foo: Foo = Foo(foo_address)
+        foo.emit_event(my_num, my_addrs, my_string)
+
+    pub def call_build_array(
+         foo_address: address,
+         a: u256,
+         b: u256,
+    ) -> u256[3]:
+        foo: Foo = Foo(foo_address)
+        return foo.build_array(a, b)

--- a/newsfragments/204.feature.md
+++ b/newsfragments/204.feature.md
@@ -1,0 +1,24 @@
+Added support for external contract calls. Contract definitions now 
+add a type to the module scope, which may be used to create contract 
+values with the contract's public functions as callable attributes.
+
+Example:
+
+```python
+contract Foo:
+    pub def build_array(a: u256, b: u256) -> u256[3]:
+        my_array: u256[3]
+        my_array[0] = a
+        my_array[1] = a * b
+        my_array[2] = b
+        return my_array
+
+contract FooProxy:
+    pub def call_build_array(
+        foo_address: address,
+        a: u256,
+        b: u256,
+    ) -> u256[3]:
+        foo: Foo = Foo(foo_address)
+        return foo.build_array(a, b)
+```


### PR DESCRIPTION
### What was wrong?

We were unable to make calls to external contracts.

### How was it fixed?

- Added a new `Contract` type. The contract type is treated like an address, but carries extra information about the contact's public interface.
- When compiling a contract, the module scope is checked for any external contract type definitions. If an external contract type is found, a set of functions is added to the contract's runtime for calling to the external contract's public interface. For now, contract type definitions are only visible to subsequently defined contracts, this can be changed later.
- Calls to external contracts in Fe (e.g. `Foo(foo_address).bar(42, my_string)`) are mapped to calls to the runtime functions mentioned above. So for example, the call mentioned before is mapped to `Foo_bar($foo_address, 42, $my_string)`. This makes the Yul code pretty easy to read.

Examples of external contract call runtime functions:

```javascript
// with return data
function Foo_build_array(addr, val_0, val_1) -> return_val {
  let instart := alloc_mstoren(0x649de2ee, 4) 
  let insize := add(4, add(64, 0)) 
  pop(abi_encode_uint256_uint256(val_0, val_1)) 
  let outsize := 96 let outstart := alloc(outsize) 
  pop(call(gas(), addr, 0, instart, insize, outstart, outsize)) 
  return_val := abi_decode_uint2563_mem(outstart, 0) 
}
            
// no return data
function Foo_emit_event(addr, val_0, val_1, val_2) {
  let instart := alloc_mstoren(0x16bc6ad2, 4) 
  let insize := add(4, add(256, ceil32(mul(mload(val_2), 1)))) 
  pop(abi_encode_uint256_address5_string11(val_0, val_1, val_2)) 
  pop(call(gas(), addr, 0, instart, insize, 0, 0)) 
}
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
