### PR TITLE
Refactor string usage to be aligned across code base and make fewer allocations

### DIFF
--- a/analyzer/src/namespace/events.rs
+++ b/analyzer/src/namespace/events.rs
@@ -12,7 +12,7 @@ pub struct Event {
 }
 
 impl Event {
-    pub fn new(name: String, fields: Vec<FixedSize>, indexed_fields: Vec<usize>) -> Self {
+    pub fn new(name: &str, fields: Vec<FixedSize>, indexed_fields: Vec<usize>) -> Self {
         let abi_fields = fields
             .iter()
             .map(|field| field.abi_name())
@@ -62,7 +62,7 @@ impl Event {
     }
 }
 
-fn build_event_topic(name: String, fields: Vec<String>) -> String {
+fn build_event_topic(name: &str, fields: Vec<String>) -> String {
     let signature = format!("{}({})", name, fields.join(","));
     get_full_signature(signature.as_bytes())
 }
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn test_new_event() {
         let event = Event::new(
-            "MyEvent".to_string(),
+            "MyEvent",
             vec![
                 FixedSize::Base(Base::Address),
                 FixedSize::Base(Base::Address),

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -195,8 +195,8 @@ impl ContractScope {
     }
 
     /// Add a static string definition to the scope.
-    pub fn add_string(&mut self, value: String) -> Result<(), SemanticError> {
-        self.string_defs.insert(value);
+    pub fn add_string(&mut self, value: &str) -> Result<(), SemanticError> {
+        self.string_defs.insert(value.to_owned());
         Ok(())
     }
 

--- a/analyzer/src/traversal/assignments.rs
+++ b/analyzer/src/traversal/assignments.rs
@@ -85,22 +85,22 @@ mod tests {
         contract_scope
             .borrow_mut()
             .add_field(
-                "foobar".to_string(),
+                "foobar",
                 Type::Map(Map {
                     key: U256,
                     value: Box::new(Type::Base(U256)),
                 }),
             )
             .unwrap();
-        let function_scope = BlockScope::from_contract_scope("".to_string(), contract_scope);
+        let function_scope = BlockScope::from_contract_scope("", contract_scope);
         function_scope
             .borrow_mut()
-            .add_var("foo".to_string(), FixedSize::Base(U256))
+            .add_var("foo", FixedSize::Base(U256))
             .unwrap();
         function_scope
             .borrow_mut()
             .add_var(
-                "bar".to_string(),
+                "bar",
                 FixedSize::Array(Array {
                     inner: U256,
                     dimension: 100,

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -60,9 +60,9 @@ pub fn contract_def(
             .module_scope()
             .borrow_mut()
             .add_type_def(
-                name.node.to_string(),
+                name.node,
                 Type::Contract(Contract {
-                    name: name.node.to_string(),
+                    name: name.node.to_owned(),
                     functions: contract_attributes.public_functions.clone(),
                 }),
             );
@@ -81,7 +81,7 @@ fn contract_field(
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::ContractField { qual: _, name, typ } = &stmt.node {
         let typ = types::type_desc(Scope::Contract(Rc::clone(&scope)), typ)?;
-        return scope.borrow_mut().add_field(name.node.to_string(), typ);
+        return scope.borrow_mut().add_field(name.node, typ);
     }
 
     unreachable!()
@@ -92,7 +92,7 @@ fn event_def(
     stmt: &Spanned<fe::ContractStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::EventDef { name, fields } = &stmt.node {
-        let name = name.node.to_string();
+        let name = name.node;
 
         let (is_indexed_bools, fields): (Vec<bool>, Vec<FixedSize>) = fields
             .iter()
@@ -122,7 +122,7 @@ fn event_def(
 
         return scope
             .borrow_mut()
-            .add_event(name.clone(), Event::new(name, fields, indexed_fields));
+            .add_event(name, Event::new(name, fields, indexed_fields));
     }
 
     unreachable!()

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -32,7 +32,7 @@ pub fn var_decl(
             }
         }
 
-        scope.borrow_mut().add_var(name, declared_type.clone())?;
+        scope.borrow_mut().add_var(&name, declared_type.clone())?;
         context.borrow_mut().add_declaration(stmt, declared_type);
 
         return Ok(());
@@ -65,7 +65,7 @@ mod tests {
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
-        BlockScope::from_contract_scope("".to_string(), contract_scope)
+        BlockScope::from_contract_scope("", contract_scope)
     }
 
     fn analyze(scope: Shared<BlockScope>, src: &str) -> Result<Context, SemanticError> {
@@ -89,7 +89,7 @@ mod tests {
         let context = analyze(Rc::clone(&scope), statement).expect("analysis failed");
         assert_eq!(context.expressions.len(), 3);
         assert_eq!(
-            scope.borrow().get_variable_def("foo".to_string()),
+            scope.borrow().get_variable_def("foo"),
             Some(FixedSize::Base(U256))
         );
     }

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -21,7 +21,7 @@ pub fn var_decl(
     stmt: &Spanned<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.node {
-        let name = expressions::expr_name_string(target)?;
+        let name = expressions::expr_name_str(target)?;
         let declared_type = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), typ)?;
         if let Some(value) = value {
             let value_attributes =
@@ -32,7 +32,7 @@ pub fn var_decl(
             }
         }
 
-        scope.borrow_mut().add_var(&name, declared_type.clone())?;
+        scope.borrow_mut().add_var(name, declared_type.clone())?;
         context.borrow_mut().add_declaration(stmt, declared_type);
 
         return Ok(());

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -143,11 +143,6 @@ pub fn expr_name_str<'a>(exp: &Spanned<fe::Expr<'a>>) -> Result<&'a str, Semanti
     unreachable!()
 }
 
-/// Retrieves the &str value of a name expression and converts it to a String.
-pub fn expr_name_string(exp: &Spanned<fe::Expr>) -> Result<String, SemanticError> {
-    expr_name_str(exp).map(|name| name.to_string())
-}
-
 /// Gather context information for an index and check for type errors.
 pub fn slices_index(
     scope: Shared<BlockScope>,

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -182,7 +182,7 @@ fn expr_name(
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Name(name) = exp.node {
-        return match scope.borrow().get_variable_def(name.to_string()) {
+        return match scope.borrow().get_variable_def(name) {
             Some(FixedSize::Base(base)) => {
                 Ok(ExpressionAttributes::new(Type::Base(base), Location::Value))
             }
@@ -296,8 +296,7 @@ fn expr_attribute(
 
         // Before we try to match any pre-defined objects, try matching as a
         // custom type
-        if let Some(FixedSize::Struct(_)) = scope.borrow().get_variable_def(object_name.to_string())
-        {
+        if let Some(FixedSize::Struct(_)) = scope.borrow().get_variable_def(object_name) {
             return expr_attribute_custom_type(Rc::clone(&scope), context, value, attr);
         }
 
@@ -346,7 +345,7 @@ fn expr_attribute_custom_type(
     let val_str = expr_name_str(value)?;
     let custom_type = scope
         .borrow()
-        .get_variable_def(val_str.to_string())
+        .get_variable_def(val_str)
         .ok_or_else(SemanticError::undefined_value)?;
     context.borrow_mut().add_expression(
         value,
@@ -370,7 +369,7 @@ fn expr_attribute_self(
     scope: Shared<BlockScope>,
     attr: &Spanned<&str>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    match scope.borrow().contract_field_def(attr.node.to_string()) {
+    match scope.borrow().contract_field_def(attr.node) {
         Some(field) => Ok(ExpressionAttributes::new(
             field.typ,
             Location::Storage {
@@ -570,7 +569,7 @@ fn expr_call_self_attribute(
         .borrow()
         .contract_scope()
         .borrow()
-        .function_def(func_name)
+        .function_def(&func_name)
     {
         let argument_attributes = expr_call_args(Rc::clone(&scope), Rc::clone(&context), args)?;
 
@@ -658,7 +657,7 @@ fn expr_call_type_attribute(
                     .borrow()
                     .contract_scope()
                     .borrow_mut()
-                    .add_created_contract(contract.name.clone());
+                    .add_created_contract(&contract.name);
 
                 Ok(ExpressionAttributes::new(
                     Type::Contract(contract),
@@ -678,7 +677,7 @@ fn expr_call_type_attribute(
                     .borrow()
                     .contract_scope()
                     .borrow_mut()
-                    .add_created_contract(contract.name.clone());
+                    .add_created_contract(&contract.name);
 
                 Ok(ExpressionAttributes::new(
                     Type::Contract(contract),
@@ -1026,7 +1025,7 @@ mod tests {
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new(module_scope);
-        BlockScope::from_contract_scope("".to_string(), contract_scope)
+        BlockScope::from_contract_scope("", contract_scope)
     }
 
     fn analyze(scope: Shared<BlockScope>, src: &str) -> Context {
@@ -1100,12 +1099,12 @@ mod tests {
         let scope = scope();
         scope
             .borrow_mut()
-            .add_var("my_addr".to_string(), FixedSize::Base(Base::Address))
+            .add_var("my_addr", FixedSize::Base(Base::Address))
             .unwrap();
         scope
             .borrow_mut()
             .add_var(
-                "my_addr_array".to_string(),
+                "my_addr_array",
                 FixedSize::Array(Array {
                     dimension: 100,
                     inner: Base::Address,
@@ -1117,7 +1116,7 @@ mod tests {
             .contract_scope()
             .borrow_mut()
             .add_field(
-                "my_addr_u256_map".to_string(),
+                "my_addr_u256_map",
                 Type::Map(Map {
                     key: Base::Address,
                     value: Box::new(Type::Base(U256)),

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -355,9 +355,9 @@ fn emit(
         },
     } = &stmt.node
     {
-        let event_name = expressions::expr_name_string(func)?;
+        let event_name = expressions::expr_name_str(func)?;
 
-        if let Some(event) = scope.borrow().contract_event_def(&event_name) {
+        if let Some(event) = scope.borrow().contract_event_def(event_name) {
             context.borrow_mut().add_emit(stmt, event.clone());
 
             let argument_attributes = args

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -40,7 +40,7 @@ fn type_def(
 ) -> Result<(), SemanticError> {
     if let fe::ModuleStmt::TypeDef { name, typ } = &def.node {
         let typ = types::type_desc(&scope.borrow().type_defs, &typ.node)?;
-        scope.borrow_mut().add_type_def(name.node.to_string(), typ);
+        scope.borrow_mut().add_type_def(name.node, typ);
         return Ok(());
     }
 

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -31,6 +31,6 @@ pub fn struct_def(
     }
     module_scope
         .borrow_mut()
-        .add_type_def(name.to_string(), Type::Struct(val));
+        .add_type_def(name, Type::Struct(val));
     Ok(())
 }

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -60,18 +60,13 @@ fn contract_def<'a>(
             } => {
                 if let Some(qual) = qual {
                     if qual.node == fe::FuncQual::Pub {
-                        c.functions.push(func_def(
-                            type_defs,
-                            name.node.to_string(),
-                            args,
-                            return_type,
-                        )?)
+                        c.functions
+                            .push(func_def(type_defs, name.node, args, return_type)?)
                     }
                 }
             }
             fe::ContractStmt::EventDef { name, fields } => {
-                c.events
-                    .push(event_def(type_defs, name.node.to_string(), fields)?)
+                c.events.push(event_def(type_defs, name.node, fields)?)
             }
             fe::ContractStmt::ContractField { .. } => {}
         }
@@ -82,7 +77,7 @@ fn contract_def<'a>(
 
 fn event_def<'a>(
     type_defs: &'a TypeDefs<'a>,
-    name: String,
+    name: &str,
     fields: &[Spanned<fe::EventField<'a>>],
 ) -> Result<Event, CompileError> {
     let fields = fields
@@ -91,8 +86,8 @@ fn event_def<'a>(
         .collect::<Result<_, _>>()?;
 
     Ok(Event {
-        name,
-        typ: "event".to_string(),
+        name: name.to_owned(),
+        typ: "event".to_owned(),
         fields,
         anonymous: false,
     })
@@ -103,7 +98,7 @@ fn event_field<'a>(
     field: &'a fe::EventField<'a>,
 ) -> Result<EventField, CompileError> {
     Ok(EventField {
-        name: String::from(field.name.node),
+        name: field.name.node.to_owned(),
         typ: type_desc(&type_defs, &field.typ.node)?,
         indexed: field.qual.is_some(),
     })
@@ -111,7 +106,7 @@ fn event_field<'a>(
 
 fn func_def<'a>(
     type_defs: &'a TypeDefs<'a>,
-    name: String,
+    name: &str,
     args: &[Spanned<fe::FuncDefArg<'a>>],
     return_type: &'a Option<Spanned<fe::TypeDesc<'a>>>,
 ) -> Result<Function, CompileError> {
@@ -130,13 +125,13 @@ fn func_def<'a>(
     };
 
     let (name, typ) = if name == "__init__" {
-        ("".to_string(), FuncType::Constructor)
+        ("", FuncType::Constructor)
     } else {
         (name, FuncType::Function)
     };
 
     Ok(Function {
-        name,
+        name: name.to_owned(),
         typ,
         inputs,
         outputs,
@@ -148,7 +143,7 @@ fn func_def_arg<'a>(
     arg: &'a fe::FuncDefArg<'a>,
 ) -> Result<FuncInput, CompileError> {
     Ok(FuncInput {
-        name: String::from(arg.name.node),
+        name: arg.name.node.to_owned(),
         typ: type_desc(&type_defs, &arg.typ.node)?,
     })
 }

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -180,7 +180,7 @@ fn type_desc<'a>(
         fe::TypeDesc::Base { base: "address" } => Ok(VarType::Address),
         fe::TypeDesc::Base { base } if base.starts_with("string") => Ok(VarType::String),
         fe::TypeDesc::Base { base } => {
-            Err(CompileError::str(format!("unrecognized type: {}", base)))
+            Err(CompileError::str(&format!("unrecognized type: {}", base)))
         }
         fe::TypeDesc::Array { typ, dimension } => {
             if let fe::TypeDesc::Base { base: "bytes" } = &typ.node {

--- a/compiler/src/abi/utils.rs
+++ b/compiler/src/abi/utils.rs
@@ -2,16 +2,16 @@ use fe_common::utils::keccak::get_partial_signature;
 
 /// Formats the name and fields and calculates the 32 byte keccak256 value of
 /// the signature.
-pub fn event_topic(name: String, fields: Vec<String>) -> String {
+pub fn event_topic(name: &str, fields: Vec<String>) -> String {
     sign_event_or_func(name, fields, 32)
 }
 /// Formats the name and params and calculates the 4 byte keccak256 value of the
 /// signature.
-pub fn func_selector(name: String, params: Vec<String>) -> String {
+pub fn func_selector(name: &str, params: Vec<String>) -> String {
     sign_event_or_func(name, params, 4)
 }
 
-fn sign_event_or_func(name: String, params: Vec<String>, size: usize) -> String {
+fn sign_event_or_func(name: &str, params: Vec<String>, size: usize) -> String {
     let signature = format!("{}({})", name, params.join(","));
     get_partial_signature(signature.as_bytes(), size)
 }

--- a/compiler/src/errors.rs
+++ b/compiler/src/errors.rs
@@ -47,16 +47,16 @@ impl CompileError {
     }
 
     /// Create a single error with a static string.
-    pub fn static_str(s: &'static str) -> Self {
+    pub fn static_str(val: &'static str) -> Self {
         Self {
-            errors: vec![ErrorKind::StaticStr(s)],
+            errors: vec![ErrorKind::StaticStr(val)],
         }
     }
 
     /// Create a single error with a string object.
-    pub fn str(s: String) -> Self {
+    pub fn str(val: &str) -> Self {
         Self {
-            errors: vec![ErrorKind::Str(s)],
+            errors: vec![ErrorKind::Str(val.to_owned())],
         }
     }
 }
@@ -75,6 +75,6 @@ impl<'a> From<serde_json::error::Error> for CompileError {
 
 impl<'a> From<ethabi::Error> for CompileError {
     fn from(e: ethabi::Error) -> Self {
-        CompileError::str(format!("ethabi error: {}", e))
+        CompileError::str(&format!("ethabi error: {}", e))
     }
 }

--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -38,7 +38,7 @@ fn compile_single_contract(
         .replace("\"", "");
 
     if bytecode == "null" {
-        return Err(CompileError::str(output.to_string()));
+        return Err(CompileError::str(&output.to_string()));
     }
 
     Ok(bytecode)

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -28,7 +28,7 @@ pub fn compile(
     // parse source
     let fe_tokens = fe_parser::get_parse_tokens(src)?;
     let fe_module = fe_parser::parsers::file_input(&fe_tokens[..])
-        .map_err(|error| CompileError::str(error.format_user(src)))?
+        .map_err(|error| CompileError::str(&error.format_user(src)))?
         .1
         .node;
 
@@ -37,7 +37,7 @@ pub fn compile(
 
     // analyze source code
     let context = fe_analyzer::analyze(&fe_module)
-        .map_err(|error| CompileError::str(error.format_user(src)))?;
+        .map_err(|error| CompileError::str(&error.format_user(src)))?;
 
     // compile to yul
     let yul_contracts = yul::compile(context, &fe_module)?;

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -75,7 +75,7 @@ fn move_expression(
         (Location::Memory, Location::Value) => Ok(data_operations::mload(typ, val)),
         (Location::Memory, Location::Memory) => Ok(data_operations::mcopym(typ, val)),
         (Location::Storage { .. }, Location::Memory) => Ok(data_operations::scopym(typ, val)),
-        _ => Err(CompileError::str(format!(
+        _ => Err(CompileError::str(&format!(
             "invalid expression move: {:?} {:?}",
             from, to
         ))),

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -121,7 +121,7 @@ fn expr_call(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expressi
                         return match (value_attributes.typ.to_owned(), attr.node) {
                             (Type::Contract(contract), func_name) => Ok(contract_operations::call(
                                 contract,
-                                func_name.to_owned(),
+                                func_name,
                                 expr(context, value)?,
                                 yul_args,
                             )),

--- a/compiler/src/yul/operations/contracts.rs
+++ b/compiler/src/yul/operations/contracts.rs
@@ -6,11 +6,11 @@ use yultsur::*;
 /// parameters.
 pub fn call(
     contract: Contract,
-    func_name: String,
+    func_name: &str,
     address: yul::Expression,
     params: Vec<yul::Expression>,
 ) -> yul::Expression {
-    let func_name = names::contract_call(&contract.name, &func_name);
+    let func_name = names::contract_call(&contract.name, func_name);
     expression! { [func_name]([address], [params...]) }
 }
 

--- a/compiler/src/yul/operations/data.rs
+++ b/compiler/src/yul/operations/data.rs
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn test_emit_event_no_indexed() {
         let event = Event::new(
-            "MyEvent".to_string(),
+            "MyEvent",
             vec![FixedSize::Base(U256), FixedSize::Base(Base::Address)],
             vec![],
         );
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn test_emit_event_one_indexed() {
         let event = Event::new(
-            "MyEvent".to_string(),
+            "MyEvent",
             vec![FixedSize::Base(U256), FixedSize::Base(Base::Address)],
             vec![0],
         );

--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -23,10 +23,10 @@ pub fn dispatcher(attributes: Vec<FunctionAttributes>) -> yul::Statement {
 }
 
 fn dispatch_arm(attributes: FunctionAttributes) -> yul::Case {
-    let selector = selector(attributes.name.clone(), &attributes.param_types);
+    let selector = selector(&attributes.name, &attributes.param_types);
 
     if !attributes.return_type.is_empty_tuple() {
-        let selection = selection(attributes.name, &attributes.param_types);
+        let selection = selection(&attributes.name, &attributes.param_types);
         let return_data = abi_operations::encode(
             vec![attributes.return_type.clone()],
             vec![expression! { raw_return }],
@@ -47,12 +47,12 @@ fn dispatch_arm(attributes: FunctionAttributes) -> yul::Case {
         };
     }
 
-    let selection = selection_as_statement(attributes.name, &attributes.param_types);
+    let selection = selection_as_statement(&attributes.name, &attributes.param_types);
 
     case! { case [selector] { [selection] } }
 }
 
-fn selector(name: String, params: &[FixedSize]) -> yul::Literal {
+fn selector(name: &str, params: &[FixedSize]) -> yul::Literal {
     let params = params
         .iter()
         .map(|param| param.abi_name())
@@ -61,7 +61,7 @@ fn selector(name: String, params: &[FixedSize]) -> yul::Literal {
     literal! {(abi_utils::func_selector(name, params))}
 }
 
-fn selection(name: String, params: &[FixedSize]) -> yul::Expression {
+fn selection(name: &str, params: &[FixedSize]) -> yul::Expression {
     let decoded_params = abi_operations::decode(
         params.to_owned(),
         literal_expression! { 4 },
@@ -73,7 +73,7 @@ fn selection(name: String, params: &[FixedSize]) -> yul::Expression {
     expression! { [name]([decoded_params...]) }
 }
 
-fn selection_as_statement(name: String, params: &[FixedSize]) -> yul::Statement {
+fn selection_as_statement(name: &str, params: &[FixedSize]) -> yul::Statement {
     yul::Statement::Expression(selection(name, params))
 }
 
@@ -87,16 +87,13 @@ mod tests {
 
     #[test]
     fn test_selector_literal_basic() {
-        assert_eq!(
-            selector("foo".to_string(), &[]).to_string(),
-            String::from("0xc2985578"),
-        )
+        assert_eq!(selector("foo", &[]).to_string(), String::from("0xc2985578"),)
     }
 
     #[test]
     fn test_selector_literal() {
         assert_eq!(
-            selector("bar".to_string(), &[FixedSize::Base(U256)]).to_string(),
+            selector("bar", &[FixedSize::Base(U256)]).to_string(),
             String::from("0x0423a132"),
         )
     }

--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -37,7 +37,7 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
                 .unzip();
             // the function selector must be added to the first 4 bytes of the calldata
             let selector = {
-                let selector = abi_utils::func_selector(function.name.clone(), param_names);
+                let selector = abi_utils::func_selector(&function.name, param_names);
                 literal_expression! { (selector) }
             };
             // the operations used to encode the parameters

--- a/parser/src/errors.rs
+++ b/parser/src/errors.rs
@@ -36,8 +36,8 @@ impl<'a> ParseError<'a> {
         Self::new(input, ErrorKind::StaticStr(string))
     }
 
-    pub fn str(input: Cursor<'a>, string: String) -> Self {
-        Self::new(input, ErrorKind::Str(string))
+    pub fn str(input: Cursor<'a>, string: &str) -> Self {
+        Self::new(input, ErrorKind::Str(string.to_owned()))
     }
 
     pub fn eof(input: Cursor<'a>) -> Self {
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn test_parse_error_factories() {
         assert_eq!(
-            ParseError::str(empty_slice!(), "foo".to_string()),
+            ParseError::str(empty_slice!(), "foo"),
             ParseError {
                 errors: vec![(empty_slice!(), Str("foo".to_string()))],
             }

--- a/parser/src/parsers.rs
+++ b/parser/src/parsers.rs
@@ -43,7 +43,7 @@ pub fn token<'a>(typ: TokenType) -> impl Fn(Cursor<'a>) -> ParseResult<&Token> {
     verify(
         next,
         move |t| t.typ == typ,
-        move |inp, _| ParseError::str(inp, format!("expected {:?} token", typ)),
+        move |inp, _| ParseError::str(inp, &format!("expected {:?} token", typ)),
     )
 }
 
@@ -58,7 +58,7 @@ pub fn name<'a>(string: &'a str) -> impl Fn(Cursor<'a>) -> ParseResult<&Token> {
     verify(
         name_token,
         move |t| t.string == string,
-        move |inp, _| ParseError::str(inp, format!("expected \"{}\" name token", string)),
+        move |inp, _| ParseError::str(inp, &format!("expected \"{}\" name token", string)),
     )
 }
 
@@ -73,7 +73,7 @@ pub fn op<'a>(string: &'a str) -> impl Fn(Cursor<'a>) -> ParseResult<&Token> {
     verify(
         op_token,
         move |t| t.string == string,
-        move |inp, _| ParseError::str(inp, format!("expected \"{}\" op token", string)),
+        move |inp, _| ParseError::str(inp, &format!("expected \"{}\" op token", string)),
     )
 }
 
@@ -793,7 +793,7 @@ pub fn arr_dim(input: Cursor) -> ParseResult<Spanned<usize>> {
         Err(_) => {
             return Err(ParseError::str(
                 num_input,
-                format!("invalid integer literal \"{}\"", num_tok.string),
+                &format!("invalid integer literal \"{}\"", num_tok.string),
             ))
         }
     };

--- a/parser/tests/test_parsers.rs
+++ b/parser/tests/test_parsers.rs
@@ -270,7 +270,7 @@ fn test_arr_dim_err() {
         standalone(arr_dim)(&toks),
         Err(ParseError::str(
             &toks[1..],
-            "invalid integer literal \"1.0\"".to_string(),
+            "invalid integer literal \"1.0\"",
         )),
     );
 }


### PR DESCRIPTION
### What was wrong?

1. We had a mix of using `String` or `&str` for function parameters with no clear guidance on when to use which
2. We were using `String` for function parameters resulting in:
    a.) Lots of verbose `to_string()`, `clone()` usage
    b.) More memory allocations than necessary

### How was it fixed?

This PR changes the code base to follow a simple rule which may not always result in fewest allocations but has seems to have reduced the overall amount of allocations while at the same time cleaning up a lot of verbosity and being very simple. The rule that was followed is to simple always use `&str` as function parameters and use `to_owned()` wherever we need to convert from a string slice to an allocated `String`.

