### PR TITLE
Tuple support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,9 @@ name = "fe-common"
 version = "0.3.0-alpha"
 dependencies = [
  "codespan-reporting",
+ "difference",
  "hex",
+ "ron",
  "serde",
  "tiny-keccak 2.0.2",
 ]
@@ -694,6 +696,7 @@ dependencies = [
  "once_cell",
  "primitive-types",
  "rand",
+ "regex",
  "rstest",
  "serde",
  "serde_json",
@@ -706,12 +709,10 @@ dependencies = [
 name = "fe-parser"
 version = "0.3.0-alpha"
 dependencies = [
- "difference",
  "fe-common",
  "insta",
  "logos",
  "regex",
- "ron",
  "serde",
  "serde_json",
  "unescape",

--- a/analyzer/src/namespace/events.rs
+++ b/analyzer/src/namespace/events.rs
@@ -13,7 +13,7 @@ impl EventDef {
     pub fn new(name: &str, fields: Vec<(String, FixedSize)>, indexed_fields: Vec<usize>) -> Self {
         let abi_fields = fields
             .iter()
-            .map(|(_, typ)| typ.abi_type_name())
+            .map(|(_, typ)| typ.abi_selector_name())
             .collect::<Vec<String>>();
         let topic = build_event_topic(name, abi_fields);
 

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -1,9 +1,9 @@
 use crate::errors::SemanticError;
 use crate::namespace::events::EventDef;
-use crate::namespace::types::{FixedSize, Type};
+use crate::namespace::types::{FixedSize, Tuple, Type};
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
 pub type Shared<T> = Rc<RefCell<T>>;
@@ -25,7 +25,12 @@ pub struct ContractFieldDef {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModuleScope {
+    /// Type definitions in a module.
     pub type_defs: HashMap<String, Type>,
+    /// Tuples that were used inside of a module.
+    ///
+    /// BTreeSet is used for ordering, this way items are retrieved in the same order every time.
+    pub tuples_used: BTreeSet<Tuple>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -83,6 +88,7 @@ impl ModuleScope {
     pub fn new() -> Shared<Self> {
         Rc::new(RefCell::new(ModuleScope {
             type_defs: HashMap::new(),
+            tuples_used: BTreeSet::new(),
         }))
     }
 

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -15,7 +15,8 @@ pub fn var_decl(
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
         let name = expressions::expr_name_string(target)?;
-        let declared_type = types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), typ)?;
+        let declared_type =
+            types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), Rc::clone(&context), typ)?;
         if let Some(value) = value {
             let value_attributes =
                 expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), value)?;

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -38,6 +38,8 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
         }
     }
 
+    context.borrow_mut().set_module(scope.into());
+
     Ok(())
 }
 

--- a/analyzer/src/traversal/types.rs
+++ b/analyzer/src/traversal/types.rs
@@ -1,19 +1,48 @@
 use crate::errors::SemanticError;
-use crate::namespace::scopes::Scope;
+use crate::namespace::scopes::{Scope, Shared};
 use crate::namespace::types;
 use crate::namespace::types::{FixedSize, Type};
+use crate::Context;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Maps a type description node to an enum type.
-pub fn type_desc(scope: Scope, typ: &Node<fe::TypeDesc>) -> Result<Type, SemanticError> {
-    types::type_desc(&scope.module_scope().borrow().type_defs, &typ.kind)
+pub fn type_desc(
+    scope: Scope,
+    context: Shared<Context>,
+    desc: &Node<fe::TypeDesc>,
+) -> Result<Type, SemanticError> {
+    let typ = types::type_desc(&scope.module_scope().borrow().type_defs, &desc.kind)?;
+    context.borrow_mut().add_type_desc(desc, typ.clone());
+
+    if let Type::Tuple(tuple) = &typ {
+        scope
+            .module_scope()
+            .borrow_mut()
+            .tuples_used
+            .insert(tuple.to_owned());
+    }
+
+    Ok(typ)
 }
 
 /// Maps a type description node to a fixed size enum type.
 pub fn type_desc_fixed_size(
     scope: Scope,
-    typ: &Node<fe::TypeDesc>,
+    context: Shared<Context>,
+    desc: &Node<fe::TypeDesc>,
 ) -> Result<FixedSize, SemanticError> {
-    types::type_desc_fixed_size(&scope.module_scope().borrow().type_defs, &typ.kind)
+    let typ = types::type_desc_fixed_size(&scope.module_scope().borrow().type_defs, &desc.kind)?;
+    context
+        .borrow_mut()
+        .add_type_desc(desc, Type::from(typ.clone()));
+    if let FixedSize::Tuple(tuple) = &typ {
+        scope
+            .module_scope()
+            .borrow_mut()
+            .tuples_used
+            .insert(tuple.to_owned());
+    }
+
+    Ok(typ)
 }

--- a/analyzer/src/traversal/utils.rs
+++ b/analyzer/src/traversal/utils.rs
@@ -1,7 +1,9 @@
+use crate::errors::SemanticError;
 use crate::namespace::types::FixedSize;
 use crate::{ExpressionAttributes, Type};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
+use std::convert::TryInto;
 
 pub fn call_arg_value(arg: &fe::CallArg) -> &Node<fe::Expr> {
     match arg {
@@ -19,4 +21,8 @@ pub fn expression_attributes_to_types(attributes: Vec<ExpressionAttributes>) -> 
 
 pub fn fixed_sizes_to_types(sizes: Vec<FixedSize>) -> Vec<Type> {
     sizes.iter().map(|param| param.clone().into()).collect()
+}
+
+pub fn types_to_fixed_sizes(sizes: Vec<Type>) -> Result<Vec<FixedSize>, SemanticError> {
+    sizes.iter().map(|param| param.clone().try_into()).collect()
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,3 +11,5 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 hex = "0.4"
 codespan-reporting = "0.11.1"
 serde = { version = "1", features = ["derive"] }
+ron = "0.5.1"
+difference = "2.0"

--- a/common/src/span.rs
+++ b/common/src/span.rs
@@ -15,6 +15,10 @@ impl Span {
         Span { start, end }
     }
 
+    pub fn zero() -> Self {
+        Span { start: 0, end: 0 }
+    }
+
     pub fn from_pair<S, E>(start_elem: S, end_elem: E) -> Self
     where
         S: Into<Span>,

--- a/common/src/utils/mod.rs
+++ b/common/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod keccak;
+pub mod ron;

--- a/common/src/utils/ron.rs
+++ b/common/src/utils/ron.rs
@@ -1,0 +1,92 @@
+use difference::{Changeset, Difference};
+use serde::Serialize;
+use std::fmt;
+
+/// Return the lines of text in the string `lines` prefixed with the prefix in
+/// the string `prefix`.
+fn prefix_lines(prefix: &str, lines: &str) -> String {
+    lines
+        .lines()
+        .map(|i| [prefix, i].concat())
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
+/// Wrapper struct for formatting changesets from the `difference` package.
+pub struct Diff(Changeset);
+
+impl Diff {
+    pub fn new(left: &str, right: &str) -> Self {
+        Self(Changeset::new(left, right, "\n"))
+    }
+}
+
+impl fmt::Display for Diff {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for d in &self.0.diffs {
+            match *d {
+                Difference::Same(ref x) => {
+                    write!(f, "{}{}", prefix_lines(" ", x), self.0.split)?;
+                }
+                Difference::Add(ref x) => {
+                    write!(f, "\x1b[92m{}\x1b[0m{}", prefix_lines("+", x), self.0.split)?;
+                }
+                Difference::Rem(ref x) => {
+                    write!(f, "\x1b[91m{}\x1b[0m{}", prefix_lines("-", x), self.0.split)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Compare the given strings and panic when not equal with a colorized line
+/// diff.
+#[macro_export]
+macro_rules! assert_strings_eq {
+    ($left:expr, $right:expr,) => {{
+        assert_strings_eq!($left, $right)
+    }};
+    ($left:expr, $right:expr) => {{
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if *left_val != *right_val {
+                    panic!(
+                        "assertion failed: `(left == right)`\ndiff:\n{}",
+                        Diff::new(left_val, right_val),
+                    )
+                }
+            }
+        }
+    }};
+    ($left:expr, $right:expr, $($args:tt)*) => {{
+        match (&($left), &($right)) {
+            (left_val, right_val) => {
+                if *left_val != *right_val {
+                    panic!(
+                        "assertion failed: `(left == right)`: {}\ndiff:\n{}",
+                        format_args!($($args)*),
+                        Diff::new(left_val, right_val),
+                    )
+                }
+            }
+        }
+    }};
+}
+
+/// Convenience function to serialize objects in RON format with custom pretty
+/// printing config and struct names.
+pub fn to_ron_string_pretty<T>(value: &T) -> ron::ser::Result<String>
+where
+    T: Serialize,
+{
+    let config = ron::ser::PrettyConfig {
+        indentor: "  ".to_string(),
+        ..Default::default()
+    };
+
+    let mut serializer = ron::ser::Serializer::new(Some(config), true);
+    value.serialize(&mut serializer)?;
+
+    Ok(serializer.into_output_string())
+}

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -34,3 +34,4 @@ evm = "0.18"
 primitive-types = { version = "0.7", default-features = false, features = ["rlp"] }
 rand = "0.7.3"
 rstest = "0.6.4"
+regex="1.1.0"

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -1,4 +1,4 @@
-use crate::abi::elements::{Contract, Event, EventField, ModuleAbis};
+use crate::abi::elements::{Component, Contract, Event, EventField, ModuleAbis};
 use crate::errors::CompileError;
 use fe_analyzer::namespace::types::AbiEncoding;
 use fe_analyzer::Context;
@@ -53,8 +53,13 @@ fn contract_def(
                         .enumerate()
                         .map(|(index, (name, typ))| EventField {
                             name: name.to_owned(),
-                            typ: typ.abi_type_name(),
+                            typ: typ.abi_json_name(),
                             indexed: attributes.indexed_fields.contains(&index),
+                            components: typ
+                                .abi_components()
+                                .iter()
+                                .map(|component| Component::from(component.to_owned()))
+                                .collect(),
                         })
                         .collect(),
                     anonymous: false,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -51,7 +51,7 @@ pub fn compile(
     let lowered_fe_module = lowering::lower(&context, fe_module.clone());
 
     // analyze the lowered AST
-    let context = fe_analyzer::analyze(&lowered_fe_module)?;
+    let context = fe_analyzer::analyze(&lowered_fe_module).expect("failed to analyze lowered AST");
 
     // compile to yul
     let yul_contracts = yul::compile(&context, &lowered_fe_module);

--- a/compiler/src/lowering/mappers/contracts.rs
+++ b/compiler/src/lowering/mappers/contracts.rs
@@ -1,6 +1,7 @@
 use fe_analyzer::Context;
 
 use crate::lowering::mappers::functions;
+use crate::lowering::mappers::types;
 use fe_parser::ast as fe;
 use fe_parser::ast::ContractStmt;
 use fe_parser::node::Node;
@@ -11,16 +12,62 @@ pub fn contract_def(context: &Context, stmt: Node<fe::ModuleStmt>) -> Node<fe::M
         let lowered_body = body
             .into_iter()
             .map(|stmt| match stmt.kind {
-                ContractStmt::EventDef { .. } => stmt,
+                ContractStmt::EventDef { .. } => event_def(context, stmt),
                 ContractStmt::FuncDef { .. } => functions::func_def(context, stmt),
             })
+            .collect();
+
+        let lowered_fields = fields
+            .into_iter()
+            .map(|field| contract_field(context, field))
             .collect();
 
         return Node::new(
             fe::ModuleStmt::ContractDef {
                 name,
-                fields,
+                fields: lowered_fields,
                 body: lowered_body,
+            },
+            stmt.span,
+        );
+    }
+
+    unreachable!()
+}
+
+fn contract_field(context: &Context, field: Node<fe::Field>) -> Node<fe::Field> {
+    Node::new(
+        fe::Field {
+            pub_qual: field.kind.pub_qual,
+            const_qual: field.kind.const_qual,
+            name: field.kind.name,
+            typ: types::type_desc(context, field.kind.typ),
+            value: field.kind.value,
+        },
+        field.span,
+    )
+}
+
+fn event_def(context: &Context, stmt: Node<fe::ContractStmt>) -> Node<fe::ContractStmt> {
+    if let fe::ContractStmt::EventDef { name, fields } = stmt.kind {
+        let lowered_fields = fields
+            .into_iter()
+            .map(|field| {
+                Node::new(
+                    fe::EventField {
+                        idx_qual: field.kind.idx_qual,
+                        name: field.kind.name,
+                        typ: types::type_desc(context, field.kind.typ),
+                    },
+                    field.span,
+                )
+            })
+            .collect();
+
+        return Node::new(
+            fe::ContractStmt::EventDef {
+                name,
+                fields: lowered_fields,
             },
             stmt.span,
         );

--- a/compiler/src/lowering/mappers/mod.rs
+++ b/compiler/src/lowering/mappers/mod.rs
@@ -2,3 +2,4 @@ mod contracts;
 mod expressions;
 mod functions;
 pub mod module;
+mod types;

--- a/compiler/src/lowering/mappers/types.rs
+++ b/compiler/src/lowering/mappers/types.rs
@@ -1,0 +1,16 @@
+use crate::lowering::names;
+use fe_analyzer::namespace::types::Type;
+use fe_analyzer::Context;
+use fe_parser::ast as fe;
+use fe_parser::node::Node;
+
+pub fn type_desc(context: &Context, desc: Node<fe::TypeDesc>) -> Node<fe::TypeDesc> {
+    let typ = context.get_type_desc(&desc).expect("missing attributes");
+
+    match typ {
+        Type::Tuple(tuple) if !tuple.is_empty() => {
+            Node::new(names::tuple_struct_type_desc(tuple), desc.span)
+        }
+        _ => desc,
+    }
+}

--- a/compiler/src/lowering/names.rs
+++ b/compiler/src/lowering/names.rs
@@ -1,1 +1,56 @@
+use fe_analyzer::namespace::types::{Base, FixedSize, Integer, SafeNames, Tuple};
+use fe_parser::ast as fe;
 
+/// The name of a lowered tuple struct definition.
+pub fn tuple_struct_string(tuple: &Tuple) -> String {
+    tuple.lower_snake()
+}
+
+/// The type description of a lowered tuple struct.
+pub fn tuple_struct_type_desc(tuple: &Tuple) -> fe::TypeDesc {
+    fe::TypeDesc::Base {
+        base: tuple_struct_string(tuple),
+    }
+}
+
+/// The name of a lowered tuple struct definition as an expression.
+pub fn tuple_struct_name(tuple: &Tuple) -> fe::Expr {
+    fe::Expr::Name(tuple_struct_string(tuple))
+}
+
+/// Maps a FixedSize type to its type description.
+pub fn fixed_size_type_desc(typ: &FixedSize) -> fe::TypeDesc {
+    match typ {
+        FixedSize::Base(base) => fe::TypeDesc::Base {
+            base: base_type_name(base),
+        },
+        FixedSize::Array(_) => todo!(),
+        FixedSize::Tuple(_) => todo!(),
+        FixedSize::String(_) => todo!(),
+        FixedSize::Contract(_) => todo!(),
+        FixedSize::Struct(_) => todo!(),
+    }
+}
+
+fn base_type_name(typ: &Base) -> String {
+    match typ {
+        Base::Numeric(number) => match number {
+            Integer::U256 => "u256",
+            Integer::U128 => "u128",
+            Integer::U64 => "u64",
+            Integer::U32 => "u32",
+            Integer::U16 => "u16",
+            Integer::U8 => "u8",
+            Integer::I256 => "i256",
+            Integer::I128 => "i128",
+            Integer::I64 => "i64",
+            Integer::I32 => "i32",
+            Integer::I16 => "i16",
+            Integer::I8 => "i8",
+        },
+        Base::Bool => "bool",
+        Base::Byte => unimplemented!("byte should be removed"),
+        Base::Address => "address",
+    }
+    .to_string()
+}

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -61,14 +61,13 @@ pub fn var_name(name: &str) -> yul::Identifier {
 
 /// Generates an ABI encoding function name for a given set of types.
 pub fn encode_name<T: AbiEncoding>(types: &[T]) -> yul::Identifier {
-    let mut full_name = "abi_encode".to_string();
+    let type_names = types
+        .iter()
+        .map(|typ| typ.lower_snake())
+        .collect::<Vec<_>>();
+    let name = format!("abi_encode_{}", type_names.join("_"));
 
-    for typ in types {
-        full_name.push('_');
-        full_name.push_str(&typ.abi_safe_name());
-    }
-
-    identifier! { (full_name) }
+    identifier! { (name) }
 }
 
 /// Generates an ABI decoding function name for a given type and location.
@@ -79,7 +78,7 @@ pub fn decode_name<T: AbiEncoding>(typ: &T, location: AbiDecodeLocation) -> yul:
         AbiDecodeLocation::Calldata => "calldata",
     };
     full_name.push('_');
-    full_name.push_str(&typ.abi_safe_name());
+    full_name.push_str(&typ.lower_snake());
     full_name.push('_');
     full_name.push_str(loc);
 
@@ -127,7 +126,7 @@ mod tests {
                 })
             ])
             .to_string(),
-            "abi_encode_uint256_bytes100"
+            "abi_encode_u256_array_byte_100"
         )
     }
 
@@ -135,7 +134,7 @@ mod tests {
     fn test_decode_name_u256_calldata() {
         assert_eq!(
             decode_name(&U256, AbiDecodeLocation::Calldata).to_string(),
-            "abi_decode_uint256_calldata"
+            "abi_decode_u256_calldata"
         )
     }
 
@@ -143,7 +142,7 @@ mod tests {
     fn test_decode_name() {
         assert_eq!(
             decode_name(&FeString { max_size: 42 }, AbiDecodeLocation::Memory).to_string(),
-            "abi_decode_string42_mem"
+            "abi_decode_string_42_mem"
         )
     }
 }

--- a/compiler/src/yul/operations/abi.rs
+++ b/compiler/src/yul/operations/abi.rs
@@ -120,7 +120,7 @@ mod tests {
     fn test_encode() {
         assert_eq!(
             encode(vec![U256], vec![expression! { 42 }]).to_string(),
-            "abi_encode_uint256(42)"
+            "abi_encode_u256(42)"
         )
     }
 
@@ -141,7 +141,7 @@ mod tests {
                 AbiDecodeLocation::Calldata
             )[0]
             .to_string(),
-            "abi_decode_string26_calldata(42, 0)"
+            "abi_decode_string_26_calldata(42, 0)"
         )
     }
 

--- a/compiler/src/yul/operations/data.rs
+++ b/compiler/src/yul/operations/data.rs
@@ -138,7 +138,7 @@ mod tests {
 
         assert_eq!(
             emit_event(event, vec![expression! { 26 }, expression! { 0x00 }]).to_string(),
-            "log1(abi_encode_uint256_address(26, 0x00), add(64, 0), 0x74bffa18f2b20140b65de9264a54040b23ab0a34e7643d52f67f7fb18be9bbcb)"
+            "log1(abi_encode_u256_address(26, 0x00), add(64, 0), 0x74bffa18f2b20140b65de9264a54040b23ab0a34e7643d52f67f7fb18be9bbcb)"
         )
     }
 

--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -55,7 +55,7 @@ fn dispatch_arm(attributes: FunctionAttributes) -> yul::Case {
 fn selector(name: &str, params: &[FixedSize]) -> yul::Literal {
     let params = params
         .iter()
-        .map(|param| param.abi_type_name())
+        .map(|param| param.abi_selector_name())
         .collect::<Vec<String>>();
 
     literal! {(abi_utils::func_selector(name, params))}

--- a/compiler/src/yul/runtime/functions/abi.rs
+++ b/compiler/src/yul/runtime/functions/abi.rs
@@ -367,7 +367,7 @@ mod tests {
     fn test_encode() {
         assert_eq!(
             encode(vec![U256, Base::Address]).to_string(),
-            "function abi_encode_uint256_address(val_0, val_1) -> ptr { ptr := avail() pop(alloc_mstoren(val_0, 32)) pop(alloc_mstoren(val_1, 32)) }"
+            "function abi_encode_u256_address(val_0, val_1) -> ptr { ptr := avail() pop(alloc_mstoren(val_0, 32)) pop(alloc_mstoren(val_1, 32)) }"
         )
     }
 
@@ -375,7 +375,7 @@ mod tests {
     fn test_decode_string_mem() {
         assert_eq!(
             decode(FeString { max_size: 100 }, AbiDecodeLocation::Memory).to_string(),
-            "function abi_decode_string100_mem(start_ptr, offset) -> decoded_ptr { let head_ptr := add(start_ptr, offset) decoded_ptr := add(start_ptr, mload(head_ptr)) }"
+            "function abi_decode_string_100_mem(start_ptr, offset) -> decoded_ptr { let head_ptr := add(start_ptr, offset) decoded_ptr := add(start_ptr, mload(head_ptr)) }"
         )
     }
 
@@ -383,7 +383,7 @@ mod tests {
     fn test_decode_string_calldata() {
         assert_eq!(
             decode(FeString { max_size: 100 }, AbiDecodeLocation::Calldata).to_string(),
-            "function abi_decode_string100_calldata(start_ptr, offset) -> decoded_ptr { let head_ptr := add(start_ptr, offset) decoded_ptr := ccopym(add(start_ptr, calldataload(head_ptr)), add(mul(calldataload(add(start_ptr, calldataload(head_ptr))), 1), 32)) }"
+            "function abi_decode_string_100_calldata(start_ptr, offset) -> decoded_ptr { let head_ptr := add(start_ptr, offset) decoded_ptr := ccopym(add(start_ptr, calldataload(head_ptr)), add(mul(calldataload(add(start_ptr, calldataload(head_ptr))), 1), 32)) }"
         )
     }
 
@@ -391,7 +391,7 @@ mod tests {
     fn test_decode_u256_mem() {
         assert_eq!(
             decode(U256, AbiDecodeLocation::Memory).to_string(),
-            "function abi_decode_uint256_mem(start_ptr, offset) -> decoded_ptr { let head_ptr := add(start_ptr, offset) decoded_ptr := mload(head_ptr) }"
+            "function abi_decode_u256_mem(start_ptr, offset) -> decoded_ptr { let head_ptr := add(start_ptr, offset) decoded_ptr := mload(head_ptr) }"
         )
     }
 }

--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -23,7 +23,7 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
             let param_names = function
                 .param_types()
                 .iter()
-                .map(|typ| typ.abi_type_name())
+                .map(|typ| typ.abi_selector_name())
                 .collect::<Vec<String>>();
 
             // create a pair of identifiers and expressions for the parameters

--- a/compiler/tests/features.rs
+++ b/compiler/tests/features.rs
@@ -1238,3 +1238,16 @@ fn aug_assign(target: usize, op: &str, value: usize, expected: usize) {
         );
     });
 }
+
+#[test]
+fn base_tuple() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "base_tuple.fe", "Foo", &[]);
+        harness.test_function(
+            &mut executor,
+            "bar",
+            &[uint_token(42), bool_token(true)],
+            Some(&tuple_token(&[uint_token(42), bool_token(true)])),
+        );
+    });
+}

--- a/compiler/tests/fixtures/demos/uniswap.fe
+++ b/compiler/tests/fixtures/demos/uniswap.fe
@@ -1,16 +1,3 @@
-struct Pair:
-    token0: address
-    token1: address
-
-struct TwoNums:
-    num1: u256
-    num2: u256
-
-struct ThreeNums:
-    num1: u256
-    num2: u256
-    num3: u256
-
 contract ERC20:
     pub def balanceOf(account: address) -> u256:
         return 0
@@ -122,12 +109,8 @@ contract UniswapV2Pair:
     pub def balanceOf(account: address) -> u256:
         return self.balances[account]
 
-    pub def get_reserves() -> ThreeNums:
-        return ThreeNums(
-            num1=self.reserve0,
-            num2=self.reserve1,
-            num3=self.block_timestamp_last
-        )
+    pub def get_reserves() -> (u256, u256, u256):
+        return (self.reserve0, self.reserve1, self.block_timestamp_last)
 
     # called once by the factory at time of deployment
     pub def initialize(token0: address, token1: address):
@@ -203,8 +186,7 @@ contract UniswapV2Pair:
         return liquidity
 
     # this low-level function should be called from a contract which performs important safety checks
-    pub def burn(to: address) -> TwoNums:
-        # (reserve0: u112, reserve1: u112) = self.get_reserves() # gas savings
+    pub def burn(to: address) -> (u256, u256):
         reserve0: u256 = self.reserve0
         reserve1: u256 = self.reserve1
         token0: ERC20 = ERC20(self.token0)
@@ -230,7 +212,7 @@ contract UniswapV2Pair:
             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
 
         emit Burn(msg.sender, amount0, amount1, to)
-        return TwoNums(num1=amount0, num2=amount1)
+        return (amount0, amount1)
 
     # this low-level function should be called from a contract which performs important safety checks
     # TODO: add support for the bytes type (https://github.com/ethereum/fe/issues/280)
@@ -335,12 +317,7 @@ contract UniswapV2Factory:
         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
 
-        salt: u256 = keccak256(
-            Pair(
-                address1=token0,
-                address2=token1
-            ).abi_encode()
-        )
+        salt: u256 = keccak256((token0, token1).abi_encode())
         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
         pair.initialize(token0, token1)
 

--- a/compiler/tests/fixtures/features/base_tuple.fe
+++ b/compiler/tests/fixtures/features/base_tuple.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(my_num: u256, my_bool: bool) -> (u256, bool):
+        return (my_num, my_bool)

--- a/compiler/tests/fixtures/stress/tuple_stress.fe
+++ b/compiler/tests/fixtures/stress/tuple_stress.fe
@@ -1,0 +1,43 @@
+contract Foo:
+    my_sto_tuple: (u256, i32)
+
+    event MyEvent:
+        my_tuple: (u256, bool, address)
+
+    pub def build_my_tuple(
+        my_num: u256,
+        my_bool: bool,
+        my_address: address
+    ) -> (u256, bool, address):
+        return (my_num, my_bool, my_address)
+
+    pub def read_my_tuple_item0(my_tuple: (u256, bool, address)) -> u256:
+        return my_tuple.item0
+
+    pub def read_my_tuple_item1(my_tuple: (u256, bool, address)) -> bool:
+        return my_tuple.item1
+
+    pub def read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address:
+        return my_tuple.item2
+
+    pub def emit_my_event(my_tuple: (u256, bool, address)):
+        emit MyEvent(my_tuple)
+
+    pub def set_my_sto_tuple(my_u256: u256, my_i32: i32):
+        assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+        self.my_sto_tuple = (my_u256, my_i32)
+
+    pub def get_my_sto_tuple() -> (u256, i32):
+        return self.my_sto_tuple.to_mem()
+
+    pub def build_tuple_and_emit():
+        my_num: u256 = self.my_sto_tuple.item0
+        my_tuple: (u256, bool, address) = (
+            self.my_sto_tuple.item0,
+            true and false,
+            address(26)
+        )
+        self.emit_my_event(my_tuple)
+
+    pub def encode_my_tuple(my_tuple: (u256, bool, address)) -> bytes[96]:
+        return my_tuple.abi_encode()

--- a/compiler/tests/lowering/fixtures/aug_assign.fe
+++ b/compiler/tests/lowering/fixtures/aug_assign.fe
@@ -1,0 +1,57 @@
+contract Foo:
+    my_num: u256
+
+    pub def add(a: u256, b: u256) -> u256:
+        a += b
+        return a
+
+    pub def sub(a: u256, b: u256) -> u256:
+        a -= b
+        return a
+
+    pub def mul(a: u256, b: u256) -> u256:
+        a *= b
+        return a
+
+    pub def div(a: u256, b: u256) -> u256:
+        a /= b
+        return a
+
+    pub def mod(a: u256, b: u256) -> u256:
+        a %= b
+        return a
+
+    pub def pow(a: u256, b: u256) -> u256:
+        a **= b
+        return a
+
+    pub def lshift(a: u8, b: u8) -> u8:
+        a <<= b
+        return a
+
+    pub def rshift(a: u8, b: u8) -> u8:
+        a >>= b
+        return a
+
+    pub def bit_or(a: u8, b: u8) -> u8:
+        a |= b
+        return a
+
+    pub def bit_xor(a: u8, b: u8) -> u8:
+        a ^= b
+        return a
+
+    pub def bit_and(a: u8, b: u8) -> u8:
+        a &= b
+        return a
+
+    pub def add_from_sto(a: u256, b: u256) -> u256:
+        self.my_num = a
+        self.my_num += b
+        return self.my_num
+
+    pub def add_from_mem(a: u256, b: u256) -> u256:
+        my_array: u256[10]
+        my_array[7] = a
+        my_array[7] += b
+        return my_array[7]

--- a/compiler/tests/lowering/fixtures/aug_assign_lowered.fe
+++ b/compiler/tests/lowering/fixtures/aug_assign_lowered.fe
@@ -1,0 +1,57 @@
+contract Foo:
+    my_num: u256
+
+    pub def add(a: u256, b: u256) -> u256:
+        a = a + b
+        return a
+
+    pub def sub(a: u256, b: u256) -> u256:
+        a = a - b
+        return a
+
+    pub def mul(a: u256, b: u256) -> u256:
+        a = a * b
+        return a
+
+    pub def div(a: u256, b: u256) -> u256:
+        a = a / b
+        return a
+
+    pub def mod(a: u256, b: u256) -> u256:
+        a = a % b
+        return a
+
+    pub def pow(a: u256, b: u256) -> u256:
+        a = a ** b
+        return a
+
+    pub def lshift(a: u8, b: u8) -> u8:
+        a = a << b
+        return a
+
+    pub def rshift(a: u8, b: u8) -> u8:
+        a = a >> b
+        return a
+
+    pub def bit_or(a: u8, b: u8) -> u8:
+        a = a | b
+        return a
+
+    pub def bit_xor(a: u8, b: u8) -> u8:
+        a = a ^ b
+        return a
+
+    pub def bit_and(a: u8, b: u8) -> u8:
+        a = a & b
+        return a
+
+    pub def add_from_sto(a: u256, b: u256) -> u256:
+        self.my_num = a
+        self.my_num = self.my_num + b
+        return self.my_num
+
+    pub def add_from_mem(a: u256, b: u256) -> u256:
+        my_array: u256[10]
+        my_array[7] = a
+        my_array[7] = my_array[7] + b
+        return my_array[7]

--- a/compiler/tests/lowering/fixtures/base_tuple.fe
+++ b/compiler/tests/lowering/fixtures/base_tuple.fe
@@ -1,0 +1,28 @@
+contract Foo:
+    my_tuple_field: (bool, address)
+
+    event MyEvent:
+        my_tuple: (bool, bool)
+        my_other_tuple: (address, address)
+
+    pub def bar(my_num: u256, my_bool: bool) -> (u256, bool):
+        return (my_num, my_bool)
+
+    pub def baz() -> (u256, bool, u8, address):
+        return (999999, false, u8(42), address(26))
+
+    pub def bing():
+        foo: (address, address, u16, i32, bool) = (address(0), address(0), u16(0), i32(0), false)
+
+    pub def bop(
+        my_tuple1: (u256, bool),
+        my_tuple2: (u256, bool, u8, address),
+        my_tuple3: (address, address, u16, i32, bool)
+    ):
+        pass
+
+    pub def food():
+        emit MyEvent(
+            (false, true),
+            (address(0), address(1))
+        )

--- a/compiler/tests/lowering/fixtures/base_tuple_lowered.fe
+++ b/compiler/tests/lowering/fixtures/base_tuple_lowered.fe
@@ -1,0 +1,68 @@
+struct tuple_u256_bool:
+    item0: u256
+    item1: bool
+
+struct tuple_u256_bool_u8_address:
+    item0: u256
+    item1: bool
+    item2: u8
+    item3: address
+
+struct tuple_bool_bool:
+    item0: bool
+    item1: bool
+
+struct tuple_bool_address:
+    item0: bool
+    item1: address
+
+struct tuple_address_address:
+    item0: address
+    item1: address
+
+struct tuple_address_address_u16_i32_bool:
+    item0: address
+    item1: address
+    item2: u16
+    item3: i32
+    item4: bool
+
+contract Foo:
+    my_tuple_field: tuple_bool_address
+
+    event MyEvent:
+        my_tuple: tuple_bool_bool
+        my_other_tuple: tuple_address_address
+
+    pub def bar(my_num: u256, my_bool: bool) -> tuple_u256_bool:
+        return tuple_u256_bool(item0=my_num, item1=my_bool)
+
+    pub def baz() -> tuple_u256_bool_u8_address:
+        return tuple_u256_bool_u8_address(
+            item0=999999,
+            item1=false,
+            item2=u8(42),
+            item3=address(26)
+        )
+
+    pub def bing():
+        foo: tuple_address_address_u16_i32_bool = tuple_address_address_u16_i32_bool(
+            item0=address(0),
+            item1=address(0),
+            item2=u16(0),
+            item3=i32(0),
+            item4=false
+        )
+
+    pub def bop(
+        my_tuple1: tuple_u256_bool,
+        my_tuple2: tuple_u256_bool_u8_address,
+        my_tuple3: tuple_address_address_u16_i32_bool
+    ):
+        pass
+
+    pub def food():
+        emit MyEvent(
+            tuple_bool_bool(item0=false, item1=true),
+            tuple_address_address(item0=address(0), item1=address(1))
+        )

--- a/compiler/tests/lowering/main.rs
+++ b/compiler/tests/lowering/main.rs
@@ -1,0 +1,44 @@
+use fe_compiler::lowering;
+use fe_parser::ast as fe;
+use regex::Regex;
+use std::fs;
+
+use fe_common::files::SourceFileId;
+use rstest::rstest;
+
+use fe_common::assert_strings_eq;
+use fe_common::utils::ron::{to_ron_string_pretty, Diff};
+
+fn lower_file(src: &str) -> fe::Module {
+    let fe_module = parse_file(src);
+    let context = fe_analyzer::analyze(&fe_module).expect("failed to get context");
+    lowering::lower(&context, fe_module.clone())
+}
+
+fn parse_file(src: &str) -> fe::Module {
+    fe_parser::parse_file(src, SourceFileId(0))
+        .expect("failed to parse file")
+        .0
+}
+
+fn replace_spans(input: String) -> String {
+    let span_re = Regex::new(r"span: Span\(\n\s*start: \d+,\n\s*end: \d+.\n\s*\),").unwrap();
+    span_re.replace_all(&input, "[span omitted]").to_string()
+}
+
+#[rstest(fixture, case("aug_assign"), case("base_tuple"))]
+fn test_lowering(fixture: &str) {
+    let src = fs::read_to_string(format!("tests/lowering/fixtures/{}.fe", fixture))
+        .expect("unable to src read fixture file");
+    let expected_lowered =
+        fs::read_to_string(format!("tests/lowering/fixtures/{}_lowered.fe", fixture))
+            .expect("unable to read lowered fixture file");
+
+    let expected_lowered_ast = parse_file(&expected_lowered);
+    let actual_lowered_ast = lower_file(&src);
+
+    assert_strings_eq!(
+        replace_spans(to_ron_string_pretty(&expected_lowered_ast).unwrap()),
+        replace_spans(to_ron_string_pretty(&actual_lowered_ast).unwrap()),
+    )
+}

--- a/compiler/tests/utils.rs
+++ b/compiler/tests/utils.rs
@@ -67,7 +67,7 @@ impl ContractHarness {
 
         let input = function
             .encode_input(input)
-            .expect("Unable to encode input");
+            .expect(&format!("Unable to encode input for {}", name));
 
         executor.call(self.address, None, input, None, false, context)
     }
@@ -95,7 +95,10 @@ impl ContractHarness {
             evm::Capture::Exit((ExitReason::Succeed(_), output)) => {
                 let output = function
                     .decode_output(&output)
-                    .expect(&format!("unable to decode output: {:?}", &output))
+                    .expect(&format!(
+                        "unable to decode output of {}: {:?}",
+                        name, &output
+                    ))
                     .pop();
                 return output;
             }

--- a/newsfragments/352.feature.md
+++ b/newsfragments/352.feature.md
@@ -1,0 +1,13 @@
+Added support for tuples with base type items.
+
+e.g.
+
+```
+contract Foo:
+    my_num: u256
+
+    pub def bar(my_num: u256, my_bool: bool) -> (u256, bool):
+        my_tuple: (u256, bool) = (my_num, my_bool)
+        self.my_num = my_tuple.item0
+        return my_tuple
+```

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -23,8 +23,6 @@ wasm-bindgen = "0.2"
 serde_json = "1"
 
 [dev-dependencies]
-difference = "2.0"
 insta = "1.7.1"
-ron = "0.5.1"
 serde_json = "1"
 wasm-bindgen-test = "0.3"

--- a/parser/src/grammar/module.rs
+++ b/parser/src/grammar/module.rs
@@ -22,7 +22,7 @@ pub fn parse_module(par: &mut Parser) -> ParseResult<Node<Module>> {
         }
     }
     let span = if body.is_empty() {
-        Span::new(0, 0)
+        Span::zero()
     } else {
         body.first().unwrap().span + body.last()
     };

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -47,10 +47,10 @@ impl<'a> Parser<'a> {
             buffered: vec![],
             paren_stack: vec![],
             indent_stack: vec![BlockIndent {
-                context_span: Span::new(0, 0),
+                context_span: Span::zero(),
                 context_name: "module".into(),
                 indent: "",
-                indent_span: Span::new(0, 0),
+                indent_span: Span::zero(),
             }],
             indent_style: None,
             diagnostics: vec![],

--- a/parser/tests/test_parser.rs
+++ b/parser/tests/test_parser.rs
@@ -1,11 +1,12 @@
 use fe_common::{diagnostics::print_diagnostics, files::FileStore};
 
+use fe_common::assert_strings_eq;
+use fe_common::utils::ron::{to_ron_string_pretty, Diff};
 use fe_parser::ast;
 use fe_parser::grammar::{contracts, expressions, functions, module, types};
 use fe_parser::{ParseResult, Parser, TokenKind};
 use serde::Serialize;
 
-#[macro_use]
 mod utils;
 
 #[derive(PartialEq)]
@@ -41,10 +42,10 @@ where
                 parser.next().unwrap();
             }
         }
-        utils::to_ron_string_pretty(&results).unwrap()
+        to_ron_string_pretty(&results).unwrap()
     } else {
         if let Ok(res) = parse_fn(&mut parser) {
-            utils::to_ron_string_pretty(&res).unwrap()
+            to_ron_string_pretty(&res).unwrap()
         } else {
             parser_err = true;
             String::new()

--- a/parser/tests/utils/mod.rs
+++ b/parser/tests/utils/mod.rs
@@ -1,96 +1,4 @@
-use difference::{Changeset, Difference};
-use serde::Serialize;
-use std::fmt;
 use std::path::PathBuf;
-
-/// Return the lines of text in the string `lines` prefixed with the prefix in
-/// the string `prefix`.
-fn prefix_lines(prefix: &str, lines: &str) -> String {
-    lines
-        .lines()
-        .map(|i| [prefix, i].concat())
-        .collect::<Vec<String>>()
-        .join("\n")
-}
-
-/// Wrapper struct for formatting changesets from the `difference` package.
-pub struct Diff(Changeset);
-
-impl Diff {
-    pub fn new(left: &str, right: &str) -> Self {
-        Self(Changeset::new(left, right, "\n"))
-    }
-}
-
-impl fmt::Display for Diff {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for d in &self.0.diffs {
-            match *d {
-                Difference::Same(ref x) => {
-                    write!(f, "{}{}", prefix_lines(" ", x), self.0.split)?;
-                }
-                Difference::Add(ref x) => {
-                    write!(f, "\x1b[92m{}\x1b[0m{}", prefix_lines("+", x), self.0.split)?;
-                }
-                Difference::Rem(ref x) => {
-                    write!(f, "\x1b[91m{}\x1b[0m{}", prefix_lines("-", x), self.0.split)?;
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-/// Compare the given strings and panic when not equal with a colorized line
-/// diff.
-#[allow(unused_macros)]
-macro_rules! assert_strings_eq {
-    ($left:expr, $right:expr,) => {{
-        assert_strings_eq!($left, $right)
-    }};
-    ($left:expr, $right:expr) => {{
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if *left_val != *right_val {
-                    panic!(
-                        "assertion failed: `(left == right)`\ndiff:\n{}",
-                        utils::Diff::new(left_val, right_val),
-                    )
-                }
-            }
-        }
-    }};
-    ($left:expr, $right:expr, $($args:tt)*) => {{
-        match (&($left), &($right)) {
-            (left_val, right_val) => {
-                if *left_val != *right_val {
-                    panic!(
-                        "assertion failed: `(left == right)`: {}\ndiff:\n{}",
-                        format_args!($($args)*),
-                        utils::Diff::new(left_val, right_val),
-                    )
-                }
-            }
-        }
-    }};
-}
-
-/// Convenience function to serialize objects in RON format with custom pretty
-/// printing config and struct names.
-#[allow(dead_code)]
-pub fn to_ron_string_pretty<T>(value: &T) -> ron::ser::Result<String>
-where
-    T: Serialize,
-{
-    let mut config = ron::ser::PrettyConfig::default();
-    // Indent with 2 spaces
-    config.indentor = "  ".to_string();
-
-    let mut serializer = ron::ser::Serializer::new(Some(config), true);
-    value.serialize(&mut serializer)?;
-
-    Ok(serializer.into_output_string())
-}
 
 #[allow(dead_code)]
 pub fn get_fixture_content(fixture_name: &str) -> (String, PathBuf) {
@@ -111,7 +19,7 @@ pub fn get_fixture_content(fixture_name: &str) -> (String, PathBuf) {
 /// Parse file content containing a test example into a tuple of input text and
 /// expected serialization.  Input text and expected serialization are separated
 /// by a line that only contains the string "---".
-pub fn parse_fixture<'a>(input: &'a str) -> Result<(&'a str, &'a str), String> {
+pub fn parse_fixture(input: &str) -> Result<(&str, &str), String> {
     let parts: Vec<_> = input.split("\n---\n").collect();
 
     if parts.len() != 2 {


### PR DESCRIPTION
To support tuples, we need the following lowerings:

**1.)** New struct definitions need to be added for each tuple that is used in the module.

For example, if `(u256, bool)` is used somewhere in a module, we must add the following struct definition to the module:

```
struct TUPLE_U256_BOOL:
  item0: u256
  item1: bool
```

**2.)** Tuple type descriptions need to be mapped to struct type descriptions.

`my_tuple: (u256, bool)` -> `my_tuple: TUPLE_U256_BOOL`

**3.)** Tuple constructions need to be mapped to struct constructions

`(42, true)` -> `TUPLE_U256_BOOL(item0=42, item1=true)`

**bonus:** Tuple deconstruction can be mapped to multiple assignments.

```
(foo, bar): (u256, bool) = my_tuple
```

->

```
foo: u256 = my_tuple.item0
bar: bool = my_tuple.item1
```

### Included in this PR:

- Lowerings 1, 2, and 3 mentioned above
- Testing for lowered source files (added some coverage for aug assigns too)
- Refactoring around "safe names". Basically, I'm trying to figure out how we should go about creating unique identifiers for generated code. In this PR, we're using the names provided by the `SafeNames` trait to to generate identifiers for the tuple structs. These names may conflict with user defined types, which is something that needs to be addressed.

One thing to note is that empty tuples are not lowered, since we don't have zero-sized structs. It's not a big deal, but it would be nice to have all tuple branches marked as `unimplemented` in the Yul codegen pass.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Write an issue for tuple destructuring.
- [ ] Write an issue for name collisions as mentioned in the 3rd bullet.
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
