### PR TITLE
Add overflow/underflow checks for multiplicatons

### DIFF
--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -130,7 +130,7 @@ mod tests {
         expected_yul,
         case("foo = 1 + 2", "$foo := checked_add_u256(1, 2)"),
         case("foo = 1 - 2", "$foo := checked_sub_unsigned(1, 2)"),
-        case("foo = 1 * 2", "$foo := mul(1, 2)"),
+        case("foo = 1 * 2", "$foo := checked_mul_u256(1, 2)"),
         case("foo = 1 / 2", "$foo := div(1, 2)"),
         case("foo = 1 ** 2", "$foo := exp(1, 2)"),
         case("foo = 1 % 2", "$foo := mod(1, 2)"),

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -264,7 +264,12 @@ pub fn expr_bin_operation(
                 }
                 _ => unimplemented!("Subtraction for non-numeric types not yet supported"),
             },
-            fe::BinOperator::Mult => Ok(expression! { mul([yul_left], [yul_right]) }),
+            fe::BinOperator::Mult => match typ {
+                Type::Base(Base::Numeric(integer)) => {
+                    Ok(expression! { [names::checked_mul(integer)]([yul_left], [yul_right]) })
+                }
+                _ => unreachable!(),
+            },
             fe::BinOperator::Div => match typ.is_signed_integer() {
                 true => Ok(expression! { sdiv([yul_left], [yul_right]) }),
                 false => Ok(expression! { div([yul_left], [yul_right]) }),
@@ -669,7 +674,7 @@ mod tests {
         expected_yul,
         case("1 + 2", "checked_add_u256(1, 2)"),
         case("1 - 2", "checked_sub_unsigned(1, 2)"),
-        case("1 * 2", "mul(1, 2)"),
+        case("1 * 2", "checked_mul_u256(1, 2)"),
         case("1 / 2", "div(1, 2)"),
         case("1 ** 2", "exp(1, 2)"),
         case("1 % 2", "mod(1, 2)"),

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -5,11 +5,19 @@ use fe_analyzer::namespace::types::{
 };
 use yultsur::*;
 
+/// Generate a function name to perform checked addition
 pub fn checked_add(size: &Integer) -> yul::Identifier {
     let size: &str = size.into();
     identifier! {(format!("checked_add_{}", size.to_lowercase()))}
 }
 
+/// Generate a function name to perform checked multiplication
+pub fn checked_mul(size: &Integer) -> yul::Identifier {
+    let size: &str = size.into();
+    identifier! {(format!("checked_mul_{}", size.to_lowercase()))}
+}
+
+/// Generate a function name to perform checked subtraction
 pub fn checked_sub(size: &Integer) -> yul::Identifier {
     let size: &str = if size.is_signed() {
         size.into()
@@ -19,10 +27,12 @@ pub fn checked_sub(size: &Integer) -> yul::Identifier {
     identifier! {(format!("checked_sub_{}", size.to_lowercase()))}
 }
 
+/// Generate a safe function name for a user defined function
 pub fn func_name(name: &str) -> yul::Identifier {
     identifier! { (format!("$${}", name)) }
 }
 
+/// Generate a safe variable name for a user defined function
 pub fn var_name(name: &str) -> yul::Identifier {
     identifier! { (format!("${}", name)) }
 }

--- a/compiler/src/yul/runtime/functions/math.rs
+++ b/compiler/src/yul/runtime/functions/math.rs
@@ -22,6 +22,25 @@ pub fn checked_add_fns() -> Vec<yul::Statement> {
     ]
 }
 
+/// Return a vector of runtime functions for multiplications with
+/// over-/underflow protection
+pub fn checked_mul_fns() -> Vec<yul::Statement> {
+    vec![
+        checked_mul_unsigned(Integer::U256),
+        checked_mul_unsigned(Integer::U128),
+        checked_mul_unsigned(Integer::U64),
+        checked_mul_unsigned(Integer::U32),
+        checked_mul_unsigned(Integer::U16),
+        checked_mul_unsigned(Integer::U8),
+        checked_mul_signed(Integer::I256),
+        checked_mul_signed(Integer::I128),
+        checked_mul_signed(Integer::I64),
+        checked_mul_signed(Integer::I32),
+        checked_mul_signed(Integer::I16),
+        checked_mul_signed(Integer::I8),
+    ]
+}
+
 /// Return a vector of runtime functions for subtraction with over-/underflow
 /// protection
 pub fn checked_sub_fns() -> Vec<yul::Statement> {
@@ -38,7 +57,45 @@ pub fn checked_sub_fns() -> Vec<yul::Statement> {
 
 // Return all math runtime functions
 pub fn all() -> Vec<yul::Statement> {
-    [checked_add_fns(), checked_sub_fns()].concat()
+    [checked_add_fns(), checked_mul_fns(), checked_sub_fns()].concat()
+}
+
+fn checked_mul_unsigned(size: Integer) -> yul::Statement {
+    if size.is_signed() {
+        panic!("Expected unsigned integer")
+    }
+    let fn_name = names::checked_mul(&size);
+    let max_value = get_max(size);
+
+    function_definition! {
+        function [fn_name](val1, val2) -> product {
+            // overflow, if val1 != 0 and val2 > (max_value / val1)
+            (if (and((iszero((iszero(val1)))), (gt(val2, (div([max_value], val1)))))) { (revert(0, 0)) })
+            (product := mul(val1, val2))
+        }
+    }
+}
+
+fn checked_mul_signed(size: Integer) -> yul::Statement {
+    if !size.is_signed() {
+        panic!("Expected signed integer")
+    }
+    let fn_name = names::checked_mul(&size);
+    let (min_value, max_value) = get_min_max(size);
+
+    function_definition! {
+        function [fn_name](val1, val2) -> product {
+            // overflow, if val1 > 0, val2 > 0 and val1 > (max_value / val2)
+            (if (and((and((sgt(val1, 0)), (sgt(val2, 0)))), (gt(val1, (div([max_value.clone()], val2)))))) { (revert(0, 0)) })
+            // underflow, if val1 > 0, val2 < 0 and val2 < (min_value / val1)
+            (if (and((and((sgt(val1, 0)), (slt(val2, 0)))), (slt(val2, (sdiv([min_value.clone()], val1)))))) { (revert(0, 0)) })
+            // underflow, if val1 < 0, val2 > 0 and val1 < (min_value / val2)
+            (if (and((and((slt(val1, 0)), (sgt(val2, 0)))), (slt(val1, (sdiv([min_value], val2)))))) { (revert(0, 0)) })
+            // overflow, if val1 < 0, val2 < 0 and val1 < (max_value / val2)
+            (if (and((and((slt(val1, 0)), (slt(val2, 0)))), (slt(val1, (sdiv([max_value], val2)))))) { (revert(0, 0)) })
+            (product := mul(val1, val2))
+        }
+    }
 }
 
 fn checked_add_unsigned(size: Integer) -> yul::Statement {

--- a/compiler/tests/evm_contracts.rs
+++ b/compiler/tests/evm_contracts.rs
@@ -751,6 +751,64 @@ fn checked_arithmetic() {
                 &[config.i_max.clone(), int_token(-0)],
                 Some(&config.i_max),
             );
+
+            // MULTIPLICATION
+            // unsigned: max_value * 2 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("mul_u{}", config.size),
+                &[config.u_max.clone(), uint_token(2)],
+            );
+
+            // unsigned: max_value * 1 works
+            harness.test_function(
+                &mut executor,
+                &format!("mul_u{}", config.size),
+                &[config.u_max.clone(), uint_token(1)],
+                Some(&config.u_max),
+            );
+
+            // signed: max_value * 2 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("mul_i{}", config.size),
+                &[config.i_max.clone(), int_token(2)],
+            );
+
+            // signed: max_value * 1 works
+            harness.test_function(
+                &mut executor,
+                &format!("mul_i{}", config.size),
+                &[config.i_max.clone(), int_token(1)],
+                Some(&config.i_max),
+            );
+
+            // signed: max_value * -2 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("mul_i{}", config.size),
+                &[config.i_max.clone(), int_token(-2)],
+            );
+
+            // signed: min_value * -2 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("mul_i{}", config.size),
+                &[config.i_min.clone(), int_token(-2)],
+            );
+
+            // signed: min_value * 1 works
+            if config.size == 256 {
+                // rust-evm has a bug with SDIV(256_min, 1). It returns 0 causing this test to
+                // fail. See: https://github.com/ethereum/fe/issues/285
+                continue;
+            }
+            harness.test_function(
+                &mut executor,
+                &format!("mul_i{}", config.size),
+                &[config.i_min.clone(), int_token(1)],
+                Some(&config.i_min),
+            );
         }
     });
 }

--- a/compiler/tests/fixtures/checked_arithmetic.fe
+++ b/compiler/tests/fixtures/checked_arithmetic.fe
@@ -71,3 +71,39 @@ contract CheckedArithmetic:
 
     pub def sub_i8(left: i8, right: i8) -> i8:
         return left - right
+
+    pub def mul_u256(left: u256, right: u256) -> u256:
+        return left * right
+
+    pub def mul_u128(left: u128, right: u128) -> u128:
+        return left * right
+
+    pub def mul_u64(left: u64, right: u64) -> u64:
+        return left * right
+
+    pub def mul_u32(left: u32, right: u32) -> u32:
+        return left * right
+
+    pub def mul_u16(left: u16, right: u16) -> u16:
+        return left * right
+
+    pub def mul_u8(left: u8, right: u8) -> u8:
+        return left * right
+
+    pub def mul_i256(left: i256, right: i256) -> i256:
+        return left * right
+
+    pub def mul_i128(left: i128, right: i128) -> i128:
+        return left * right
+
+    pub def mul_i64(left: i64, right: i64) -> i64:
+        return left * right
+
+    pub def mul_i32(left: i32, right: i32) -> i32:
+        return left * right
+
+    pub def mul_i16(left: i16, right: i16) -> i16:
+        return left * right
+
+    pub def mul_i8(left: i8, right: i8) -> i8:
+        return left * right

--- a/newsfragments/271.feature.md
+++ b/newsfragments/271.feature.md
@@ -1,0 +1,1 @@
+Add over/underflow checks for multiplications of all integers


### PR DESCRIPTION
### What was wrong?

We do not yet perform overflow/underflow checks for multiplications.

### How was it fixed?

Pretty straight forward based on the previous implementations for add and sub. Except for that pesty rusty-evm bug that I created an issue for: https://github.com/ethereum/fe/issues/285
