### PR TITLE
Properly reject octal number literals

### DIFF
--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -290,7 +290,7 @@ impl Integer {
 
     // Returns `true` if `num` represents a number that fits the type
     pub fn fits(&self, num: &str) -> bool {
-        let radix = 10;
+        const RADIX: u32 = 10;
 
         fn handle_parse_error<T>(result: Result<T, ParseIntError>) -> bool {
             if let Err(error) = result {
@@ -308,20 +308,25 @@ impl Integer {
             true
         }
 
+        // We reject octal number literals.
+        if num.len() > 1 && num.starts_with('0') {
+            return false;
+        }
+
         match self {
-            Integer::U8 => handle_parse_error(u8::from_str_radix(num, radix)),
-            Integer::U16 => handle_parse_error(u16::from_str_radix(num, radix)),
-            Integer::U32 => handle_parse_error(u32::from_str_radix(num, radix)),
-            Integer::U64 => handle_parse_error(u64::from_str_radix(num, radix)),
-            Integer::U128 => handle_parse_error(u128::from_str_radix(num, radix)),
-            Integer::U256 => BigInt::parse_bytes(num.as_bytes(), radix)
+            Integer::U8 => handle_parse_error(u8::from_str_radix(num, RADIX)),
+            Integer::U16 => handle_parse_error(u16::from_str_radix(num, RADIX)),
+            Integer::U32 => handle_parse_error(u32::from_str_radix(num, RADIX)),
+            Integer::U64 => handle_parse_error(u64::from_str_radix(num, RADIX)),
+            Integer::U128 => handle_parse_error(u128::from_str_radix(num, RADIX)),
+            Integer::U256 => BigInt::parse_bytes(num.as_bytes(), RADIX)
                 .map_or(false, |val| val >= BigInt::from(0) && val <= u256_max()),
-            Integer::I8 => handle_parse_error(i8::from_str_radix(num, radix)),
-            Integer::I16 => handle_parse_error(i16::from_str_radix(num, radix)),
-            Integer::I32 => handle_parse_error(i32::from_str_radix(num, radix)),
-            Integer::I64 => handle_parse_error(i64::from_str_radix(num, radix)),
-            Integer::I128 => handle_parse_error(i128::from_str_radix(num, radix)),
-            Integer::I256 => BigInt::parse_bytes(num.as_bytes(), radix)
+            Integer::I8 => handle_parse_error(i8::from_str_radix(num, RADIX)),
+            Integer::I16 => handle_parse_error(i16::from_str_radix(num, RADIX)),
+            Integer::I32 => handle_parse_error(i32::from_str_radix(num, RADIX)),
+            Integer::I64 => handle_parse_error(i64::from_str_radix(num, RADIX)),
+            Integer::I128 => handle_parse_error(i128::from_str_radix(num, RADIX)),
+            Integer::I256 => BigInt::parse_bytes(num.as_bytes(), RADIX)
                 .map_or(false, |val| val >= i256_min() && val <= i256_max()),
         }
     }

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -58,6 +58,7 @@ use std::fs;
         "numeric_capacity_mismatch/literal_too_small.fe",
         "NumericCapacityMismatch"
     ),
+    case("numeric_capacity_mismatch/octal_number.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u128_neg.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u128_pos.fe", "NumericCapacityMismatch"),
     case("numeric_capacity_mismatch/u16_neg.fe", "NumericCapacityMismatch"),

--- a/compiler/tests/fixtures/compile_errors/numeric_capacity_mismatch/octal_number.fe
+++ b/compiler/tests/fixtures/compile_errors/numeric_capacity_mismatch/octal_number.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def test() -> u8:
+        return u8(000)

--- a/newsfragments/222.bugfix.md
+++ b/newsfragments/222.bugfix.md
@@ -1,0 +1,1 @@
+Properly reject octal number literals


### PR DESCRIPTION
### What was wrong?
Currently, the analyzer doesn't consider number literals that start with `0`. This leads to ICE in the `yul` mapping pass.
fixes #222 

### How was it fixed?
Reject a number literal if it starts with `0` and has more than two digits.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history

### Related problem
I also found that lexer doesn't tokenize correctly if number literals start with `0` followed by non zero value.
For example, `02` is tokenized into 
```
    [
        Token {
            typ: NUMBER,
            string: "0",
            span: Span {
                start: 0,
                end: 1,
            },
            line: "02\n",
        },
        Token {
            typ: NUMBER,
            string: "2",
            span: Span {
                start: 1,
                end: 2,
            },
            line: "02\n",
        },
        Token {
            typ: NEWLINE,
            string: "\n",
            span: Span {
                start: 2,
                end: 3,
            },
            line: "02\n",
        },
        Token {
            typ: ENDMARKER,
            string: "",
            span: Span {
                start: 3,
                end: 3,
            },
            line: "",
        },
    ],
```

I'll open an issue for this and address it in another PR.

EDIT: opened #331.