### PR TITLE
Implement keccak256 as builtin method

### DIFF
--- a/analyzer/src/builtins.rs
+++ b/analyzer/src/builtins.rs
@@ -5,7 +5,6 @@ use strum::EnumString;
 pub enum ValueMethod {
     Clone,
     ToMem,
-    Keccak256,
     AbiEncode,
     AbiEncodePacked,
 }

--- a/analyzer/src/builtins.rs
+++ b/analyzer/src/builtins.rs
@@ -1,4 +1,7 @@
-use strum::EnumString;
+use strum::{
+    EnumString,
+    IntoStaticStr,
+};
 
 #[derive(Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "snake_case")]
@@ -7,6 +10,12 @@ pub enum ValueMethod {
     ToMem,
     AbiEncode,
     AbiEncodePacked,
+}
+
+#[derive(Clone, Debug, PartialEq, EnumString, IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum GlobalMethod {
+    Keccak256,
 }
 
 #[derive(Debug, PartialEq, EnumString)]

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -22,6 +22,7 @@ use crate::namespace::types::{
     Struct,
     Type,
 };
+use builtins::GlobalMethod;
 use fe_parser::ast as fe;
 use fe_parser::span::{
     Span,
@@ -222,6 +223,7 @@ impl ExpressionAttributes {
 /// The type of a function call.
 #[derive(Clone, Debug, PartialEq)]
 pub enum CallType {
+    BuiltinFunction { func: GlobalMethod },
     TypeConstructor { typ: Type },
     SelfAttribute { func_name: String },
     ValueAttribute,

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -614,7 +614,6 @@ fn expr_call_value_attribute(
         {
             ValueMethod::Clone => value_attributes.into_cloned(),
             ValueMethod::ToMem => value_attributes.into_cloned_from_sto(),
-            ValueMethod::Keccak256 => todo!(),
             ValueMethod::AbiEncode => todo!(),
             ValueMethod::AbiEncodePacked => todo!(),
         };

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 
 use crate::builtins::ContractTypeMethod;
+use builtins::GlobalMethod;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use std::convert::TryFrom;
@@ -456,6 +457,9 @@ fn expr_call(
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Call { func, args } = &exp.node {
         return match expr_call_type(Rc::clone(&scope), Rc::clone(&context), func)? {
+            CallType::BuiltinFunction { func } => {
+                expr_call_builtin_function(scope, context, func, args)
+            }
             CallType::TypeConstructor { typ } => {
                 expr_call_type_constructor(scope, context, typ, args)
             }
@@ -470,6 +474,32 @@ fn expr_call(
     }
 
     unreachable!()
+}
+
+fn expr_call_builtin_function(
+    scope: Shared<BlockScope>,
+    context: Shared<Context>,
+    typ: GlobalMethod,
+    args: &Spanned<Vec<Spanned<fe::CallArg>>>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    let argument_attributes = expr_call_args(Rc::clone(&scope), Rc::clone(&context), args)?;
+    match typ {
+        GlobalMethod::Keccak256 => {
+            if argument_attributes.len() != 1 {
+                return Err(SemanticError::wrong_number_of_params());
+            }
+            if !matches!(
+                expression_attributes_to_types(argument_attributes).first(),
+                Some(Type::Array(Array {
+                    inner: Base::Byte,
+                    ..
+                }))
+            ) {
+                return Err(SemanticError::type_error());
+            }
+            Ok(ExpressionAttributes::new(Type::Base(U256), Location::Value))
+        }
+    }
 }
 
 fn expr_call_struct_constructor(
@@ -745,6 +775,9 @@ fn expr_name_call_type(
     name: &str,
 ) -> Result<CallType, SemanticError> {
     match name {
+        "keccak256" => Ok(CallType::BuiltinFunction {
+            func: GlobalMethod::Keccak256,
+        }),
         "address" => Ok(CallType::TypeConstructor {
             typ: Type::Base(Base::Address),
         }),

--- a/common/src/utils/keccak.rs
+++ b/common/src/utils/keccak.rs
@@ -7,12 +7,17 @@ pub fn get_full_signature(content: &[u8]) -> String {
     get_partial_signature(content, 32)
 }
 
-pub fn get_partial_signature(content: &[u8], size: usize) -> String {
+/// Return the keccak256 hash of the given content as an array of bytes
+pub fn get_keccak256(content: &[u8]) -> [u8; 32] {
     let mut keccak = Keccak::v256();
     let mut selector = [0u8; 32];
 
     keccak.update(content);
     keccak.finalize(&mut selector);
 
-    format!("0x{}", hex::encode(&selector[0..size]))
+    selector
+}
+
+pub fn get_partial_signature(content: &[u8], size: usize) -> String {
+    format!("0x{}", hex::encode(&get_keccak256(content)[0..size]))
 }

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -136,7 +136,6 @@ fn expr_call(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expressi
                                     builtins::ValueMethod::Clone => expr(context, value),
                                     builtins::ValueMethod::AbiEncode => todo!(),
                                     builtins::ValueMethod::AbiEncodePacked => todo!(),
-                                    builtins::ValueMethod::Keccak256 => todo!(),
                                 }
                             }
                         };

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -7,6 +7,7 @@ use std::fs;
     fixture_file,
     expected_error,
     case("call_event_with_wrong_types.fe", "TypeError"),
+    case("keccak_called_with_wrong_type.fe", "TypeError"),
     case("continue_without_loop.fe", "ContinueWithoutLoop"),
     case("continue_without_loop_2.fe", "ContinueWithoutLoop"),
     case("break_without_loop.fe", "BreakWithoutLoop"),

--- a/compiler/tests/evm_runtime.rs
+++ b/compiler/tests/evm_runtime.rs
@@ -174,3 +174,22 @@ fn test_abi_unpack() {
         );
     })
 }
+
+#[test]
+fn test_keccak256() {
+    with_executor(&|mut executor| {
+        test_runtime_functions(
+            &mut executor,
+            functions::std(),
+            statements! {
+                (let num := 63806209331542711802848847270949280092855778197726125910674179583545433573378)
+                (let result :=109966633016701122630199943745061001312678661825260870342362413625737614346915)
+                // Can be validated with solidity
+                // uint(keccak256(abi.encodePacked(uint(63806209331542711802848847270949280092855778197726125910674179583545433573378))));
+                // which returns 109966633016701122630199943745061001312678661825260870342362413625737614346915
+                (mstore(0, num))
+                [assert_eq!(result, (keccak256(0, 32)))]
+            },
+        );
+    })
+}

--- a/compiler/tests/fixtures/compile_errors/keccak_called_with_wrong_type.fe
+++ b/compiler/tests/fixtures/compile_errors/keccak_called_with_wrong_type.fe
@@ -1,0 +1,5 @@
+contract Foo:
+
+    pub def bar() -> u256:
+        wrong: u256[1]
+        return keccak256(wrong)

--- a/compiler/tests/fixtures/keccak.fe
+++ b/compiler/tests/fixtures/keccak.fe
@@ -1,0 +1,10 @@
+contract Keccak:
+
+    pub def return_hash_from_u8(val: bytes[1]) -> u256:
+        return keccak256(val)
+
+    pub def return_hash_from_foo(val: bytes[3]) -> u256:
+        return keccak256(val)
+
+    pub def return_hash_from_u256(val: bytes[32]) -> u256:
+        return keccak256(val)

--- a/compiler/tests/utils.rs
+++ b/compiler/tests/utils.rs
@@ -14,6 +14,18 @@ use std::str::FromStr;
 use stringreader::StringReader;
 use yultsur::*;
 
+pub trait ToBeBytes {
+    fn to_be_bytes(&self) -> [u8; 32];
+}
+
+impl ToBeBytes for U256 {
+    fn to_be_bytes(&self) -> [u8; 32] {
+        let mut input_bytes: [u8; 32] = [0; 32];
+        self.to_big_endian(&mut input_bytes);
+        input_bytes
+    }
+}
+
 #[allow(dead_code)]
 pub type Executor<'a> = evm::executor::StackExecutor<'a, 'a, evm::backend::MemoryBackend<'a>>;
 
@@ -266,6 +278,11 @@ pub fn test_runtime_functions(
 #[allow(dead_code)]
 pub fn uint_token(n: usize) -> ethabi::Token {
     ethabi::Token::Uint(U256::from(n))
+}
+
+#[allow(dead_code)]
+pub fn uint_token_from_dec_str(val: &str) -> ethabi::Token {
+    ethabi::Token::Uint(U256::from_dec_str(val).expect("Not a valid dec string"))
 }
 
 #[allow(dead_code)]

--- a/newsfragments/255.feature.md
+++ b/newsfragments/255.feature.md
@@ -1,0 +1,10 @@
+Implement global `keccak256` method. The method expects one parameter of `bytes[n]`
+and returns the hash as an `u256`. In a future version `keccak256` will most likely
+be moved behind an import so that it has to be imported (e.g. `from std.crypto import keccak256`).
+
+Example:
+
+```
+pub def hash_single_byte(val: bytes[1]) -> u256:
+    return keccak256(val)
+```


### PR DESCRIPTION
### What was wrong?

As discussed in #188. Fe needs to expose the `keccak256` hash function to be usable from user code.

### How was it fixed?

1. Implemented `keccak256` as a global function
2. Analyzer ensures it can only be called with `bytes[n]` parameter
3. Mapper is pretty straight forward
4. keccak utils were slightly refactored to expose a bare `get_keccak256` method
5. Added contract tests to calculate various keccaks
6. Added test to prove `keccak256` can not be called with arrays of other types
7. Added bare runtime tests for the YUL `keccak256` function

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
