### PR TITLE
Panic when Yul mapping fails; print friendly message when fe panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,7 @@ dependencies = [
  "fe-parser",
  "hex",
  "maplit",
+ "once_cell",
  "primitive-types",
  "rand",
  "rstest",

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -26,6 +26,7 @@ stringreader = "0.1"
 # This fork supports concurrent compilation, which is required for Rust tests.
 solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true }
 maplit = "1.0.2"
+once_cell = "1.5.2"
 
 [dev-dependencies]
 evm-runtime = "0.18"

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -47,7 +47,7 @@ pub fn compile(
         .map_err(|error| CompileError::str(&error.format_user(src)))?;
 
     // compile to yul
-    let yul_contracts = yul::compile(&context, &lowered_fe_module)?;
+    let yul_contracts = yul::compile(&context, &lowered_fe_module);
 
     // compile to bytecode if required
     #[cfg(feature = "solc-backend")]

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -1,4 +1,3 @@
-use crate::errors::CompileError;
 use crate::yul::mappers::expressions;
 use crate::yul::operations::data as data_operations;
 use fe_analyzer::namespace::types::FixedSize;
@@ -12,10 +11,7 @@ use std::convert::TryFrom;
 use yultsur::*;
 
 /// Builds a Yul statement from a Fe assignment.
-pub fn assign(
-    context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+pub fn assign(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Assign { targets, value } = &stmt.kind {
         if targets.len() > 1 {
             unimplemented!("multiple assignment targets")
@@ -26,52 +22,50 @@ pub fn assign(
                 context.get_expression(first_target),
                 context.get_expression(value),
             ) {
-                let target = expressions::expr(&context, first_target)?;
-                let value = expressions::expr(&context, value)?;
+                let target = expressions::expr(&context, first_target);
+                let value = expressions::expr(&context, value);
 
                 let typ = FixedSize::try_from(target_attributes.typ.to_owned())
-                    .map_err(|_| CompileError::static_str("invalid attributes"))?;
+                    .expect("invalid attributes");
 
-                return Ok(
-                    match (
-                        value_attributes.final_location(),
-                        target_attributes.final_location(),
-                    ) {
-                        (Location::Memory, Location::Storage { .. }) => {
-                            data_operations::mcopys(typ, target, value)
-                        }
-                        (Location::Memory, Location::Value) => {
-                            let target = expr_as_ident(target)?;
-                            let value = data_operations::mload(typ, value);
-                            statement! { [target] := [value] }
-                        }
-                        (Location::Memory, Location::Memory) => {
-                            let target = expr_as_ident(target)?;
-                            statement! { [target] := [value] }
-                        }
-                        (Location::Storage { .. }, Location::Storage { .. }) => {
-                            data_operations::scopys(typ, target, value)
-                        }
-                        (Location::Storage { .. }, Location::Value) => {
-                            let target = expr_as_ident(target)?;
-                            let value = data_operations::sload(typ, value);
-                            statement! { [target] := [value] }
-                        }
-                        (Location::Storage { .. }, Location::Memory) => {
-                            unreachable!("raw sto to mem assign")
-                        }
-                        (Location::Value, Location::Memory) => {
-                            data_operations::mstore(typ, target, value)
-                        }
-                        (Location::Value, Location::Storage { .. }) => {
-                            data_operations::sstore(typ, target, value)
-                        }
-                        (Location::Value, Location::Value) => {
-                            let target = expr_as_ident(target)?;
-                            statement! { [target] := [value] }
-                        }
-                    },
-                );
+                return match (
+                    value_attributes.final_location(),
+                    target_attributes.final_location(),
+                ) {
+                    (Location::Memory, Location::Storage { .. }) => {
+                        data_operations::mcopys(typ, target, value)
+                    }
+                    (Location::Memory, Location::Value) => {
+                        let target = expr_as_ident(target);
+                        let value = data_operations::mload(typ, value);
+                        statement! { [target] := [value] }
+                    }
+                    (Location::Memory, Location::Memory) => {
+                        let target = expr_as_ident(target);
+                        statement! { [target] := [value] }
+                    }
+                    (Location::Storage { .. }, Location::Storage { .. }) => {
+                        data_operations::scopys(typ, target, value)
+                    }
+                    (Location::Storage { .. }, Location::Value) => {
+                        let target = expr_as_ident(target);
+                        let value = data_operations::sload(typ, value);
+                        statement! { [target] := [value] }
+                    }
+                    (Location::Storage { .. }, Location::Memory) => {
+                        unreachable!("raw sto to mem assign")
+                    }
+                    (Location::Value, Location::Memory) => {
+                        data_operations::mstore(typ, target, value)
+                    }
+                    (Location::Value, Location::Storage { .. }) => {
+                        data_operations::sstore(typ, target, value)
+                    }
+                    (Location::Value, Location::Value) => {
+                        let target = expr_as_ident(target);
+                        statement! { [target] := [value] }
+                    }
+                };
             }
         }
     }
@@ -79,12 +73,12 @@ pub fn assign(
     unreachable!()
 }
 
-fn expr_as_ident(expr: yul::Expression) -> Result<yul::Identifier, CompileError> {
+fn expr_as_ident(expr: yul::Expression) -> yul::Identifier {
     if let yul::Expression::Identifier(ident) = expr {
-        return Ok(ident);
+        ident
+    } else {
+        panic!("expression is not an identifier");
     }
-
-    Err(CompileError::static_str("expression is not an identifier"))
 }
 
 #[cfg(test)]

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -1,4 +1,3 @@
-use crate::errors::CompileError;
 use crate::yul::constructor;
 use crate::yul::mappers::functions;
 use crate::yul::runtime;
@@ -13,7 +12,7 @@ pub fn contract_def(
     context: &Context,
     stmt: &Node<fe::ModuleStmt>,
     created_contracts: Vec<yul::Object>,
-) -> Result<yul::Object, CompileError> {
+) -> yul::Object {
     if let fe::ModuleStmt::ContractDef { name, body } = &stmt.kind {
         let contract_name = name.kind;
         let mut init_function = None;
@@ -25,12 +24,10 @@ pub fn contract_def(
                 (context.get_function(stmt), &stmt.kind)
             {
                 if name.kind == "__init__" {
-                    init_function = Some((
-                        functions::func_def(context, stmt)?,
-                        attributes.param_types(),
-                    ))
+                    init_function =
+                        Some((functions::func_def(context, stmt), attributes.param_types()))
                 } else {
-                    user_functions.push(functions::func_def(context, stmt)?)
+                    user_functions.push(functions::func_def(context, stmt))
                 }
             }
         }
@@ -99,12 +96,12 @@ pub fn contract_def(
         };
 
         // We return the contract initialization object.
-        return Ok(yul::Object {
+        return yul::Object {
             name: identifier! { (contract_name) },
             code: constructor_code,
             objects: constructor_objects,
             data,
-        });
+        };
     }
 
     unreachable!()

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -1,4 +1,3 @@
-use crate::errors::CompileError;
 use crate::yul::mappers::expressions;
 use crate::yul::names;
 use fe_analyzer::namespace::types::{
@@ -11,17 +10,14 @@ use fe_parser::node::Node;
 use yultsur::*;
 
 /// Builds a Yul statement from a Fe variable declaration
-pub fn var_decl(
-    context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+pub fn var_decl(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     let decl_type = context.get_declaration(stmt).expect("missing attributes");
 
     if let fe::FuncStmt::VarDecl { target, value, .. } = &stmt.kind {
         let target = names::var_name(expressions::expr_name_str(&target));
 
-        return Ok(if let Some(value) = value {
-            let value = expressions::expr(context, &value)?;
+        return if let Some(value) = value {
+            let value = expressions::expr(context, &value);
             statement! { let [target] := [value] }
         } else {
             match decl_type {
@@ -31,7 +27,7 @@ pub fn var_decl(
                     statement! { let [target] := alloc([size]) }
                 }
             }
-        });
+        };
     }
 
     unreachable!()

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -1,4 +1,3 @@
-use crate::errors::CompileError;
 use crate::yul::mappers::{
     assignments,
     declarations,
@@ -21,18 +20,15 @@ use yultsur::*;
 pub fn multiple_func_stmt(
     context: &Context,
     statements: &[Node<fe::FuncStmt>],
-) -> Result<Vec<yul::Statement>, CompileError> {
+) -> Vec<yul::Statement> {
     statements
         .iter()
         .map(|statement| func_stmt(context, statement))
-        .collect::<Result<Vec<_>, _>>()
+        .collect()
 }
 
 /// Builds a Yul function definition from a Fe function definition.
-pub fn func_def(
-    context: &Context,
-    def: &Node<fe::ContractStmt>,
-) -> Result<yul::Statement, CompileError> {
+pub fn func_def(context: &Context, def: &Node<fe::ContractStmt>) -> yul::Statement {
     if let (
         Some(attributes),
         fe::ContractStmt::FuncDef {
@@ -46,20 +42,20 @@ pub fn func_def(
     {
         let function_name = names::func_name(name.kind);
         let param_names = args.iter().map(|arg| func_def_arg(arg)).collect::<Vec<_>>();
-        let function_statements = multiple_func_stmt(context, body)?;
+        let function_statements = multiple_func_stmt(context, body);
 
         return if attributes.return_type.is_empty_tuple() {
-            Ok(function_definition! {
+            function_definition! {
                 function [function_name]([param_names...]) {
                     [function_statements...]
                 }
-            })
+            }
         } else {
-            Ok(function_definition! {
+            function_definition! {
                 function [function_name]([param_names...]) -> return_val {
                     [function_statements...]
                 }
-            })
+            }
         };
     }
 
@@ -72,7 +68,7 @@ fn func_def_arg(arg: &Node<fe::FuncDefArg>) -> yul::Identifier {
     names::var_name(name)
 }
 
-fn func_stmt(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
+fn func_stmt(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     match &stmt.kind {
         fe::FuncStmt::Return { .. } => func_return(context, stmt),
         fe::FuncStmt::VarDecl { .. } => declarations::var_decl(context, stmt),
@@ -84,14 +80,14 @@ fn func_stmt(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Statem
         fe::FuncStmt::If { .. } => if_statement(context, stmt),
         fe::FuncStmt::Assert { .. } => assert(context, stmt),
         fe::FuncStmt::Expr { .. } => expr(context, stmt),
-        fe::FuncStmt::Pass => Ok(statement! { pop(0) }),
+        fe::FuncStmt::Pass => statement! { pop(0) },
         fe::FuncStmt::Break => break_statement(context, stmt),
         fe::FuncStmt::Continue => continue_statement(context, stmt),
         fe::FuncStmt::Revert => revert(stmt),
     }
 }
 
-fn for_loop(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
+fn for_loop(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::For {
         target,
         iter,
@@ -99,9 +95,9 @@ fn for_loop(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Stateme
         or_else: _,
     } = &stmt.kind
     {
-        let iterator = expressions::expr(context, iter)?;
+        let iterator = expressions::expr(context, iter);
         let target_var = names::var_name(expressions::expr_name_str(target));
-        let yul_body = multiple_func_stmt(context, body)?;
+        let yul_body = multiple_func_stmt(context, body);
         return if let Some(ExpressionAttributes {
             typ: Type::Array(array),
             ..
@@ -109,170 +105,153 @@ fn for_loop(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Stateme
         {
             let size = literal_expression! { (array.size) };
             let inner_size = literal_expression! { (array.inner.size()) };
-            Ok(block_statement! {
+            block_statement! {
                 (for {(let i := 0)} (lt(i, [size])) {(i := add(i, 1))}
                 {
                     // Below yul statement to load values from memory to `target_var`.
                     (let [target_var] := [expression! { mloadn([expression! { add([iterator], (mul(i, [inner_size.clone()]))) }], [inner_size]) }])
                     [yul_body...]
                 })
-            })
+            }
         } else {
-            Err(CompileError::static_str("missing iter expression"))
+            panic!("missing iter expression")
         };
     }
     unreachable!()
 }
 
-fn if_statement(
-    context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+fn if_statement(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::If {
         test,
         body,
         or_else,
     } = &stmt.kind
     {
-        let yul_test = expressions::expr(context, &test)?;
-        let yul_body = multiple_func_stmt(context, body)?;
-        let yul_or_else = multiple_func_stmt(context, or_else)?;
+        let yul_test = expressions::expr(context, &test);
+        let yul_body = multiple_func_stmt(context, body);
+        let yul_or_else = multiple_func_stmt(context, or_else);
 
-        return Ok(switch! {
+        return switch! {
             switch ([yul_test])
             (case 1 {[yul_body...]})
             (case 0 {[yul_or_else...]})
-        });
-    }
-
-    unreachable!()
-}
-
-fn expr(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
-    if let fe::FuncStmt::Expr { value } = &stmt.kind {
-        let expr = expressions::expr(context, value)?;
-
-        let attributes = context.get_expression(value).expect("missing attributes");
-
-        return if attributes.typ.is_empty_tuple() {
-            Ok(yul::Statement::Expression(expr))
-        } else {
-            Ok(statement! { pop([expr])})
         };
     }
 
     unreachable!()
 }
 
-fn revert(stmt: &Node<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
-    if let fe::FuncStmt::Revert = &stmt.kind {
-        return Ok(statement! { revert(0, 0) });
+fn expr(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
+    if let fe::FuncStmt::Expr { value } = &stmt.kind {
+        let expr = expressions::expr(context, value);
+
+        let attributes = context.get_expression(value).expect("missing attributes");
+
+        return if attributes.typ.is_empty_tuple() {
+            yul::Statement::Expression(expr)
+        } else {
+            statement! { pop([expr])}
+        };
     }
 
     unreachable!()
 }
 
-fn emit(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
+fn revert(stmt: &Node<fe::FuncStmt>) -> yul::Statement {
+    if let fe::FuncStmt::Revert = &stmt.kind {
+        return statement! { revert(0, 0) };
+    }
+
+    unreachable!()
+}
+
+fn emit(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Emit { value } = &stmt.kind {
         if let fe::Expr::Call { func: _, args } = &value.kind {
             let event_values = args
                 .kind
                 .iter()
                 .map(|arg| expressions::call_arg(context, arg))
-                .collect::<Result<_, _>>()?;
+                .collect();
 
             if let Some(event) = context.get_emit(stmt) {
-                return Ok(data_operations::emit_event(event.to_owned(), event_values));
+                return data_operations::emit_event(event.to_owned(), event_values);
             }
 
-            return Err(CompileError::static_str("missing event definition"));
+            panic!("missing event definition");
         }
 
-        return Err(CompileError::static_str(
-            "emit statements must contain a call expression",
-        ));
+        panic!("emit statements must contain a call expression",);
     }
 
     unreachable!()
 }
 
-fn assert(context: &Context, stmt: &Node<fe::FuncStmt>) -> Result<yul::Statement, CompileError> {
+fn assert(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Assert { test, msg: _ } = &stmt.kind {
-        let test = expressions::expr(context, test)?;
+        let test = expressions::expr(context, test);
 
-        return Ok(statement! { if (iszero([test])) { (revert(0, 0)) } });
+        return statement! { if (iszero([test])) { (revert(0, 0)) } };
     }
 
     unreachable!()
 }
 
-fn break_statement(
-    _context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+fn break_statement(_context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Break {} = &stmt.kind {
-        return Ok(statement! { break });
+        return statement! { break };
     }
 
     unreachable!()
 }
 
-fn continue_statement(
-    _context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+fn continue_statement(_context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Continue {} = &stmt.kind {
-        return Ok(statement! { continue });
+        return statement! { continue };
     }
 
     unreachable!()
 }
 
-fn func_return(
-    context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+fn func_return(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Return { value } = &stmt.kind {
         return match value {
             Some(value) => {
                 // Ensure `return ()` is handled as if the function does not return
                 let attributes = context.get_expression(value).expect("Missing attributes");
                 if attributes.is_empty_tuple() {
-                    return Ok(statement! { leave });
+                    return statement! { leave };
                 }
 
-                let value = expressions::expr(context, value)?;
-                return Ok(block_statement! {
+                let value = expressions::expr(context, value);
+                return block_statement! {
                     (return_val := [value])
                     (leave)
-                });
+                };
             }
-            None => Ok(statement! { leave }),
+            None => statement! { leave },
         };
     }
 
     unreachable!()
 }
 
-fn while_loop(
-    context: &Context,
-    stmt: &Node<fe::FuncStmt>,
-) -> Result<yul::Statement, CompileError> {
+fn while_loop(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::While {
         test,
         body,
         or_else: _,
     } = &stmt.kind
     {
-        let test = expressions::expr(context, test)?;
-        let yul_body = multiple_func_stmt(context, body)?;
+        let test = expressions::expr(context, test);
+        let yul_body = multiple_func_stmt(context, body);
 
-        return Ok(block_statement! {
+        return block_statement! {
             (for {} ([test]) {}
             {
                 [yul_body...]
             })
-        });
+        };
     }
 
     unreachable!()

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -1,4 +1,3 @@
-use crate::errors::CompileError;
 use crate::yul::mappers::contracts;
 use fe_analyzer::Context;
 use fe_parser::ast as fe;
@@ -8,11 +7,11 @@ use yultsur::yul;
 pub type YulContracts = HashMap<String, yul::Object>;
 
 /// Builds a vector of Yul contracts from a Fe module.
-pub fn module(context: &Context, module: &fe::Module) -> Result<YulContracts, CompileError> {
+pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
     module
         .body
         .iter()
-        .try_fold(YulContracts::new(), |mut contracts, stmt| {
+        .fold(YulContracts::new(), |mut contracts, stmt| {
             match &stmt.kind {
                 fe::ModuleStmt::TypeDef { .. } => {}
                 fe::ModuleStmt::ContractDef { name, .. } => {
@@ -26,7 +25,7 @@ pub fn module(context: &Context, module: &fe::Module) -> Result<YulContracts, Co
                         .map(|contract_name| contracts[contract_name].clone())
                         .collect::<Vec<_>>();
 
-                    let contract = contracts::contract_def(context, stmt, created_contracts)?;
+                    let contract = contracts::contract_def(context, stmt, created_contracts);
 
                     if contracts.insert(name.kind.to_string(), contract).is_some() {
                         panic!("duplicate contract definition");
@@ -37,6 +36,6 @@ pub fn module(context: &Context, module: &fe::Module) -> Result<YulContracts, Co
                 fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
             }
 
-            Ok(contracts)
+            contracts
         })
 }

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,6 +1,5 @@
 //! Fe to Yul compiler.
 
-use crate::errors::CompileError;
 use crate::types::{
     FeModuleAst,
     NamedYulContracts,
@@ -16,9 +15,14 @@ pub mod runtime;
 mod utils;
 
 /// Compiles Fe source code to Yul.
-pub fn compile(context: &Context, module: &FeModuleAst) -> Result<NamedYulContracts, CompileError> {
-    Ok(mappers::module::module(context, module)?
+///
+/// # Panics
+///
+/// Any failure to compile an AST to Yul is considered a bug, and thus panics.
+/// Invalid ASTs should be caught by an analysis step prior to Yul generation.
+pub fn compile(context: &Context, module: &FeModuleAst) -> NamedYulContracts {
+    mappers::module::module(context, module)
         .drain()
         .map(|(name, object)| (name, object.to_string().replace("\"", "\\\"")))
-        .collect::<NamedYulContracts>())
+        .collect::<NamedYulContracts>()
 }

--- a/compiler/src/yul/operations/abi.rs
+++ b/compiler/src/yul/operations/abi.rs
@@ -56,7 +56,11 @@ pub fn encode_size<T: AbiEncoding>(types: Vec<T>, vals: Vec<yul::Expression>) ->
 }
 
 /// Returns an expression that gives the max size of the encoded values.
-pub fn static_encode_size<T: AbiEncoding>(types: Vec<T>) -> Result<yul::Expression, String> {
+///
+/// # Panics
+/// This will panic if any of the elements of the `types` vector have dynamic
+/// size.
+pub fn static_encode_size<T: AbiEncoding>(types: Vec<T>) -> yul::Expression {
     let mut static_size = 0;
 
     for typ in types {
@@ -75,10 +79,7 @@ pub fn static_encode_size<T: AbiEncoding>(types: Vec<T>) -> Result<yul::Expressi
                         static_size += utils::ceil_32(inner_size * size)
                     }
                     AbiArraySize::Dynamic => {
-                        return Err(
-                            "tried to get the static encoding size of dynamically sized value"
-                                .to_string(),
-                        )
+                        panic!("tried to get the static encoding size of dynamically sized value")
                     }
                 }
             }
@@ -86,7 +87,7 @@ pub fn static_encode_size<T: AbiEncoding>(types: Vec<T>) -> Result<yul::Expressi
         }
     }
 
-    Ok(literal_expression! { (static_size) })
+    literal_expression! { (static_size) }
 }
 
 /// Returns a list of expressions that can be used to decode given types.
@@ -168,7 +169,6 @@ mod tests {
                 }),
                 FixedSize::bool()
             ])
-            .expect("failed to get static size")
             .to_string(),
             "1376"
         )

--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -63,8 +63,7 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
                 }
             } else {
                 let decoding_size =
-                    abi_operations::static_encode_size(vec![function.return_type.clone()])
-                        .expect("failed to get the static encoding size");
+                    abi_operations::static_encode_size(vec![function.return_type.clone()]);
                 let decoding_operation = abi_operations::decode(
                     vec![function.return_type],
                     identifier_expression! { outstart },

--- a/newsfragments/327.internal.md
+++ b/newsfragments/327.internal.md
@@ -1,0 +1,1 @@
+Failures in the Yul generation phase now panic; any failure is a bug.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use clap::{
 
 mod _utils;
 use crate::_utils::pretty_curly_print;
+use fe_compiler::errors::install_compiler_panic_hook;
 use fe_compiler::types::CompiledModule;
 
 const DEFAULT_OUTPUT_DIR_NAME: &str = "output";
@@ -34,6 +35,8 @@ arg_enum! {
 }
 
 pub fn main() {
+    install_compiler_panic_hook();
+
     let matches = App::new("Fe")
         .version(VERSION)
         .about("Compiler for the Fe language")


### PR DESCRIPTION
### What was wrong?

A yul mapping failure is indicative of a bug in the compiler, but the yul mappers were returning Result types. Fixes #168.

### How was it fixed?

Yul mappers now all panic on failure. I also added a panic hook to log the following message when fe panics:

```
You've hit an internal compiler error. This is a bug in the Fe compiler.
Fe is still under heavy development, and isn't yet ready for production use.

If you would, please report this bug at the following URL:
  https://github.com/ethereum/fe/issues/new
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
