### PR TITLE
Introduce new FixedSize::bool() API in fe::analyzer

### DIFF
--- a/analyzer/src/namespace/events.rs
+++ b/analyzer/src/namespace/events.rs
@@ -82,7 +82,7 @@ mod tests {
             vec![
                 FixedSize::Base(Base::Address),
                 FixedSize::Base(Base::Address),
-                FixedSize::Base(Base::Bool),
+                FixedSize::bool(),
             ],
             vec![1],
         );
@@ -92,16 +92,13 @@ mod tests {
             vec![
                 FixedSize::Base(Base::Address),
                 FixedSize::Base(Base::Address),
-                FixedSize::Base(Base::Bool),
+                FixedSize::bool(),
             ],
         );
 
         assert_eq!(
             event.non_indexed_fields(),
-            vec![
-                (0, FixedSize::Base(Base::Address)),
-                (2, FixedSize::Base(Base::Bool))
-            ]
+            vec![(0, FixedSize::Base(Base::Address)), (2, FixedSize::bool())]
         );
 
         assert_eq!(

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -343,10 +343,7 @@ mod tests {
         ContractScope,
         ModuleScope,
     };
-    use crate::namespace::types::{
-        Base,
-        FixedSize,
-    };
+    use crate::namespace::types::FixedSize;
     use std::rc::Rc;
 
     #[test]
@@ -376,10 +373,10 @@ mod tests {
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
         block_scope_1
             .borrow_mut()
-            .add_var("some_thing", FixedSize::Base(Base::Bool))
+            .add_var("some_thing", FixedSize::bool())
             .unwrap();
         assert_eq!(
-            Some(FixedSize::Base(Base::Bool)),
+            Some(FixedSize::bool()),
             block_scope_1.borrow().get_variable_def("some_thing")
         );
     }
@@ -393,10 +390,10 @@ mod tests {
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
         block_scope_1
             .borrow_mut()
-            .add_var("some_thing", FixedSize::Base(Base::Bool))
+            .add_var("some_thing", FixedSize::bool())
             .unwrap();
         assert_eq!(
-            Some(FixedSize::Base(Base::Bool)),
+            Some(FixedSize::bool()),
             block_scope_2.borrow().get_variable_def("some_thing")
         );
     }
@@ -410,7 +407,7 @@ mod tests {
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
         block_scope_2
             .borrow_mut()
-            .add_var("some_thing", FixedSize::Base(Base::Bool))
+            .add_var("some_thing", FixedSize::bool())
             .unwrap();
         assert_eq!(None, block_scope_1.borrow().get_variable_def("some_thing"));
     }

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -415,6 +415,10 @@ impl FixedSize {
 
         false
     }
+
+    pub fn bool() -> Self {
+        FixedSize::Base(Base::Bool)
+    }
 }
 
 impl TryFrom<Type> for FixedSize {

--- a/compiler/src/yul/operations/abi.rs
+++ b/compiler/src/yul/operations/abi.rs
@@ -166,7 +166,7 @@ mod tests {
                     inner: Base::Address,
                     size: 42
                 }),
-                FixedSize::Base(Base::Bool)
+                FixedSize::bool()
             ])
             .expect("failed to get static size")
             .to_string(),

--- a/compiler/src/yul/operations/structs.rs
+++ b/compiler/src/yul/operations/structs.rs
@@ -20,7 +20,6 @@ pub fn get_attribute(
 mod tests {
     use crate::yul::operations::structs;
     use fe_analyzer::namespace::types::{
-        Base,
         FixedSize,
         Struct,
     };
@@ -29,8 +28,8 @@ mod tests {
     #[test]
     fn test_new() {
         let mut val = Struct::new("Foo");
-        val.add_field("bar", &FixedSize::Base(Base::Bool));
-        val.add_field("bar2", &FixedSize::Base(Base::Bool));
+        val.add_field("bar", &FixedSize::bool());
+        val.add_field("bar2", &FixedSize::bool());
         let params = vec![
             identifier_expression! { (1) },
             identifier_expression! { (2) },

--- a/compiler/src/yul/runtime/functions/structs.rs
+++ b/compiler/src/yul/runtime/functions/structs.rs
@@ -102,7 +102,6 @@ pub fn struct_apis(struct_type: Struct) -> Vec<yul::Statement> {
 mod tests {
     use crate::yul::runtime::functions::structs;
     use fe_analyzer::namespace::types::{
-        Base,
         FixedSize,
         Struct,
     };
@@ -118,8 +117,8 @@ mod tests {
     #[test]
     fn test_struct_api_generation() {
         let mut val = Struct::new("Foo");
-        val.add_field("bar", &FixedSize::Base(Base::Bool));
-        val.add_field("bar2", &FixedSize::Base(Base::Bool));
+        val.add_field("bar", &FixedSize::bool());
+        val.add_field("bar2", &FixedSize::bool());
         assert_eq!(
             structs::generate_new_fn(&val).to_string(),
             "function struct_Foo_new(bar, bar2) -> return_val { return_val := alloc(32) mstore(return_val, bar) let bar2_ptr := alloc(32) mstore(bar2_ptr, bar2) }"         )
@@ -128,8 +127,8 @@ mod tests {
     #[test]
     fn test_struct_getter_generation() {
         let mut val = Struct::new("Foo");
-        val.add_field("bar", &FixedSize::Base(Base::Bool));
-        val.add_field("bar2", &FixedSize::Base(Base::Bool));
+        val.add_field("bar", &FixedSize::bool());
+        val.add_field("bar2", &FixedSize::bool());
         assert_eq!(
             structs::generate_get_fn(&val, &val.get_field_names().get(0).unwrap()).to_string(),
             "function struct_Foo_get_bar_ptr(ptr) -> return_val { return_val := add(ptr, 31) }"

--- a/compiler/tests/runtime.rs
+++ b/compiler/tests/runtime.rs
@@ -318,7 +318,7 @@ fn test_runtime_house_struct() {
     house.add_field("price", &FixedSize::Base(Base::Numeric(Integer::U256)));
     house.add_field("size", &FixedSize::Base(Base::Numeric(Integer::U256)));
     house.add_field("rooms", &FixedSize::Base(Base::Numeric(Integer::U8)));
-    house.add_field("vacant", &FixedSize::Base(Base::Bool));
+    house.add_field("vacant", &FixedSize::bool());
     let house_api = functions::structs::struct_apis(house);
 
     with_executor(&|mut executor| {


### PR DESCRIPTION
### What was wrong?

The only way to get a `FixedSize::Base(Base::Bool)` variant is to use that very API. 
As mentioned in #274, a constructor API like `FixedSize::bool()` makes this easier.


### How was it fixed?

To improve developer ergonomics, this commit introduces a new API
```
FixedSize::bool()
```

which is equivalent to:

```
FixedSize::Base(Base::Bool)
```

Closes #274

