### PR TITLE
Structs in the ABI

### DIFF
--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -2,43 +2,30 @@ use crate::abi::elements::{
     Contract,
     Event,
     EventField,
-    FuncInput,
-    FuncOutput,
-    FuncType,
-    Function,
     ModuleAbis,
-    VarType,
 };
 use crate::errors::CompileError;
+use fe_analyzer::namespace::types::AbiEncoding;
+use fe_analyzer::Context;
 use fe_parser::ast as fe;
 use fe_parser::span::Spanned;
-use std::collections::HashMap;
-
-type TypeDefs<'a> = HashMap<&'a str, &'a fe::TypeDesc<'a>>;
 
 /// Parse a map of contract ABIs from the input `module`.
-pub fn module<'a>(module: &'a fe::Module<'a>) -> Result<ModuleAbis, CompileError> {
-    let mut type_defs = TypeDefs::new();
-
+pub fn module<'a>(
+    context: &Context,
+    module: &'a fe::Module<'a>,
+) -> Result<ModuleAbis, CompileError> {
     module
         .body
         .iter()
         .try_fold(ModuleAbis::new(), |mut abis, stmt| {
-            match &stmt.node {
-                fe::ModuleStmt::TypeDef { name, typ } => {
-                    if type_defs.insert(name.node, &typ.node).is_some() {
-                        return Err(CompileError::static_str("duplicate type definition"));
-                    }
+            if let fe::ModuleStmt::ContractDef { name, body } = &stmt.node {
+                if abis
+                    .insert(name.node.to_string(), contract_def(context, body)?)
+                    .is_some()
+                {
+                    return Err(CompileError::static_str("duplicate contract definition"));
                 }
-                fe::ModuleStmt::ContractDef { name, body } => {
-                    if abis
-                        .insert(name.node.to_string(), contract_def(&type_defs, body)?)
-                        .is_some()
-                    {
-                        return Err(CompileError::static_str("duplicate contract definition"));
-                    }
-                }
-                _ => {}
             };
 
             Ok(abis)
@@ -46,168 +33,58 @@ pub fn module<'a>(module: &'a fe::Module<'a>) -> Result<ModuleAbis, CompileError
 }
 
 fn contract_def<'a>(
-    type_defs: &'a TypeDefs<'a>,
+    context: &Context,
     body: &[Spanned<fe::ContractStmt<'a>>],
 ) -> Result<Contract, CompileError> {
-    body.iter().try_fold(Contract::new(), |mut c, s| {
-        match &s.node {
-            fe::ContractStmt::FuncDef {
-                qual,
-                name,
-                args,
-                return_type,
-                ..
-            } => {
-                if let Some(qual) = qual {
-                    if qual.node == fe::FuncQual::Pub {
-                        c.functions
-                            .push(func_def(type_defs, name.node, args, return_type)?)
-                    }
+    body.iter().try_fold(Contract::new(), |mut contract, stmt| {
+        match &stmt.node {
+            fe::ContractStmt::FuncDef { .. } => {
+                let attributes = context
+                    .get_function(stmt)
+                    .expect("missing function attributes");
+
+                if attributes.is_public {
+                    contract.functions.push(attributes.to_owned().into())
                 }
             }
-            fe::ContractStmt::EventDef { name, fields } => {
-                c.events.push(event_def(type_defs, name.node, fields)?)
+            fe::ContractStmt::EventDef { .. } => {
+                let attributes = context
+                    .get_event(stmt)
+                    .expect("missing function attributes");
+
+                let event = Event {
+                    name: attributes.name.to_owned(),
+                    typ: "event".to_string(),
+                    fields: attributes
+                        .fields
+                        .iter()
+                        .enumerate()
+                        .map(|(index, (name, typ))| EventField {
+                            name: name.to_owned(),
+                            typ: typ.abi_type_name(),
+                            indexed: attributes.indexed_fields.contains(&index),
+                        })
+                        .collect(),
+                    anonymous: false,
+                };
+
+                contract.events.push(event);
             }
             fe::ContractStmt::ContractField { .. } => {}
         }
 
-        Ok(c)
+        Ok(contract)
     })
-}
-
-fn event_def<'a>(
-    type_defs: &'a TypeDefs<'a>,
-    name: &str,
-    fields: &[Spanned<fe::EventField<'a>>],
-) -> Result<Event, CompileError> {
-    let fields = fields
-        .iter()
-        .map(|field| event_field(type_defs, &field.node))
-        .collect::<Result<_, _>>()?;
-
-    Ok(Event {
-        name: name.to_owned(),
-        typ: "event".to_owned(),
-        fields,
-        anonymous: false,
-    })
-}
-
-fn event_field<'a>(
-    type_defs: &'a TypeDefs<'a>,
-    field: &'a fe::EventField<'a>,
-) -> Result<EventField, CompileError> {
-    Ok(EventField {
-        name: field.name.node.to_owned(),
-        typ: type_desc(&type_defs, &field.typ.node)?,
-        indexed: field.qual.is_some(),
-    })
-}
-
-fn func_def<'a>(
-    type_defs: &'a TypeDefs<'a>,
-    name: &str,
-    args: &[Spanned<fe::FuncDefArg<'a>>],
-    return_type: &'a Option<Spanned<fe::TypeDesc<'a>>>,
-) -> Result<Function, CompileError> {
-    let inputs = args
-        .iter()
-        .map(|arg| func_def_arg(type_defs, &arg.node))
-        .collect::<Result<Vec<FuncInput>, CompileError>>()?;
-
-    let outputs = if let Some(return_type) = return_type {
-        match type_desc(type_defs, &return_type.node)? {
-            // Should there be a different ABI for `pub def foo() -> ():` and `pub def foo():`?
-            VarType::Tuple(items) if items.is_empty() => vec![],
-            _ => vec![FuncOutput {
-                name: "".to_string(),
-                typ: type_desc(type_defs, &return_type.node)?,
-            }],
-        }
-    } else {
-        vec![]
-    };
-
-    let (name, typ) = if name == "__init__" {
-        ("", FuncType::Constructor)
-    } else {
-        (name, FuncType::Function)
-    };
-
-    Ok(Function {
-        name: name.to_owned(),
-        typ,
-        inputs,
-        outputs,
-    })
-}
-
-fn func_def_arg<'a>(
-    type_defs: &'a TypeDefs<'a>,
-    arg: &'a fe::FuncDefArg<'a>,
-) -> Result<FuncInput, CompileError> {
-    Ok(FuncInput {
-        name: arg.name.node.to_owned(),
-        typ: type_desc(&type_defs, &arg.typ.node)?,
-    })
-}
-
-fn type_desc<'a>(
-    type_defs: &'a TypeDefs<'a>,
-    typ: &'a fe::TypeDesc<'a>,
-) -> Result<VarType, CompileError> {
-    if let fe::TypeDesc::Base { base } = typ {
-        if let Some(custom_type) = type_defs.get(base) {
-            return type_desc(type_defs, custom_type);
-        }
-    }
-
-    match typ {
-        fe::TypeDesc::Base { base: "u256" } => Ok(VarType::Uint256),
-        fe::TypeDesc::Base { base: "u128" } => Ok(VarType::Uint128),
-        fe::TypeDesc::Base { base: "u64" } => Ok(VarType::Uint64),
-        fe::TypeDesc::Base { base: "u32" } => Ok(VarType::Uint32),
-        fe::TypeDesc::Base { base: "u16" } => Ok(VarType::Uint16),
-        fe::TypeDesc::Base { base: "u8" } => Ok(VarType::Uint8),
-        fe::TypeDesc::Base { base: "i256" } => Ok(VarType::Int256),
-        fe::TypeDesc::Base { base: "i128" } => Ok(VarType::Int128),
-        fe::TypeDesc::Base { base: "i64" } => Ok(VarType::Int64),
-        fe::TypeDesc::Base { base: "i32" } => Ok(VarType::Int32),
-        fe::TypeDesc::Base { base: "i16" } => Ok(VarType::Int16),
-        fe::TypeDesc::Base { base: "i8" } => Ok(VarType::Int8),
-        fe::TypeDesc::Base { base: "bool" } => Ok(VarType::Bool),
-        fe::TypeDesc::Base { base: "address" } => Ok(VarType::Address),
-        fe::TypeDesc::Base { base } if base.starts_with("string") => Ok(VarType::String),
-        fe::TypeDesc::Base { base } => {
-            Err(CompileError::str(&format!("unrecognized type: {}", base)))
-        }
-        fe::TypeDesc::Array { typ, dimension } => {
-            if let fe::TypeDesc::Base { base: "bytes" } = &typ.node {
-                return Ok(VarType::FixedBytes(*dimension));
-            }
-
-            let inner = type_desc(type_defs, &typ.node)?;
-            Ok(VarType::FixedArray(Box::new(inner), *dimension))
-        }
-        fe::TypeDesc::Map { .. } => Err(CompileError::static_str("maps not supported in ABI")),
-        fe::TypeDesc::Tuple { items } => {
-            let items = items
-                .iter()
-                .map(|item| type_desc(type_defs, &item.node))
-                .collect::<Result<_, _>>()?;
-            Ok(VarType::Tuple(items))
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::abi::builder;
-    use crate::abi::elements::VarType;
+    use fe_analyzer;
     use fe_parser::parsers;
 
     #[test]
-    fn module_function() {
+    fn build_contract_abi() {
         let tokens = fe_parser::get_parse_tokens(
             "\
             \ncontract Foo:\
@@ -216,9 +93,9 @@ mod tests {
             \n  pub def __init__(x: address):\
             \n    pass\
             \n  def baz(x: address) -> u256:\
-            \n    pass\
+            \n    revert\
             \n  pub def bar(x: u256) -> u256[10]:\
-            \n    pass",
+            \n    revert",
         )
         .expect("unable to parse contract");
 
@@ -226,31 +103,21 @@ mod tests {
             .expect("unable to build module AST")
             .1
             .node;
-        let abis = builder::module(&module).expect("unable to build ABIs");
+        let context = fe_analyzer::analyze(&module).expect("failed to analyze source");
+        let abis = builder::module(&context, &module).expect("unable to build ABI");
 
         if let Some(abi) = abis.get("Foo") {
-            assert_eq!(abi.events[0].name, "Food", "event name should be Food");
-            assert_eq!(abi.functions.len(), 2, "too many functions in ABI");
-            assert_eq!(abi.functions[0].name, "", "constructor not found in ABI");
-            assert_eq!(
-                abi.functions[0].inputs[0].typ,
-                VarType::Address,
-                "constructor has incorrect input value"
-            );
-            assert_eq!(
-                abi.functions[1].name, "bar",
-                "function \"bar\" not found in ABI"
-            );
-            assert_eq!(
-                abi.functions[1].inputs[0].typ,
-                VarType::Uint256,
-                "function \"bar\" has incorrect input value"
-            );
-            assert_eq!(
-                abi.functions[1].outputs[0].typ,
-                VarType::FixedArray(Box::new(VarType::Uint256), 10),
-                "function \"bar\" has incorrect output type"
-            );
+            // event
+            assert_eq!(abi.events[0].name, "Food");
+            // function count
+            assert_eq!(abi.functions.len(), 2);
+            // __init__
+            assert_eq!(abi.functions[0].name, "");
+            assert_eq!(abi.functions[0].inputs[0].typ, "address",);
+            // bar
+            assert_eq!(abi.functions[1].name, "bar",);
+            assert_eq!(abi.functions[1].inputs[0].typ, "uint256",);
+            assert_eq!(abi.functions[1].outputs[0].typ, "uint256[10]",);
         } else {
             panic!("contract \"Foo\" not found in module")
         }

--- a/compiler/src/abi/mod.rs
+++ b/compiler/src/abi/mod.rs
@@ -5,6 +5,7 @@ use crate::types::{
     FeModuleAst,
     NamedAbis,
 };
+use fe_analyzer::Context;
 
 mod builder;
 pub mod utils;
@@ -13,8 +14,8 @@ pub mod utils;
 pub mod elements;
 
 /// Builds ABIs for each contract in the module.
-pub fn build(module: &FeModuleAst) -> Result<NamedAbis, CompileError> {
-    builder::module(module)?
+pub fn build(context: &Context, module: &FeModuleAst) -> Result<NamedAbis, CompileError> {
+    builder::module(context, module)?
         .drain()
         .map(|(name, abi)| abi.json(true).map(|json| (name, json)))
         .collect::<Result<NamedAbis, _>>()

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -31,15 +31,15 @@ pub fn compile(
         .1
         .node;
 
-    // build abi
-    let json_abis = abi::build(&fe_module)?;
-
     // analyze source code
     let context = fe_analyzer::analyze(&fe_module)
         .map_err(|error| CompileError::str(&error.format_user(src)))?;
 
+    // build abi
+    let json_abis = abi::build(&context, &fe_module)?;
+
     // compile to yul
-    let yul_contracts = yul::compile(context, &fe_module)?;
+    let yul_contracts = yul::compile(&context, &fe_module)?;
 
     // compile to bytecode if required
     #[cfg(feature = "solc-backend")]

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -27,7 +27,7 @@ pub fn contract_def(
                 if name.node == "__init__" {
                     init = Some((
                         functions::func_def(context, stmt)?,
-                        attributes.param_types.clone(),
+                        attributes.param_types(),
                     ))
                 } else {
                     user_functions.push(functions::func_def(context, stmt)?)

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -16,8 +16,8 @@ pub mod runtime;
 mod utils;
 
 /// Compiles Fe source code to Yul.
-pub fn compile(context: Context, module: &FeModuleAst) -> Result<NamedYulContracts, CompileError> {
-    Ok(mappers::module::module(&context, module)?
+pub fn compile(context: &Context, module: &FeModuleAst) -> Result<NamedYulContracts, CompileError> {
+    Ok(mappers::module::module(context, module)?
         .drain()
         .map(|(name, object)| (name, object.to_string().replace("\"", "\\\"")))
         .collect::<NamedYulContracts>())

--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -27,10 +27,10 @@ pub fn dispatcher(attributes: Vec<FunctionAttributes>) -> yul::Statement {
 }
 
 fn dispatch_arm(attributes: FunctionAttributes) -> yul::Case {
-    let selector = selector(&attributes.name, &attributes.param_types);
+    let selector = selector(&attributes.name, &attributes.param_types());
 
     if !attributes.return_type.is_empty_tuple() {
-        let selection = selection(&attributes.name, &attributes.param_types);
+        let selection = selection(&attributes.name, &attributes.param_types());
         let return_data = abi_operations::encode(
             vec![attributes.return_type.clone()],
             vec![expression! { raw_return }],
@@ -51,7 +51,7 @@ fn dispatch_arm(attributes: FunctionAttributes) -> yul::Case {
         };
     }
 
-    let selection = selection_as_statement(&attributes.name, &attributes.param_types);
+    let selection = selection_as_statement(&attributes.name, &attributes.param_types());
 
     case! { case [selector] { [selection] } }
 }
@@ -59,7 +59,7 @@ fn dispatch_arm(attributes: FunctionAttributes) -> yul::Case {
 fn selector(name: &str, params: &[FixedSize]) -> yul::Literal {
     let params = params
         .iter()
-        .map(|param| param.abi_name())
+        .map(|param| param.abi_type_name())
         .collect::<Vec<String>>();
 
     literal! {(abi_utils::func_selector(name, params))}

--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -24,14 +24,14 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
             // get the name of the call function and its parameters
             let function_name = names::contract_call(&contract_name, &function.name);
             let param_names = function
-                .param_types
+                .param_types()
                 .iter()
-                .map(|typ| typ.abi_name())
+                .map(|typ| typ.abi_type_name())
                 .collect::<Vec<String>>();
 
             // create a pair of identifiers and expressions for the parameters
             let (param_idents, param_exprs): (Vec<yul::Identifier>, Vec<yul::Expression>) = (0
-                ..function.param_types.len())
+                ..function.params.len())
                 .into_iter()
                 .map(|n| {
                     let name = format!("val_{}", n);
@@ -47,9 +47,9 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
             };
             // the operations used to encode the parameters
             let encoding_operation =
-                abi_operations::encode(function.param_types.clone(), param_exprs.clone());
+                abi_operations::encode(function.param_types(), param_exprs.clone());
             // the size of the encoded data
-            let encoding_size = abi_operations::encode_size(function.param_types, param_exprs);
+            let encoding_size = abi_operations::encode_size(function.param_types(), param_exprs);
 
             if function.return_type.is_empty_tuple() {
                 // there is no return data to handle

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -39,7 +39,7 @@ pub fn build(context: &Context, contract: &Spanned<fe::ModuleStmt>) -> Vec<yul::
             let contracts_batch = external_functions
                 .clone()
                 .into_iter()
-                .map(|function| function.param_types)
+                .map(|function| function.param_types())
                 .collect();
 
             let structs_batch = attributes
@@ -63,7 +63,7 @@ pub fn build(context: &Context, contract: &Spanned<fe::ModuleStmt>) -> Vec<yul::
                 .public_functions
                 .to_owned()
                 .into_iter()
-                .map(|attributes| attributes.param_types)
+                .map(|attributes| attributes.param_types())
                 .collect::<Vec<_>>()
                 .concat()
                 .into_iter()
@@ -73,7 +73,7 @@ pub fn build(context: &Context, contract: &Spanned<fe::ModuleStmt>) -> Vec<yul::
             let init_params_batch =
                 if let Some(init_attributes) = attributes.init_function.to_owned() {
                     init_attributes
-                        .param_types
+                        .param_types()
                         .into_iter()
                         .map(|typ| (typ, AbiDecodeLocation::Memory))
                         .collect::<Vec<_>>()

--- a/compiler/tests/demo_uniswap.rs
+++ b/compiler/tests/demo_uniswap.rs
@@ -143,6 +143,18 @@ fn uniswap_contracts() {
             Some(&uint_token(1000)),
         );
 
+        // Validate reserves.
+        pair_harness.test_function(
+            &mut executor,
+            "get_reserves",
+            &[],
+            Some(&tuple_token(&[
+                uint_token_from_dec_str("200000000000000000000"),
+                uint_token_from_dec_str("100000000000000000000"),
+                uint_token_from_dec_str("0"),
+            ])),
+        );
+
         /* BOB PERFORMS A SWAP */
 
         // Set Bob as the token1 caller, this is so Bob can perform a swap.
@@ -177,6 +189,18 @@ fn uniswap_contracts() {
             Some(&uint_token_from_dec_str("1993")),
         );
 
+        // Validate reserves.
+        pair_harness.test_function(
+            &mut executor,
+            "get_reserves",
+            &[],
+            Some(&tuple_token(&[
+                uint_token_from_dec_str("199999999999999998007"),
+                uint_token_from_dec_str("100000000000000001000"),
+                uint_token_from_dec_str("0"),
+            ])),
+        );
+
         /* ALICE REMOVES LIQUIDITY */
 
         // Alice sends liquidity back to pair contract.
@@ -188,7 +212,29 @@ fn uniswap_contracts() {
         );
 
         // Alice burns the liquidity that she has sent back.
-        pair_harness.test_function(&mut executor, "burn", &[alice.clone()], None);
+        pair_harness.test_function(
+            &mut executor,
+            "burn",
+            &[alice.clone()],
+            Some(&tuple_token(&[
+                uint_token_from_dec_str("199999999999999996592"),
+                uint_token_from_dec_str("100000000000000000292"),
+            ])),
+        );
+
+        /* VALIDATE LIQUIDITY REMOVAL */
+
+        // Validate reserves.
+        pair_harness.test_function(
+            &mut executor,
+            "get_reserves",
+            &[],
+            Some(&tuple_token(&[
+                uint_token_from_dec_str("1415"),
+                uint_token_from_dec_str("708"),
+                uint_token_from_dec_str("0"),
+            ])),
+        );
 
         /* SANITY CHECK TOKEN BALANCES */
 

--- a/compiler/tests/fixtures/demos/uniswap.fe
+++ b/compiler/tests/fixtures/demos/uniswap.fe
@@ -122,14 +122,12 @@ contract UniswapV2Pair:
     pub def balanceOf(account: address) -> u256:
         return self.balances[account]
 
-    # TODO: support structs in the public interface (https://github.com/ethereum/fe/issues/282)
-    pub def get_reserves(): # -> ThreeNums:
-#        return ThreeNums(
-#            num1=self.reserve0,
-#            num2=self.reserve1,
-#            num3=self.block_time_stamp
-#        )
-        pass
+    pub def get_reserves() -> ThreeNums:
+        return ThreeNums(
+            num1=self.reserve0,
+            num2=self.reserve1,
+            num3=self.block_timestamp_last
+        )
 
     # called once by the factory at time of deployment
     pub def initialize(token0: address, token1: address):
@@ -205,8 +203,7 @@ contract UniswapV2Pair:
         return liquidity
 
     # this low-level function should be called from a contract which performs important safety checks
-    # TODO: support structs in the public interface (https://github.com/ethereum/fe/issues/282)
-    pub def burn(to: address): # -> TwoNums:
+    pub def burn(to: address) -> TwoNums:
         # (reserve0: u112, reserve1: u112) = self.get_reserves() # gas savings
         reserve0: u256 = self.reserve0
         reserve1: u256 = self.reserve1
@@ -233,7 +230,7 @@ contract UniswapV2Pair:
             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
 
         emit Burn(msg.sender, amount0, amount1, to)
-        #return TwoNums(num1=amount0, num2=amount1)
+        return TwoNums(num1=amount0, num2=amount1)
 
     # this low-level function should be called from a contract which performs important safety checks
     # TODO: add support for the bytes type (https://github.com/ethereum/fe/issues/280)

--- a/compiler/tests/fixtures/stress/abi_encoding_stress.fe
+++ b/compiler/tests/fixtures/stress/abi_encoding_stress.fe
@@ -1,3 +1,9 @@
+struct MyStruct:
+    my_num: u256
+    my_num2: u8
+    my_bool: bool
+    my_addr: address
+
 contract Foo:
     my_addrs: address[5]
     my_u128: u128
@@ -49,6 +55,21 @@ contract Foo:
 
     pub def get_my_bytes() -> bytes[100]:
         return self.my_bytes.to_mem()
+
+    pub def get_my_struct() -> MyStruct:
+        return MyStruct(
+            my_num=42,
+            my_num2=u8(26),
+            my_bool=true,
+            my_addr=address(123456)
+        )
+
+    pub def mod_my_struct(my_struct: MyStruct) -> MyStruct:
+        my_struct.my_num = 12341234
+        my_struct.my_num2 = u8(42)
+        my_struct.my_bool = false
+        my_struct.my_addr = address(9999)
+        return my_struct
 
     pub def emit_my_event():
         emit MyEvent(

--- a/compiler/tests/stress.rs
+++ b/compiler/tests/stress.rs
@@ -145,6 +145,26 @@ fn abi_encoding_stress() {
         harness.test_function(&mut executor, "set_my_bytes", &[my_bytes.clone()], None);
         harness.test_function(&mut executor, "get_my_bytes", &[], Some(&my_bytes));
 
+        let my_tuple1 = tuple_token(&[
+            uint_token(42),
+            uint_token(26),
+            bool_token(true),
+            address_token("000000000000000000000000000000000001e240"),
+        ]);
+        let my_tuple2 = tuple_token(&[
+            uint_token(12341234),
+            uint_token(42),
+            bool_token(false),
+            address_token("00000000000000000000000000000000000270f"),
+        ]);
+        harness.test_function(&mut executor, "get_my_struct", &[], Some(&my_tuple1));
+        harness.test_function(
+            &mut executor,
+            "mod_my_struct",
+            &[my_tuple1],
+            Some(&my_tuple2),
+        );
+
         harness.test_function(&mut executor, "emit_my_event", &[], None);
 
         harness.events_emitted(

--- a/compiler/tests/utils.rs
+++ b/compiler/tests/utils.rs
@@ -327,6 +327,11 @@ pub fn address_array_token(v: &[&str]) -> ethabi::Token {
 }
 
 #[allow(dead_code)]
+pub fn tuple_token(tokens: &[ethabi::Token]) -> ethabi::Token {
+    ethabi::Token::Tuple(tokens.to_owned())
+}
+
+#[allow(dead_code)]
 pub fn to_2s_complement(val: isize) -> U256 {
     // Since this API takes an `isize` we can be sure that the min and max values
     // will never be above what fits the `I256` type which has the same capacity

--- a/docs/build.md
+++ b/docs/build.md
@@ -11,7 +11,7 @@ The following commands only build the Fe -> Yul compiler components.
 
 **Full**
 
-The Fe compiler depends on the Solidty compiler for transforming Yul IR to EVM bytecode. We currently use [solc-rust](https://github.com/axic/solc-rust) to perform this. In order to compile solc-rust, the following must be installed on your system:
+The Fe compiler depends on the Solidity compiler for transforming Yul IR to EVM bytecode. We currently use [solc-rust](https://github.com/axic/solc-rust) to perform this. In order to compile solc-rust, the following must be installed on your system:
 
 - cmake
 - libboost

--- a/newsfragments/296.feature.md
+++ b/newsfragments/296.feature.md
@@ -1,0 +1,1 @@
+The JSON ABI builder now supports structs as both input and output.


### PR DESCRIPTION
### What was wrong?

fixes #282 

Structs were not being added to the ABI. For example, we could not build the JSON ABI for the following example:

```
struct MyStruct:
  num1: u256
  num2: u256

contract MyContract:
  pub def foo(my_struct: MyStruct) -> MyStruct:
    return my_struct
```

### How was it fixed?

- Added `components` to the `AbiEncoding` trait.
- Added field names to function and event attributes.
- Updated the ABI builder to use information from the analyzer.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
