### PR TITLE
Proper Revert reasons

### DIFF
--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -188,10 +188,15 @@ fn emit(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
 }
 
 fn assert(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
-    if let fe::FuncStmt::Assert { test, msg: _ } = &stmt.kind {
+    if let fe::FuncStmt::Assert { test, msg } = &stmt.kind {
         let test = expressions::expr(context, test);
-
-        return statement! { if (iszero([test])) { (revert(0, 0)) } };
+        return match msg {
+            Some(val) => {
+                let msg = expressions::expr(context, val);
+                statement! { if (iszero([test])) { (revert_with_reason_string([msg])) } }
+            }
+            None => statement! { if (iszero([test])) { (revert(0, 0)) } },
+        };
     }
 
     unreachable!()

--- a/compiler/tests/fixtures/features/assert.fe
+++ b/compiler/tests/fixtures/features/assert.fe
@@ -1,3 +1,9 @@
 contract Foo:
     pub def bar(baz: u256):
         assert baz > 5
+
+    pub def revert_with_static_string(baz: u256):
+        assert baz > 5, "Must be greater than five"
+
+    pub def revert_with(baz: u256, reason: string1000):
+        assert baz > 5, reason

--- a/compiler/tests/fixtures/solidity/revert_test.sol
+++ b/compiler/tests/fixtures/solidity/revert_test.sol
@@ -1,0 +1,13 @@
+contract Foo {
+  function revert_me() public pure returns(uint){
+    revert("Not enough Ether provided.");
+  }
+
+  function revert_with_long_string() public pure returns(uint){
+    revert("A muuuuuch longer reason string that consumes multiple words");
+  }
+
+  function revert_with_empty_string() public pure returns(uint){
+    revert("");
+  }
+}

--- a/compiler/tests/solidity.rs
+++ b/compiler/tests/solidity.rs
@@ -1,0 +1,44 @@
+//! Solidity tests that help us prove assumptions about how Solidty handles
+//! certain things
+
+#![cfg(feature = "solc-backend")]
+use rstest::rstest;
+
+mod utils;
+use utils::*;
+
+#[rstest(
+    method,
+    reason,
+    case("revert_me", "Not enough Ether provided."),
+    case(
+        "revert_with_long_string",
+        "A muuuuuch longer reason string that consumes multiple words"
+    ),
+    case("revert_with_empty_string", "")
+)]
+fn test_revert_string_reason(method: &str, reason: &str) {
+    with_executor(&|mut executor| {
+        let harness = deploy_solidity_contract(&mut executor, "revert_test.sol", "Foo", &[]);
+
+        let exit = harness.capture_call(&mut executor, method, &[]);
+
+        let expected_reason = format!("0x{}", hex::encode(encode_error_reason(reason)));
+        if let evm::Capture::Exit((evm::ExitReason::Revert(_), output)) = exit {
+            assert_eq!(format!("0x{}", hex::encode(&output)), expected_reason);
+        } else {
+            panic!("failed")
+        };
+    })
+}
+
+#[rstest(reason_str, expected_encoding,
+    case("Not enough Ether provided.", "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a4e6f7420656e6f7567682045746865722070726f76696465642e000000000000"),
+    case("A muuuuuch longer reason string that consumes multiple words", "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003c41206d75757575756368206c6f6e67657220726561736f6e20737472696e67207468617420636f6e73756d6573206d756c7469706c6520776f72647300000000"),
+    case("", "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"),
+    case("foo", "0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003666f6f0000000000000000000000000000000000000000000000000000000000"),
+)]
+fn test_revert_reason_encoding(reason_str: &str, expected_encoding: &str) {
+    let encoded = encode_error_reason(reason_str);
+    assert_eq!(format!("0x{}", hex::encode(&encoded)), expected_encoding);
+}

--- a/newsfragments/288.feature.md
+++ b/newsfragments/288.feature.md
@@ -1,0 +1,17 @@
+Support for revert messages in assert statements
+
+E.g
+
+```
+assert a == b, "my revert statement"
+```
+
+The provided string is abi-encoded as if it were a call
+to a function `Error(string)`. For example, the revert string `"Not enough Ether provided."` returns the following hexadecimal as error return data:
+
+```
+0x08c379a0                                                         // Function selector for Error(string)
+0x0000000000000000000000000000000000000000000000000000000000000020 // Data offset
+0x000000000000000000000000000000000000000000000000000000000000001a // String length
+0x4e6f7420656e6f7567682045746865722070726f76696465642e000000000000 // String data
+```

--- a/newsfragments/342.internal.md
+++ b/newsfragments/342.internal.md
@@ -1,0 +1,2 @@
+Added support for running tests against solidity fixtures.
+Also added tests that cover how solidity encodes revert reason strings.


### PR DESCRIPTION
### What was wrong?

As described in #288 we do currently not support revert reason strings in `assert` statements.

### How was it fixed?

1. Added a bit machinery to test solidity fixtures and added a new category of tests for such cases
2. Added tests to prove how solidity handles revert reason strings
3. Added a new runtime function `revert_with_reason_string` which follows the error encoding that solidity uses: https://docs.soliditylang.org/en/latest/control-structures.html#revert
3. Added tests for this new runtime method and as a byproduct refactored some helpers to allow detailed testing of reverts as well as setting up a runtime that exposes static strings
4. Hooked up the mapping of `assert` to use the new runtime method when a string reason is given
5. Added several test cases to prove the functionality of assert strings with static strings, longer strings, passed in strings

