### PR TITLE
Use Into<String> instead of String for scope APIs

### DIFF
--- a/analyzer/src/namespace/events.rs
+++ b/analyzer/src/namespace/events.rs
@@ -12,12 +12,16 @@ pub struct Event {
 }
 
 impl Event {
-    pub fn new(name: String, fields: Vec<FixedSize>, indexed_fields: Vec<usize>) -> Self {
+    pub fn new<T: Into<String>>(
+        name: T,
+        fields: Vec<FixedSize>,
+        indexed_fields: Vec<usize>,
+    ) -> Self {
         let abi_fields = fields
             .iter()
             .map(|field| field.abi_name())
             .collect::<Vec<String>>();
-        let topic = build_event_topic(name, abi_fields);
+        let topic = build_event_topic(name.into(), abi_fields);
 
         Self {
             topic,

--- a/analyzer/src/traversal/assignments.rs
+++ b/analyzer/src/traversal/assignments.rs
@@ -85,7 +85,7 @@ mod tests {
         contract_scope
             .borrow_mut()
             .add_field(
-                "foobar".to_string(),
+                "foobar",
                 Type::Map(Map {
                     key: U256,
                     value: Box::new(Type::Base(U256)),
@@ -95,12 +95,12 @@ mod tests {
         let function_scope = BlockScope::from_contract_scope("".to_string(), contract_scope);
         function_scope
             .borrow_mut()
-            .add_var("foo".to_string(), FixedSize::Base(U256))
+            .add_var("foo", FixedSize::Base(U256))
             .unwrap();
         function_scope
             .borrow_mut()
             .add_var(
-                "bar".to_string(),
+                "bar",
                 FixedSize::Array(Array {
                     inner: U256,
                     dimension: 100,

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -81,7 +81,7 @@ fn contract_field(
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::ContractField { qual: _, name, typ } = &stmt.node {
         let typ = types::type_desc(Scope::Contract(Rc::clone(&scope)), typ)?;
-        return scope.borrow_mut().add_field(name.node.to_string(), typ);
+        return scope.borrow_mut().add_field(name.node, typ);
     }
 
     unreachable!()
@@ -122,7 +122,7 @@ fn event_def(
 
         return scope
             .borrow_mut()
-            .add_event(name.clone(), Event::new(name, fields, indexed_fields));
+            .add_event(&name, Event::new(&name, fields, indexed_fields));
     }
 
     unreachable!()

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -89,7 +89,7 @@ mod tests {
         let context = analyze(Rc::clone(&scope), statement).expect("analysis failed");
         assert_eq!(context.expressions.len(), 3);
         assert_eq!(
-            scope.borrow().get_variable_def("foo".to_string()),
+            scope.borrow().get_variable_def("foo"),
             Some(FixedSize::Base(U256))
         );
     }

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -182,7 +182,7 @@ fn expr_name(
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Name(name) = exp.node {
-        return match scope.borrow().get_variable_def(name.to_string()) {
+        return match scope.borrow().get_variable_def(name) {
             Some(FixedSize::Base(base)) => {
                 Ok(ExpressionAttributes::new(Type::Base(base), Location::Value))
             }
@@ -296,8 +296,7 @@ fn expr_attribute(
 
         // Before we try to match any pre-defined objects, try matching as a
         // custom type
-        if let Some(FixedSize::Struct(_)) = scope.borrow().get_variable_def(object_name.to_string())
-        {
+        if let Some(FixedSize::Struct(_)) = scope.borrow().get_variable_def(object_name) {
             return expr_attribute_custom_type(Rc::clone(&scope), context, value, attr);
         }
 
@@ -346,7 +345,7 @@ fn expr_attribute_custom_type(
     let val_str = expr_name_str(value)?;
     let custom_type = scope
         .borrow()
-        .get_variable_def(val_str.to_string())
+        .get_variable_def(val_str)
         .ok_or_else(SemanticError::undefined_value)?;
     context.borrow_mut().add_expression(
         value,
@@ -370,7 +369,7 @@ fn expr_attribute_self(
     scope: Shared<BlockScope>,
     attr: &Spanned<&str>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    match scope.borrow().contract_field_def(attr.node.to_string()) {
+    match scope.borrow().contract_field_def(attr.node) {
         Some(field) => Ok(ExpressionAttributes::new(
             field.typ,
             Location::Storage {
@@ -658,7 +657,7 @@ fn expr_call_type_attribute(
                     .borrow()
                     .contract_scope()
                     .borrow_mut()
-                    .add_created_contract(contract.name.clone());
+                    .add_created_contract(&contract.name);
 
                 Ok(ExpressionAttributes::new(
                     Type::Contract(contract),
@@ -678,7 +677,7 @@ fn expr_call_type_attribute(
                     .borrow()
                     .contract_scope()
                     .borrow_mut()
-                    .add_created_contract(contract.name.clone());
+                    .add_created_contract(&contract.name);
 
                 Ok(ExpressionAttributes::new(
                     Type::Contract(contract),
@@ -1100,12 +1099,12 @@ mod tests {
         let scope = scope();
         scope
             .borrow_mut()
-            .add_var("my_addr".to_string(), FixedSize::Base(Base::Address))
+            .add_var("my_addr", FixedSize::Base(Base::Address))
             .unwrap();
         scope
             .borrow_mut()
             .add_var(
-                "my_addr_array".to_string(),
+                "my_addr_array",
                 FixedSize::Array(Array {
                     dimension: 100,
                     inner: Base::Address,
@@ -1117,7 +1116,7 @@ mod tests {
             .contract_scope()
             .borrow_mut()
             .add_field(
-                "my_addr_u256_map".to_string(),
+                "my_addr_u256_map",
                 Type::Map(Map {
                     key: Base::Address,
                     value: Box::new(Type::Base(U256)),

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -63,7 +63,7 @@ pub fn func_def(
 
         let is_public = qual.is_some();
         contract_scope.borrow_mut().add_function(
-            name.clone(),
+            &name,
             is_public,
             param_types.clone(),
             return_type.clone(),
@@ -166,10 +166,10 @@ fn func_def_arg(
     scope: Shared<BlockScope>,
     arg: &Spanned<fe::FuncDefArg>,
 ) -> Result<FixedSize, SemanticError> {
-    let name = arg.node.name.node.to_string();
     let typ = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), &arg.node.typ)?;
-
-    scope.borrow_mut().add_var(name, typ.clone())?;
+    scope
+        .borrow_mut()
+        .add_var(arg.node.name.node, typ.clone())?;
 
     Ok(typ)
 }
@@ -220,9 +220,7 @@ fn for_loop(
             // Step 3: Make sure iter is in the function scope & it should be an array.
             let target_type = verify_is_array(scope, Rc::clone(&context), iter)?;
             let target_name = expressions::expr_name_str(target)?;
-            body_scope
-                .borrow_mut()
-                .add_var(target_name.to_string(), target_type)?;
+            body_scope.borrow_mut().add_var(target_name, target_type)?;
             // Step 4: Traverse the statements within the `for loop` body scope.
             traverse_statements(body_scope, context, body)
         }
@@ -478,7 +476,7 @@ mod tests {
 
         let def = scope
             .borrow()
-            .function_def("foo".to_string())
+            .function_def("foo")
             .expect("No definiton for foo exists");
 
         assert_eq!(def.is_public, false);


### PR DESCRIPTION
@g-r-a-n-t I've been thinking about this change and wanted to get your opinion on it. Basically, for all the scope APIs that currently take `String` as a parameter I changed them to take `Into<String>`. The benefit is that callsites get slightly cleaner because both `&str` and `String` will be accepted. The downside is that the generic syntax makes the function definition slightly more verbose.

Another alternative to consider would be to change all the function parameters to `&str` instead which might actually be a good balance because it looks less bloaty compared to the generic syntax and still gets rid of all the `to_string()`, `clone()`, `to_owned()` at the callsites (while sometimes demanding an additional `&` if we are coming from a `String`. This is also what's  [recommended here](https://users.rust-lang.org/t/idiomatic-string-parmeter-types-str-vs-asref-str-vs-into-string/7934/7).

Interested to hear your opinion about this.