### PR TITLE
Created contracts included in constructor object.

### DIFF
--- a/compiler/tests/features.rs
+++ b/compiler/tests/features.rs
@@ -1002,6 +1002,28 @@ fn create_contract() {
     })
 }
 
+#[test]
+fn create_contract_from_init() {
+    with_executor(&|mut executor| {
+        let factory_harness = deploy_contract(
+            &mut executor,
+            "create_contract_from_init.fe",
+            "FooFactory",
+            &[],
+        );
+
+        let foo_address = factory_harness
+            .call_function(&mut executor, "get_foo_addr", &[])
+            .expect("factory did not return an address")
+            .to_address()
+            .expect("not an address");
+
+        let foo_harness = load_contract(foo_address, "create_contract_from_init.fe", "Foo");
+
+        foo_harness.test_function(&mut executor, "get_my_num", &[], Some(&uint_token(42)));
+    })
+}
+
 #[rstest(
     fixture_file,
     contract_name,

--- a/compiler/tests/fixtures/demos/uniswap.fe
+++ b/compiler/tests/fixtures/demos/uniswap.fe
@@ -315,9 +315,8 @@ contract UniswapV2Factory:
         pair: address
         index: u256
 
-    # TODO: fix issue with "missing data object" for the pair contract (https://github.com/ethereum/fe/issues/284)
-    # pub def __init__(fee_to_setter: address):
-    #    self.fee_to_setter = fee_to_setter
+    pub def __init__(fee_to_setter: address):
+       self.fee_to_setter = fee_to_setter
 
     pub def fee_to() -> address:
         return self.fee_to

--- a/compiler/tests/fixtures/features/create_contract.fe
+++ b/compiler/tests/fixtures/features/create_contract.fe
@@ -4,6 +4,5 @@ contract Foo:
 
 contract FooFactory:
     pub def create_foo() -> address:
-        # value and salt
         foo: Foo = Foo.create(0)
         return address(foo)

--- a/compiler/tests/fixtures/features/create_contract_from_init.fe
+++ b/compiler/tests/fixtures/features/create_contract_from_init.fe
@@ -1,0 +1,12 @@
+contract Foo:
+    pub def get_my_num() -> u256:
+        return 42
+
+contract FooFactory:
+    foo_addr: address
+
+    pub def __init__():
+        self.foo_addr = address(Foo.create(0))
+
+    pub def get_foo_addr() -> address:
+        return self.foo_addr

--- a/newsfragments/304.bugfix.md
+++ b/newsfragments/304.bugfix.md
@@ -1,0 +1,3 @@
+Contracts that create other contracts can now include `__init__` functions.
+
+See https://github.com/ethereum/fe/issues/284


### PR DESCRIPTION
### What was wrong?

fixes #284

### How was it fixed?

Added the `created_contracts` vector to the constructor object.

---

The Yul optimizer does not currently remove these objects if they are unused. Meaning, created contracts will be included in the initialization code twice no matter what. This does not increase the contract size, but increases the initialization code size.

The cost of this extra tx data is 16 for non-zero bytes and 4 for zero bytes (see [appendix g](https://ethereum.github.io/yellowpaper/paper.pdf)).

For example, say we write a contract that deploys an ERC-20 contract and has an `__init__` that does **not** create an ERC-20 contract. A compiled Fe ERC-20 contract is about `2600` bytes. So, the extra cost would be slightly less than `42000`, which is roughly equivalent to the cost of 2 `sstore` operations. This is a non-trivial expense and we should find a way to remove these unused data object. It might be the case that the Yul team plans on implementing this, so we don't have to worry about. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Create an issue to track the gas issue. #305
- [x] Add a test where a contract is created in `__init__`.
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
