### PR TITLE
Properly reject circular dependency when using create/create2

### DIFF
--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -9,6 +9,7 @@ pub enum ErrorKind {
     AlreadyDefined,
     BreakWithoutLoop,
     CannotMove,
+    CircularDependency,
     ContinueWithoutLoop,
     EventInvocationExpected,
     KeyWordArgsRequired,
@@ -40,6 +41,14 @@ impl SemanticError {
     pub fn break_without_loop() -> Self {
         SemanticError {
             kind: ErrorKind::BreakWithoutLoop,
+            context: vec![],
+        }
+    }
+
+    /// Create a new error with kind `CircularDependency`
+    pub fn circular_dependency() -> Self {
+        SemanticError {
+            kind: ErrorKind::CircularDependency,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -6,25 +6,25 @@ use fe_parser::node::Span;
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum ErrorKind {
+    AlreadyDefined,
     BreakWithoutLoop,
+    CannotMove,
     ContinueWithoutLoop,
     EventInvocationExpected,
     KeyWordArgsRequired,
     MissingEventDefinition,
     MissingReturn,
+    MoreThanThreeIndexedParams,
+    NotCallable,
     NotSubscriptable,
     NumericCapacityMismatch,
+    NumericLiteralExpected,
     SignedExponentNotAllowed,
     StringCapacityMismatch,
+    TypeError,
     UndefinedValue,
     UnexpectedReturn,
-    TypeError,
-    CannotMove,
-    NotCallable,
-    NumericLiteralExpected,
-    MoreThanThreeIndexedParams,
     WrongNumberOfParams,
-    AlreadyDefined,
 }
 
 #[derive(Debug, PartialEq)]

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -16,6 +16,8 @@ use std::fs;
     case("call_undefined_function_on_external_contract.fe", "UndefinedValue"),
     case("call_undefined_function_on_memory_struct.fe", "UndefinedValue"),
     case("call_undefined_function_on_storage_struct.fe", "UndefinedValue"),
+    case("circular_dependency_create.fe", "CircularDependency"),
+    case("circular_dependency_create2.fe", "CircularDependency"),
     case("continue_without_loop_2.fe", "ContinueWithoutLoop"),
     case("continue_without_loop.fe", "ContinueWithoutLoop"),
     case("duplicate_contract_in_module.fe", "AlreadyDefined"),

--- a/compiler/tests/fixtures/compile_errors/circular_dependency_create.fe
+++ b/compiler/tests/fixtures/compile_errors/circular_dependency_create.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    pub def bar() -> address:
+        foo: Foo = Foo.create(0)
+
+        return address(foo)

--- a/compiler/tests/fixtures/compile_errors/circular_dependency_create2.fe
+++ b/compiler/tests/fixtures/compile_errors/circular_dependency_create2.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    pub def bar() -> address:
+        foo: Foo = Foo.create2(2, 0)
+
+        return address(foo)

--- a/newsfragments/362.bugfix.md
+++ b/newsfragments/362.bugfix.md
@@ -1,0 +1,12 @@
+Properly reject code that creates a circular dependency when using `create` or `create2`.
+
+Example, the follwing code is now rightfully rejected because it tries to create an
+instance of `Foo` from within the `Foo` contract itself.
+
+```
+contract Foo:
+  pub def bar()->address:
+    foo:Foo=Foo.create(0)
+
+    return address(foo)
+```


### PR DESCRIPTION
### What was wrong?

As found by the fuzzer in #362, circular dependencies when using `create` or `create2` were not correctly rejected yet.

### How was it fixed?

In the analyzer we check if the name of the contract to create is the same as the contract of the inherited scope. If so, we reject it with a newly added `CircularDependency` kind.
