### PR TITLE
Panic if Yul compilation fails.

### DIFF
--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -41,7 +41,10 @@ pub fn compile(src: FeSrc, _with_bytecode: bool) -> Result<CompiledModule, Compi
     // compile to bytecode if required
     #[cfg(feature = "solc-backend")]
     let bytecode_contracts = if _with_bytecode {
-        evm::compile(yul_contracts.clone())?
+        match evm::compile(yul_contracts.clone()) {
+            Err(error) => panic!("Yul compilation failed: {}", error),
+            Ok(contracts) => contracts,
+        }
     } else {
         std::collections::HashMap::new()
     };

--- a/newsfragments/218.feature.md
+++ b/newsfragments/218.feature.md
@@ -1,0 +1,1 @@
+The CLI now panics if an error is encountered during Yul compilation.


### PR DESCRIPTION
### What was wrong?

We return an error to the user when Yul compilation fails. We should be panicking.

### How was it fixed?

Changed the compiler so that it panics instead of returning an error.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
