### PR TITLE
Support boolean not operator

### DIFF
--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -272,10 +272,15 @@ pub fn expr_unary_operation(
 ) -> Result<yul::Expression, CompileError> {
     if let fe::Expr::UnaryOperation { op, operand } = &exp.node {
         let yul_operand = expr(context, operand)?;
-        if let fe::UnaryOperator::USub = &op.node {
-            let zero = literal_expression! {0};
-            return Ok(expression! { sub([zero], [yul_operand]) });
-        }
+
+        return match &op.node {
+            fe::UnaryOperator::USub => {
+                let zero = literal_expression! {0};
+                Ok(expression! { sub([zero], [yul_operand]) })
+            }
+            fe::UnaryOperator::Not => Ok(expression! { iszero([yul_operand]) }),
+            _ => todo!(),
+        };
     }
 
     unreachable!()

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -88,6 +88,8 @@ fn test_assert() {
     case("call_statement_with_args_2.fe", &[], uint_token(100)),
     case("return_bool_true.fe", &[], bool_token(true)),
     case("return_bool_false.fe", &[], bool_token(false)),
+    case("return_bool_inverted.fe", &[bool_token(true)], bool_token(false)),
+    case("return_bool_inverted.fe", &[bool_token(false)], bool_token(true)),
     case("return_u256_from_called_fn_with_args.fe", &[], uint_token(200)),
     case("return_u256_from_called_fn.fe", &[], uint_token(42)),
     case("return_u256.fe", &[], uint_token(42)),

--- a/compiler/tests/fixtures/return_bool_inverted.fe
+++ b/compiler/tests/fixtures/return_bool_inverted.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(some_condition: bool) -> bool:
+        return not some_condition

--- a/newsfragments/264.feature.md
+++ b/newsfragments/264.feature.md
@@ -1,0 +1,8 @@
+Implement support for boolean `not` operator.
+
+Example:
+
+```
+if not covid_test.is_positive(person):
+    allow_boarding(person)
+```


### PR DESCRIPTION
### What was wrong?

Fe doesn't yet support the boolean `not` operator. E.g. the following code doesn't compile:

```
if not covid_test.is_positive(person):
    allow_boarding(person)
```

### How was it fixed?

1. Analyzer validates `UnaryOperator::Not` is used with `bool` only
2. Mapper maps it to `iszero([operand])`
3. Tests
