### PR TITLE
Improve visibility of subsequently defined contracts

### DIFF
--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -109,7 +109,12 @@ impl From<Shared<ContractScope>> for ContractAttributes {
 
         let external_contracts = scope.borrow().get_module_type_defs(|typ| {
             if let Type::Contract(contract) = typ {
-                Some(contract.to_owned())
+                // Skip our own contract
+                if contract.name == scope.borrow().name {
+                    None
+                } else {
+                    Some(contract.to_owned())
+                }
             } else {
                 None
             }

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -35,6 +35,7 @@ pub struct ModuleScope {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ContractScope {
+    pub name: String,
     pub parent: Shared<ModuleScope>,
     pub interface: Vec<String>,
     pub event_defs: HashMap<String, Event>,
@@ -107,8 +108,9 @@ impl ModuleScope {
 }
 
 impl ContractScope {
-    pub fn new(parent: Shared<ModuleScope>) -> Shared<Self> {
+    pub fn new(name: &str, parent: Shared<ModuleScope>) -> Shared<Self> {
         Rc::new(RefCell::new(ContractScope {
+            name: name.to_owned(),
             parent,
             function_defs: HashMap::new(),
             event_defs: HashMap::new(),
@@ -352,7 +354,7 @@ mod tests {
     #[test]
     fn test_scope_resolution_on_first_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         assert_eq!(block_scope_1, block_scope_1.borrow().function_scope());
         assert_eq!(contract_scope, block_scope_1.borrow().contract_scope());
@@ -361,7 +363,7 @@ mod tests {
     #[test]
     fn test_scope_resolution_on_second_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
@@ -372,7 +374,7 @@ mod tests {
     #[test]
     fn test_1st_level_def_lookup_on_1st_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         block_scope_1
             .borrow_mut()
@@ -387,7 +389,7 @@ mod tests {
     #[test]
     fn test_1st_level_def_lookup_on_2nd_level_block_scope() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
@@ -404,7 +406,7 @@ mod tests {
     #[test]
     fn test_2nd_level_def_lookup_on_1nd_level_block_scope_fails() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
@@ -418,7 +420,7 @@ mod tests {
     #[test]
     fn test_inherits_type() {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         assert_eq!(
             true,

--- a/analyzer/src/traversal/assignments.rs
+++ b/analyzer/src/traversal/assignments.rs
@@ -81,7 +81,7 @@ mod tests {
     // - bar: u256[100]
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         contract_scope
             .borrow_mut()
             .add_field(

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -31,7 +31,7 @@ pub fn contract_def(
     stmt: &Spanned<fe::ModuleStmt>,
 ) -> Result<Shared<ContractScope>, SemanticError> {
     if let fe::ModuleStmt::ContractDef { name, body } = &stmt.node {
-        let contract_scope = ContractScope::new(Rc::clone(&module_scope));
+        let contract_scope = ContractScope::new(name.node, Rc::clone(&module_scope));
 
         for stmt in body.iter() {
             match &stmt.node {

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -64,7 +64,7 @@ mod tests {
 
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         BlockScope::from_contract_scope("", contract_scope)
     }
 

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -1124,7 +1124,7 @@ mod tests {
 
     fn scope() -> Shared<BlockScope> {
         let module_scope = ModuleScope::new();
-        let contract_scope = ContractScope::new(module_scope);
+        let contract_scope = ContractScope::new("", module_scope);
         BlockScope::from_contract_scope("", contract_scope)
     }
 

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -448,7 +448,7 @@ mod tests {
 
     fn scope() -> Shared<ContractScope> {
         let module_scope = ModuleScope::new();
-        ContractScope::new(module_scope)
+        ContractScope::new("", module_scope)
     }
 
     fn analyze(scope: Shared<ContractScope>, src: &str) -> Context {

--- a/compiler/tests/fixtures/demos/uniswap.fe
+++ b/compiler/tests/fixtures/demos/uniswap.fe
@@ -156,9 +156,7 @@ contract UniswapV2Pair:
 
     # if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
     def _mint_fee(reserve0: u256, reserve1: u256) -> bool:
-        # TODO: The interfaces of subsequently defined contracts should be visible (https://github.com/ethereum/fe/issues/283)
-        # fee_to: address = UniswapV2Factory(factory).fee_to()
-        fee_to: address = address(0)
+        fee_to: address = UniswapV2Factory(self.factory).fee_to()
         fee_on: bool = fee_to != address(0)
         k_last: u256 = self.k_last # gas savings
         if fee_on:

--- a/compiler/tests/fixtures/features/two_contracts.fe
+++ b/compiler/tests/fixtures/features/two_contracts.fe
@@ -1,7 +1,19 @@
 contract Foo:
+
+    other: Bar
+
+    pub def external_bar() -> u256:
+        return Bar(address(0)).bar()
+
     pub def foo() -> u256:
         return 42
 
 contract Bar:
+
+    other: Foo
+
+    pub def external_foo() -> u256:
+        return Foo(address(0)).foo()
+
     pub def bar() -> u256:
         return 26

--- a/newsfragments/298.feature.md
+++ b/newsfragments/298.feature.md
@@ -1,0 +1,25 @@
+Make subsequently defined contracts visible.
+
+Before this change:
+
+```
+# can't see Bar
+contract Foo:
+   ...
+# can see Foo
+contract Bar:
+   ...
+```
+
+With this change the restriction is lifted and the following becomes possible.
+
+```
+contract Foo:
+    bar: Bar
+    pub def external_bar() -> u256:
+        return self.bar.bar()
+contract Bar:
+    foo: Foo
+    pub def external_foo() -> u256:
+        return self.foo.foo()
+```


### PR DESCRIPTION
### What was wrong?

This superseded #294 

If two contracts are defined in a module, only the second contract can see the interface of the first.

e.g.

```python
# can't see Bar
contract Foo:
   ...

# can see Foo
contract Bar:
   ...
```

### How was it fixed?

1. Contract analysis is split into multiple passes:
    1 The first pass collects contracts with their function definition but does not inspect function bodies and contract fields
    2. Once every contract was analyzed, we analyze the function bodies and contract field of each contract in a subsequent pass
   
2. Because the module scope now contains all contracts it needs a way to filter out the main contract when it is aggregating `external_contracts`. To do that, `name` was added to `ContractScope` (we also have `name` for `BlockScope` so there's a precedence for having the `name` as a scope identifier) so that we can filter out the "self contract" upon aggregation.
3. The Uniswap demo was updated to use that feature

This PR doesn't yet address issue #299 though.