### PR TITLE
Lowering pass and tuple support

### DIFF
--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -15,6 +15,7 @@ use crate::namespace::events::EventDef;
 use crate::namespace::scopes::{
     ContractFunctionDef,
     ContractScope,
+    ModuleScope,
     Shared,
 };
 use crate::namespace::types::{
@@ -282,6 +283,19 @@ impl From<ContractFunctionDef> for FunctionAttributes {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct ModuleAttributes {
+    pub type_defs: HashMap<String, Type>,
+}
+
+impl From<Shared<ModuleScope>> for ModuleAttributes {
+    fn from(scope: Shared<ModuleScope>) -> Self {
+        Self {
+            type_defs: scope.borrow().type_defs.clone(),
+        }
+    }
+}
+
 /// Contains contextual information about a Fe module and can be queried using
 /// `Spanned` AST nodes.
 #[derive(Clone, Debug, Default)]
@@ -293,6 +307,7 @@ pub struct Context {
     contracts: HashMap<NodeId, ContractAttributes>,
     calls: HashMap<NodeId, CallType>,
     events: HashMap<NodeId, EventDef>,
+    module: Option<ModuleAttributes>,
 }
 
 impl Context {
@@ -309,6 +324,7 @@ impl Context {
             contracts: HashMap::new(),
             calls: HashMap::new(),
             events: HashMap::new(),
+            module: None,
         }
     }
 
@@ -384,6 +400,14 @@ impl Context {
     /// Get information that has been attributed to an event definition node.
     pub fn get_event<T: Into<NodeId>>(&self, node_id: T) -> Option<&EventDef> {
         self.events.get(&node_id.into())
+    }
+
+    pub fn set_module(&mut self, attributes: ModuleAttributes) {
+        self.module = Some(attributes);
+    }
+
+    pub fn get_module<T: Into<NodeId>>(&self) -> Option<&ModuleAttributes> {
+        self.module.as_ref()
     }
 }
 

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -44,6 +44,8 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
         }
     }
 
+    context.borrow_mut().set_module(scope.into());
+
     Ok(())
 }
 

--- a/analyzer/src/traversal/utils.rs
+++ b/analyzer/src/traversal/utils.rs
@@ -1,3 +1,4 @@
+use crate::errors::SemanticError;
 use crate::namespace::types::FixedSize;
 use crate::{
     ExpressionAttributes,
@@ -5,6 +6,7 @@ use crate::{
 };
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
+use std::convert::TryInto;
 
 pub fn call_arg_value<'a>(arg: &'a fe::CallArg<'a>) -> &'a Node<fe::Expr<'a>> {
     match arg {
@@ -22,4 +24,8 @@ pub fn expression_attributes_to_types(attributes: Vec<ExpressionAttributes>) -> 
 
 pub fn fixed_sizes_to_types(sizes: Vec<FixedSize>) -> Vec<Type> {
     sizes.iter().map(|param| param.clone().into()).collect()
+}
+
+pub fn types_to_fixed_sizes(sizes: Vec<Type>) -> Result<Vec<FixedSize>, SemanticError> {
+    sizes.iter().map(|param| param.clone().try_into()).collect()
 }

--- a/compiler/src/lowering/mappers/module.rs
+++ b/compiler/src/lowering/mappers/module.rs
@@ -1,1 +1,28 @@
+use fe_analyzer::namespace::types::Type;
+use fe_analyzer::Context;
 
+use fe_parser::ast as fe;
+use fe_parser::node::{
+    Node,
+    Span,
+};
+
+pub fn module(context: &Context, module: &fe::Module) -> fe::Module {
+    let attributes = context.get_module()?;
+
+    let tuples_used = attributes
+        .type_defs
+        .values()
+        .into_iter()
+        .filter_map(|typ| match typ {
+            Type::Tuple(tuple) => Some(tuple),
+            _ => None,
+        });
+}
+
+fn struct_def_from_tuple() -> fe::ModuleStmt {
+    fe::ModuleStmt::StructDef {
+        name: Node::new("my_tuple", Span::new(0, 0)),
+        body: vec![],
+    }
+}

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -356,7 +356,7 @@ pub fn slice_index(
 fn expr_tuple(exp: &Node<fe::Expr>) -> Result<yul::Expression, CompileError> {
     if let fe::Expr::Tuple { elts } = &exp.kind {
         if !elts.is_empty() {
-            todo!("Non empty Tuples aren't yet supported")
+            unimplemented!()
         } else {
             return Ok(literal_expression! {0x0});
         }

--- a/compiler/tests/features.rs
+++ b/compiler/tests/features.rs
@@ -1186,3 +1186,16 @@ fn self_address() {
         );
     });
 }
+
+#[test]
+fn base_tuple() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "base_tuple.fe", "Foo", &[]);
+        harness.test_function(
+            &mut executor,
+            "my_address",
+            &[],
+            Some(&ethabi::Token::Address(harness.address)),
+        );
+    });
+}

--- a/compiler/tests/fixtures/features/base_tuple.fe
+++ b/compiler/tests/fixtures/features/base_tuple.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(my_num: u256, my_bool: bool) -> (u256, bool):
+        return (my_num, my_bool)


### PR DESCRIPTION
closes #205 

The goal of this PR is to lay the groundwork for lowering and use it to support tuples.

See how Rust does it: https://rustc-dev-guide.rust-lang.org/lowering.html.

Terms:
- High-level Intermediate Representation (HIR): A subset of Fe-lang that can be digested by the Yul generator.
- Lowering: The process of mapping the source AST to an HIR AST.

Design questions/thoughts:
- :heavy_check_mark:  We will not be able use spans as primary node IDs anymore, since the HIR will not be parsed from a string. So, we will need to introduce a new form of identification. 
  - Should node IDs be deterministic or random? I'm leaning towards random since it's easier to implement. See the [uuid crate](https://docs.rs/uuid/0.8.2/uuid/).
  - See [Identifiers in rustc](https://rustc-dev-guide.rust-lang.org/identifiers.html?highlight=NodeId#in-the-ast).
  - Where exactly do we add an ID? `Spanned` or the node itself? or somewhere else?
    - `Spanned` would probably be least invasive.
    - Rust assigns IDs to each node. They also have different types of IDs for different nodes.
    - ~~I'm leaning towards placing IDs in the individual nodes and leaving `Spanned` the way it is.~~
    - On second thought, our AST doesn't have `Kinds` like rustc (see [here](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_hir/struct.Expr.html)). So assigning IDs to nodes won't be very clean. Maybe we should add IDs to `Spanned` afterall. It may warrant a name change from `Spanned` to `Node`. 
    - Fixed in #315. We now need to fix #318.
- Should we reanalyze the HIR AST, or do we want to build up node attributes as we go?
  - Reanalyzing adds more computational overhead, but may be simpler to implement.
  - Reanalyzing also adds more transparency, since definitions would be added to the HIR AST, which could be printed by the compiler. Otherwise, we would just be altering the attributes of a given node, which doesn't event constitute lowering.
  - Overall, I'm leaning towards reanalyzing.
- Should we reuse the existing AST structs or create new ones for the HIR?
  - I'm thinking we should just reuse the existing ones. The HIR will just consist of a subset of node types. If the Yul codegen pass encounters a non-HIR node, it should panic.
  - Rust has separate structs for the HIR. We could do the same in the future, but I don't think it's necessary right now. 
- Does the lowering API and general architecture need to be any different than the current Fe -> Yul pass? In that, we traverse the AST once and map each node.
  - Probably not. We just need to make sure everything that is needed at each node is provided in the `Context` attributes. For example, if a tuple is used inside of a contract, we should record this on the contract or module node, so the tuple's struct definition can be added.
- We should make sure naming conflicts are impossible during lowering. This can be avoided by using illegal names and adding some sort of `non_strict_mode` parameter to `analysis` that eases up name checks.
- Shorthand macros for writing Fe HIR ASTs would be helpful.

Currently, I'm thinking all of the passes will look like this:

- **Parsing**: takes source code and produces an AST.
- **First analysis**: takes the source AST and produces node attributes.
  - The purpose of this pass is to find errors and build up contextual information.
- **Lowering**: Takes the source AST and the node attributes and produces an HIR AST (new).
- **Second analysis**: Takes the HIR AST and produces node attributes (also new, but doesn't require new code).
  - The purpose of this pass is only to build up contextual information.
- **Yul codegen**: Takes the HIR AST and node attributes and produces Yul code.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
