### PR TITLE
Ordered struct fields.

### DIFF
--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -39,7 +39,6 @@ pub trait FeSized {
 /// needed by our encoding/decoding functions to properly read and write data.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct AbiUintSize {
-    ///
     pub data_size: usize,
     pub padded_size: usize,
 }
@@ -164,6 +163,7 @@ pub struct Tuple {
 pub struct Struct {
     pub name: String,
     fields: BTreeMap<String, Base>,
+    order: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -182,37 +182,48 @@ impl Struct {
         Struct {
             name: name.to_string(),
             fields: BTreeMap::new(),
+            order: vec![],
         }
     }
 
-    // Return `true` if the struct has any fields, otherwise return `false`
+    /// Return `true` if the struct has any fields, otherwise return `false`
     pub fn is_empty(&self) -> bool {
         self.fields.is_empty()
     }
 
     /// Add a field to the struct
     pub fn add_field(&mut self, name: &str, value: &Base) -> Option<Base> {
+        self.order.push(name.to_string());
         self.fields.insert(name.to_string(), value.clone())
     }
 
-    // Return the type of the given field name
+    /// Return the type of the given field name
     pub fn get_field_type(&self, name: &str) -> Option<&Base> {
         self.fields.get(name)
     }
 
-    // Return the index of the given field name
+    /// Return the index of the given field name
     pub fn get_field_index(&self, name: &str) -> Option<usize> {
-        self.fields.keys().position(|field| field == name)
+        self.order.iter().position(|field| field == name)
     }
 
-    // Return a vector of field types
+    /// Return a vector of field types
     pub fn get_field_types(&self) -> Vec<Type> {
-        self.fields.values().map(|val| val.clone().into()).collect()
+        self.order
+            .iter()
+            .map(|name| {
+                Type::Base(
+                    self.get_field_type(name)
+                        .expect("no entry for field name")
+                        .to_owned(),
+                )
+            })
+            .collect()
     }
 
-    //Return a vector of field names
+    /// Return a vector of field names
     pub fn get_field_names(&self) -> Vec<String> {
-        self.fields.keys().cloned().collect()
+        self.order.clone()
     }
 }
 

--- a/compiler/tests/fixtures/structs.fe
+++ b/compiler/tests/fixtures/structs.fe
@@ -1,40 +1,55 @@
 struct House:
     price: u256
     size: u256
+    rooms: u8
     vacant: bool
 
 contract Foo:
     my_house: House
 
     pub def create_house():
-        self.my_house = House(price=1, size=2, vacant=false)
+        self.my_house = House(price=1, size=2, rooms=u8(5), vacant=false)
         assert self.my_house.price == 1
         assert self.my_house.size == 2
+        assert self.my_house.rooms == u8(5)
         assert self.my_house.vacant == false
         # We change only the size and check other fields are unchanged
         self.my_house.size = 50
         assert self.my_house.size == 50
         assert self.my_house.price == 1
+        assert self.my_house.rooms == u8(5)
         assert self.my_house.vacant == false
         # We change only the price and check other fields are unchanged
         self.my_house.price = 1000
         assert self.my_house.size == 50
         assert self.my_house.price == 1000
+        assert self.my_house.rooms == u8(5)
         assert self.my_house.vacant == false
-
-
+        self.my_house.vacant = true
+        assert self.my_house.size == 50
+        assert self.my_house.price == 1000
+        assert self.my_house.rooms == u8(5)
+        assert self.my_house.vacant
+        self.my_house.rooms = u8(100)
+        assert self.my_house.size == 50
+        assert self.my_house.price == 1000
+        assert self.my_house.rooms == u8(100)
+        assert self.my_house.vacant
 
     pub def bar() -> u256:
-        building: House = House(price=300, size=500, vacant=true)
+        building: House = House(price=300, size=500, rooms=u8(20), vacant=true)
         assert building.size == 500
         assert building.price == 300
+        #assert building.rooms == u8(20)
         assert building.vacant
 
         building.vacant = false
         building.price = 1
         building.size = 2
+        building.rooms = u8(10)
 
         assert building.vacant == false
         assert building.price == 1
         assert building.size == 2
+        assert building.rooms == u8(10)
         return building.size


### PR DESCRIPTION
### What was wrong?

The expanded test was failing with a type error on struct initialization since the values are retrieved in an effectively random order.

### How was it fixed?

Added a vector to keep track of field order.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
