### PR TITLE
Increase coverage timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-wasm-test:
 
 .PHONY: coverage
 coverage:
-	cargo tarpaulin --workspace --all-features --verbose --exclude-files 'tests/*' --exclude-files 'main.rs' --out xml html
+	cargo tarpaulin --workspace --all-features --verbose --timeout 120 --exclude-files 'tests/*' --exclude-files 'main.rs' --out xml html
 
 .PHONY: clippy
 clippy:


### PR DESCRIPTION
### What was wrong?

Coverage was getting flaky because the Uniswap tests take a while to run.

### How was it fixed?

Increased timeout from one to two minutes

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
