### PR TITLE
Fix crash in abi builder on unknown type with short name

### DIFF
--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -178,7 +178,7 @@ fn type_desc<'a>(
         fe::TypeDesc::Base { base: "i8" } => Ok(VarType::Int8),
         fe::TypeDesc::Base { base: "bool" } => Ok(VarType::Bool),
         fe::TypeDesc::Base { base: "address" } => Ok(VarType::Address),
-        fe::TypeDesc::Base { base } if &base[..6] == "string" => Ok(VarType::String),
+        fe::TypeDesc::Base { base } if base.starts_with("string") => Ok(VarType::String),
         fe::TypeDesc::Base { base } => {
             Err(CompileError::str(format!("unrecognized type: {}", base)))
         }


### PR DESCRIPTION
### What was wrong?

The abi builder crashed on an unknown type (with a short name) in a function signature. Eg:
```
contract F:
  pub def f(x: foo) -> bool:
    return true
```

This presumably should have been caught by the analyzer; I haven't looked into how it slipped through the cracks.

### How was it fixed?

changed `if &base[..6] == "string"` to `if base.starts_with("string")`. Other similar tests all use `starts_with` already, btw.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
