### PR TITLE
Support for self.address and bool operations

### DIFF
--- a/analyzer/src/builtins.rs
+++ b/analyzer/src/builtins.rs
@@ -66,3 +66,9 @@ pub enum TxField {
     GasPrice,
     Origin,
 }
+
+#[derive(Debug, PartialEq, EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum SelfField {
+    Address,
+}

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -62,7 +62,9 @@ use std::fs;
         "NumericCapacityMismatch"
     ),
     case("external_call_type_error.fe", "TypeError"),
-    case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams")
+    case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams"),
+    case("non_bool_and.fe", "TypeError"),
+    case("non_bool_or.fe", "TypeError")
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -183,6 +183,16 @@ fn test_assert() {
     case("return_gte_i256.fe", &[int_token(-1), int_token(-2)], bool_token(true)),
     case("return_gte_i256.fe", &[int_token(-1), int_token(-1)], bool_token(true)),
     case("return_gte_i256.fe", &[int_token(-2), int_token(-1)], bool_token(false)),
+    // `and` bool operation
+    case("return_bool_op_and.fe", &[bool_token(true), bool_token(true)], bool_token(true)),
+    case("return_bool_op_and.fe", &[bool_token(true), bool_token(false)], bool_token(false)),
+    case("return_bool_op_and.fe", &[bool_token(false), bool_token(true)], bool_token(false)),
+    case("return_bool_op_and.fe", &[bool_token(false), bool_token(false)], bool_token(false)),
+    // `or` bool operation
+    case("return_bool_op_or.fe", &[bool_token(true), bool_token(true)], bool_token(true)),
+    case("return_bool_op_or.fe", &[bool_token(true), bool_token(false)], bool_token(true)),
+    case("return_bool_op_or.fe", &[bool_token(false), bool_token(true)], bool_token(true)),
+    case("return_bool_op_or.fe", &[bool_token(false), bool_token(false)], bool_token(false)),
 )]
 fn test_method_return(fixture_file: &str, input: &[ethabi::Token], expected: ethabi::Token) {
     with_executor(&|mut executor| {
@@ -1214,4 +1224,17 @@ fn can_deploy_fixture(fixture_file: &str, contract_name: &str) {
     with_executor(&|mut executor| {
         deploy_contract(&mut executor, fixture_file, contract_name, &[]);
     })
+}
+
+#[test]
+fn self_address() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "self_address.fe", "Foo", &[]);
+        harness.test_function(
+            &mut executor,
+            "my_address",
+            &[],
+            Some(&ethabi::Token::Address(harness.address)),
+        );
+    });
 }

--- a/compiler/tests/fixtures/compile_errors/non_bool_and.fe
+++ b/compiler/tests/fixtures/compile_errors/non_bool_and.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: bool, y: u256) -> bool:
+        return x and y

--- a/compiler/tests/fixtures/compile_errors/non_bool_or.fe
+++ b/compiler/tests/fixtures/compile_errors/non_bool_or.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: bool, y: u256) -> bool:
+        return y or x

--- a/compiler/tests/fixtures/return_bool_op_and.fe
+++ b/compiler/tests/fixtures/return_bool_op_and.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: bool, y: bool) -> bool:
+        return x and y

--- a/compiler/tests/fixtures/return_bool_op_or.fe
+++ b/compiler/tests/fixtures/return_bool_op_or.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: bool, y: bool) -> bool:
+        return x or y

--- a/compiler/tests/fixtures/self_address.fe
+++ b/compiler/tests/fixtures/self_address.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def my_address() -> address:
+        return self.address

--- a/newsfragments/270.feature.md
+++ b/newsfragments/270.feature.md
@@ -1,0 +1,29 @@
+Support for the boolean operations `and` and `or`.
+
+Examples:
+
+```
+contract Foo:
+    pub def bar(x: bool, y: bool) -> bool:
+        return x and y
+```
+
+```
+contract Foo:
+    pub def bar(x: bool, y: bool) -> bool:
+        return x or y
+```
+
+Support for `self.address`.
+
+This expression returns the address of the current contract.
+
+Example:
+
+```
+contract Foo:
+    pub def bar() -> address:
+        return self.address
+```
+
+

--- a/spec/index.md
+++ b/spec/index.md
@@ -74,7 +74,8 @@ be used as the names of:
 > KW_SELFVALUE      : `self`\
 > KW_STRUCT         : `struct`\
 > KW_TRUE           : `true`\
-> KW_WHILE          : `while`
+> KW_WHILE          : `while` \
+> KW_ADDRESS        : `address`
 
 
 #### 2.1.2. Reserved keywords


### PR DESCRIPTION
### What was wrong?

We didn't support the two small features mentioned above. They are both needed for the Uniswap demo.

### How was it fixed?

- analyzing the expressions
- mapping the expressions
- testing

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
