### PR TITLE
Properly reject emitting undefined events

### DIFF
--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -9,6 +9,7 @@ pub enum ErrorKind {
     BreakWithoutLoop,
     ContinueWithoutLoop,
     KeyWordArgsRequired,
+    MissingEventDefinition,
     MissingReturn,
     NotSubscriptable,
     NumericCapacityMismatch,
@@ -54,6 +55,14 @@ impl SemanticError {
     pub fn kw_args_required() -> Self {
         SemanticError {
             kind: ErrorKind::KeyWordArgsRequired,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `MissingEventDefinition`
+    pub fn missing_event_definition() -> Self {
+        SemanticError {
+            kind: ErrorKind::MissingEventDefinition,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -8,6 +8,7 @@ use fe_parser::node::Span;
 pub enum ErrorKind {
     BreakWithoutLoop,
     ContinueWithoutLoop,
+    EventInvocationExpected,
     KeyWordArgsRequired,
     MissingEventDefinition,
     MissingReturn,
@@ -47,6 +48,14 @@ impl SemanticError {
     pub fn continue_without_loop() -> Self {
         SemanticError {
             kind: ErrorKind::ContinueWithoutLoop,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `EventIncovationExpected`
+    pub fn event_invocation_expected() -> Self {
+        SemanticError {
+            kind: ErrorKind::EventInvocationExpected,
             context: vec![],
         }
     }

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -359,7 +359,7 @@ fn emit(
     {
         let event_name = expressions::expr_name_str(func)?;
 
-        if let Some(event) = scope.borrow().contract_event_def(event_name) {
+        return if let Some(event) = scope.borrow().contract_event_def(event_name) {
             context.borrow_mut().add_emit(stmt, event.clone());
 
             let argument_attributes = args
@@ -371,11 +371,13 @@ fn emit(
             if fixed_sizes_to_types(event.all_field_types())
                 != expression_attributes_to_types(argument_attributes)
             {
-                return Err(SemanticError::type_error());
+                Err(SemanticError::type_error())
+            } else {
+                Ok(())
             }
-        }
-
-        return Ok(());
+        } else {
+            Err(SemanticError::missing_event_definition())
+        };
     }
 
     unreachable!()

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -26,6 +26,7 @@ use std::fs;
     case("duplicate_typedef_in_module.fe", "AlreadyDefined"),
     case("duplicate_var_in_child_scope.fe", "AlreadyDefined"),
     case("duplicate_var_in_contract_method.fe", "AlreadyDefined"),
+    case("emit_undefined_event.fe", "MissingEventDefinition"),
     case("external_call_type_error.fe", "TypeError"),
     case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams"),
     case("indexed_event.fe", "MoreThanThreeIndexedParams"),

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -27,6 +27,7 @@ use std::fs;
     case("duplicate_var_in_child_scope.fe", "AlreadyDefined"),
     case("duplicate_var_in_contract_method.fe", "AlreadyDefined"),
     case("emit_undefined_event.fe", "MissingEventDefinition"),
+    case("emit_without_call.fe", "EventInvocationExpected"),
     case("external_call_type_error.fe", "TypeError"),
     case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams"),
     case("indexed_event.fe", "MoreThanThreeIndexedParams"),

--- a/compiler/tests/fixtures/compile_errors/emit_undefined_event.fe
+++ b/compiler/tests/fixtures/compile_errors/emit_undefined_event.fe
@@ -1,0 +1,4 @@
+contract Bar:
+
+  pub def test():
+    emit DoesNotExist()

--- a/compiler/tests/fixtures/compile_errors/emit_without_call.fe
+++ b/compiler/tests/fixtures/compile_errors/emit_without_call.fe
@@ -1,0 +1,4 @@
+contract Bar:
+
+  pub def test():
+    emit something

--- a/newsfragments/212.bugfix.md
+++ b/newsfragments/212.bugfix.md
@@ -1,0 +1,1 @@
+Properly reject `emit` not followed by an event invocation

--- a/newsfragments/250.bugfix.md
+++ b/newsfragments/250.bugfix.md
@@ -1,0 +1,8 @@
+Properly reject code that tries to emit a non-existing event.
+
+Example that now produces a compile time error:
+
+```
+emit DoesNotExist()
+```
+


### PR DESCRIPTION

### What was wrong?

Currently we do not reject code that uses `emit` with some undefined event such as `emit DoesNotExist`

Fixes #250

### How was it fixed?

1. Introduced a new error type `MissingEventDefinition`
2. Return `Err(SemanticError::missing_event_definition())` when the emitted event does not exit
3. Added a test case
