### PR TITLE
Give the AST ownership of its strings.

### DIFF
--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -811,31 +811,34 @@ pub fn type_desc_base(
 
 pub fn type_desc(defs: &HashMap<String, Type>, typ: &fe::TypeDesc) -> Result<Type, SemanticError> {
     match typ {
-        fe::TypeDesc::Base { base: "u256" } => Ok(Type::Base(U256)),
-        fe::TypeDesc::Base { base: "u128" } => Ok(Type::Base(Base::Numeric(Integer::U128))),
-        fe::TypeDesc::Base { base: "u64" } => Ok(Type::Base(Base::Numeric(Integer::U64))),
-        fe::TypeDesc::Base { base: "u32" } => Ok(Type::Base(Base::Numeric(Integer::U32))),
-        fe::TypeDesc::Base { base: "u16" } => Ok(Type::Base(Base::Numeric(Integer::U16))),
-        fe::TypeDesc::Base { base: "u8" } => Ok(Type::Base(Base::Numeric(Integer::U8))),
-        fe::TypeDesc::Base { base: "i256" } => Ok(Type::Base(Base::Numeric(Integer::I256))),
-        fe::TypeDesc::Base { base: "i128" } => Ok(Type::Base(Base::Numeric(Integer::I128))),
-        fe::TypeDesc::Base { base: "i64" } => Ok(Type::Base(Base::Numeric(Integer::I64))),
-        fe::TypeDesc::Base { base: "i32" } => Ok(Type::Base(Base::Numeric(Integer::I32))),
-        fe::TypeDesc::Base { base: "i16" } => Ok(Type::Base(Base::Numeric(Integer::I16))),
-        fe::TypeDesc::Base { base: "i8" } => Ok(Type::Base(Base::Numeric(Integer::I8))),
-        fe::TypeDesc::Base { base: "bool" } => Ok(Type::Base(Base::Bool)),
-        fe::TypeDesc::Base { base: "bytes" } => Ok(Type::Base(Base::Byte)),
-        fe::TypeDesc::Base { base: "address" } => Ok(Type::Base(Base::Address)),
-        fe::TypeDesc::Base { base } if base.starts_with("string") => Ok(Type::String(
-            TryFrom::try_from(*base).map_err(|_| SemanticError::type_error())?,
-        )),
-        fe::TypeDesc::Base { base } => {
-            if let Some(typ) = defs.get(base.to_owned()) {
-                return Ok(typ.clone());
+        fe::TypeDesc::Base { base } => match base.as_str() {
+            "u256" => Ok(Type::Base(U256)),
+            "u128" => Ok(Type::Base(Base::Numeric(Integer::U128))),
+            "u64" => Ok(Type::Base(Base::Numeric(Integer::U64))),
+            "u32" => Ok(Type::Base(Base::Numeric(Integer::U32))),
+            "u16" => Ok(Type::Base(Base::Numeric(Integer::U16))),
+            "u8" => Ok(Type::Base(Base::Numeric(Integer::U8))),
+            "i256" => Ok(Type::Base(Base::Numeric(Integer::I256))),
+            "i128" => Ok(Type::Base(Base::Numeric(Integer::I128))),
+            "i64" => Ok(Type::Base(Base::Numeric(Integer::I64))),
+            "i32" => Ok(Type::Base(Base::Numeric(Integer::I32))),
+            "i16" => Ok(Type::Base(Base::Numeric(Integer::I16))),
+            "i8" => Ok(Type::Base(Base::Numeric(Integer::I8))),
+            "bool" => Ok(Type::Base(Base::Bool)),
+            "bytes" => Ok(Type::Base(Base::Byte)),
+            "address" => Ok(Type::Base(Base::Address)),
+            base => {
+                if base.starts_with("string") {
+                    Ok(Type::String(
+                        TryFrom::try_from(base).map_err(|_| SemanticError::type_error())?,
+                    ))
+                } else if let Some(typ) = defs.get(base) {
+                    Ok(typ.clone())
+                } else {
+                    Err(SemanticError::undefined_value())
+                }
             }
-
-            Err(SemanticError::undefined_value())
-        }
+        },
         fe::TypeDesc::Array { typ, dimension } => Ok(Type::Array(Array {
             inner: type_desc_base(defs, &typ.kind)?,
             size: *dimension,

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -31,7 +31,7 @@ pub fn contract_def(
     stmt: &Node<fe::ModuleStmt>,
 ) -> Result<Shared<ContractScope>, SemanticError> {
     if let fe::ModuleStmt::ContractDef { name, body } = &stmt.kind {
-        let contract_scope = ContractScope::new(name.kind, Rc::clone(&module_scope));
+        let contract_scope = ContractScope::new(&name.kind, Rc::clone(&module_scope));
 
         for stmt in body.iter() {
             match &stmt.kind {
@@ -58,9 +58,9 @@ pub fn contract_def(
             .module_scope()
             .borrow_mut()
             .add_type_def(
-                name.kind,
+                &name.kind,
                 Type::Contract(Contract {
-                    name: name.kind.to_owned(),
+                    name: name.kind.to_string(),
                     functions: contract_attributes.public_functions,
                 }),
             )?;
@@ -107,7 +107,7 @@ fn contract_field(
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::ContractField { qual: _, name, typ } = &stmt.kind {
         let typ = types::type_desc(Scope::Contract(Rc::clone(&scope)), typ)?;
-        return scope.borrow_mut().add_field(name.kind, typ);
+        return scope.borrow_mut().add_field(&name.kind, typ);
     }
 
     unreachable!()
@@ -119,7 +119,7 @@ fn event_def(
     stmt: &Node<fe::ContractStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::EventDef { name, fields } = &stmt.kind {
-        let name = name.kind;
+        let name = &name.kind;
 
         let (is_indexed_bools, fields): (Vec<bool>, Vec<(String, FixedSize)>) = fields
             .iter()

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -21,7 +21,7 @@ pub fn var_decl(
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
-        let name = expressions::expr_name_str(target)?;
+        let name = expressions::expr_name_string(target)?;
         let declared_type = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), typ)?;
         if let Some(value) = value {
             let value_attributes =
@@ -32,7 +32,7 @@ pub fn var_decl(
             }
         }
 
-        scope.borrow_mut().add_var(name, declared_type.clone())?;
+        scope.borrow_mut().add_var(&name, declared_type.clone())?;
         context.borrow_mut().add_declaration(stmt, declared_type);
 
         return Ok(());

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -47,7 +47,7 @@ pub fn func_def(
         body: _,
     } = &def.kind
     {
-        let name = name.kind;
+        let name = &name.kind;
         let function_scope = BlockScope::from_contract_scope(name, Rc::clone(&contract_scope));
 
         let is_public = qual.is_some();
@@ -104,7 +104,7 @@ pub fn func_body(
     {
         let host_func_def = contract_scope
             .borrow()
-            .function_def(name.kind)
+            .function_def(&name.kind)
             .unwrap_or_else(|| panic!("Failed to lookup function definition for {}", &name.kind));
 
         // If the return type is an empty tuple we do not have to validate any further
@@ -167,7 +167,7 @@ fn func_def_arg(
     scope: Shared<BlockScope>,
     arg: &Node<fe::FuncDefArg>,
 ) -> Result<(String, FixedSize), SemanticError> {
-    let name = arg.kind.name.kind;
+    let name = &arg.kind.name.kind;
     let typ = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), &arg.kind.typ)?;
 
     scope.borrow_mut().add_var(name, typ.clone())?;
@@ -220,8 +220,8 @@ fn for_loop(
             let body_scope = BlockScope::from_block_scope(BlockScopeType::Loop, Rc::clone(&scope));
             // Step 3: Make sure iter is in the function scope & it should be an array.
             let target_type = verify_is_array(scope, Rc::clone(&context), iter)?;
-            let target_name = expressions::expr_name_str(target)?;
-            body_scope.borrow_mut().add_var(target_name, target_type)?;
+            let target_name = expressions::expr_name_string(target)?;
+            body_scope.borrow_mut().add_var(&target_name, target_type)?;
             // Step 4: Traverse the statements within the `for loop` body scope.
             traverse_statements(body_scope, context, body)
         }
@@ -356,7 +356,7 @@ fn emit(
     {
         return match kind {
             fe::Expr::Call { func, args } => {
-                let event_name = expressions::expr_name_str(func)?;
+                let event_name = &expressions::expr_name_string(func)?;
 
                 return if let Some(event) = scope.borrow().contract_event_def(event_name) {
                     context.borrow_mut().add_emit(stmt, event.clone());

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -23,7 +23,7 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
         match &stmt.kind {
             fe::ModuleStmt::TypeDef { .. } => type_def(Rc::clone(&scope), stmt)?,
             fe::ModuleStmt::StructDef { name, body } => {
-                structs::struct_def(Rc::clone(&scope), name.kind, body)?
+                structs::struct_def(Rc::clone(&scope), &name.kind, body)?
             }
             fe::ModuleStmt::ContractDef { .. } => {
                 // Collect contract statements and the scope that we create for them. After we
@@ -50,7 +50,7 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
 fn type_def(scope: Shared<ModuleScope>, def: &Node<fe::ModuleStmt>) -> Result<(), SemanticError> {
     if let fe::ModuleStmt::TypeDef { name, typ } = &def.kind {
         let typ = types::type_desc(&scope.borrow().type_defs, &typ.kind)?;
-        scope.borrow_mut().add_type_def(name.kind, typ)?;
+        scope.borrow_mut().add_type_def(&name.kind, typ)?;
         return Ok(());
     }
 

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -25,7 +25,7 @@ pub fn struct_def(
         let StructStmt::StructField { name, typ, .. } = &stmt.kind;
         let field_type = type_desc(&module_scope.borrow().type_defs, &typ.kind)?;
         if let Type::Base(base_typ) = field_type {
-            val.add_field(name.kind, &FixedSize::Base(base_typ))?;
+            val.add_field(&name.kind, &FixedSize::Base(base_typ))?;
         } else {
             todo!("Non-Base type fields aren't yet supported")
         }

--- a/analyzer/src/traversal/utils.rs
+++ b/analyzer/src/traversal/utils.rs
@@ -6,7 +6,7 @@ use crate::{
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
-pub fn call_arg_value<'a>(arg: &'a fe::CallArg<'a>) -> &'a Node<fe::Expr<'a>> {
+pub fn call_arg_value(arg: &fe::CallArg) -> &Node<fe::Expr> {
     match arg {
         fe::CallArg::Arg(value) => value,
         fe::CallArg::Kwarg(fe::Kwarg { value, .. }) => value,

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -11,10 +11,7 @@ use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Parse a map of contract ABIs from the input `module`.
-pub fn module<'a>(
-    context: &Context,
-    module: &'a fe::Module<'a>,
-) -> Result<ModuleAbis, CompileError> {
+pub fn module(context: &Context, module: &fe::Module) -> Result<ModuleAbis, CompileError> {
     module
         .body
         .iter()
@@ -32,9 +29,9 @@ pub fn module<'a>(
         })
 }
 
-fn contract_def<'a>(
+fn contract_def(
     context: &Context,
-    body: &[Node<fe::ContractStmt<'a>>],
+    body: &[Node<fe::ContractStmt>],
 ) -> Result<Contract, CompileError> {
     body.iter().try_fold(Contract::new(), |mut contract, stmt| {
         match &stmt.kind {

--- a/compiler/src/lowering/mod.rs
+++ b/compiler/src/lowering/mod.rs
@@ -7,6 +7,6 @@ mod mappers;
 mod names;
 
 /// Lowers the Fe source AST to a Fe HIR AST.
-pub fn lower<'a>(_context: &Context, module: &FeModuleAst<'a>) -> FeModuleAst<'a> {
+pub fn lower(_context: &Context, module: &FeModuleAst) -> FeModuleAst {
     module.clone()
 }

--- a/compiler/src/types.rs
+++ b/compiler/src/types.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 /// The name of a Fe contract.
 pub type ContractName = String;
 /// The AST of a Fe module.
-pub type FeModuleAst<'a> = fe::Module<'a>;
+pub type FeModuleAst = fe::Module;
 /// The ABI of a contract as a string.
 pub type JsonAbi = String;
 /// The source of a Fe module as a static string.

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -14,7 +14,7 @@ pub fn contract_def(
     created_contracts: Vec<yul::Object>,
 ) -> yul::Object {
     if let fe::ModuleStmt::ContractDef { name, body } = &stmt.kind {
-        let contract_name = name.kind;
+        let contract_name = &name.kind;
         let mut init_function = None;
         let mut user_functions = vec![];
 

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -14,7 +14,7 @@ pub fn var_decl(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement 
     let decl_type = context.get_declaration(stmt).expect("missing attributes");
 
     if let fe::FuncStmt::VarDecl { target, value, .. } = &stmt.kind {
-        let target = names::var_name(expressions::expr_name_str(&target));
+        let target = names::var_name(&expressions::expr_name_string(&target));
 
         return if let Some(value) = value {
             let value = expressions::expr(context, &value);

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -40,7 +40,7 @@ pub fn func_def(context: &Context, def: &Node<fe::ContractStmt>) -> yul::Stateme
         },
     ) = (context.get_function(def).to_owned(), &def.kind)
     {
-        let function_name = names::func_name(name.kind);
+        let function_name = names::func_name(&name.kind);
         let param_names = args.iter().map(|arg| func_def_arg(arg)).collect::<Vec<_>>();
         let function_statements = multiple_func_stmt(context, body);
 
@@ -63,7 +63,7 @@ pub fn func_def(context: &Context, def: &Node<fe::ContractStmt>) -> yul::Stateme
 }
 
 fn func_def_arg(arg: &Node<fe::FuncDefArg>) -> yul::Identifier {
-    let name = arg.kind.name.kind;
+    let name = &arg.kind.name.kind;
 
     names::var_name(name)
 }
@@ -96,7 +96,7 @@ fn for_loop(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     } = &stmt.kind
     {
         let iterator = expressions::expr(context, iter);
-        let target_var = names::var_name(expressions::expr_name_str(target));
+        let target_var = names::var_name(&expressions::expr_name_string(target));
         let yul_body = multiple_func_stmt(context, body);
         return if let Some(ExpressionAttributes {
             typ: Type::Array(array),

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -27,7 +27,7 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
 
                     let contract = contracts::contract_def(context, stmt, created_contracts);
 
-                    if contracts.insert(name.kind.to_string(), contract).is_some() {
+                    if contracts.insert(name.kind.clone(), contract).is_some() {
                         panic!("duplicate contract definition");
                     }
                 }

--- a/compiler/src/yul/utils.rs
+++ b/compiler/src/yul/utils.rs
@@ -7,7 +7,7 @@ use fe_analyzer::namespace::types::{
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
-pub fn call_arg_value<'a>(arg: &'a fe::CallArg<'a>) -> &'a Node<fe::Expr<'a>> {
+pub fn call_arg_value(arg: &fe::CallArg) -> &Node<fe::Expr> {
     match arg {
         fe::CallArg::Arg(value) => value,
         fe::CallArg::Kwarg(fe::Kwarg { value, .. }) => value,

--- a/newsfragments/332.internal.md
+++ b/newsfragments/332.internal.md
@@ -1,0 +1,1 @@
+AST nodes use `String`s instead of `&str`s. This way we can perform incremental compilation on the AST.

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -6,120 +6,106 @@ use serde::{
 use crate::node::Node;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Module<'a> {
-    #[serde(borrow)]
-    pub body: Vec<Node<ModuleStmt<'a>>>,
+pub struct Module {
+    pub body: Vec<Node<ModuleStmt>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum ModuleStmt<'a> {
+pub enum ModuleStmt {
     TypeDef {
-        name: Node<&'a str>,
-        #[serde(borrow)]
-        typ: Node<TypeDesc<'a>>,
+        name: Node<String>,
+        typ: Node<TypeDesc>,
     },
     SimpleImport {
-        #[serde(borrow)]
-        names: Vec<Node<SimpleImportName<'a>>>,
+        names: Vec<Node<SimpleImportName>>,
     },
     FromImport {
-        #[serde(borrow)]
-        path: Node<FromImportPath<'a>>,
-        #[serde(borrow)]
-        names: Node<FromImportNames<'a>>,
+        path: Node<FromImportPath>,
+        names: Node<FromImportNames>,
     },
     ContractDef {
-        name: Node<&'a str>,
-        #[serde(borrow)]
-        body: Vec<Node<ContractStmt<'a>>>,
+        name: Node<String>,
+        body: Vec<Node<ContractStmt>>,
     },
     StructDef {
-        name: Node<&'a str>,
-        #[serde(borrow)]
-        body: Vec<Node<StructStmt<'a>>>,
+        name: Node<String>,
+        body: Vec<Node<StructStmt>>,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum TypeDesc<'a> {
+pub enum TypeDesc {
     Base {
-        base: &'a str,
+        base: String,
     },
     Array {
-        typ: Box<Node<TypeDesc<'a>>>,
+        typ: Box<Node<TypeDesc>>,
         dimension: usize,
     },
     Map {
-        from: Box<Node<TypeDesc<'a>>>,
-        to: Box<Node<TypeDesc<'a>>>,
+        from: Box<Node<TypeDesc>>,
+        to: Box<Node<TypeDesc>>,
     },
     Tuple {
-        items: Vec<Node<TypeDesc<'a>>>,
+        items: Vec<Node<TypeDesc>>,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct SimpleImportName<'a> {
-    #[serde(borrow)]
-    pub path: Vec<Node<&'a str>>,
-    pub alias: Option<Node<&'a str>>,
+pub struct SimpleImportName {
+    pub path: Vec<Node<String>>,
+    pub alias: Option<Node<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum FromImportPath<'a> {
+pub enum FromImportPath {
     Absolute {
-        #[serde(borrow)]
-        path: Vec<Node<&'a str>>,
+        path: Vec<Node<String>>,
     },
     Relative {
         parent_level: usize,
-        #[serde(borrow)]
-        path: Vec<Node<&'a str>>,
+        path: Vec<Node<String>>,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum FromImportNames<'a> {
+pub enum FromImportNames {
     Star,
-    #[serde(borrow)]
-    List(Vec<Node<FromImportName<'a>>>),
+    List(Vec<Node<FromImportName>>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct FromImportName<'a> {
-    #[serde(borrow)]
-    pub name: Node<&'a str>,
-    pub alias: Option<Node<&'a str>>,
+pub struct FromImportName {
+    pub name: Node<String>,
+    pub alias: Option<Node<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum ContractStmt<'a> {
+pub enum ContractStmt {
     ContractField {
         qual: Option<Node<ContractFieldQual>>,
-        #[serde(borrow)]
-        name: Node<&'a str>,
-        typ: Node<TypeDesc<'a>>,
+        name: Node<String>,
+        typ: Node<TypeDesc>,
     },
     EventDef {
-        name: Node<&'a str>,
-        fields: Vec<Node<EventField<'a>>>,
+        name: Node<String>,
+        fields: Vec<Node<EventField>>,
     },
     FuncDef {
         qual: Option<Node<FuncQual>>,
-        name: Node<&'a str>,
-        args: Vec<Node<FuncDefArg<'a>>>,
-        return_type: Option<Node<TypeDesc<'a>>>,
-        body: Vec<Node<FuncStmt<'a>>>,
+        name: Node<String>,
+        args: Vec<Node<FuncDefArg>>,
+        return_type: Option<Node<TypeDesc>>,
+        body: Vec<Node<FuncStmt>>,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum StructStmt<'a> {
+pub enum StructStmt {
     StructField {
         qual: Option<Node<StructFieldQual>>,
-        #[serde(borrow)]
-        name: Node<&'a str>,
-        typ: Node<TypeDesc<'a>>,
+        name: Node<String>,
+        typ: Node<TypeDesc>,
     },
 }
 
@@ -136,11 +122,10 @@ pub enum StructFieldQual {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct EventField<'a> {
+pub struct EventField {
     pub qual: Option<Node<EventFieldQual>>,
-    #[serde(borrow)]
-    pub name: Node<&'a str>,
-    pub typ: Node<TypeDesc<'a>>,
+    pub name: Node<String>,
+    pub typ: Node<TypeDesc>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -154,57 +139,55 @@ pub enum FuncQual {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct FuncDefArg<'a> {
-    #[serde(borrow)]
-    pub name: Node<&'a str>,
-    pub typ: Node<TypeDesc<'a>>,
+pub struct FuncDefArg {
+    pub name: Node<String>,
+    pub typ: Node<TypeDesc>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum FuncStmt<'a> {
+pub enum FuncStmt {
     Return {
-        #[serde(borrow)]
-        value: Option<Node<Expr<'a>>>,
+        value: Option<Node<Expr>>,
     },
     VarDecl {
-        target: Node<Expr<'a>>,
-        typ: Node<TypeDesc<'a>>,
-        value: Option<Node<Expr<'a>>>,
+        target: Node<Expr>,
+        typ: Node<TypeDesc>,
+        value: Option<Node<Expr>>,
     },
     Assign {
-        targets: Vec<Node<Expr<'a>>>,
-        value: Node<Expr<'a>>,
+        targets: Vec<Node<Expr>>,
+        value: Node<Expr>,
     },
     AugAssign {
-        target: Node<Expr<'a>>,
+        target: Node<Expr>,
         op: Node<BinOperator>,
-        value: Node<Expr<'a>>,
+        value: Node<Expr>,
     },
     For {
-        target: Node<Expr<'a>>,
-        iter: Node<Expr<'a>>,
-        body: Vec<Node<FuncStmt<'a>>>,
-        or_else: Vec<Node<FuncStmt<'a>>>,
+        target: Node<Expr>,
+        iter: Node<Expr>,
+        body: Vec<Node<FuncStmt>>,
+        or_else: Vec<Node<FuncStmt>>,
     },
     While {
-        test: Node<Expr<'a>>,
-        body: Vec<Node<FuncStmt<'a>>>,
-        or_else: Vec<Node<FuncStmt<'a>>>,
+        test: Node<Expr>,
+        body: Vec<Node<FuncStmt>>,
+        or_else: Vec<Node<FuncStmt>>,
     },
     If {
-        test: Node<Expr<'a>>,
-        body: Vec<Node<FuncStmt<'a>>>,
-        or_else: Vec<Node<FuncStmt<'a>>>,
+        test: Node<Expr>,
+        body: Vec<Node<FuncStmt>>,
+        or_else: Vec<Node<FuncStmt>>,
     },
     Assert {
-        test: Node<Expr<'a>>,
-        msg: Option<Node<Expr<'a>>>,
+        test: Node<Expr>,
+        msg: Option<Node<Expr>>,
     },
     Emit {
-        value: Node<Expr<'a>>,
+        value: Node<Expr>,
     },
     Expr {
-        value: Node<Expr<'a>>,
+        value: Node<Expr>,
     },
     Pass,
     Break,
@@ -213,91 +196,87 @@ pub enum FuncStmt<'a> {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum Expr<'a> {
+pub enum Expr {
     Ternary {
-        if_expr: Box<Node<Expr<'a>>>,
-        test: Box<Node<Expr<'a>>>,
-        else_expr: Box<Node<Expr<'a>>>,
+        if_expr: Box<Node<Expr>>,
+        test: Box<Node<Expr>>,
+        else_expr: Box<Node<Expr>>,
     },
     BoolOperation {
-        left: Box<Node<Expr<'a>>>,
+        left: Box<Node<Expr>>,
         op: Node<BoolOperator>,
-        right: Box<Node<Expr<'a>>>,
+        right: Box<Node<Expr>>,
     },
     BinOperation {
-        left: Box<Node<Expr<'a>>>,
+        left: Box<Node<Expr>>,
         op: Node<BinOperator>,
-        right: Box<Node<Expr<'a>>>,
+        right: Box<Node<Expr>>,
     },
     UnaryOperation {
         op: Node<UnaryOperator>,
-        operand: Box<Node<Expr<'a>>>,
+        operand: Box<Node<Expr>>,
     },
     CompOperation {
-        left: Box<Node<Expr<'a>>>,
+        left: Box<Node<Expr>>,
         op: Node<CompOperator>,
-        right: Box<Node<Expr<'a>>>,
+        right: Box<Node<Expr>>,
     },
     Attribute {
-        value: Box<Node<Expr<'a>>>,
-        attr: Node<&'a str>,
+        value: Box<Node<Expr>>,
+        attr: Node<String>,
     },
     Subscript {
-        value: Box<Node<Expr<'a>>>,
-        slices: Node<Vec<Node<Slice<'a>>>>,
+        value: Box<Node<Expr>>,
+        slices: Node<Vec<Node<Slice>>>,
     },
     Call {
-        func: Box<Node<Expr<'a>>>,
-        args: Node<Vec<Node<CallArg<'a>>>>,
+        func: Box<Node<Expr>>,
+        args: Node<Vec<Node<CallArg>>>,
     },
     List {
-        elts: Vec<Node<Expr<'a>>>,
+        elts: Vec<Node<Expr>>,
     },
     ListComp {
-        elt: Box<Node<Expr<'a>>>,
-        comps: Vec<Node<Comprehension<'a>>>,
+        elt: Box<Node<Expr>>,
+        comps: Vec<Node<Comprehension>>,
     },
     Tuple {
-        elts: Vec<Node<Expr<'a>>>,
+        elts: Vec<Node<Expr>>,
     },
     Bool(bool),
-    Name(&'a str),
-    Num(&'a str),
-    Str(Vec<&'a str>),
+    Name(String),
+    Num(String),
+    Str(Vec<String>),
     Ellipsis,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum Slice<'a> {
+pub enum Slice {
     Slice {
-        #[serde(borrow)]
-        lower: Option<Box<Node<Expr<'a>>>>,
-        upper: Option<Box<Node<Expr<'a>>>>,
-        step: Option<Box<Node<Expr<'a>>>>,
+        lower: Option<Box<Node<Expr>>>,
+        upper: Option<Box<Node<Expr>>>,
+        step: Option<Box<Node<Expr>>>,
     },
-    Index(Box<Node<Expr<'a>>>),
+    Index(Box<Node<Expr>>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum CallArg<'a> {
-    #[serde(borrow)]
-    Arg(Node<Expr<'a>>),
-    Kwarg(Kwarg<'a>),
+pub enum CallArg {
+    Arg(Node<Expr>),
+    Kwarg(Kwarg),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Kwarg<'a> {
-    #[serde(borrow)]
-    pub name: Node<&'a str>,
-    pub value: Box<Node<Expr<'a>>>,
+pub struct Kwarg {
+    pub name: Node<String>,
+    pub value: Box<Node<Expr>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct Comprehension<'a> {
-    #[serde(borrow)]
-    pub target: Box<Node<Expr<'a>>>,
-    pub iter: Box<Node<Expr<'a>>>,
-    pub ifs: Vec<Node<Expr<'a>>>,
+pub struct Comprehension {
+    pub target: Box<Node<Expr>>,
+    pub iter: Box<Node<Expr>>,
+    pub ifs: Vec<Node<Expr>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/parser/src/ast_traits.rs
+++ b/parser/src/ast_traits.rs
@@ -71,9 +71,14 @@ impl TryFrom<&Token<'_>> for Node<FuncQual> {
     }
 }
 
-impl<'a> From<&'a Token<'a>> for Node<TypeDesc<'a>> {
+impl<'a> From<&'a Token<'a>> for Node<TypeDesc> {
     fn from(token: &'a Token<'a>) -> Self {
-        Node::new(TypeDesc::Base { base: token.string }, token.span)
+        Node::new(
+            TypeDesc::Base {
+                base: token.string.to_string(),
+            },
+            token.span,
+        )
     }
 }
 

--- a/parser/src/builders.rs
+++ b/parser/src/builders.rs
@@ -329,7 +329,7 @@ pub fn op_expr_builder<'a, F, G, B, OperatorT>(
 where
     F: Fn(Cursor<'a>) -> ParseResult<Node<Expr>>,
     G: Fn(Cursor<'a>) -> ParseResult<OperatorT>,
-    B: Fn(Node<Expr<'a>>, OperatorT, Node<Expr<'a>>) -> Expr<'a>,
+    B: Fn(Node<Expr>, OperatorT, Node<Expr>) -> Expr,
 {
     move |input| {
         let (input, head) = operand(input)?;

--- a/parser/src/tokenizer/types.rs
+++ b/parser/src/tokenizer/types.rs
@@ -49,8 +49,8 @@ impl<'a> From<&Token<'a>> for Span {
     }
 }
 
-impl<'a> From<&Token<'a>> for Node<&'a str> {
+impl<'a> From<&Token<'a>> for Node<String> {
     fn from(tok: &Token<'a>) -> Self {
-        Node::new(tok.string, tok.span)
+        Node::new(tok.string.to_string(), tok.span)
     }
 }


### PR DESCRIPTION
### What was wrong?

Before, the AST used slices that point to parts of the source string. This is not compatible with the lowering pass, since we will be adding nodes to the AST.

part of #306 

### How was it fixed?

Refactored the AST to use `String`s instead of `&str`s.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
