### PR TITLE
Fix issue where explicit return of implicit empty truple crashes the compiler

### DIFF
--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -25,7 +25,9 @@ use crate::traversal::{
 };
 use crate::{
     Context,
+    ExpressionAttributes,
     FunctionAttributes,
+    Location,
 };
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
@@ -402,9 +404,11 @@ fn func_return(
     context: Shared<Context>,
     stmt: &Spanned<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
-    if let fe::FuncStmt::Return { value: Some(value) } = &stmt.node {
-        let attributes =
-            expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), value)?;
+    if let fe::FuncStmt::Return { value } = &stmt.node {
+        let attributes = match value {
+            Some(val) => expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), val)?,
+            None => ExpressionAttributes::new(Type::Tuple(Tuple::empty()), Location::Value),
+        };
 
         let host_func_def = scope
             .borrow()

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -1150,7 +1150,8 @@ fn create_contract() {
     fixture_file,
     contract_name,
     case("ownable.fe", "Ownable"),
-    case("empty.fe", "Empty")
+    case("empty.fe", "Empty"),
+    case("return_empty_tuple.fe", "Foo")
 )]
 fn can_deploy_fixture(fixture_file: &str, contract_name: &str) {
     with_executor(&|mut executor| {

--- a/compiler/tests/fixtures/return_empty_tuple.fe
+++ b/compiler/tests/fixtures/return_empty_tuple.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+  pub def explicit_return():
+    return
+
+  pub def implicit():
+    pass

--- a/newsfragments/261.bugfix.md
+++ b/newsfragments/261.bugfix.md
@@ -1,0 +1,13 @@
+Fix crash when return is used without value.
+
+These two methods should both be treated as returning `()`
+
+```
+  pub def explicit_return():
+    return
+
+  pub def implicit():
+    pass
+```
+
+Without this change, the `explicit_return` crashes the compiler.


### PR DESCRIPTION
### What was wrong?

These two methods should both be treated as returning `()`

```
  pub def explicit_return():
    return

  pub def implicit():
    pass
```

Without this change, the `explicit_return` crashes the compiler.

### How was it fixed?

Treat a `None` value in `FuncStmt::Return` as having an expression with an empty tuple.
