### PR TITLE
Add test that demos sqrt and min function needed for the Uniswap demo

### DIFF
--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -775,6 +775,26 @@ fn keccak() {
 }
 
 #[test]
+fn math() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "math.fe", "Math", &[]);
+        harness.test_function(
+            &mut executor,
+            "sqrt",
+            &[uint_token(16000)],
+            Some(&uint_token(126)),
+        );
+
+        harness.test_function(
+            &mut executor,
+            "min",
+            &[uint_token(1), uint_token(2)],
+            Some(&uint_token(1)),
+        );
+    });
+}
+
+#[test]
 fn erc20_token() {
     with_executor(&|mut executor| {
         let token_name = string_token("Fe Coin");

--- a/compiler/tests/fixtures/math.fe
+++ b/compiler/tests/fixtures/math.fe
@@ -1,0 +1,17 @@
+contract Math:
+
+    # https://github.com/Uniswap/uniswap-v2-core/blob/4dd59067c76dea4a0e8e4bfdda41877a6b16dedc/contracts/libraries/Math.sol#L11-L22
+    pub def sqrt(val: u256) -> u256:
+        z: u256
+        if (val > 3):
+            z = val
+            x: u256 = val / 2 + 1
+            while (x < z):
+                z = x
+                x = (val / x + x) / 2
+        elif (val != 0):
+            z = 1
+        return z
+
+    pub def min(x: u256, y: u256) -> u256:
+        return x if x < y else y


### PR DESCRIPTION
### What was wrong?

We need a Fe implementation of `sqrt` and `min` for the Uniswap demo.

### How was it fixed?

Added a fixture `math.fe` that implements those.

