### PR TITLE
Reject invalid emit

### DIFF
--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -355,10 +355,10 @@ fn emit(
     } = &stmt.kind
     {
         return match kind {
-            fe::Expr::Call { func, args } => {
-                let event_name = &expressions::expr_name_string(func)?;
+            fe::Expr::Call { func, args } if matches!(&func.kind, fe::Expr::Name(_)) => {
+                let event_name = expressions::expr_name_string(func)?;
 
-                return if let Some(event) = scope.borrow().contract_event_def(event_name) {
+                return if let Some(event) = scope.borrow().contract_event_def(&event_name) {
                     context.borrow_mut().add_emit(stmt, event.clone());
 
                     let argument_attributes = args

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -29,6 +29,7 @@ use std::fs;
     case("duplicate_var_in_contract_method.fe", "AlreadyDefined"),
     case("emit_undefined_event.fe", "MissingEventDefinition"),
     case("emit_without_call.fe", "EventInvocationExpected"),
+    case("emit_with_invalid_call.fe", "EventInvocationExpected"),
     case("external_call_type_error.fe", "TypeError"),
     case("external_call_wrong_number_of_params.fe", "WrongNumberOfParams"),
     case("indexed_event.fe", "MoreThanThreeIndexedParams"),

--- a/compiler/tests/fixtures/compile_errors/emit_with_invalid_call.fe
+++ b/compiler/tests/fixtures/compile_errors/emit_with_invalid_call.fe
@@ -1,0 +1,3 @@
+contract Foo:
+  pub def foo():
+    emit MyEvent("foo", 1000)()

--- a/newsfragments/211.bugfix.md
+++ b/newsfragments/211.bugfix.md
@@ -1,0 +1,1 @@
+Properly reject invalid emit


### PR DESCRIPTION
### What was wrong?

We currently crash on code such as `emit foo()()` which is mostly due because we don't properly reject it in the parser stage (See https://github.com/ethereum/fe/issues/337)

### How was it fixed?

Fixed it with an extra check in the analyzer pass and filed #337 because the parser is currently getting rewritten.

