### PR TITLE
Stable rust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,11 +31,11 @@ jobs:
           target
           !target/**/*serde*
         key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install latest nightly
+    - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2021-03-15
+        toolchain: stable
         override: true
     - name: coverage with tarpaulin
       run: |
@@ -58,11 +58,11 @@ jobs:
           target
           !target/**/*serde*
         key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install latest nightly
+    - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2021-03-15
+        toolchain: stable
         override: true
         components: rustfmt, clippy
     - name: Validate release notes entry
@@ -76,7 +76,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
+        args: --all-targets --all-features -- -D warnings
 
   test:
     # Build & Test runs on all platforms
@@ -104,11 +104,11 @@ jobs:
       if: startsWith(matrix.os,'ubuntu')
       run: |
         "${GITHUB_WORKSPACE}/.github/install_deps.sh"
-    - name: Install latest nightly
+    - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2021-03-15
+        toolchain: stable
         override: true
     - name: Build
       run: cargo build --all-features --verbose
@@ -120,11 +120,11 @@ jobs:
       container: davesque/rust-wasm
       steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
+      - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-03-15
+          toolchain: stable
           override: true
       - name: Run WASM tests
         run: wasm-pack test --node -- --workspace
@@ -153,11 +153,11 @@ jobs:
           if: startsWith(matrix.os,'macOS')
           run: |
             brew install boost
-        - name: Install latest nightly
+        - name: Install rust
           uses: actions-rs/toolchain@v1
           with:
             profile: minimal
-            toolchain: nightly-2021-03-15
+            toolchain: stable
             override: true
         - name: Build
           run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "fe-common",
  "fe-parser",
  "hex",
+ "lexical-core",
  "num-bigint",
  "rstest",
  "strum",
@@ -970,6 +971,19 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ lint: rustfmt clippy
 build-docs:
 	cargo doc --no-deps --workspace
 
+README.md: src/main.rs
+	cargo readme --no-title --no-indent-headings > README.md
+
 notes:
 	towncrier --yes --version $(version)
 	git commit -m "Compile release notes"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <img src="https://raw.githubusercontent.com/ethereum/fe/master/logo/fe_svg/fe_source.svg" width="150px">
- 
+
 Fe is an emerging smart contract language for the Ethereum blockchain.
 
 [![Build Status](https://github.com/ethereum/fe/workflows/CI/badge.svg)](https://github.com/ethereum/fe/actions)
@@ -56,7 +56,7 @@ Run `fe --help` to explore further options.
 
 The following is a simple contract implemented in Fe.
 
-```
+```fe
 type BookMsg = bytes[100]
 
 contract GuestBook:
@@ -82,3 +82,6 @@ The most advanced example that we can provide at this point is a fully working [
 
 - Twitter: [@official_fe](https://twitter.com/official_fe)
 - Chat: [Discord](https://discord.gg/ywpkAXFjZH)
+
+
+License: Apache-2.0

--- a/analyzer/Cargo.toml
+++ b/analyzer/Cargo.toml
@@ -15,3 +15,4 @@ hex = "0.4"
 ansi_term = "0.12.1"
 num-bigint = "0.3.1"
 strum = { version = "0.20.0", features = ["derive"] }
+lexical-core = "0.7.6"

--- a/analyzer/src/builtins.rs
+++ b/analyzer/src/builtins.rs
@@ -1,7 +1,4 @@
-use strum::{
-    EnumString,
-    IntoStaticStr,
-};
+use strum::{EnumString, IntoStaticStr};
 
 #[derive(Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "snake_case")]

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -12,25 +12,13 @@ mod traversal;
 
 use crate::errors::SemanticError;
 use crate::namespace::events::EventDef;
-use crate::namespace::scopes::{
-    ContractFunctionDef,
-    ContractScope,
-    Shared,
-};
-use crate::namespace::types::{
-    Contract,
-    FixedSize,
-    Struct,
-    Type,
-};
+use crate::namespace::scopes::{ContractFunctionDef, ContractScope, Shared};
+use crate::namespace::types::{Contract, FixedSize, Struct, Type};
 use builtins::GlobalMethod;
 use fe_parser::ast as fe;
 use fe_parser::node::NodeId;
 use std::cell::RefCell;
-use std::collections::{
-    HashMap,
-    HashSet,
-};
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 /// Indicates where an expression is stored.
@@ -402,15 +390,9 @@ pub fn analyze(module: &fe::Module) -> Result<Context, SemanticError> {
 #[cfg(feature = "fix-context-harness")]
 pub mod test_utils {
     use crate::namespace::types::FixedSize;
-    use crate::{
-        Context,
-        ExpressionAttributes,
-    };
+    use crate::{Context, ExpressionAttributes};
     use fe_parser::ast as fe;
-    use fe_parser::node::{
-        Node,
-        Span,
-    };
+    use fe_parser::node::{Node, Span};
 
     pub struct ContextHarness {
         pub context: Context,

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -3,7 +3,6 @@
 //! This library is used to analyze the semantics of a given Fe AST. It detects
 //! any semantic errors within a given AST and produces a `Context` instance
 //! that can be used to query contextual information attributed to AST nodes.
-#![feature(int_error_matching)]
 
 pub mod builtins;
 pub mod errors;

--- a/analyzer/src/namespace/events.rs
+++ b/analyzer/src/namespace/events.rs
@@ -1,7 +1,4 @@
-use crate::namespace::types::{
-    AbiEncoding,
-    FixedSize,
-};
+use crate::namespace::types::{AbiEncoding, FixedSize};
 use fe_common::utils::keccak;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -74,10 +71,7 @@ fn build_event_topic(name: &str, fields: Vec<String>) -> String {
 #[cfg(test)]
 mod tests {
     use crate::namespace::events::EventDef;
-    use crate::namespace::types::{
-        Base,
-        FixedSize,
-    };
+    use crate::namespace::types::{Base, FixedSize};
 
     #[test]
     fn test_new_event() {

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -1,15 +1,9 @@
 use crate::errors::SemanticError;
 use crate::namespace::events::EventDef;
-use crate::namespace::types::{
-    FixedSize,
-    Type,
-};
+use crate::namespace::types::{FixedSize, Type};
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::collections::{
-    HashMap,
-    HashSet,
-};
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 pub type Shared<T> = Rc<RefCell<T>>;
@@ -344,12 +338,7 @@ impl BlockScope {
 
 #[cfg(test)]
 mod tests {
-    use crate::namespace::scopes::{
-        BlockScope,
-        BlockScopeType,
-        ContractScope,
-        ModuleScope,
-    };
+    use crate::namespace::scopes::{BlockScope, BlockScopeType, ContractScope, ModuleScope};
     use crate::namespace::types::FixedSize;
     use std::rc::Rc;
 

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -1,10 +1,6 @@
 use crate::errors::SemanticError;
 use fe_parser::ast as fe;
-use std::collections::{
-    btree_map::Entry,
-    BTreeMap,
-    HashMap,
-};
+use std::collections::{btree_map::Entry, BTreeMap, HashMap};
 use std::convert::TryFrom;
 
 use crate::FunctionAttributes;
@@ -286,11 +282,7 @@ impl Integer {
 
     /// Returns `true` if `num` represents a number that fits the type
     pub fn fits(&self, num: &str) -> bool {
-        use lexical_core::{
-            parse,
-            ErrorCode,
-            FromLexical,
-        };
+        use lexical_core::{parse, ErrorCode, FromLexical};
         fn check_fit<T: FromLexical>(num: &str) -> bool {
             if let Err(err) = parse::<T>(num.as_bytes()) {
                 match err.code {

--- a/analyzer/src/operations.rs
+++ b/analyzer/src/operations.rs
@@ -1,11 +1,5 @@
 use crate::errors::SemanticError;
-use crate::namespace::types::{
-    Array,
-    Base,
-    Map,
-    Type,
-    U256,
-};
+use crate::namespace::types::{Array, Base, Map, Type, U256};
 
 use fe_parser::ast as fe;
 
@@ -127,13 +121,7 @@ fn bin_bit(left: &Type, right: &Type) -> Result<Type, SemanticError> {
 #[cfg(test)]
 mod tests {
     use crate::errors::ErrorKind;
-    use crate::namespace::types::{
-        Array,
-        Base,
-        Map,
-        Type,
-        U256,
-    };
+    use crate::namespace::types::{Array, Base, Map, Type, U256};
     use crate::operations;
     use rstest::rstest;
 

--- a/analyzer/src/traversal/assignments.rs
+++ b/analyzer/src/traversal/assignments.rs
@@ -1,8 +1,5 @@
 use crate::errors::SemanticError;
-use crate::namespace::scopes::{
-    BlockScope,
-    Shared,
-};
+use crate::namespace::scopes::{BlockScope, Shared};
 use crate::operations;
 use crate::traversal::expressions;
 use crate::Context;
@@ -70,29 +67,12 @@ pub fn aug_assign(
 
 #[cfg(test)]
 mod tests {
-    use crate::errors::{
-        ErrorKind,
-        SemanticError,
-    };
-    use crate::namespace::scopes::{
-        BlockScope,
-        ContractScope,
-        ModuleScope,
-        Shared,
-    };
-    use crate::namespace::types::{
-        Array,
-        FixedSize,
-        Map,
-        Type,
-        U256,
-    };
+    use crate::errors::{ErrorKind, SemanticError};
+    use crate::namespace::scopes::{BlockScope, ContractScope, ModuleScope, Shared};
+    use crate::namespace::types::{Array, FixedSize, Map, Type, U256};
     use crate::traversal::assignments::assign;
     use crate::Context;
-    use fe_parser::{
-        grammar::functions::parse_stmt,
-        parse_code_chunk,
-    };
+    use fe_parser::{grammar::functions::parse_stmt, parse_code_chunk};
     use rstest::rstest;
     use std::rc::Rc;
 

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -1,24 +1,9 @@
 use crate::errors::SemanticError;
 use crate::namespace::events::EventDef;
-use crate::namespace::scopes::{
-    ContractScope,
-    ModuleScope,
-    Scope,
-    Shared,
-};
-use crate::namespace::types::{
-    Contract,
-    FixedSize,
-    Type,
-};
-use crate::traversal::{
-    functions,
-    types,
-};
-use crate::{
-    Context,
-    ContractAttributes,
-};
+use crate::namespace::scopes::{ContractScope, ModuleScope, Scope, Shared};
+use crate::namespace::types::{Contract, FixedSize, Type};
+use crate::traversal::{functions, types};
+use crate::{Context, ContractAttributes};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use std::rc::Rc;

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -1,14 +1,7 @@
 use crate::errors::SemanticError;
-use crate::namespace::scopes::{
-    BlockScope,
-    Scope,
-    Shared,
-};
+use crate::namespace::scopes::{BlockScope, Scope, Shared};
 use crate::namespace::types::Type;
-use crate::traversal::{
-    expressions,
-    types,
-};
+use crate::traversal::{expressions, types};
 use crate::Context;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -43,26 +36,12 @@ pub fn var_decl(
 
 #[cfg(test)]
 mod tests {
-    use crate::errors::{
-        ErrorKind,
-        SemanticError,
-    };
-    use crate::namespace::scopes::{
-        BlockScope,
-        ContractScope,
-        ModuleScope,
-        Shared,
-    };
-    use crate::namespace::types::{
-        FixedSize,
-        U256,
-    };
+    use crate::errors::{ErrorKind, SemanticError};
+    use crate::namespace::scopes::{BlockScope, ContractScope, ModuleScope, Shared};
+    use crate::namespace::types::{FixedSize, U256};
     use crate::traversal::declarations::var_decl;
     use crate::Context;
-    use fe_parser::{
-        grammar::functions::parse_stmt,
-        parse_code_chunk,
-    };
+    use fe_parser::{grammar::functions::parse_stmt, parse_code_chunk};
     use std::rc::Rc;
 
     fn scope() -> Shared<BlockScope> {

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -1,45 +1,19 @@
 use crate::builtins;
 use crate::errors::SemanticError;
-use crate::namespace::scopes::{
-    BlockScope,
-    ContractFunctionDef,
-    Shared,
-};
+use crate::namespace::scopes::{BlockScope, ContractFunctionDef, Shared};
 use crate::namespace::types::{
-    Array,
-    Base,
-    Contract,
-    FeString,
-    FixedSize,
-    Integer,
-    Struct,
-    Tuple,
-    Type,
-    U256,
+    Array, Base, Contract, FeString, FixedSize, Integer, Struct, Tuple, Type, U256,
 };
 use crate::operations;
 use crate::traversal::utils::{
-    call_arg_value,
-    expression_attributes_to_types,
-    fixed_sizes_to_types,
+    call_arg_value, expression_attributes_to_types, fixed_sizes_to_types,
 };
-use crate::{
-    CallType,
-    Context,
-    ExpressionAttributes,
-    Location,
-};
+use crate::{CallType, Context, ExpressionAttributes, Location};
 
 use crate::builtins::ContractTypeMethod;
 use builtins::GlobalMethod;
 use builtins::ValueMethod;
-use builtins::{
-    BlockField,
-    ChainField,
-    MsgField,
-    Object,
-    TxField,
-};
+use builtins::{BlockField, ChainField, MsgField, Object, TxField};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use std::convert::TryFrom;
@@ -1064,27 +1038,10 @@ fn expr_bool_operation(
 #[cfg(test)]
 #[cfg(feature = "fix-context-harness")]
 mod tests {
-    use crate::namespace::scopes::{
-        BlockScope,
-        ContractScope,
-        ModuleScope,
-        Shared,
-    };
-    use crate::namespace::types::{
-        Array,
-        Base,
-        FixedSize,
-        Integer,
-        Map,
-        Type,
-        U256,
-    };
+    use crate::namespace::scopes::{BlockScope, ContractScope, ModuleScope, Shared};
+    use crate::namespace::types::{Array, Base, FixedSize, Integer, Map, Type, U256};
     use crate::traversal::expressions::expr;
-    use crate::{
-        Context,
-        ExpressionAttributes,
-        Location,
-    };
+    use crate::{Context, ExpressionAttributes, Location};
     use fe_parser as parser;
     use rstest::rstest;
     use std::rc::Rc;

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -1,33 +1,9 @@
 use crate::errors::SemanticError;
-use crate::namespace::scopes::{
-    BlockScope,
-    BlockScopeType,
-    ContractScope,
-    Scope,
-    Shared,
-};
-use crate::namespace::types::{
-    Base,
-    FixedSize,
-    Tuple,
-    Type,
-};
-use crate::traversal::utils::{
-    expression_attributes_to_types,
-    fixed_sizes_to_types,
-};
-use crate::traversal::{
-    assignments,
-    declarations,
-    expressions,
-    types,
-};
-use crate::{
-    Context,
-    ExpressionAttributes,
-    FunctionAttributes,
-    Location,
-};
+use crate::namespace::scopes::{BlockScope, BlockScopeType, ContractScope, Scope, Shared};
+use crate::namespace::types::{Base, FixedSize, Tuple, Type};
+use crate::traversal::utils::{expression_attributes_to_types, fixed_sizes_to_types};
+use crate::traversal::{assignments, declarations, expressions, types};
+use crate::{Context, ExpressionAttributes, FunctionAttributes, Location};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use std::rc::Rc;
@@ -428,26 +404,12 @@ fn func_return(
 #[cfg(test)]
 mod tests {
     use crate::namespace::scopes::{
-        BlockScope,
-        BlockScopeParent,
-        BlockScopeType,
-        ContractScope,
-        ModuleScope,
-        Shared,
+        BlockScope, BlockScopeParent, BlockScopeType, ContractScope, ModuleScope, Shared,
     };
-    use crate::namespace::types::{
-        FixedSize,
-        U256,
-    };
-    use crate::traversal::functions::{
-        func_body,
-        func_def,
-    };
+    use crate::namespace::types::{FixedSize, U256};
+    use crate::traversal::functions::{func_body, func_def};
     use crate::Context;
-    use fe_parser::{
-        grammar::functions::parse_fn_def,
-        parse_code_chunk,
-    };
+    use fe_parser::{grammar::functions::parse_fn_def, parse_code_chunk};
     use std::rc::Rc;
 
     fn scope() -> Shared<ContractScope> {

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -1,13 +1,7 @@
 use crate::errors::SemanticError;
-use crate::namespace::scopes::{
-    ModuleScope,
-    Shared,
-};
+use crate::namespace::scopes::{ModuleScope, Shared};
 use crate::namespace::types;
-use crate::traversal::{
-    contracts,
-    structs,
-};
+use crate::traversal::{contracts, structs};
 use crate::Context;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -1,19 +1,8 @@
-use fe_parser::{
-    ast::Field,
-    node::Node,
-};
+use fe_parser::{ast::Field, node::Node};
 
 use crate::errors::SemanticError;
-use crate::namespace::scopes::{
-    ModuleScope,
-    Shared,
-};
-use crate::namespace::types::{
-    type_desc,
-    FixedSize,
-    Struct,
-    Type,
-};
+use crate::namespace::scopes::{ModuleScope, Shared};
+use crate::namespace::types::{type_desc, FixedSize, Struct, Type};
 
 pub fn struct_def(
     module_scope: Shared<ModuleScope>,

--- a/analyzer/src/traversal/types.rs
+++ b/analyzer/src/traversal/types.rs
@@ -1,10 +1,7 @@
 use crate::errors::SemanticError;
 use crate::namespace::scopes::Scope;
 use crate::namespace::types;
-use crate::namespace::types::{
-    FixedSize,
-    Type,
-};
+use crate::namespace::types::{FixedSize, Type};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 

--- a/analyzer/src/traversal/utils.rs
+++ b/analyzer/src/traversal/utils.rs
@@ -1,8 +1,5 @@
 use crate::namespace::types::FixedSize;
-use crate::{
-    ExpressionAttributes,
-    Type,
-};
+use crate::{ExpressionAttributes, Type};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 

--- a/analyzer/tests/analysis.rs
+++ b/analyzer/tests/analysis.rs
@@ -1,20 +1,9 @@
 #![cfg(feature = "ignore")]
 use fe_analyzer;
-use fe_analyzer::namespace::types::{
-    Array,
-    Base,
-    Map,
-    Type,
-};
-use fe_analyzer::{
-    ExpressionAttributes,
-    Location,
-};
+use fe_analyzer::namespace::types::{Array, Base, Map, Type};
+use fe_analyzer::{ExpressionAttributes, Location};
 use fe_parser::ast as fe;
-use fe_parser::node::{
-    Node,
-    Span,
-};
+use fe_parser::node::{Node, Span};
 
 const GUEST_BOOK: &str = include_str!("fixtures/guest_book.fe");
 

--- a/common/src/diagnostics.rs
+++ b/common/src/diagnostics.rs
@@ -1,18 +1,7 @@
-use crate::files::{
-    FileStore,
-    SourceFileId,
-};
-pub use codespan_reporting::diagnostic::{
-    Diagnostic as CsDiagnostic,
-    Label,
-    LabelStyle,
-    Severity,
-};
+use crate::files::{FileStore, SourceFileId};
+pub use codespan_reporting::diagnostic::{Diagnostic as CsDiagnostic, Label, LabelStyle, Severity};
 use codespan_reporting::term;
-use term::termcolor::{
-    BufferWriter,
-    ColorChoice,
-};
+use term::termcolor::{BufferWriter, ColorChoice};
 
 pub type Diagnostic = CsDiagnostic<SourceFileId>;
 

--- a/common/src/files.rs
+++ b/common/src/files.rs
@@ -6,10 +6,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ops::Range;
 use std::path::Path;
-use std::{
-    fs,
-    io,
-};
+use std::{fs, io};
 
 pub struct SourceFile {
     id: SourceFileId,

--- a/common/src/span.rs
+++ b/common/src/span.rs
@@ -1,12 +1,5 @@
-use serde::{
-    Deserialize,
-    Serialize,
-};
-use std::ops::{
-    Add,
-    AddAssign,
-    Range,
-};
+use serde::{Deserialize, Serialize};
+use std::ops::{Add, AddAssign, Range};
 
 /// An exclusive span of byte offsets in a source file.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Copy, Clone, Hash, Eq)]
@@ -41,10 +34,7 @@ impl Add for Span {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
-        use std::cmp::{
-            max,
-            min,
-        };
+        use std::cmp::{max, min};
         Self {
             start: min(self.start, other.start),
             end: max(self.end, other.end),

--- a/common/src/utils/keccak.rs
+++ b/common/src/utils/keccak.rs
@@ -1,7 +1,4 @@
-use tiny_keccak::{
-    Hasher,
-    Keccak,
-};
+use tiny_keccak::{Hasher, Keccak};
 
 /// Get the full 32 byte hash of the content.
 pub fn full(content: &[u8]) -> String {

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -1,9 +1,4 @@
-use crate::abi::elements::{
-    Contract,
-    Event,
-    EventField,
-    ModuleAbis,
-};
+use crate::abi::elements::{Contract, Event, EventField, ModuleAbis};
 use crate::errors::CompileError;
 use fe_analyzer::namespace::types::AbiEncoding;
 use fe_analyzer::Context;
@@ -77,10 +72,7 @@ fn contract_def(
 mod tests {
     use crate::abi::builder;
     use fe_analyzer;
-    use fe_parser::{
-        grammar::module::parse_module,
-        parse_code_chunk,
-    };
+    use fe_parser::{grammar::module::parse_module, parse_code_chunk};
 
     #[test]
     fn build_contract_abi() {

--- a/compiler/src/abi/elements.rs
+++ b/compiler/src/abi/elements.rs
@@ -1,15 +1,8 @@
 use crate::errors::CompileError;
-use fe_analyzer::namespace::types::{
-    AbiComponent,
-    AbiEncoding,
-    FixedSize,
-};
+use fe_analyzer::namespace::types::{AbiComponent, AbiEncoding, FixedSize};
 use fe_analyzer::FunctionAttributes;
 use serde::ser::SerializeSeq;
-use serde::{
-    Serialize,
-    Serializer,
-};
+use serde::{Serialize, Serializer};
 use std::collections::HashMap;
 
 /// The ABIs for each contract in a Fe module.
@@ -242,13 +235,7 @@ impl From<FunctionAttributes> for Function {
 #[cfg(test)]
 mod tests {
     use crate::abi::elements::{
-        Contract,
-        Event,
-        EventField,
-        FuncInput,
-        FuncOutput,
-        FuncType,
-        Function,
+        Contract, Event, EventField, FuncInput, FuncOutput, FuncType, Function,
     };
 
     #[test]

--- a/compiler/src/abi/mod.rs
+++ b/compiler/src/abi/mod.rs
@@ -1,10 +1,7 @@
 //! Fe to ABI builder.
 
 use crate::errors::CompileError;
-use crate::types::{
-    FeModuleAst,
-    NamedAbis,
-};
+use crate::types::{FeModuleAst, NamedAbis};
 use fe_analyzer::Context;
 
 mod builder;

--- a/compiler/src/evm/mod.rs
+++ b/compiler/src/evm/mod.rs
@@ -1,12 +1,7 @@
 //! Fe to EVM compiler.
 
 use crate::errors::CompileError;
-use crate::types::{
-    Bytecode,
-    NamedBytecodeContracts,
-    NamedYulContracts,
-    YulIr,
-};
+use crate::types::{Bytecode, NamedBytecodeContracts, NamedYulContracts, YulIr};
 
 /// Compile a map of Yul contracts to a map of bytecode contracts.
 pub fn compile(

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,14 +1,7 @@
 //! Modules for compiling Fe and building ABIs.
 
-use crate::errors::{
-    CompileError,
-    ErrorKind,
-};
-use crate::types::{
-    CompiledContract,
-    CompiledModule,
-    NamedContracts,
-};
+use crate::errors::{CompileError, ErrorKind};
+use crate::types::{CompiledContract, CompiledModule, NamedContracts};
 use fe_common::files::SourceFileId;
 use fe_parser::parse_file;
 pub mod abi;

--- a/compiler/src/yul/constructor.rs
+++ b/compiler/src/yul/constructor.rs
@@ -1,8 +1,5 @@
 use crate::yul::operations::abi as abi_operations;
-use fe_analyzer::namespace::types::{
-    AbiDecodeLocation,
-    FixedSize,
-};
+use fe_analyzer::namespace::types::{AbiDecodeLocation, FixedSize};
 use yultsur::*;
 
 /// Builds a constructor for a contract with no init function.

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -1,10 +1,7 @@
 use crate::yul::mappers::expressions;
 use crate::yul::operations::data as data_operations;
 use fe_analyzer::namespace::types::FixedSize;
-use fe_analyzer::{
-    Context,
-    Location,
-};
+use fe_analyzer::{Context, Location};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use std::convert::TryFrom;
@@ -85,17 +82,9 @@ fn expr_as_ident(expr: yul::Expression) -> yul::Identifier {
 #[cfg(feature = "fix-context-harness")]
 mod tests {
     use crate::yul::mappers::assignments::assign;
-    use fe_analyzer::namespace::types::{
-        Array,
-        Type,
-        U256,
-    };
+    use fe_analyzer::namespace::types::{Array, Type, U256};
     use fe_analyzer::test_utils::ContextHarness;
-    use fe_analyzer::{
-        Context,
-        ExpressionAttributes,
-        Location,
-    };
+    use fe_analyzer::{Context, ExpressionAttributes, Location};
     use fe_parser as parser;
     use rstest::rstest;
 

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -1,9 +1,6 @@
 use crate::yul::mappers::expressions;
 use crate::yul::names;
-use fe_analyzer::namespace::types::{
-    FeSized,
-    FixedSize,
-};
+use fe_analyzer::namespace::types::{FeSized, FixedSize};
 use fe_analyzer::Context;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -37,19 +34,9 @@ pub fn var_decl(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement 
 #[cfg(feature = "fix-context-harness")]
 mod tests {
     use crate::yul::mappers::declarations::var_decl;
-    use fe_analyzer::namespace::types::{
-        Array,
-        Base,
-        FixedSize,
-        Type,
-        U256,
-    };
+    use fe_analyzer::namespace::types::{Array, Base, FixedSize, Type, U256};
     use fe_analyzer::test_utils::ContextHarness;
-    use fe_analyzer::{
-        Context,
-        ExpressionAttributes,
-        Location,
-    };
+    use fe_analyzer::{Context, ExpressionAttributes, Location};
     use fe_parser as parser;
 
     fn map(context: &Context, src: &str) -> String {

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -1,34 +1,14 @@
 use crate::yul::names;
 use crate::yul::operations::{
-    abi as abi_operations,
-    contracts as contract_operations,
-    data as data_operations,
+    abi as abi_operations, contracts as contract_operations, data as data_operations,
     structs as struct_operations,
 };
 use crate::yul::utils::call_arg_value;
-use builtins::{
-    BlockField,
-    ChainField,
-    MsgField,
-    Object,
-    TxField,
-};
+use builtins::{BlockField, ChainField, MsgField, Object, TxField};
 use fe_analyzer::builtins;
-use fe_analyzer::builtins::{
-    ContractTypeMethod,
-    GlobalMethod,
-};
-use fe_analyzer::namespace::types::{
-    Base,
-    FeSized,
-    FixedSize,
-    Type,
-};
-use fe_analyzer::{
-    CallType,
-    Context,
-    Location,
-};
+use fe_analyzer::builtins::{ContractTypeMethod, GlobalMethod};
+use fe_analyzer::namespace::types::{Base, FeSized, FixedSize, Type};
+use fe_analyzer::{CallType, Context, Location};
 use fe_common::utils::keccak;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -517,22 +497,10 @@ fn expr_bool_operation(context: &Context, exp: &Node<fe::Expr>) -> yul::Expressi
 #[cfg(test)]
 #[cfg(feature = "fix-context-harness")]
 mod tests {
-    use crate::yul::mappers::expressions::{
-        expr,
-        Location,
-    };
-    use fe_analyzer::namespace::types::{
-        Array,
-        Base,
-        Map,
-        Type,
-        U256,
-    };
+    use crate::yul::mappers::expressions::{expr, Location};
+    use fe_analyzer::namespace::types::{Array, Base, Map, Type, U256};
     use fe_analyzer::test_utils::ContextHarness;
-    use fe_analyzer::{
-        Context,
-        ExpressionAttributes,
-    };
+    use fe_analyzer::{Context, ExpressionAttributes};
     use fe_parser as parser;
     use rstest::rstest;
 

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -1,18 +1,8 @@
-use crate::yul::mappers::{
-    assignments,
-    declarations,
-    expressions,
-};
+use crate::yul::mappers::{assignments, declarations, expressions};
 use crate::yul::names;
 use crate::yul::operations::data as data_operations;
-use fe_analyzer::namespace::types::{
-    FeSized,
-    Type,
-};
-use fe_analyzer::{
-    Context,
-    ExpressionAttributes,
-};
+use fe_analyzer::namespace::types::{FeSized, Type};
+use fe_analyzer::{Context, ExpressionAttributes};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use yultsur::*;

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,9 +1,6 @@
 //! Fe to Yul compiler.
 
-use crate::types::{
-    FeModuleAst,
-    NamedYulContracts,
-};
+use crate::types::{FeModuleAst, NamedYulContracts};
 use fe_analyzer::Context;
 
 pub mod constants;

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -1,8 +1,4 @@
-use fe_analyzer::namespace::types::{
-    AbiDecodeLocation,
-    AbiEncoding,
-    Integer,
-};
+use fe_analyzer::namespace::types::{AbiDecodeLocation, AbiEncoding, Integer};
 use yultsur::*;
 
 /// Generate a function name to perform checked addition
@@ -115,17 +111,9 @@ pub fn struct_getter_call(struct_name: &str, field_name: &str) -> yul::Identifie
 
 #[cfg(test)]
 mod tests {
-    use crate::yul::names::{
-        decode_name,
-        encode_name,
-    };
+    use crate::yul::names::{decode_name, encode_name};
     use fe_analyzer::namespace::types::{
-        AbiDecodeLocation,
-        Array,
-        Base,
-        FeString,
-        FixedSize,
-        U256,
+        AbiDecodeLocation, Array, Base, FeString, FixedSize, U256,
     };
 
     #[test]

--- a/compiler/src/yul/operations/abi.rs
+++ b/compiler/src/yul/operations/abi.rs
@@ -2,11 +2,7 @@ use crate::yul::names;
 use crate::yul::operations::data as data_operations;
 use crate::yul::utils;
 use fe_analyzer::namespace::types::{
-    AbiArraySize,
-    AbiDecodeLocation,
-    AbiEncoding,
-    AbiType,
-    AbiUintSize,
+    AbiArraySize, AbiDecodeLocation, AbiEncoding, AbiType, AbiUintSize,
 };
 use yultsur::*;
 
@@ -114,19 +110,9 @@ pub fn decode<T: AbiEncoding>(
 
 #[cfg(test)]
 mod tests {
-    use crate::yul::operations::abi::{
-        decode,
-        encode,
-        encode_size,
-        static_encode_size,
-    };
+    use crate::yul::operations::abi::{decode, encode, encode_size, static_encode_size};
     use fe_analyzer::namespace::types::{
-        AbiDecodeLocation,
-        Array,
-        Base,
-        FeString,
-        FixedSize,
-        U256,
+        AbiDecodeLocation, Array, Base, FeString, FixedSize, U256,
     };
     use yultsur::*;
 

--- a/compiler/src/yul/operations/data.rs
+++ b/compiler/src/yul/operations/data.rs
@@ -1,10 +1,6 @@
 use crate::yul::operations::abi as abi_operations;
 use fe_analyzer::namespace::events::EventDef;
-use fe_analyzer::namespace::types::{
-    Array,
-    FeSized,
-    FixedSize,
-};
+use fe_analyzer::namespace::types::{Array, FeSized, FixedSize};
 use yultsur::*;
 
 /// Loads a value of the given type from storage.
@@ -124,16 +120,9 @@ pub fn indexed_array(
 
 #[cfg(test)]
 mod tests {
-    use crate::yul::operations::data::{
-        emit_event,
-        sum,
-    };
+    use crate::yul::operations::data::{emit_event, sum};
     use fe_analyzer::namespace::events::EventDef;
-    use fe_analyzer::namespace::types::{
-        Base,
-        FixedSize,
-        U256,
-    };
+    use fe_analyzer::namespace::types::{Base, FixedSize, U256};
     use yultsur::*;
 
     #[test]

--- a/compiler/src/yul/operations/structs.rs
+++ b/compiler/src/yul/operations/structs.rs
@@ -19,10 +19,7 @@ pub fn get_attribute(
 #[cfg(test)]
 mod tests {
     use crate::yul::operations::structs;
-    use fe_analyzer::namespace::types::{
-        FixedSize,
-        Struct,
-    };
+    use fe_analyzer::namespace::types::{FixedSize, Struct};
     use yultsur::*;
 
     #[test]

--- a/compiler/src/yul/runtime/abi_dispatcher.rs
+++ b/compiler/src/yul/runtime/abi_dispatcher.rs
@@ -1,11 +1,7 @@
 use crate::abi::utils as abi_utils;
 use crate::yul::names;
 use crate::yul::operations::abi as abi_operations;
-use fe_analyzer::namespace::types::{
-    AbiDecodeLocation,
-    AbiEncoding,
-    FixedSize,
-};
+use fe_analyzer::namespace::types::{AbiDecodeLocation, AbiEncoding, FixedSize};
 use fe_analyzer::FunctionAttributes;
 use yultsur::*;
 
@@ -84,10 +80,7 @@ fn selection_as_statement(name: &str, params: &[FixedSize]) -> yul::Statement {
 #[cfg(test)]
 mod tests {
     use crate::yul::runtime::abi_dispatcher::selector;
-    use fe_analyzer::namespace::types::{
-        FixedSize,
-        U256,
-    };
+    use fe_analyzer::namespace::types::{FixedSize, U256};
 
     #[test]
     fn test_selector_literal_basic() {

--- a/compiler/src/yul/runtime/functions/abi.rs
+++ b/compiler/src/yul/runtime/functions/abi.rs
@@ -2,11 +2,7 @@ use crate::yul::names;
 use crate::yul::operations::data as data_operations;
 use crate::yul::utils;
 use fe_analyzer::namespace::types::{
-    AbiArraySize,
-    AbiDecodeLocation,
-    AbiEncoding,
-    AbiType,
-    AbiUintSize,
+    AbiArraySize, AbiDecodeLocation, AbiEncoding, AbiType, AbiUintSize,
 };
 use yultsur::*;
 
@@ -364,16 +360,8 @@ fn decode_tuple(elems: Vec<AbiType>, location: AbiDecodeLocation) -> yul::Expres
 
 #[cfg(test)]
 mod tests {
-    use crate::yul::runtime::functions::abi::{
-        decode,
-        encode,
-    };
-    use fe_analyzer::namespace::types::{
-        AbiDecodeLocation,
-        Base,
-        FeString,
-        U256,
-    };
+    use crate::yul::runtime::functions::abi::{decode, encode};
+    use fe_analyzer::namespace::types::{AbiDecodeLocation, Base, FeString, U256};
 
     #[test]
     fn test_encode() {

--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -2,10 +2,7 @@ use crate::abi::utils as abi_utils;
 use crate::yul::names;
 use crate::yul::operations::abi as abi_operations;
 use fe_analyzer::namespace::types::Contract;
-use fe_analyzer::namespace::types::{
-    AbiDecodeLocation,
-    AbiEncoding,
-};
+use fe_analyzer::namespace::types::{AbiDecodeLocation, AbiEncoding};
 use yultsur::*;
 
 /// Return all contacts runtime functions

--- a/compiler/src/yul/runtime/functions/structs.rs
+++ b/compiler/src/yul/runtime/functions/structs.rs
@@ -1,8 +1,5 @@
 use crate::yul::names;
-use fe_analyzer::namespace::types::{
-    FeSized,
-    Struct,
-};
+use fe_analyzer::namespace::types::{FeSized, Struct};
 use yultsur::*;
 
 /// Generate a YUL function that can be used to create an instance of
@@ -101,10 +98,7 @@ pub fn struct_apis(struct_type: Struct) -> Vec<yul::Statement> {
 #[cfg(test)]
 mod tests {
     use crate::yul::runtime::functions::structs;
-    use fe_analyzer::namespace::types::{
-        FixedSize,
-        Struct,
-    };
+    use fe_analyzer::namespace::types::{FixedSize, Struct};
 
     #[test]
     fn test_empty_struct() {

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -1,15 +1,8 @@
 mod abi_dispatcher;
 pub mod functions;
 
-use fe_analyzer::namespace::types::{
-    AbiDecodeLocation,
-    Contract,
-    FixedSize,
-};
-use fe_analyzer::{
-    Context,
-    FunctionAttributes,
-};
+use fe_analyzer::namespace::types::{AbiDecodeLocation, Contract, FixedSize};
+use fe_analyzer::{Context, FunctionAttributes};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use yultsur::*;

--- a/compiler/src/yul/utils.rs
+++ b/compiler/src/yul/utils.rs
@@ -1,9 +1,4 @@
-use fe_analyzer::namespace::types::{
-    AbiArraySize,
-    AbiEncoding,
-    AbiType,
-    AbiUintSize,
-};
+use fe_analyzer::namespace::types::{AbiArraySize, AbiEncoding, AbiType, AbiUintSize};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
@@ -56,13 +51,7 @@ pub fn ceil_32(n: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use crate::yul::utils::abi_head_offsets;
-    use fe_analyzer::namespace::types::{
-        Array,
-        Base,
-        FeString,
-        FixedSize,
-        U256,
-    };
+    use fe_analyzer::namespace::types::{Array, Base, FeString, FixedSize, U256};
 
     #[test]
     fn test_head_offsets() {

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -2,10 +2,7 @@
 
 #![cfg(feature = "solc-backend")]
 mod utils;
-use fe_analyzer::errors::{
-    ErrorKind::*,
-    SemanticError,
-};
+use fe_analyzer::errors::{ErrorKind::*, SemanticError};
 use fe_common::diagnostics::print_diagnostics;
 use fe_common::files::FileStore;
 use fe_compiler::errors::ErrorKind;

--- a/compiler/tests/features.rs
+++ b/compiler/tests/features.rs
@@ -2,10 +2,7 @@
 
 #![cfg(feature = "solc-backend")]
 use evm_runtime::Handler;
-use primitive_types::{
-    H160,
-    U256,
-};
+use primitive_types::{H160, U256};
 use rstest::rstest;
 use std::collections::BTreeMap;
 use std::iter;

--- a/compiler/tests/runtime.rs
+++ b/compiler/tests/runtime.rs
@@ -6,12 +6,7 @@ use rstest::rstest;
 use yultsur::*;
 
 mod utils;
-use fe_analyzer::namespace::types::{
-    Base,
-    FixedSize,
-    Integer,
-    Struct,
-};
+use fe_analyzer::namespace::types::{Base, FixedSize, Integer, Struct};
 use fe_common::utils::keccak;
 use utils::*;
 

--- a/compiler/tests/utils.rs
+++ b/compiler/tests/utils.rs
@@ -1,24 +1,11 @@
 #![cfg(feature = "solc-backend")]
-use compiler::errors::{
-    CompileError,
-    ErrorKind,
-};
-use evm_runtime::{
-    ExitReason,
-    Handler,
-};
+use compiler::errors::{CompileError, ErrorKind};
+use evm_runtime::{ExitReason, Handler};
 use fe_common::diagnostics::print_diagnostics;
-use fe_common::files::{
-    FileStore,
-    SourceFileId,
-};
+use fe_common::files::{FileStore, SourceFileId};
 use fe_compiler as compiler;
 use fe_compiler::yul::runtime::functions;
-use primitive_types::{
-    H160,
-    H256,
-    U256,
-};
+use primitive_types::{H160, H256, U256};
 use std::collections::BTreeMap;
 use std::fs;
 use std::str::FromStr;

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -1,7 +1,4 @@
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::{Deserialize, Serialize};
 
 use crate::node::Node;
 

--- a/parser/src/grammar/contracts.rs
+++ b/parser/src/grammar/contracts.rs
@@ -1,22 +1,9 @@
 use super::functions::parse_fn_def;
-use super::types::{
-    parse_event_def,
-    parse_field,
-    parse_opt_qualifier,
-};
+use super::types::{parse_event_def, parse_field, parse_opt_qualifier};
 
-use crate::ast::{
-    ConstQualifier,
-    ModuleStmt,
-    PubQualifier,
-};
+use crate::ast::{ConstQualifier, ModuleStmt, PubQualifier};
 use crate::node::Node;
-use crate::{
-    ParseFailed,
-    ParseResult,
-    Parser,
-    TokenKind,
-};
+use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 
 // Rule: all "statement" level parse functions consume their trailing
 // newline(s), either directly or via a function they call.

--- a/parser/src/grammar/expressions.rs
+++ b/parser/src/grammar/expressions.rs
@@ -1,19 +1,6 @@
-use crate::ast::{
-    self,
-    CallArg,
-    Expr,
-    Kwarg,
-    Slice,
-};
+use crate::ast::{self, CallArg, Expr, Kwarg, Slice};
 use crate::node::Node;
-use crate::{
-    Label,
-    ParseFailed,
-    ParseResult,
-    Parser,
-    Token,
-    TokenKind,
-};
+use crate::{Label, ParseFailed, ParseResult, Parser, Token, TokenKind};
 
 // Expressions are parsed in Pratt's top-down operator precedence style.
 // See this article for a nice explanation:

--- a/parser/src/grammar/functions.rs
+++ b/parser/src/grammar/functions.rs
@@ -1,21 +1,10 @@
 use super::expressions::parse_expr;
 use super::types::parse_type_desc;
 
-use crate::ast::{
-    BinOperator,
-    ContractStmt,
-    FuncDefArg,
-    FuncStmt,
-    PubQualifier,
-};
+use crate::ast::{BinOperator, ContractStmt, FuncDefArg, FuncStmt, PubQualifier};
 use crate::lexer::TokenKind;
 use crate::node::Node;
-use crate::{
-    Label,
-    ParseFailed,
-    ParseResult,
-    Parser,
-};
+use crate::{Label, ParseFailed, ParseResult, Parser};
 
 /// Parse a function definition. The optional `pub` qualifier must be parsed by
 /// the caller, and passed in.

--- a/parser/src/grammar/module.rs
+++ b/parser/src/grammar/module.rs
@@ -1,23 +1,8 @@
 use super::contracts::parse_contract_def;
-use super::types::{
-    parse_struct_def,
-    parse_type_def,
-};
-use crate::ast::{
-    Module,
-    ModuleStmt,
-    SimpleImportName,
-};
-use crate::node::{
-    Node,
-    Span,
-};
-use crate::{
-    ParseFailed,
-    ParseResult,
-    Parser,
-    TokenKind,
-};
+use super::types::{parse_struct_def, parse_type_def};
+use crate::ast::{Module, ModuleStmt, SimpleImportName};
+use crate::node::{Node, Span};
+use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 
 /// Parse a [`Module`].
 pub fn parse_module(par: &mut Parser) -> ParseResult<Node<Module>> {

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -1,25 +1,10 @@
 use crate::ast::{
-    ConstQualifier,
-    ContractStmt,
-    EventField,
-    Field,
-    GenericArg,
-    IdxQualifier,
-    ModuleStmt,
-    PubQualifier,
-    TypeDesc,
+    ConstQualifier, ContractStmt, EventField, Field, GenericArg, IdxQualifier, ModuleStmt,
+    PubQualifier, TypeDesc,
 };
 use crate::grammar::expressions::parse_expr;
-use crate::node::{
-    Node,
-    Span,
-};
-use crate::{
-    ParseFailed,
-    ParseResult,
-    Parser,
-    TokenKind,
-};
+use crate::node::{Node, Span};
+use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 
 /// Parse a [`ModuleStmt::StructDef`].
 /// # Panics

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1,10 +1,7 @@
 mod token;
 use crate::node::Span;
 use logos::Logos;
-pub use token::{
-    Token,
-    TokenKind,
-};
+pub use token::{Token, TokenKind};
 
 pub struct Lexer<'a> {
     inner: logos::Lexer<'a, TokenKind>,
@@ -45,10 +42,7 @@ impl<'a> Iterator for Lexer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::lexer::{
-        Lexer,
-        TokenKind,
-    };
+    use crate::lexer::{Lexer, TokenKind};
     use TokenKind::*;
 
     fn check(input: &str, expected: &[TokenKind]) {

--- a/parser/src/lexer/token.rs
+++ b/parser/src/lexer/token.rs
@@ -1,7 +1,4 @@
-use crate::node::{
-    Node,
-    Span,
-};
+use crate::node::{Node, Span};
 use logos::Logos;
 use std::ops::Add;
 

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,24 +1,13 @@
 pub mod ast;
 pub mod grammar;
 pub mod lexer;
-pub use lexer::{
-    Token,
-    TokenKind,
-};
+pub use lexer::{Token, TokenKind};
 mod parser;
-pub use parser::{
-    Label,
-    ParseFailed,
-    ParseResult,
-    Parser,
-};
+pub use parser::{Label, ParseFailed, ParseResult, Parser};
 pub mod node;
 
 use ast::Module;
-use fe_common::{
-    diagnostics::Diagnostic,
-    files::SourceFileId,
-};
+use fe_common::{diagnostics::Diagnostic, files::SourceFileId};
 
 /// Parse a [`Module`] from the file content string.
 ///

--- a/parser/src/node.rs
+++ b/parser/src/node.rs
@@ -1,8 +1,5 @@
 pub use fe_common::Span;
-use serde::{
-    Deserialize,
-    Serialize,
-};
+use serde::{Deserialize, Serialize};
 use std::ops::Add;
 use uuid::Uuid;
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,24 +1,12 @@
 #![allow(unused_variables, dead_code, unused_imports)]
 
-use fe_common::diagnostics::{
-    Diagnostic,
-    Label as CsLabel,
-    LabelStyle,
-    Severity,
-};
+use fe_common::diagnostics::{Diagnostic, Label as CsLabel, LabelStyle, Severity};
 use fe_common::files::SourceFileId;
 
 use crate::ast::Module;
-use crate::lexer::{
-    Lexer,
-    Token,
-    TokenKind,
-};
+use crate::lexer::{Lexer, Token, TokenKind};
 use crate::node::Span;
-use std::{
-    error,
-    fmt,
-};
+use std::{error, fmt};
 
 #[derive(Debug)]
 pub struct ParseFailed;

--- a/parser/tests/test_parser.rs
+++ b/parser/tests/test_parser.rs
@@ -1,21 +1,8 @@
-use fe_common::{
-    diagnostics::print_diagnostics,
-    files::FileStore,
-};
+use fe_common::{diagnostics::print_diagnostics, files::FileStore};
 
 use fe_parser::ast;
-use fe_parser::grammar::{
-    contracts,
-    expressions,
-    functions,
-    module,
-    types,
-};
-use fe_parser::{
-    ParseResult,
-    Parser,
-    TokenKind,
-};
+use fe_parser::grammar::{contracts, expressions, functions, module, types};
+use fe_parser::{ParseResult, Parser, TokenKind};
 use serde::Serialize;
 
 #[macro_use]

--- a/parser/tests/utils/mod.rs
+++ b/parser/tests/utils/mod.rs
@@ -1,7 +1,4 @@
-use difference::{
-    Changeset,
-    Difference,
-};
+use difference::{Changeset, Difference};
 use serde::Serialize;
 use std::fmt;
 use std::path::PathBuf;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-max_width = 100
-imports_layout = "Vertical"
-wrap_comments = true
-comment_width = 80

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,27 +87,16 @@ The most advanced example that we can provide at this point is a fully working [
 */
 
 use std::fs;
-use std::io::{
-    Error,
-    Write,
-};
+use std::io::{Error, Write};
 use std::path::Path;
 
-use clap::{
-    arg_enum,
-    values_t,
-    App,
-    Arg,
-};
+use clap::{arg_enum, values_t, App, Arg};
 
 mod _utils;
 use crate::_utils::pretty_curly_print;
 use fe_common::diagnostics::print_diagnostics;
 use fe_common::files::FileStore;
-use fe_compiler::errors::{
-    install_compiler_panic_hook,
-    ErrorKind,
-};
+use fe_compiler::errors::{install_compiler_panic_hook, ErrorKind};
 use fe_compiler::types::CompiledModule;
 
 const DEFAULT_OUTPUT_DIR_NAME: &str = "output";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,90 @@
-#![feature(external_doc)]
-#![doc(include = "../README.md")]
+/*!
+
+<img src="https://raw.githubusercontent.com/ethereum/fe/master/logo/fe_svg/fe_source.svg" width="150px">
+
+Fe is an emerging smart contract language for the Ethereum blockchain.
+
+[![Build Status](https://github.com/ethereum/fe/workflows/CI/badge.svg)](https://github.com/ethereum/fe/actions)
+[![Coverage](https://codecov.io/gh/ethereum/fe/branch/master/graph/badge.svg)](https://codecov.io/gh/ethereum/fe)
+
+
+## Overview
+
+Fe is a statically typed language for the Ethereum Virtual Machine (EVM). It is inspired by Python and Rust and is easy to learn -- even for developers who are new to the Ethereum ecosystem.
+
+## Features & Goals
+
+* Bounds and overflow checking
+* Decidability by limitation of dynamic program behavior
+* More precise gas estimation (as a consequence of decidability)
+* Static typing
+* Pure function support
+* Binary fixed-point math
+* Restrictions on reentrancy
+* Static looping
+* Module imports
+* Standard library
+* Usage of [YUL](https://docs.soliditylang.org/en/latest/yul.html) IR to target both EVM and eWASM
+* WASM compiler binaries for enhanced portability and in-browser compilation of
+  Fe contracts
+* Implementation in a powerful, systems-oriented language (Rust) with strong safety guarantees to reduce risk of compiler bugs
+
+Additional information about design goals and background can be found in the [official announcement](https://snakecharmers.ethereum.org/fe-a-new-language-for-the-ethereum-ecosystem/).
+
+## Language Specification
+
+We aim to provide a full language specification that should eventually be used to formally verify the correctness of the compiler. A work in progress draft of the specification can be found [here](https://github.com/ethereum/fe/blob/master/spec/index.md).
+
+## Progress
+
+Fe development is still in its early stages. We have a basic [Roadmap for 2021](https://notes.ethereum.org/LVhaTF30SJOpkbG1iVw1jg) that we want to follow. We generally try to drive the development by working through real world use cases. Our next goal is to provide a working Uniswap implementation in Fe which will help us to advance and form the language.
+
+Fe had its first alpha release January 2021 and is now following a monthly release cycle.
+
+## Getting started
+
+- [Build the compiler](https://github.com/ethereum/fe/blob/master/docs/build.md)
+- [Or download the binary release](https://github.com/ethereum/fe/releases)
+
+To compile Fe code:
+
+1. Run `fe path/to/fe_source.fe`
+2. Fe creates a directory `output` in the current working directory that contains the compiled binary and abi.
+
+Run `fe --help` to explore further options.
+
+## Examples
+
+The following is a simple contract implemented in Fe.
+
+```fe
+type BookMsg = bytes[100]
+
+contract GuestBook:
+    pub guest_book: map<address, BookMsg>
+
+    event Signed:
+        book_msg: BookMsg
+
+    pub def sign(book_msg: BookMsg):
+        self.guest_book[msg.sender] = book_msg
+
+        emit Signed(book_msg=book_msg)
+
+    pub def get_msg(addr: address) -> BookMsg:
+        return self.guest_book[addr].to_mem()
+```
+
+A lot more working examples can be found in our [test fixtures directory](https://github.com/ethereum/fe/tree/master/compiler/tests/fixtures).
+
+The most advanced example that we can provide at this point is a fully working [ERC20 implementation](https://github.com/ethereum/fe/blob/master/compiler/tests/fixtures/demos/erc20_token.fe).
+
+## Community
+
+- Twitter: [@official_fe](https://twitter.com/official_fe)
+- Chat: [Discord](https://discord.gg/ywpkAXFjZH)
+
+*/
 
 use std::fs;
 use std::io::{


### PR DESCRIPTION
### What was wrong?

Fe requires nightly rust, but there's no particularly compelling reason for that.

### How was it fixed?

- Replaced `#![feature(int_error_matching)]` with the lexical-core crate.
- Replaced `#![feature(external_doc)]` with cargo-readme. This isn't quite the same, but it works well enough. README.md is now generated from the main.rs doc comment, which now contains the readme content. (`make README.md` will run the appropriate command, if you first `cargo install cargo-readme`)
- Removed the nightly rustfmt options. I deleted rustfmt.toml. max_width was set to the default; imports_layout, wrap_comments, and comment_width are nightly-only. This changes the `use` lines in most files, of course.

(Both of the compiler features above are likely to be stabilized eventually; I'd be happy to switch back when they are. No idea whether the rustfmt options ever will be.)

We could use stable rustc and nightly rustfmt, but that would basically guarantee that new contributors will fail the rustfmt lint check. I think the rustfmt defaults are fine; probably 99% of rust projects use the defaults.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
