### PR TITLE
Overflow/Underflow protection for subtraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,7 @@ dependencies = [
  "fe-common",
  "fe-parser",
  "hex",
+ "maplit",
  "primitive-types",
  "rand",
  "rstest",

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -125,7 +125,7 @@ pub enum Base {
     Address,
 }
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, IntoStaticStr)]
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd, Ord, Eq, IntoStaticStr)]
 pub enum Integer {
     U256,
     U128,

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -25,6 +25,7 @@ stringreader = "0.1"
 # Optional
 # This fork supports concurrent compilation, which is required for Rust tests.
 solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true }
+maplit = "1.0.2"
 
 [dev-dependencies]
 evm-runtime = "0.18"

--- a/compiler/src/yul/constants.rs
+++ b/compiler/src/yul/constants.rs
@@ -1,0 +1,59 @@
+use fe_analyzer::namespace::types::Integer;
+use maplit::hashmap;
+use std::collections::HashMap;
+use yultsur::*;
+
+/// Return a hashmap containing min/max YUL literals for each supported integer
+/// size
+pub fn numeric_min_max() -> HashMap<Integer, (yul::Expression, yul::Expression)> {
+    hashmap! {
+        Integer::U256 => (
+            literal_expression! {0x0},
+            literal_expression! {0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff},
+        ),
+        Integer::U128 => (
+            literal_expression! {0x0},
+            literal_expression! {0xffffffffffffffffffffffffffffffff},
+        ),
+        Integer::U64 => (
+            literal_expression! {0x0},
+            literal_expression! {0xffffffffffffffff},
+        ),
+        Integer::U32 => (
+            literal_expression! {0x0},
+            literal_expression! {0xffffffff},
+        ),
+        Integer::U16 => (
+            literal_expression! {0x0},
+            literal_expression! {0xffff},
+        ),
+        Integer::U8 => (
+            literal_expression! {0x0},
+            literal_expression! {0xff},
+        ),
+        Integer::I256 => (
+            literal_expression! {0x8000000000000000000000000000000000000000000000000000000000000000},
+            literal_expression! {0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff}
+        ),
+        Integer::I128 => (
+            literal_expression! {0xffffffffffffffffffffffffffffffff80000000000000000000000000000000},
+            literal_expression! {0x7fffffffffffffffffffffffffffffff}
+        ),
+        Integer::I64 => (
+            literal_expression! {0xffffffffffffffffffffffffffffffffffffffffffffffff8000000000000000},
+            literal_expression! {0x7fffffffffffffff}
+        ),
+        Integer::I32 => (
+            literal_expression! {0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000},
+            literal_expression! {0x7fffffff}
+        ),
+        Integer::I16 => (
+            literal_expression! {0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8000},
+            literal_expression! {0x7fff}
+        ),
+        Integer::I8 => (
+            literal_expression! {0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80},
+            literal_expression! {0x7f}
+        )
+    }
+}

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -129,7 +129,7 @@ mod tests {
         assignment,
         expected_yul,
         case("foo = 1 + 2", "$foo := checked_add_u256(1, 2)"),
-        case("foo = 1 - 2", "$foo := sub(1, 2)"),
+        case("foo = 1 - 2", "$foo := checked_sub_unsigned(1, 2)"),
         case("foo = 1 * 2", "$foo := mul(1, 2)"),
         case("foo = 1 / 2", "$foo := div(1, 2)"),
         case("foo = 1 ** 2", "$foo := exp(1, 2)"),

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -14,7 +14,6 @@ use fe_analyzer::namespace::types::{
     Base,
     FeSized,
     FixedSize,
-    Integer,
     Type,
 };
 use fe_analyzer::{
@@ -242,45 +241,17 @@ pub fn expr_bin_operation(
 
         return match op.node {
             fe::BinOperator::Add => match typ {
-                Type::Base(Base::Numeric(Integer::I256)) => {
-                    Ok(expression! { checked_add_i256([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::I128)) => {
-                    Ok(expression! { checked_add_i128([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::I64)) => {
-                    Ok(expression! { checked_add_i64([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::I32)) => {
-                    Ok(expression! { checked_add_i32([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::I16)) => {
-                    Ok(expression! { checked_add_i16([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::I8)) => {
-                    Ok(expression! { checked_add_i8([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::U256)) => {
-                    Ok(expression! { checked_add_u256([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::U128)) => {
-                    Ok(expression! { checked_add_u128([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::U64)) => {
-                    Ok(expression! { checked_add_u64([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::U32)) => {
-                    Ok(expression! { checked_add_u32([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::U16)) => {
-                    Ok(expression! { checked_add_u16([yul_left], [yul_right]) })
-                }
-                Type::Base(Base::Numeric(Integer::U8)) => {
-                    Ok(expression! { checked_add_u8([yul_left], [yul_right]) })
+                Type::Base(Base::Numeric(integer)) => {
+                    Ok(expression! { [names::checked_add(integer)]([yul_left], [yul_right]) })
                 }
                 _ => unimplemented!("Addition for non-numeric types not yet supported"),
             },
-            fe::BinOperator::Sub => Ok(expression! { sub([yul_left], [yul_right]) }),
+            fe::BinOperator::Sub => match typ {
+                Type::Base(Base::Numeric(integer)) => {
+                    Ok(expression! { [names::checked_sub(integer)]([yul_left], [yul_right]) })
+                }
+                _ => unimplemented!("Subtraction for non-numeric types not yet supported"),
+            },
             fe::BinOperator::Mult => Ok(expression! { mul([yul_left], [yul_right]) }),
             fe::BinOperator::Div => match typ.is_signed_integer() {
                 true => Ok(expression! { sdiv([yul_left], [yul_right]) }),
@@ -697,7 +668,7 @@ mod tests {
         expression,
         expected_yul,
         case("1 + 2", "checked_add_u256(1, 2)"),
-        case("1 - 2", "sub(1, 2)"),
+        case("1 - 2", "checked_sub_unsigned(1, 2)"),
         case("1 * 2", "mul(1, 2)"),
         case("1 / 2", "div(1, 2)"),
         case("1 ** 2", "exp(1, 2)"),

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -7,6 +7,7 @@ use crate::types::{
 };
 use fe_analyzer::Context;
 
+pub mod constants;
 mod constructor;
 mod mappers;
 mod names;

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -1,8 +1,23 @@
 use fe_analyzer::namespace::types::{
     AbiDecodeLocation,
     AbiEncoding,
+    Integer,
 };
 use yultsur::*;
+
+pub fn checked_add(size: &Integer) -> yul::Identifier {
+    let size: &str = size.into();
+    identifier! {(format!("checked_add_{}", size.to_lowercase()))}
+}
+
+pub fn checked_sub(size: &Integer) -> yul::Identifier {
+    let size: &str = if size.is_signed() {
+        size.into()
+    } else {
+        "unsigned"
+    };
+    identifier! {(format!("checked_sub_{}", size.to_lowercase()))}
+}
 
 pub fn func_name(name: &str) -> yul::Identifier {
     identifier! { (format!("$${}", name)) }

--- a/compiler/src/yul/runtime/functions/mod.rs
+++ b/compiler/src/yul/runtime/functions/mod.rs
@@ -9,7 +9,7 @@ pub mod structs;
 
 /// Returns all functions that should be available during runtime.
 pub fn std() -> Vec<yul::Statement> {
-    vec![
+    let fns = vec![
         data::avail(),
         data::alloc(),
         data::alloc_mstoren(),
@@ -36,17 +36,6 @@ pub fn std() -> Vec<yul::Statement> {
         abi::pack(AbiDecodeLocation::Memory),
         contracts::create2(),
         contracts::create(),
-        math::checked_add_u256(),
-        math::checked_add_u128(),
-        math::checked_add_u64(),
-        math::checked_add_u32(),
-        math::checked_add_u16(),
-        math::checked_add_u8(),
-        math::checked_add_i256(),
-        math::checked_add_i128(),
-        math::checked_add_i64(),
-        math::checked_add_i32(),
-        math::checked_add_i16(),
-        math::checked_add_i8(),
-    ]
+    ];
+    [fns, math::all()].concat()
 }

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -649,6 +649,8 @@ fn checked_arithmetic() {
         );
 
         for config in NumericAbiTokenBounds::get_all().iter() {
+            // ADDITION
+
             // unsigned: max_value + 1 fails
             harness.test_function_reverts(
                 &mut executor,
@@ -692,6 +694,52 @@ fn checked_arithmetic() {
                 &format!("add_i{}", config.size),
                 &[config.i_min.clone(), int_token(0)],
                 Some(&config.i_min),
+            );
+
+            // SUBTRACTION
+            // unsigned: min_value - 1 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("sub_u{}", config.size),
+                &[config.u_min.clone(), uint_token(1)],
+            );
+
+            // unsigned: min_value - 0 works
+            harness.test_function(
+                &mut executor,
+                &format!("sub_u{}", config.size),
+                &[config.u_min.clone(), uint_token(0)],
+                Some(&config.u_min),
+            );
+
+            // signed: min_value - 1 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("sub_i{}", config.size),
+                &[config.i_min.clone(), int_token(1)],
+            );
+
+            // signed: min_value - 0 works
+            harness.test_function(
+                &mut executor,
+                &format!("sub_i{}", config.size),
+                &[config.i_min.clone(), int_token(0)],
+                Some(&config.i_min),
+            );
+
+            // signed: max_value - -1 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("sub_i{}", config.size),
+                &[config.i_max.clone(), int_token(-1)],
+            );
+
+            // signed: max_value - -0 works
+            harness.test_function(
+                &mut executor,
+                &format!("sub_i{}", config.size),
+                &[config.i_max.clone(), int_token(-0)],
+                Some(&config.i_max),
             );
         }
     });

--- a/compiler/tests/fixtures/checked_arithmetic.fe
+++ b/compiler/tests/fixtures/checked_arithmetic.fe
@@ -35,3 +35,39 @@ contract CheckedArithmetic:
 
     pub def add_i8(left: i8, right: i8) -> i8:
         return left + right
+
+    pub def sub_u256(left: u256, right: u256) -> u256:
+        return left - right
+
+    pub def sub_u128(left: u128, right: u128) -> u128:
+        return left - right
+
+    pub def sub_u64(left: u64, right: u64) -> u64:
+        return left - right
+
+    pub def sub_u32(left: u32, right: u32) -> u32:
+        return left - right
+
+    pub def sub_u16(left: u16, right: u16) -> u16:
+        return left - right
+
+    pub def sub_u8(left: u8, right: u8) -> u8:
+        return left - right
+
+    pub def sub_i256(left: i256, right: i256) -> i256:
+        return left - right
+
+    pub def sub_i128(left: i128, right: i128) -> i128:
+        return left - right
+
+    pub def sub_i64(left: i64, right: i64) -> i64:
+        return left - right
+
+    pub def sub_i32(left: i32, right: i32) -> i32:
+        return left - right
+
+    pub def sub_i16(left: i16, right: i16) -> i16:
+        return left - right
+
+    pub def sub_i8(left: i8, right: i8) -> i8:
+        return left - right

--- a/newsfragments/267.feature.md
+++ b/newsfragments/267.feature.md
@@ -1,0 +1,4 @@
+Perform over/underflow checks for subtractions (SafeMath).
+
+With this change all subtractions (e.g `x - y`) for signed and unsigned
+integers check for over- and underflows and revert if necessary.


### PR DESCRIPTION
### What was wrong?

We need subtraction to perform over/underflow checks by default (#153)

### How was it fixed?

1. Refactored existing code based on `add` to move all min/max values into a shared map
2. Added code to generically generate names for these functions with also cleans up dispatching
3. Refactored code to generate functions based on all min/max values and the generic function name generation
4. Then added `sub` protection based on the refactoring
5. Added tests.
