### PR TITLE
Add checks for integer division

### DIFF
--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -131,7 +131,7 @@ mod tests {
         case("foo = 1 + 2", "$foo := checked_add_u256(1, 2)"),
         case("foo = 1 - 2", "$foo := checked_sub_unsigned(1, 2)"),
         case("foo = 1 * 2", "$foo := checked_mul_u256(1, 2)"),
-        case("foo = 1 / 2", "$foo := div(1, 2)"),
+        case("foo = 1 / 2", "$foo := checked_div_unsigned(1, 2)"),
         case("foo = 1 ** 2", "$foo := exp(1, 2)"),
         case("foo = 1 % 2", "$foo := mod(1, 2)"),
         case("foo = 1 & 2", "$foo := and(1, 2)"),

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -269,9 +269,11 @@ pub fn expr_bin_operation(
                 }
                 _ => unreachable!(),
             },
-            fe::BinOperator::Div => match typ.is_signed_integer() {
-                true => Ok(expression! { sdiv([yul_left], [yul_right]) }),
-                false => Ok(expression! { div([yul_left], [yul_right]) }),
+            fe::BinOperator::Div => match typ {
+                Type::Base(Base::Numeric(integer)) => {
+                    Ok(expression! { [names::checked_div(integer)]([yul_left], [yul_right]) })
+                }
+                _ => unreachable!(),
             },
             fe::BinOperator::BitAnd => Ok(expression! { and([yul_left], [yul_right]) }),
             fe::BinOperator::BitOr => Ok(expression! { or([yul_left], [yul_right]) }),
@@ -686,7 +688,7 @@ mod tests {
         case("1 + 2", "checked_add_u256(1, 2)"),
         case("1 - 2", "checked_sub_unsigned(1, 2)"),
         case("1 * 2", "checked_mul_u256(1, 2)"),
-        case("1 / 2", "div(1, 2)"),
+        case("1 / 2", "checked_div_unsigned(1, 2)"),
         case("1 ** 2", "exp(1, 2)"),
         case("1 % 2", "mod(1, 2)"),
         case("1 & 2", "and(1, 2)"),

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -11,6 +11,16 @@ pub fn checked_add(size: &Integer) -> yul::Identifier {
     identifier! {(format!("checked_add_{}", size.to_lowercase()))}
 }
 
+/// Generate a function name to perform checked division
+pub fn checked_div(size: &Integer) -> yul::Identifier {
+    let size: &str = if size.is_signed() {
+        size.into()
+    } else {
+        "unsigned"
+    };
+    identifier! {(format!("checked_div_{}", size.to_lowercase()))}
+}
+
 /// Generate a function name to perform checked multiplication
 pub fn checked_mul(size: &Integer) -> yul::Identifier {
     let size: &str = size.into();

--- a/compiler/src/yul/runtime/functions/math.rs
+++ b/compiler/src/yul/runtime/functions/math.rs
@@ -119,8 +119,7 @@ fn checked_add_signed(size: Integer) -> yul::Statement {
         panic!("Expected signed integer")
     }
     let (min_value, max_value) = get_min_max(size.clone());
-    let size: &str = size.into();
-    let fn_name = identifier! {(format!("checked_add_{}", size.to_lowercase()))};
+    let fn_name = names::checked_add(&size);
     function_definition! {
         function [fn_name](val1, val2) -> sum {
             // overflow, if val1 >= 0 and val2 > (max_value - val1)

--- a/compiler/tests/features.rs
+++ b/compiler/tests/features.rs
@@ -749,6 +749,44 @@ fn checked_arithmetic() {
                 Some(&config.i_max),
             );
 
+            // DIVISON
+            // unsigned: anything / 0 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("div_u{}", config.size),
+                &[config.u_max.clone(), uint_token(0)],
+            );
+
+            // unsigned: 3 / 2 works
+            harness.test_function(
+                &mut executor,
+                &format!("div_u{}", config.size),
+                &[uint_token(3), uint_token(2)],
+                Some(&uint_token(1)),
+            );
+
+            // signed: anything / 0 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("div_i{}", config.size),
+                &[config.i_max.clone(), int_token(0)],
+            );
+
+            // signed: min_value / -1 fails
+            harness.test_function_reverts(
+                &mut executor,
+                &format!("div_i{}", config.size),
+                &[config.i_min.clone(), int_token(-1)],
+            );
+
+            // unsigned: 3 / -2 works
+            harness.test_function(
+                &mut executor,
+                &format!("div_i{}", config.size),
+                &[int_token(3), int_token(-2)],
+                Some(&int_token(-1)),
+            );
+
             // MULTIPLICATION
             // unsigned: max_value * 2 fails
             harness.test_function_reverts(

--- a/compiler/tests/fixtures/features/checked_arithmetic.fe
+++ b/compiler/tests/fixtures/features/checked_arithmetic.fe
@@ -75,6 +75,42 @@ contract CheckedArithmetic:
     pub def mul_u256(left: u256, right: u256) -> u256:
         return left * right
 
+    pub def div_u256(left: u256, right: u256) -> u256:
+        return left / right
+
+    pub def div_u128(left: u128, right: u128) -> u128:
+        return left / right
+
+    pub def div_u64(left: u64, right: u64) -> u64:
+        return left / right
+
+    pub def div_u32(left: u32, right: u32) -> u32:
+        return left / right
+
+    pub def div_u16(left: u16, right: u16) -> u16:
+        return left / right
+
+    pub def div_u8(left: u8, right: u8) -> u8:
+        return left / right
+
+    pub def div_i256(left: i256, right: i256) -> i256:
+        return left / right
+
+    pub def div_i128(left: i128, right: i128) -> i128:
+        return left / right
+
+    pub def div_i64(left: i64, right: i64) -> i64:
+        return left / right
+
+    pub def div_i32(left: i32, right: i32) -> i32:
+        return left / right
+
+    pub def div_i16(left: i16, right: i16) -> i16:
+        return left / right
+
+    pub def div_i8(left: i8, right: i8) -> i8:
+        return left / right
+
     pub def mul_u128(left: u128, right: u128) -> u128:
         return left * right
 

--- a/newsfragments/308.feature.md
+++ b/newsfragments/308.feature.md
@@ -1,0 +1,1 @@
+Perform checks for divison operations on integers


### PR DESCRIPTION
### What was wrong?

Integer division operations are currently unchecked which can lead fatal errors.

### How was it fixed?

Pretty straight forward like the previous checks for other arithmetic operations.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
