### PR TITLE
Fix visibility issue with subsequently defined contracts

### DIFF
--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -109,7 +109,12 @@ impl From<Shared<ContractScope>> for ContractAttributes {
 
         let external_contracts = scope.borrow().get_module_type_defs(|typ| {
             if let Type::Contract(contract) = typ {
-                Some(contract.to_owned())
+                // Skip our own contract
+                if contract.name == scope.borrow().name {
+                    None
+                } else {
+                    Some(contract.to_owned())
+                }
             } else {
                 None
             }

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -43,6 +43,7 @@ pub struct ModuleScope {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContractScope {
+    pub name: String,
     pub parent: Shared<ModuleScope>,
     pub interface: Vec<String>,
     pub event_defs: HashMap<String, Event>,
@@ -173,8 +174,9 @@ impl ModuleScope {
 }
 
 impl ContractScope {
-    pub fn new(parent: Shared<ModuleScope>) -> Shared<Self> {
+    pub fn new(name: &str, parent: Shared<ModuleScope>) -> Shared<Self> {
         Rc::new(RefCell::new(ContractScope {
+            name: name.to_owned(),
             parent,
             function_defs: HashMap::new(),
             event_defs: HashMap::new(),
@@ -430,7 +432,7 @@ mod tests {
     #[test]
     fn test_scope_resolution_on_first_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         assert_eq!(block_scope_1, block_scope_1.borrow().function_scope());
         assert_eq!(contract_scope, block_scope_1.borrow().contract_scope());
@@ -439,7 +441,7 @@ mod tests {
     #[test]
     fn test_scope_resolution_on_second_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
@@ -450,7 +452,7 @@ mod tests {
     #[test]
     fn test_1st_level_def_lookup_on_1st_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         block_scope_1
             .borrow_mut()
@@ -465,7 +467,7 @@ mod tests {
     #[test]
     fn test_1st_level_def_lookup_on_2nd_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
@@ -482,7 +484,7 @@ mod tests {
     #[test]
     fn test_2nd_level_def_lookup_on_1nd_level_block_scope_fails() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
@@ -496,7 +498,7 @@ mod tests {
     #[test]
     fn test_inherits_type() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         assert_eq!(
             true,

--- a/analyzer/src/traversal/assignments.rs
+++ b/analyzer/src/traversal/assignments.rs
@@ -81,7 +81,7 @@ mod tests {
     // - bar: u256[100]
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         contract_scope
             .borrow_mut()
             .add_field(

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -30,7 +30,7 @@ pub fn contract_def(
     stmt: &Spanned<fe::ModuleStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::ModuleStmt::ContractDef { name, .. } = &stmt.node {
-        let contract_scope = ContractScope::new(Rc::clone(&module_scope));
+        let contract_scope = ContractScope::new(name.node, Rc::clone(&module_scope));
 
         contract_scope
             .borrow()

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -64,7 +64,7 @@ mod tests {
 
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         BlockScope::from_contract_scope("", contract_scope)
     }
 

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -1124,7 +1124,7 @@ mod tests {
 
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         BlockScope::from_contract_scope("", contract_scope)
     }
 

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -448,7 +448,7 @@ mod tests {
 
     fn scope() -> Shared<ContractScope> {
         let module_scope = ModuleScope::new();
-        ContractScope::new(module_scope)
+        ContractScope::new("", module_scope)
     }
 
     fn analyze(scope: Shared<ContractScope>, src: &str) -> Context {

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -6,9 +6,11 @@ use crate::namespace::scopes::{
 use crate::namespace::types;
 use crate::traversal::{
     contracts,
+    functions,
     structs,
 };
 use crate::Context;
+use crate::ContractAttributes;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
 use std::rc::Rc;
@@ -17,6 +19,9 @@ use std::rc::Rc;
 pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), SemanticError> {
     let scope = ModuleScope::new();
 
+    // Walk over the module but ignore everything that is *inside* contracts.
+    // This is to make contract types known prior to where we know their exact shape
+    // so that they can already be used as types in other contracts.
     for stmt in module.body.iter() {
         match &stmt.node {
             fe::ModuleStmt::TypeDef { .. } => type_def(Rc::clone(&scope), stmt)?,
@@ -28,6 +33,35 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
             }
             fe::ModuleStmt::FromImport { .. } => unimplemented!(),
             fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
+        }
+    }
+
+    // Now inspect the bodies of the contract. At this point they can use other
+    // contract types in storage declarations and function signatures because we
+    // know the types from the previous walk.
+    for module_stmt in module.body.iter() {
+        if let fe::ModuleStmt::ContractDef { .. } = &module_stmt.node {
+            contracts::contract_body(Rc::clone(&scope), Rc::clone(&context), module_stmt)?;
+        }
+    }
+
+    // Final walk: At this point we know all contract types with their exact shape.
+    // What's left is to walk through the function bodies to analyze them.
+    for module_stmt in module.body.iter() {
+        if let fe::ModuleStmt::ContractDef { name, body } = &module_stmt.node {
+            let contract_scope = scope.borrow().contract_def(name.node).expect("msg").scope;
+            for stmt in body.iter() {
+                if let fe::ContractStmt::FuncDef { .. } = &stmt.node {
+                    functions::func_body(Rc::clone(&contract_scope), Rc::clone(&context), stmt)
+                        .map_err(|error| error.with_context(stmt.span))?;
+                }
+            }
+            // At this point, the contract attributes are final and can be added to the
+            // context
+            let contract_attributes = ContractAttributes::from(Rc::clone(&contract_scope));
+            context
+                .borrow_mut()
+                .add_contract(module_stmt, contract_attributes);
         }
     }
 

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -90,6 +90,7 @@ pub fn build(context: &Context, contract: &Spanned<fe::ModuleStmt>) -> Vec<yul::
             let batch = [public_functions_batch, init_params_batch, contracts_batch].concat();
             functions::abi::batch_decode(batch)
         };
+
         let contract_calls = {
             attributes
                 .external_contracts

--- a/compiler/tests/fixtures/demos/uniswap.fe
+++ b/compiler/tests/fixtures/demos/uniswap.fe
@@ -156,9 +156,7 @@ contract UniswapV2Pair:
 
     # if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
     def _mint_fee(reserve0: u256, reserve1: u256) -> bool:
-        # TODO: The interfaces of subsequently defined contracts should be visible (https://github.com/ethereum/fe/issues/283)
-        # fee_to: address = UniswapV2Factory(factory).fee_to()
-        fee_to: address = address(0)
+        fee_to: address = UniswapV2Factory(self.factory).fee_to()
         fee_on: bool = fee_to != address(0)
         k_last: u256 = self.k_last # gas savings
         if fee_on:

--- a/compiler/tests/fixtures/two_contracts.fe
+++ b/compiler/tests/fixtures/two_contracts.fe
@@ -1,7 +1,19 @@
 contract Foo:
+
+    bar: Bar
+
+    pub def external_bar() -> u256:
+        return self.bar.bar()
+
     pub def foo() -> u256:
         return 42
 
 contract Bar:
+
+    foo: Foo
+
+    pub def external_foo() -> u256:
+        return self.foo.foo()
+
     pub def bar() -> u256:
         return 26

--- a/newsfragments/283.feature.md
+++ b/newsfragments/283.feature.md
@@ -1,0 +1,31 @@
+Make subsequently defined contracts visible.
+
+Before this change:
+
+```
+# can't see Bar
+contract Foo:
+   ...
+
+# can see Foo
+contract Bar:
+   ...
+```
+
+With this change the restriction is lifted and the following becomes possible.
+
+```
+contract Foo:
+
+    bar: Bar
+
+    pub def external_bar() -> u256:
+        return self.bar.bar()
+
+contract Bar:
+
+    foo: Foo
+
+    pub def external_foo() -> u256:
+        return self.foo.foo()
+```


### PR DESCRIPTION
### What is wrong?

If two contracts are defined in a module, only the second contract can see the interface of the first.

e.g.

```python
# can't see Bar
contract Foo:
   ...

# can see Foo
contract Bar:
   ...
```

### How was it fixed?

1. Contract analysis is split into multiple passes:
    1 The first pass collects just the names of the contracts and makes them available as types without further inspecting the contracts
    2. Next we inspect all contract bodies and we update all contract types to contain the actual function signatures
    3. Lastly we walk over all function bodies which is save at this point because now we have all information to e.g. parse something like `ExternalContract(some_address).some_api()`
2. To make this happen, two more APIs where added to the scope `add_contract_def` and `update_contract_def`. The last one is needed to update the contract types in the second phase (as explained above)
3. There's a bit of extra machinery to deal with the fact that part of the scope may be setup with contracts that were only partially resolved at the time when they were used but the scope has a way to mitigate that to ensure it always returns the up to date version when it is queried.
4. Because the module scope now contains all contracts it needs a way to filter out the main contract when it is aggregating `external_contracts`. To do that, `name` was added to `ContractScope` (we also have `name` for `BlockScope` so there's a precedence for having the `name` as a scope identifier) so that we can filter out the "self contract" upon aggregation.
5. The Uniswap demo was updated to use that feature

