### PR TITLE
Readme: Fix link to ERC20 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ contract GuestBook:
 
 A lot more working examples can be found in our [test fixtures directory](https://github.com/ethereum/fe/tree/master/compiler/tests/fixtures).
 
-The most advanced example that we can provide at this point is a fully working [ERC20 implementation](https://github.com/ethereum/fe/blob/master/compiler/tests/fixtures/erc20_token.fe).
+The most advanced example that we can provide at this point is a fully working [ERC20 implementation](https://github.com/ethereum/fe/blob/master/compiler/tests/fixtures/demos/erc20_token.fe).
 
 ## Community
 


### PR DESCRIPTION
### What was wrong?

Link in the Readme to the ERC20 implementation does not work

### How was it fixed?

Added the link I believe is the right one: https://github.com/ethereum/fe/blob/master/compiler/tests/fixtures/demos/erc20_token.fe
