### PR TITLE
Add get_type_defs/get_module_type_defs to scope

### DIFF
--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -100,20 +100,13 @@ impl From<Shared<ContractScope>> for ContractAttributes {
             }
         }
 
-        let external_contracts = scope
-            .borrow()
-            .module_scope()
-            .borrow()
-            .type_defs
-            .values()
-            .filter_map(|typ| {
-                if let Type::Contract(contract) = typ {
-                    Some(contract.to_owned())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let external_contracts = scope.borrow().get_module_type_defs(|typ| {
+            if let Type::Contract(contract) = typ {
+                Some(contract.to_owned())
+            } else {
+                None
+            }
+        });
 
         ContractAttributes {
             public_functions,

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -91,6 +91,11 @@ impl ModuleScope {
     pub fn add_type_def(&mut self, name: String, typ: Type) {
         self.type_defs.insert(name, typ);
     }
+
+    /// Filter module scope for type definitions that match the given predicate
+    pub fn get_type_defs<B, F: FnMut(&Type) -> Option<B>>(&self, predicate: F) -> Vec<B> {
+        self.type_defs.values().filter_map(predicate).collect()
+    }
 }
 
 impl ContractScope {
@@ -109,6 +114,11 @@ impl ContractScope {
     /// Return the module scope that the contract scope inherits from
     pub fn module_scope(&self) -> Shared<ModuleScope> {
         Rc::clone(&self.parent)
+    }
+
+    /// Filter module scope for type definitions that match the given predicate
+    pub fn get_module_type_defs<B, F: FnMut(&Type) -> Option<B>>(&self, predicate: F) -> Vec<B> {
+        self.module_scope().borrow().get_type_defs(predicate)
     }
 
     /// Lookup contract event definition by its name.


### PR DESCRIPTION
### What was wrong?

Nothing wrong but a fall out from #203. This adds convenience helper to the contract and module scopes to filter for a list of type defintions.

### How was it fixed?

Basically took some existing code and put it in a function + wrangling 20 minutes about the right syntax for the closure.

