### PR TITLE
Replace gitter with discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ The most advanced example that we can provide at this point is a fully working [
 ## Community
 
 - Twitter: [@official_fe](https://twitter.com/official_fe)
-- Chat: [gitter/ethereum/fe](http://gitter.im/ethereum/fe)
+- Chat: [Discord](https://discord.gg/ywpkAXFjZH)


### PR DESCRIPTION
### What was wrong?

Need to replace gitter link with discord

### How was it fixed?

Replaced it

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
