### PR TITLE
Reject non-string assert reasons with TypeError

### DIFF
--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -395,8 +395,10 @@ fn assert(
     if let fe::FuncStmt::Assert { test, msg } = &stmt.kind {
         verify_is_boolean(Rc::clone(&scope), Rc::clone(&context), test)?;
         if let Some(msg) = msg {
-            // TODO: type check for a string once strings are supported
-            let _msg_attributes = expressions::expr(scope, context, msg)?;
+            let msg_attributes = expressions::expr(scope, context, msg)?;
+            if !matches!(msg_attributes.typ, Type::String(_)) {
+                return Err(SemanticError::type_error());
+            }
         }
 
         return Ok(());

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -8,6 +8,7 @@ use std::fs;
 #[rstest(
     fixture_file,
     expected_error,
+    case("assert_reason_not_string.fe", "TypeError"),
     case("break_without_loop_2.fe", "BreakWithoutLoop"),
     case("break_without_loop.fe", "BreakWithoutLoop"),
     case("call_event_with_wrong_types.fe", "TypeError"),

--- a/compiler/tests/fixtures/compile_errors/assert_reason_not_string.fe
+++ b/compiler/tests/fixtures/compile_errors/assert_reason_not_string.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def foo():
+        assert true, 1

--- a/newsfragments/335.bugfix.md
+++ b/newsfragments/335.bugfix.md
@@ -1,0 +1,1 @@
+Reject non-string assert reasons as type error


### PR DESCRIPTION
### What was wrong?

We do currently not enforce that assert reasons are of type string.

### How was it fixed?

- added type check
- added test

