### PR TITLE
Checked pow

### DIFF
--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -12,6 +12,7 @@ pub enum ErrorKind {
     MissingReturn,
     NotSubscriptable,
     NumericCapacityMismatch,
+    SignedExponentNotAllowed,
     StringCapacityMismatch,
     UndefinedValue,
     UnexpectedReturn,
@@ -77,6 +78,14 @@ impl SemanticError {
     pub fn numeric_capacity_mismatch() -> Self {
         SemanticError {
             kind: ErrorKind::NumericCapacityMismatch,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `SignedExponentNotAllowed`
+    pub fn signed_exponent_not_allowed() -> Self {
+        SemanticError {
+            kind: ErrorKind::SignedExponentNotAllowed,
             context: vec![],
         }
     }

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -262,6 +262,7 @@ impl TryFrom<&str> for FeString {
 }
 
 impl Integer {
+    /// Returns `true` if the integer is signed, otherwise `false`
     pub fn is_signed(&self) -> bool {
         matches!(
             self,
@@ -274,6 +275,13 @@ impl Integer {
         )
     }
 
+    // Returns `true` if the integer is at least the same size (or larger) than
+    // `other`
+    pub fn can_hold(&self, other: &Integer) -> bool {
+        self.size() >= other.size()
+    }
+
+    // Returns `true` if `num` represents a number that fits the type
     pub fn fits(&self, num: &str) -> bool {
         let radix = 10;
 

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -410,15 +410,39 @@ fn expr_bin_operation(
     context: Shared<Context>,
     exp: &Spanned<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    if let fe::Expr::BinOperation { left, op: _, right } = &exp.node {
+    if let fe::Expr::BinOperation { left, op, right } = &exp.node {
         let left_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), left)?;
         let right_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), right)?;
+
+        if let fe::BinOperator::Pow = op.node {
+            if let (Type::Base(Base::Numeric(left)), Type::Base(Base::Numeric(right))) =
+                (&left_attributes.typ, &right_attributes.typ)
+            {
+                // The exponent is not allowed to be a signed integer. To allow calculations
+                // such as -2 ** 3 we allow the right hand side to be an unsigned integer
+                // even if the left side is a signed integer. It is allowed as long as the
+                // right side is the same size or smaller than the left side (e.g. i16 ** u16
+                // but not i16 ** u32). The type of the result will be the type of the left
+                // side and under/overflow checks are based on that type.
+                if right.is_signed() {
+                    return Err(SemanticError::signed_exponent_not_allowed());
+                }
+                if left.is_signed() && left.can_hold(&right) {
+                    return Ok(ExpressionAttributes::new(
+                        left_attributes.typ,
+                        Location::Value,
+                    ));
+                }
+            } else {
+                return Err(SemanticError::type_error());
+            }
+        }
 
         validate_types_equal(&left_attributes, &right_attributes)?;
 
         // for now we assume these are the only possible attributes
         return Ok(ExpressionAttributes::new(
-            right_attributes.typ,
+            left_attributes.typ,
             Location::Value,
         ));
     }

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -132,7 +132,7 @@ mod tests {
         case("foo = 1 - 2", "$foo := checked_sub_unsigned(1, 2)"),
         case("foo = 1 * 2", "$foo := checked_mul_u256(1, 2)"),
         case("foo = 1 / 2", "$foo := checked_div_unsigned(1, 2)"),
-        case("foo = 1 ** 2", "$foo := exp(1, 2)"),
+        case("foo = 1 ** 2", "$foo := checked_exp_u256(1, 2)"),
         case("foo = 1 % 2", "$foo := checked_mod_unsigned(1, 2)"),
         case("foo = 1 & 2", "$foo := and(1, 2)"),
         case("foo = 1 | 2", "$foo := or(1, 2)"),

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -289,7 +289,12 @@ pub fn expr_bin_operation(
                 }
                 _ => unreachable!(),
             },
-            fe::BinOperator::Pow => Ok(expression! { exp([yul_left], [yul_right]) }),
+            fe::BinOperator::Pow => match typ {
+                Type::Base(Base::Numeric(integer)) => {
+                    Ok(expression! { [names::checked_exp(integer)]([yul_left], [yul_right]) })
+                }
+                _ => unreachable!(),
+            },
             _ => unimplemented!(),
         };
     }
@@ -696,7 +701,7 @@ mod tests {
         case("1 - 2", "checked_sub_unsigned(1, 2)"),
         case("1 * 2", "checked_mul_u256(1, 2)"),
         case("1 / 2", "checked_div_unsigned(1, 2)"),
-        case("1 ** 2", "exp(1, 2)"),
+        case("1 ** 2", "checked_exp_u256(1, 2)"),
         case("1 % 2", "checked_mod_unsigned(1, 2)"),
         case("1 & 2", "and(1, 2)"),
         case("1 | 2", "or(1, 2)"),

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -31,6 +31,12 @@ pub fn checked_mod(size: &Integer) -> yul::Identifier {
     identifier! {(format!("checked_mod_{}", sign.to_lowercase()))}
 }
 
+/// Generate a function name to perform checked exponentiation
+pub fn checked_exp(size: &Integer) -> yul::Identifier {
+    let size: &str = size.into();
+    identifier! {(format!("checked_exp_{}", size.to_lowercase()))}
+}
+
 /// Generate a function name to perform checked multiplication
 pub fn checked_mul(size: &Integer) -> yul::Identifier {
     let size: &str = size.into();

--- a/compiler/src/yul/runtime/functions/math.rs
+++ b/compiler/src/yul/runtime/functions/math.rs
@@ -36,6 +36,28 @@ pub fn checked_div_fns() -> Vec<yul::Statement> {
     ]
 }
 
+/// Return a vector of runtime functions for exponentiation with over-/underflow
+/// protection
+pub fn checked_exp_fns() -> Vec<yul::Statement> {
+    vec![
+        checked_exp_unsigned(),
+        checked_exp_signed(),
+        checked_exp_helper(),
+        _checked_exp_unsigned(Integer::U256),
+        _checked_exp_unsigned(Integer::U128),
+        _checked_exp_unsigned(Integer::U64),
+        _checked_exp_unsigned(Integer::U32),
+        _checked_exp_unsigned(Integer::U16),
+        _checked_exp_unsigned(Integer::U8),
+        _checked_exp_signed(Integer::I256),
+        _checked_exp_signed(Integer::I128),
+        _checked_exp_signed(Integer::I64),
+        _checked_exp_signed(Integer::I32),
+        _checked_exp_signed(Integer::I16),
+        _checked_exp_signed(Integer::I8),
+    ]
+}
+
 /// Return a vector of runtime functions for checked modulo arithmetic
 pub fn checked_mod_fns() -> Vec<yul::Statement> {
     vec![checked_mod_unsigned(), checked_mod_signed()]
@@ -79,6 +101,7 @@ pub fn all() -> Vec<yul::Statement> {
     [
         checked_add_fns(),
         checked_div_fns(),
+        checked_exp_fns(),
         checked_mod_fns(),
         checked_mul_fns(),
         checked_sub_fns(),
@@ -225,6 +248,179 @@ fn checked_sub_signed(size: Integer) -> yul::Statement {
             // overflow, if val2 < 0 and val1 > (max_value + val2)
             (if (and((slt(val2, 0)), (sgt(val1, (add([max_value], val2)))))) { (revert(0, 0)) })
             (diff := sub(val1, val2))
+        }
+    }
+}
+
+fn _checked_exp_signed(size: Integer) -> yul::Statement {
+    if !size.is_signed() {
+        panic!("Expected signed integer")
+    }
+    let (min_value, max_value) = get_min_max(size.clone());
+    let fn_name = names::checked_exp(&size);
+    function_definition! {
+        function [fn_name](base, exponent) -> power {
+            (power := checked_exp_signed(base, exponent, [min_value], [max_value]))
+        }
+    }
+}
+
+fn _checked_exp_unsigned(size: Integer) -> yul::Statement {
+    if size.is_signed() {
+        panic!("Expected unsigned integer")
+    }
+    let (_, max_value) = get_min_max(size.clone());
+    let fn_name = names::checked_exp(&size);
+    function_definition! {
+        function [fn_name](base, exponent) -> power {
+            (power := checked_exp_unsigned(base, exponent, [max_value]))
+        }
+    }
+}
+
+fn checked_exp_helper() -> yul::Statement {
+    // TODO: Refactor once https://github.com/ethereum/fe/issues/314 is resolved
+    yul::Statement::FunctionDefinition(yul::FunctionDefinition {
+        name: identifier! { ("checked_exp_helper") },
+        parameters: identifiers! { ("_power") ("_base") ("exponent") ("max")},
+        returns: identifiers! { ("power") ("base")},
+        block: block! {
+            (power := _power)
+            (base := _base)
+            (for {} (gt(exponent, 1)) {}
+            {
+                // overflow check for base * base
+                (if (gt(base, (div(max, base)))) { (revert(0, 0)) })
+                (if (and(exponent, 1)) {
+                    // No checks for power := mul(power, base) needed, because the check
+                    // for base * base above is sufficient, since:
+                    // |power| <= base (proof by induction) and thus:
+                    // |power * base| <= base * base <= max <= |min| (for signed)
+                    // (this is equally true for signed and unsigned exp)
+                    (power := (mul(power, base)))
+                })
+                (base := (mul(base, base)))
+                (exponent := shr(1, exponent))
+            })
+        },
+    })
+}
+
+fn checked_exp_signed() -> yul::Statement {
+    // Refactor once https://github.com/ethereum/fe/issues/314 is resolved
+    let checked_exp_helper_call = yul::Statement::Assignment(yul::Assignment {
+        identifiers: identifiers! { ("power") ("base")},
+        expression: expression! { checked_exp_helper(power, base, exponent, max) },
+    });
+
+    function_definition! {
+        function checked_exp_signed(base, exponent, min, max) -> power {
+            // Currently, `leave` avoids this function being inlined.
+            // YUL team is working on optimizer improvements to fix that.
+
+            // Note that 0**0 == 1
+            ([switch! {
+                switch exponent
+                (case 0 {
+                    (power := 1 )
+                    (leave)
+                })
+                (case 1 {
+                    (power := base )
+                    (leave)
+                })
+            }])
+            (if (iszero(base)) {
+                (power := 0 )
+                (leave)
+            })
+            (power := 1 )
+            // We pull out the first iteration because it is the only one in which
+            // base can be negative.
+            // Exponent is at least 2 here.
+            // overflow check for base * base
+            ([switch! {
+                switch (sgt(base, 0))
+                (case 1 {
+                    (if (gt(base, (div(max, base)))) {
+                        (revert(0, 0))
+                    })
+                })
+                (case 0 {
+                    (if (slt(base, (sdiv(max, base)))) {
+                        (revert(0, 0))
+                    })
+                })
+            }])
+            (if (and(exponent, 1)) {
+                (power := base )
+            })
+            (base := (mul(base, base)))
+            (exponent := shr(1, exponent))
+            // // Below this point, base is always positive.
+            ([checked_exp_helper_call]) // power = 1, base = 16 which is wrong
+            (if (and((sgt(power, 0)), (gt(power, (div(max, base)))))) { (revert(0, 0)) })
+            (if (and((slt(power, 0)), (slt(power, (sdiv(min, base)))))) { (revert(0, 0)) })
+            (power := (mul(power, base)))
+        }
+    }
+}
+
+fn checked_exp_unsigned() -> yul::Statement {
+    // TODO: Refactor once https://github.com/ethereum/fe/issues/314 is resolved
+    let checked_exp_helper_call = yul::Statement::Assignment(yul::Assignment {
+        identifiers: identifiers! { ("power") ("base")},
+        expression: expression! { checked_exp_helper(1, base, exponent, max) },
+    });
+
+    function_definition! {
+        function checked_exp_unsigned(base, exponent, max) -> power {
+            // Currently, `leave` avoids this function being inlined.
+            // YUL team is working on optimizer improvements to fix that.
+
+            // Note that 0**0 == 1
+            (if (iszero(exponent)) {
+                (power := 1 )
+                (leave)
+            })
+            (if (iszero(base)) {
+                (power := 0 )
+                (leave)
+            })
+            // Specializations for small bases
+            ([switch! {
+                switch base
+                // 0 is handled above
+                (case 1 {
+                    (power := 1 )
+                    (leave)
+                })
+                (case 2 {
+                    (if (gt(exponent, 255)) {
+                        (revert(0, 0))
+                    })
+                    (power := (exp(2, exponent)))
+                    (if (gt(power, max)) {
+                        (revert(0, 0))
+                    })
+                    (leave)
+                })
+            }])
+            (if (and((sgt(power, 0)), (gt(power, (div(max, base)))))) { (revert(0, 0)) })
+
+            (if (or((and((lt(base, 11)), (lt(exponent, 78)))), (and((lt(base, 307)), (lt(exponent, 32)))))) {
+                (power := (exp(base, exponent)))
+                (if (gt(power, max)) {
+                    (revert(0, 0))
+                })
+                (leave)
+            })
+
+            ([checked_exp_helper_call])
+            (if (gt(power, (div(max, base)))) {
+                (revert(0, 0))
+            })
+            (power := (mul(power, base)))
         }
     }
 }

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -66,7 +66,9 @@ use std::fs;
     case("external_call_type_error.fe", "TypeError"),
     case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams"),
     case("non_bool_and.fe", "TypeError"),
-    case("non_bool_or.fe", "TypeError")
+    case("non_bool_or.fe", "TypeError"),
+    case("pow_with_wrong_capacity.fe", "TypeError"),
+    case("pow_with_signed_exponent.fe", "SignedExponentNotAllowed")
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: &str) {
     let src = fs::read_to_string(format!("tests/fixtures/compile_errors/{}", fixture_file))

--- a/compiler/tests/fixtures/compile_errors/pow_with_signed_exponent.fe
+++ b/compiler/tests/fixtures/compile_errors/pow_with_signed_exponent.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar(base: i128, exponent: i128) -> i128:
+        return base ** exponent

--- a/compiler/tests/fixtures/compile_errors/pow_with_wrong_capacity.fe
+++ b/compiler/tests/fixtures/compile_errors/pow_with_wrong_capacity.fe
@@ -1,0 +1,5 @@
+contract Foo:
+
+    pub def bar(base: i128, exponent: u256) -> i128:
+        # Exponent can be unsigned but needs to be same size or smaller
+        return base ** exponent

--- a/compiler/tests/fixtures/features/checked_arithmetic.fe
+++ b/compiler/tests/fixtures/features/checked_arithmetic.fe
@@ -179,3 +179,39 @@ contract CheckedArithmetic:
 
     pub def mod_i8(left: i8, right: i8) -> i8:
         return left % right
+
+    pub def pow_u256(left: u256, right: u256) -> u256:
+        return left ** right
+
+    pub def pow_u128(left: u128, right: u128) -> u128:
+        return left ** right
+
+    pub def pow_u64(left: u64, right: u64) -> u64:
+        return left ** right
+
+    pub def pow_u32(left: u32, right: u32) -> u32:
+        return left ** right
+
+    pub def pow_u16(left: u16, right: u16) -> u16:
+        return left ** right
+
+    pub def pow_u8(left: u8, right: u8) -> u8:
+        return left ** right
+
+    pub def pow_i256(left: i256, right: u256) -> i256:
+        return left ** right
+
+    pub def pow_i128(left: i128, right: u128) -> i128:
+        return left ** right
+
+    pub def pow_i64(left: i64, right: u64) -> i64:
+        return left ** right
+
+    pub def pow_i32(left: i32, right: u32) -> i32:
+        return left ** right
+
+    pub def pow_i16(left: i16, right: u16) -> i16:
+        return left ** right
+
+    pub def pow_i8(left: i8, right: u8) -> i8:
+        return left ** right

--- a/compiler/tests/fixtures/features/return_pow_i256.fe
+++ b/compiler/tests/fixtures/features/return_pow_i256.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(x: i8, y: u8) -> i8:
+        return x ** y

--- a/compiler/tests/runtime.rs
+++ b/compiler/tests/runtime.rs
@@ -366,3 +366,16 @@ fn test_runtime_house_struct() {
         );
     })
 }
+
+#[test]
+fn checked_exp_signed() {
+    with_executor(&|mut executor| {
+        test_runtime_functions(
+            &mut executor,
+            functions::std(),
+            statements! {
+                [assert_eq!(4, (checked_exp_signed(2, 2, 0, 100)))]
+            },
+        );
+    })
+}

--- a/newsfragments/313.feature.md
+++ b/newsfragments/313.feature.md
@@ -1,0 +1,1 @@
+Perform over/underflow checks for exponentiation operations on integers


### PR DESCRIPTION
### What was wrong?

We need to perform over/underflow checks for exponentiation maths.

### How was it fixed?

Pretty much like with the other operations except that for exponentiation we can not support that the exponent is signed. To still allow calculations such as `-2 ** 3` we allow the right hand side to be unsigned as long as it size is the equal or smaller than the left hand side. The resulting expression gets the type of the left hand side which is also what will be used for the under/overflow checks.
