### PR TITLE
Reorganize runtime functions

### DIFF
--- a/compiler/src/yul/runtime/functions/abi.rs
+++ b/compiler/src/yul/runtime/functions/abi.rs
@@ -10,6 +10,15 @@ use fe_analyzer::namespace::types::{
 };
 use yultsur::*;
 
+/// Return all abi runtime functions
+pub fn all() -> Vec<yul::Statement> {
+    vec![
+        unpack(),
+        pack(AbiDecodeLocation::Calldata),
+        pack(AbiDecodeLocation::Memory),
+    ]
+}
+
 /// Creates a batch of encoding function for the given type arrays.
 ///
 /// It sorts the functions and removes duplicates.

--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -8,6 +8,11 @@ use fe_analyzer::namespace::types::{
 };
 use yultsur::*;
 
+/// Return all contacts runtime functions
+pub fn all() -> Vec<yul::Statement> {
+    vec![create2(), create()]
+}
+
 /// Builds a set of functions used to make calls to the given contract's public
 /// functions.
 pub fn calls(contract: Contract) -> Vec<yul::Statement> {

--- a/compiler/src/yul/runtime/functions/data.rs
+++ b/compiler/src/yul/runtime/functions/data.rs
@@ -1,5 +1,35 @@
 use yultsur::*;
 
+/// Return all data runtime functions
+pub fn all() -> Vec<yul::Statement> {
+    vec![
+        avail(),
+        alloc(),
+        alloc_mstoren(),
+        free(),
+        ccopym(),
+        load_data_string(),
+        mcopys(),
+        scopym(),
+        mcopym(),
+        scopys(),
+        mloadn(),
+        sloadn(),
+        bytes_sloadn(),
+        cloadn(),
+        mstoren(),
+        sstoren(),
+        bytes_sstoren(),
+        bytes_mcopys(),
+        bytes_scopym(),
+        bytes_scopys(),
+        map_value_ptr(),
+        ceil32(),
+        ternary(),
+        set_zero(),
+    ]
+}
+
 /// Returns the highest available pointer.
 pub fn avail() -> yul::Statement {
     function_definition! {

--- a/compiler/src/yul/runtime/functions/mod.rs
+++ b/compiler/src/yul/runtime/functions/mod.rs
@@ -1,4 +1,3 @@
-use fe_analyzer::namespace::types::AbiDecodeLocation;
 use yultsur::*;
 
 pub mod abi;
@@ -9,36 +8,5 @@ pub mod structs;
 
 /// Returns all functions that should be available during runtime.
 pub fn std() -> Vec<yul::Statement> {
-    let fns = vec![
-        data::avail(),
-        data::alloc(),
-        data::alloc_mstoren(),
-        data::free(),
-        data::ccopym(),
-        data::load_data_string(),
-        data::mcopys(),
-        data::scopym(),
-        data::mcopym(),
-        data::scopys(),
-        data::mloadn(),
-        data::sloadn(),
-        data::bytes_sloadn(),
-        data::cloadn(),
-        data::mstoren(),
-        data::sstoren(),
-        data::bytes_sstoren(),
-        data::bytes_mcopys(),
-        data::bytes_scopym(),
-        data::bytes_scopys(),
-        data::map_value_ptr(),
-        data::ceil32(),
-        data::ternary(),
-        data::set_zero(),
-        abi::unpack(),
-        abi::pack(AbiDecodeLocation::Calldata),
-        abi::pack(AbiDecodeLocation::Memory),
-        contracts::create2(),
-        contracts::create(),
-    ];
-    [fns, math::all()].concat()
+    [contracts::all(), abi::all(), data::all(), math::all()].concat()
 }


### PR DESCRIPTION
### What was wrong?

Runtime functions of the `yul` module needed to be exposed individually, making it cumbersome to expose them all at ones, especially given that the runtime API might grow in the future

### How was it fixed?

This commit moves yul runtime functions of various modules into dedicated `*::all()` APIs to make exposing them easier.

Closes #269
