### PR TITLE
Update g++ in CI system dependencies

### DIFF
--- a/.github/install_deps.sh
+++ b/.github/install_deps.sh
@@ -1,3 +1,3 @@
 sudo apt-get install -y libboost-all-dev
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
-sudo update-alternatives --set g++ "/usr/bin/g++-8"
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 50
+sudo update-alternatives --set g++ "/usr/bin/g++-10"

--- a/.github/install_deps.sh
+++ b/.github/install_deps.sh
@@ -1,0 +1,3 @@
+sudo apt-get install -y libboost-all-dev
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
+sudo update-alternatives --set g++ "/usr/bin/g++-8"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-03-15
         override: true
     - name: coverage with tarpaulin
       run: |
@@ -62,7 +62,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-03-15
         override: true
         components: rustfmt, clippy
     - name: Validate release notes entry
@@ -108,7 +108,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: nightly-2021-03-15
         override: true
     - name: Build
       run: cargo build --all-features --verbose
@@ -124,7 +124,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-03-15
           override: true
       - name: Run WASM tests
         run: wasm-pack test --node -- --workspace
@@ -157,7 +157,7 @@ jobs:
           uses: actions-rs/toolchain@v1
           with:
             profile: minimal
-            toolchain: nightly
+            toolchain: nightly-2021-03-15
             override: true
         - name: Build
           run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,7 @@ jobs:
     steps:
     - name: Install system dependencies
       run: |
-        sudo apt-get install -y libboost-all-dev
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
-        sudo update-alternatives --set g++ "/usr/bin/g++-8"
+        "${GITHUB_WORKSPACE}/.github/install_deps.sh"
     - uses: actions/checkout@v2
     - name: Cache Rust dependencies
       uses: actions/cache@v1.1.2
@@ -50,9 +48,7 @@ jobs:
     steps:
     - name: Install system dependencies
       run: |
-        sudo apt-get install -y libboost-all-dev
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
-        sudo update-alternatives --set g++ "/usr/bin/g++-8"
+        "${GITHUB_WORKSPACE}/.github/install_deps.sh"
     - uses: actions/checkout@v2
     - name: Cache Rust dependencies
       uses: actions/cache@v1.1.2
@@ -109,9 +105,7 @@ jobs:
     - name: Install Linux dependencies
       if: startsWith(matrix.os,'ubuntu')
       run: |
-        sudo apt-get install -y libboost-all-dev
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
-        sudo update-alternatives --set g++ "/usr/bin/g++-8"
+        "${GITHUB_WORKSPACE}/.github/install_deps.sh"
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
@@ -156,9 +150,7 @@ jobs:
         - name: Install Linux dependencies
           if: startsWith(matrix.os,'ubuntu')
           run: |
-            sudo apt-get install -y libboost-all-dev
-            sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 50
-            sudo update-alternatives --set g++ "/usr/bin/g++-8"
+            "${GITHUB_WORKSPACE}/.github/install_deps.sh"
         - name: Install Mac System dependencies
           if: startsWith(matrix.os,'macOS')
           run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,6 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
-    - name: Build
-      run: cargo build --all-features --verbose
     - name: Lint with clippy
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v2
     - name: Install system dependencies
       run: |
         "${GITHUB_WORKSPACE}/.github/install_deps.sh"
-    - uses: actions/checkout@v2
     - name: Cache Rust dependencies
       uses: actions/cache@v1.1.2
       with:
@@ -46,10 +46,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - name: Install system dependencies
       run: |
         "${GITHUB_WORKSPACE}/.github/install_deps.sh"
-    - uses: actions/checkout@v2
     - name: Cache Rust dependencies
       uses: actions/cache@v1.1.2
       with:


### PR DESCRIPTION
### What was wrong?

CI is borked

### How was it fixed?

1. A bit of cleanup, moving the repeated installation steps into a single script
2. `g++-8` appears to not be available in `ubuntu-latest` but that's ok, changed to `g++-10` instead
3. Temporary fixing rust nightly to a nightly from mid-march as it appears the current nightly errors which might be temporary or means we will need to cut a new `solc-rust` and/or `yultsur` release with updated dependencies
4. Created an issue to unpin the nightly in the future when the issues are resolved: https://github.com/ethereum/fe/issues/357
5. Sneaked in a minor CI perf improvement by removing an unnecessary build step from the linting job
