### PR TITLE
Fix ICE when '__init__' returns any other type than '()'

### DIFF
--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -63,6 +63,11 @@ pub fn func_def(
             .transpose()?
             .unwrap_or_else(|| Tuple::empty().into());
 
+        // `__init__` must not return any type other than `()`.
+        if name == "__init__" && !return_type.is_empty_tuple() {
+            return Err(SemanticError::type_error());
+        }
+
         let attributes: FunctionAttributes = contract_scope
             .borrow_mut()
             .add_function(

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -71,6 +71,7 @@ use std::fs;
     case("return_addition_with_mixed_types.fe", "TypeError"),
     case("return_call_to_fn_with_param_type_mismatch.fe", "TypeError"),
     case("return_call_to_fn_without_return.fe", "TypeError"),
+    case("return_from_init.fe", "TypeError"),
     case("return_lt_mixed_types.fe", "TypeError"),
     case("strict_boolean_if_else.fe", "TypeError"),
     case("string_capacity_mismatch.fe", "StringCapacityMismatch"),

--- a/compiler/tests/fixtures/compile_errors/return_from_init.fe
+++ b/compiler/tests/fixtures/compile_errors/return_from_init.fe
@@ -1,0 +1,3 @@
+contract C:
+    pub def __init__() -> i32:
+        return 0

--- a/newsfragments/323.bugfix.md
+++ b/newsfragments/323.bugfix.md
@@ -1,0 +1,9 @@
+Ensure analyzer rejects code that uses return values for `__init__` functions.
+
+An example that now produces a compile time error:
+
+```
+contract C:
+    pub def __init__() -> i32:
+        return 0
+```

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -1,11 +1,11 @@
-This directory collects "newsfragments": short files that each contain
-a snippet of ReST-formatted text that will be added to the next
+This directory collects "newsfragments": short files that each contains
+a snippet of markdown formatted text that will be added to the next
 release notes. This should be a description of aspects of the change
 (if any) that are relevant to users. (This contrasts with the
 commit message and PR description, which are a description of the change as
 relevant to people working on the code itself.)
 
-Each file should be named like `<ISSUE>.<TYPE>.rst`, where
+Each file should be named like `<ISSUE>.<TYPE>.md`, where
 `<ISSUE>` is an issue numbers, and `<TYPE>` is one of:
 
 * `feature`


### PR DESCRIPTION
fixes #307.

### What was wrong?
Semantic checks missed `__init__` return type.

### How was it fixed?
Assert the return type is `()`.

- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
