### PR TITLE
Run code coverage on all features (solc-backend)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libboost-all-dev
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
+        sudo update-alternatives --set g++ "/usr/bin/g++-8"
     - uses: actions/checkout@v2
     - name: Cache Rust dependencies
       uses: actions/cache@v1.1.2

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-wasm-test:
 
 .PHONY: coverage
 coverage:
-	cargo tarpaulin --all --verbose --exclude-files 'tests/*' --exclude-files 'main.rs' --out xml html
+	cargo tarpaulin --workspace --all-features --verbose --exclude-files 'tests/*' --exclude-files 'main.rs' --out xml html
 
 .PHONY: clippy
 clippy:


### PR DESCRIPTION
### What was wrong?

Code coverage reports don't include tests that require the solc-backend feature.

### How was it fixed?

Added `--all-features` flag to the cargo tarpaulin command (and replaced the deprecated `--all` with `--workspace`).