### PR TITLE
Support updating struct fields in storage

### DIFF
--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -202,6 +202,11 @@ impl Struct {
         self.fields.get(name)
     }
 
+    // Return the index of the given field name
+    pub fn get_field_index(&self, name: &str) -> Option<usize> {
+        self.fields.keys().position(|field| field == name)
+    }
+
     // Return a vector of field types
     pub fn get_field_types(&self) -> Vec<Type> {
         self.fields.values().map(|val| val.clone().into()).collect()

--- a/compiler/src/yul/runtime/functions/structs.rs
+++ b/compiler/src/yul/runtime/functions/structs.rs
@@ -63,9 +63,7 @@ pub fn generate_new_fn(struct_type: &Struct) -> yul::Statement {
 pub fn generate_get_fn(struct_type: &Struct, field_name: &str) -> yul::Statement {
     let function_name = names::struct_getter_call(&struct_type.name, field_name);
     let field_index = struct_type
-        .get_field_names()
-        .iter()
-        .position(|field| field == field_name)
+        .get_field_index(field_name)
         .unwrap_or_else(|| panic!("No field {} in {}", field_name, struct_type.name));
     let field_offset = field_index * 32;
 

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -978,6 +978,8 @@ fn sized_vals_in_sto() {
 fn structs() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "structs.fe", "Foo", &[]);
+
+        harness.test_function(&mut executor, "create_house", &[], None);
         harness.test_function(&mut executor, "bar", &[], Some(&uint_token(2)));
     });
 }

--- a/compiler/tests/fixtures/structs.fe
+++ b/compiler/tests/fixtures/structs.fe
@@ -4,6 +4,25 @@ struct House:
     vacant: bool
 
 contract Foo:
+    my_house: House
+
+    pub def create_house():
+        self.my_house = House(1,2,false)
+        assert self.my_house.price == 1
+        assert self.my_house.size == 2
+        assert self.my_house.vacant == false
+        # We change only the size and check other fields are unchanged
+        self.my_house.size = 50
+        assert self.my_house.size == 50
+        assert self.my_house.price == 1
+        assert self.my_house.vacant == false
+        # We change only the price and check other fields are unchanged
+        self.my_house.price = 1000
+        assert self.my_house.size == 50
+        assert self.my_house.price == 1000
+        assert self.my_house.vacant == false
+
+
 
     pub def bar() -> u256:
         building: House = House(300, 500, true)

--- a/newsfragments/246.feature.md
+++ b/newsfragments/246.feature.md
@@ -1,0 +1,8 @@
+Support updating individual struct fields in storage.
+
+Example:
+
+```
+ pub def update_house_price(price: u256):
+        self.my_house.price = price
+```


### PR DESCRIPTION
### What was wrong?

We did not support updating individual struct fields in storage (e.g. `self.my_struct.some_field = 1`)

### How was it fixed?

1. Make the traversal recognize nested attribute expressions
2. Map them to carry the location of the entire struct
3. Map field of storage struct to a pointer of `ptr_of_storage_struct + 32 * field_index`
4. Add test

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
