### PR TITLE
Full support for empty tuples

### DIFF
--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -157,6 +157,20 @@ impl ExpressionAttributes {
         }
     }
 
+    /// Return `true` if the type of the expression is an empty Tuple, otherwise
+    /// `false`
+    pub fn is_empty_tuple(&self) -> bool {
+        if let ExpressionAttributes {
+            typ: Type::Tuple(tuple),
+            ..
+        } = self
+        {
+            tuple.is_empty()
+        } else {
+            false
+        }
+    }
+
     /// Adds a move to memory, if it is already in memory.
     pub fn into_cloned(mut self) -> Result<Self, SemanticError> {
         if self.location != Location::Memory {

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -14,6 +14,7 @@ use crate::namespace::types::{
     FixedSize,
     Integer,
     Struct,
+    Tuple,
     Type,
     U256,
 };
@@ -65,7 +66,7 @@ pub fn expr(
         fe::Expr::Call { .. } => expr_call(scope, Rc::clone(&context), exp),
         fe::Expr::List { .. } => expr_list(scope, Rc::clone(&context), exp),
         fe::Expr::ListComp { .. } => unimplemented!(),
-        fe::Expr::Tuple { .. } => unimplemented!(),
+        fe::Expr::Tuple { .. } => expr_tuple(scope, Rc::clone(&context), exp),
         fe::Expr::Str(_) => expr_str(scope, exp),
         fe::Expr::Ellipsis => unimplemented!(),
     }
@@ -109,6 +110,25 @@ pub fn expr_list(
                 });
             }
             return Err(SemanticError::type_error());
+        }
+    }
+    unreachable!()
+}
+
+/// Gather context information for a tuple expression and check for type errors.
+pub fn expr_tuple(
+    _scope: Shared<BlockScope>,
+    _context: Shared<Context>,
+    exp: &Spanned<fe::Expr>,
+) -> Result<ExpressionAttributes, SemanticError> {
+    if let fe::Expr::Tuple { elts } = &exp.node {
+        if elts.is_empty() {
+            return Ok(ExpressionAttributes::new(
+                Type::Tuple(Tuple::empty()),
+                Location::Memory,
+            ));
+        } else {
+            todo!("Non-empty Tuples not supported yet")
         }
     }
     unreachable!()

--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -163,6 +163,7 @@ pub enum VarType {
     FixedBytes(usize),
     FixedArray(Box<VarType>, usize),
     String,
+    Tuple(Vec<VarType>),
 }
 
 /// The mutability of a public function.
@@ -177,25 +178,33 @@ pub enum StateMutability {
 }
 
 impl fmt::Display for VarType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            VarType::Bool => write!(f, "bool"),
-            VarType::Uint256 => write!(f, "uint256"),
-            VarType::Uint128 => write!(f, "uint128"),
-            VarType::Uint64 => write!(f, "uint64"),
-            VarType::Uint32 => write!(f, "uint32"),
-            VarType::Uint16 => write!(f, "uint16"),
-            VarType::Uint8 => write!(f, "uint8"),
-            VarType::Int256 => write!(f, "int256"),
-            VarType::Int128 => write!(f, "int128"),
-            VarType::Int64 => write!(f, "int64"),
-            VarType::Int32 => write!(f, "int32"),
-            VarType::Int16 => write!(f, "int16"),
-            VarType::Int8 => write!(f, "int8"),
-            VarType::Address => write!(f, "address"),
-            VarType::FixedBytes(size) => write!(f, "bytes{}", size),
-            VarType::FixedArray(inner, dim) => write!(f, "{}[{}]", inner, dim),
-            VarType::String => write!(f, "string"),
+            VarType::Bool => write!(formatter, "bool"),
+            VarType::Uint256 => write!(formatter, "uint256"),
+            VarType::Uint128 => write!(formatter, "uint128"),
+            VarType::Uint64 => write!(formatter, "uint64"),
+            VarType::Uint32 => write!(formatter, "uint32"),
+            VarType::Uint16 => write!(formatter, "uint16"),
+            VarType::Uint8 => write!(formatter, "uint8"),
+            VarType::Int256 => write!(formatter, "int256"),
+            VarType::Int128 => write!(formatter, "int128"),
+            VarType::Int64 => write!(formatter, "int64"),
+            VarType::Int32 => write!(formatter, "int32"),
+            VarType::Int16 => write!(formatter, "int16"),
+            VarType::Int8 => write!(formatter, "int8"),
+            VarType::Address => write!(formatter, "address"),
+            VarType::FixedBytes(size) => write!(formatter, "bytes{}", size),
+            VarType::FixedArray(inner, dim) => write!(formatter, "{}[{}]", inner, dim),
+            VarType::String => write!(formatter, "string"),
+            VarType::Tuple(items) => {
+                let items = items
+                    .iter()
+                    .map(VarType::to_string)
+                    .collect::<Vec<String>>()
+                    .join(",");
+                write!(formatter, "({})", items)
+            }
         }
     }
 }

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -55,7 +55,7 @@ pub fn expr(context: &Context, exp: &Spanned<fe::Expr>) -> Result<yul::Expressio
             fe::Expr::Call { .. } => expr_call(context, exp),
             fe::Expr::List { .. } => unimplemented!(),
             fe::Expr::ListComp { .. } => unimplemented!(),
-            fe::Expr::Tuple { .. } => unimplemented!(),
+            fe::Expr::Tuple { .. } => expr_tuple(exp),
             fe::Expr::Str(_) => expr_str(exp),
             fe::Expr::Ellipsis => unimplemented!(),
         }?;
@@ -337,6 +337,18 @@ pub fn slice_index(
     if let fe::Slice::Index(index) = &slice.node {
         let spanned = utils::spanned_expression(&slice.span, index.as_ref());
         return expr(context, &spanned);
+    }
+
+    unreachable!()
+}
+
+fn expr_tuple(exp: &Spanned<fe::Expr>) -> Result<yul::Expression, CompileError> {
+    if let fe::Expr::Tuple { elts } = &exp.node {
+        if !elts.is_empty() {
+            todo!("Non empty Tuples aren't yet supported")
+        } else {
+            return Ok(literal_expression! {0x0});
+        }
     }
 
     unreachable!()

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -242,8 +242,13 @@ fn func_return(
     if let fe::FuncStmt::Return { value } = &stmt.node {
         return match value {
             Some(value) => {
-                let value = expressions::expr(context, value)?;
+                // Ensure `return ()` is handled as if the function does not return
+                let attributes = context.get_expression(value).expect("Missing attributes");
+                if attributes.is_empty_tuple() {
+                    return Ok(statement! { leave });
+                }
 
+                let value = expressions::expr(context, value)?;
                 return Ok(block_statement! {
                     (return_val := [value])
                     (leave)

--- a/compiler/tests/fixtures/return_empty_tuple.fe
+++ b/compiler/tests/fixtures/return_empty_tuple.fe
@@ -1,7 +1,19 @@
 contract Foo:
 
-  pub def explicit_return():
+  pub def explicit_return_a1():
     return
 
-  pub def implicit():
+  pub def explicit_return_a2():
+    return ()
+
+  pub def explicit_return_b1() ->():
+    return
+
+  pub def explicit_return_b2() ->():
+    return ()
+
+  pub def implicit_a1():
+    pass
+
+  pub def implicit_a2() ->():
     pass

--- a/newsfragments/276.feature.md
+++ b/newsfragments/276.feature.md
@@ -1,0 +1,28 @@
+Add full support for empty Tuples.
+
+All functions in Fe implicitly return an empty Tuple if they have no other return value.
+However, before this change one was not able to use the empty Tuple syntax `()` explicitly.
+
+With this change, all of these are treated equally:
+
+```
+contract Foo:
+
+  pub def explicit_return_a1():
+    return
+
+  pub def explicit_return_a2():
+    return ()
+
+  pub def explicit_return_b1() ->():
+    return
+
+  pub def explicit_return_b2() ->():
+    return ()
+
+  pub def implicit_a1():
+    pass
+
+  pub def implicit_a2() ->():
+    pass
+```

--- a/parser/tests/fixtures/parsers/func_def.ron
+++ b/parser/tests/fixtures/parsers/func_def.ron
@@ -1,5 +1,7 @@
 def foo(x: bool):
     x
+def foo(x: bool) -> ():
+    x
 pub def foo(x: bool) -> bool:
     x
 ---
@@ -60,18 +62,12 @@ pub def foo(x: bool) -> bool:
   ),
   Spanned(
     node: FuncDef(
-      qual: Some(Spanned(
-        node: Pub,
-        span: Span(
-          start: 24,
-          end: 27,
-        ),
-      )),
+      qual: None,
       name: Spanned(
         node: "foo",
         span: Span(
-          start: 32,
-          end: 35,
+          start: 28,
+          end: 31,
         ),
       ),
       args: [
@@ -80,8 +76,8 @@ pub def foo(x: bool) -> bool:
             name: Spanned(
               node: "x",
               span: Span(
-                start: 36,
-                end: 37,
+                start: 32,
+                end: 33,
               ),
             ),
             typ: Spanned(
@@ -89,24 +85,24 @@ pub def foo(x: bool) -> bool:
                 base: "bool",
               ),
               span: Span(
-                start: 39,
-                end: 43,
+                start: 35,
+                end: 39,
               ),
             ),
           ),
           span: Span(
-            start: 36,
-            end: 43,
+            start: 32,
+            end: 39,
           ),
         ),
       ],
       return_type: Some(Spanned(
-        node: Base(
-          base: "bool",
+        node: Tuple(
+          items: [],
         ),
         span: Span(
-          start: 48,
-          end: 52,
+          start: 44,
+          end: 46,
         ),
       )),
       body: [
@@ -115,15 +111,83 @@ pub def foo(x: bool) -> bool:
             value: Name("x"),
           ),
           span: Span(
-            start: 58,
-            end: 59,
+            start: 52,
+            end: 53,
           ),
         ),
       ],
     ),
     span: Span(
       start: 24,
-      end: 59,
+      end: 53,
+    ),
+  ),
+  Spanned(
+    node: FuncDef(
+      qual: Some(Spanned(
+        node: Pub,
+        span: Span(
+          start: 54,
+          end: 57,
+        ),
+      )),
+      name: Spanned(
+        node: "foo",
+        span: Span(
+          start: 62,
+          end: 65,
+        ),
+      ),
+      args: [
+        Spanned(
+          node: FuncDefArg(
+            name: Spanned(
+              node: "x",
+              span: Span(
+                start: 66,
+                end: 67,
+              ),
+            ),
+            typ: Spanned(
+              node: Base(
+                base: "bool",
+              ),
+              span: Span(
+                start: 69,
+                end: 73,
+              ),
+            ),
+          ),
+          span: Span(
+            start: 66,
+            end: 73,
+          ),
+        ),
+      ],
+      return_type: Some(Spanned(
+        node: Base(
+          base: "bool",
+        ),
+        span: Span(
+          start: 78,
+          end: 82,
+        ),
+      )),
+      body: [
+        Spanned(
+          node: Expr(
+            value: Name("x"),
+          ),
+          span: Span(
+            start: 88,
+            end: 89,
+          ),
+        ),
+      ],
+    ),
+    span: Span(
+      start: 54,
+      end: 89,
     ),
   ),
 ]

--- a/parser/tests/fixtures/parsers/type_desc.ron
+++ b/parser/tests/fixtures/parsers/type_desc.ron
@@ -1,14 +1,53 @@
+()
+(u8, u16)
 address
 map<address, bool>
 ---
 [
   Spanned(
+    node: Tuple(
+      items: [],
+    ),
+    span: Span(
+      start: 0,
+      end: 2,
+    ),
+  ),
+  Spanned(
+    node: Tuple(
+      items: [
+        Spanned(
+          node: Base(
+            base: "u8",
+          ),
+          span: Span(
+            start: 4,
+            end: 6,
+          ),
+        ),
+        Spanned(
+          node: Base(
+            base: "u16",
+          ),
+          span: Span(
+            start: 8,
+            end: 11,
+          ),
+        ),
+      ],
+    ),
+    span: Span(
+      start: 3,
+      end: 12,
+    ),
+  ),
+  Spanned(
     node: Base(
       base: "address",
     ),
     span: Span(
-      start: 0,
-      end: 7,
+      start: 13,
+      end: 20,
     ),
   ),
   Spanned(
@@ -18,8 +57,8 @@ map<address, bool>
           base: "address",
         ),
         span: Span(
-          start: 12,
-          end: 19,
+          start: 25,
+          end: 32,
         ),
       ),
       to: Spanned(
@@ -27,14 +66,14 @@ map<address, bool>
           base: "bool",
         ),
         span: Span(
-          start: 21,
-          end: 25,
+          start: 34,
+          end: 38,
         ),
       ),
     ),
     span: Span(
-      start: 8,
-      end: 26,
+      start: 21,
+      end: 39,
     ),
   ),
 ]


### PR DESCRIPTION
### What was wrong?

Even though functions do always implicitly return empy tuples it isn't yet supported to actually use the empty tuple syntax (`()`) in code.

E.g. the following doesn't work:

```
  pub def explicit_return():
    return ()
```

This doesn't work either:

```
  pub def explicit_return() -> ():
    pass
```

With this change, all of these are treated equal:

```
contract Foo:

  pub def explicit_return_a1():
    return

  pub def explicit_return_a2():
    return ()

  pub def explicit_return_b1() ->():
    return

  pub def explicit_return_b2() ->():
    return ()

  pub def implicit_a1():
    pass

  pub def implicit_a2() ->():
    pass
```

### How was it fixed?

1. Taught the Parser how to parse tuples via the `tuple_type` function
2. Added tests for tuple parsing
3. Added support for (empty!) tuples in the analyzer and mapper pass
4. Taught the mapper to treat `return ()` as if there is no return at all (`leave`)
5. A few more tests

### To-Do

- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
