### PR TITLE
Fixes unicode and brackets tokens in the parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /target
 **/*.rs.bk
 tarpaulin-report.html


### PR DESCRIPTION
* Checks for balanced brackets ( { and ] in a parser
* Handle unicode chars as error tokens in the parser

Fixes #226
Fixes #221
