### PR TITLE
Fix bug where compilation of contracts without public functions would result in malformed YUL

### DIFF
--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -16,9 +16,13 @@ pub fn dispatcher(attributes: Vec<FunctionAttributes>) -> yul::Statement {
         .map(|arm| dispatch_arm(arm.to_owned()))
         .collect::<Vec<_>>();
 
-    switch! {
-        switch (cloadn(0, 4))
-        [arms...]
+    if arms.is_empty() {
+        return statement! { pop(0) };
+    } else {
+        switch! {
+            switch (cloadn(0, 4))
+            [arms...]
+        }
     }
 }
 

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -1053,3 +1053,10 @@ fn create_contract() {
         foo_harness.test_function(&mut executor, "get_my_num", &[], Some(&uint_token(42)));
     })
 }
+
+#[rstest(fixture_file, contract_name, case("ownable.fe", "Ownable"))]
+fn can_deploy_fixture(fixture_file: &str, contract_name: &str) {
+    with_executor(&|mut executor| {
+        deploy_contract(&mut executor, fixture_file, contract_name, &[]);
+    })
+}

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -1054,7 +1054,12 @@ fn create_contract() {
     })
 }
 
-#[rstest(fixture_file, contract_name, case("ownable.fe", "Ownable"))]
+#[rstest(
+    fixture_file,
+    contract_name,
+    case("ownable.fe", "Ownable"),
+    case("empty.fe", "Empty")
+)]
 fn can_deploy_fixture(fixture_file: &str, contract_name: &str) {
     with_executor(&|mut executor| {
         deploy_contract(&mut executor, fixture_file, contract_name, &[]);

--- a/compiler/tests/fixtures/empty.fe
+++ b/compiler/tests/fixtures/empty.fe
@@ -1,0 +1,2 @@
+contract Empty:
+  lonely: u256

--- a/newsfragments/219.bugfix.md
+++ b/newsfragments/219.bugfix.md
@@ -1,0 +1,8 @@
+Fix bug where compilation of contracts without public functions would result in illegal YUL.
+
+E.g without this change, the following doesn't compile to proper YUL
+
+```
+contract Empty:
+  lonely: u256
+```


### PR DESCRIPTION
### What was wrong?

As identified by the fuzzer in #219 contracts without any public functions compile to faulty YUL.

### How was it fixed?

Compile to `pop(0)` instead of `switch (..)` when there are no public functions.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
