### PR TITLE
Require KWargs for struct initialization

### DIFF
--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -8,6 +8,7 @@ use fe_parser::span::Span;
 pub enum ErrorKind {
     BreakWithoutLoop,
     ContinueWithoutLoop,
+    KeyWordArgsRequired,
     MissingReturn,
     NotSubscriptable,
     NumericCapacityMismatch,
@@ -44,6 +45,14 @@ impl SemanticError {
     pub fn continue_without_loop() -> Self {
         SemanticError {
             kind: ErrorKind::ContinueWithoutLoop,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `KeyWordArgsRequired`
+    pub fn kw_args_required() -> Self {
+        SemanticError {
+            kind: ErrorKind::KeyWordArgsRequired,
             context: vec![],
         }
     }

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -530,6 +530,7 @@ fn expr_call_struct_constructor(
     typ: Struct,
     args: &Spanned<Vec<Spanned<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
+    validate_are_kw_args(&args.node)?;
     let argument_attributes = expr_call_args(Rc::clone(&scope), Rc::clone(&context), args)?;
 
     if typ.get_field_types() != expression_attributes_to_types(argument_attributes) {
@@ -886,6 +887,17 @@ fn expr_attribute_call_type(
     }
 
     unreachable!()
+}
+
+fn validate_are_kw_args(args: &[Spanned<fe::CallArg>]) -> Result<(), SemanticError> {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.node, fe::CallArg::Arg(_)))
+    {
+        return Err(SemanticError::kw_args_required());
+    }
+
+    Ok(())
 }
 
 fn validate_is_numeric_literal(call_arg: &fe::CallArg) -> Result<String, SemanticError> {

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -28,6 +28,7 @@ use std::fs;
     case("type_constructor_from_variable.fe", "NumericLiteralExpected"),
     case("needs_mem_copy.fe", "CannotMove"),
     case("string_capacity_mismatch.fe", "StringCapacityMismatch"),
+    case("struct_call_without_kw_args.fe", "KeyWordArgsRequired"),
     case("numeric_capacity_mismatch/u8_neg.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u8_pos.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u16_neg.fe", "NumericCapacityMismatch"),

--- a/compiler/tests/fixtures/compile_errors/struct_call_without_kw_args.fe
+++ b/compiler/tests/fixtures/compile_errors/struct_call_without_kw_args.fe
@@ -1,0 +1,8 @@
+struct House:
+    vacant: bool
+    price: u256
+
+contract Foo:
+
+    pub def bar():
+        my_house: House = House(true, price=1000000)

--- a/compiler/tests/fixtures/structs.fe
+++ b/compiler/tests/fixtures/structs.fe
@@ -7,7 +7,7 @@ contract Foo:
     my_house: House
 
     pub def create_house():
-        self.my_house = House(1,2,false)
+        self.my_house = House(price=1, size=2, vacant=false)
         assert self.my_house.price == 1
         assert self.my_house.size == 2
         assert self.my_house.vacant == false
@@ -25,7 +25,7 @@ contract Foo:
 
 
     pub def bar() -> u256:
-        building: House = House(300, 500, true)
+        building: House = House(price=300, size=500, vacant=true)
         assert building.size == 500
         assert building.price == 300
         assert building.vacant

--- a/newsfragments/260.feature.md
+++ b/newsfragments/260.feature.md
@@ -1,0 +1,15 @@
+Require structs to be initialized using keyword arguments.
+
+Example:
+
+```
+struct House:
+    vacant: bool
+    price: u256
+```
+
+Previously, `House` could be instantiated as `House(true, 1000000)`.
+With this change it is required to be instantiated like `House(vacant=true, price=1000000)`
+
+This ensures property assignment is less prone to get mixed up. It also makes struct
+initialization visually stand out more from function calls.


### PR DESCRIPTION
### What was wrong?

Example:

```
struct House:
    vacant: bool
    price: u256
```

Currently, `House` can be instantiated as `House(true, 1000000)`.

This means:

1. Property assignment can easily get mixed up leading to bugs
2. struct initialization is visually very close to regular function invocations

### How was it fixed?

With this change it is required to be instantiated like `House(vacant=true, price=1000000)`

While working on this it got me thinking if this is something that should be handled on the parser stage instead but I don't think that would be straight forward because technically there is nothing the syntax is identical with method invocation syntax.

We **could** move this into the parser stage **if** we used a distinct syntax such as `House(vacant: true, price: 100)`. But I'm personally ok to keep it as with the check being handled by the analyzer.
