### PR TITLE
Tighten AST for emit statements

### DIFF
--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -11,7 +11,6 @@ pub enum ErrorKind {
     CannotMove,
     CircularDependency,
     ContinueWithoutLoop,
-    EventInvocationExpected,
     KeyWordArgsRequired,
     MissingEventDefinition,
     MissingReturn,
@@ -57,14 +56,6 @@ impl SemanticError {
     pub fn continue_without_loop() -> Self {
         SemanticError {
             kind: ErrorKind::ContinueWithoutLoop,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `EventIncovationExpected`
-    pub fn event_invocation_expected() -> Self {
-        SemanticError {
-            kind: ErrorKind::EventInvocationExpected,
             context: vec![],
         }
     }

--- a/compiler/src/lowering/mappers/expressions.rs
+++ b/compiler/src/lowering/mappers/expressions.rs
@@ -95,7 +95,8 @@ pub fn multiple_exprs(context: &Context, exp: Vec<Node<fe::Expr>>) -> Vec<Node<f
     exp.into_iter().map(|exp| expr(context, exp)).collect()
 }
 
-fn call_args(
+/// Lowers call arguments
+pub fn call_args(
     context: &Context,
     args: Node<Vec<Node<fe::CallArg>>>,
 ) -> Node<Vec<Node<fe::CallArg>>> {

--- a/compiler/src/lowering/mappers/functions.rs
+++ b/compiler/src/lowering/mappers/functions.rs
@@ -43,8 +43,9 @@ fn func_stmt(context: &Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::FuncSt
             targets: expressions::multiple_exprs(context, targets),
             value: expressions::expr(context, value),
         }],
-        fe::FuncStmt::Emit { value } => vec![fe::FuncStmt::Emit {
-            value: expressions::expr(context, value),
+        fe::FuncStmt::Emit { name, args } => vec![fe::FuncStmt::Emit {
+            name,
+            args: expressions::call_args(context, args),
         }],
         fe::FuncStmt::AugAssign { target, op, value } => aug_assign(context, target, op, value),
         fe::FuncStmt::For {

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -166,22 +166,18 @@ fn revert(stmt: &Node<fe::FuncStmt>) -> yul::Statement {
 }
 
 fn emit(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
-    if let fe::FuncStmt::Emit { value } = &stmt.kind {
-        if let fe::Expr::Call { func: _, args } = &value.kind {
-            let event_values = args
-                .kind
-                .iter()
-                .map(|arg| expressions::call_arg(context, arg))
-                .collect();
+    if let fe::FuncStmt::Emit { args, .. } = &stmt.kind {
+        let event_values = args
+            .kind
+            .iter()
+            .map(|arg| expressions::call_arg(context, arg))
+            .collect();
 
-            if let Some(event) = context.get_emit(stmt) {
-                return data_operations::emit_event(event.to_owned(), event_values);
-            }
-
-            panic!("missing event definition");
+        if let Some(event) = context.get_emit(stmt) {
+            return data_operations::emit_event(event.to_owned(), event_values);
         }
 
-        panic!("emit statements must contain a call expression",);
+        panic!("missing event definition");
     }
 
     unreachable!()

--- a/compiler/tests/compile_errors.rs
+++ b/compiler/tests/compile_errors.rs
@@ -36,8 +36,6 @@ use rstest::rstest;
     case("duplicate_var_in_child_scope.fe", AlreadyDefined),
     case("duplicate_var_in_contract_method.fe", AlreadyDefined),
     case("emit_undefined_event.fe", MissingEventDefinition),
-    case("emit_without_call.fe", EventInvocationExpected),
-    case("emit_with_invalid_call.fe", EventInvocationExpected),
     case("external_call_type_error.fe", TypeError),
     case("external_call_wrong_number_of_params.fe", WrongNumberOfParams),
     case("indexed_event.fe", MoreThanThreeIndexedParams),

--- a/compiler/tests/fixtures/compile_errors/emit_with_invalid_call.fe
+++ b/compiler/tests/fixtures/compile_errors/emit_with_invalid_call.fe
@@ -1,3 +1,0 @@
-contract Foo:
-  pub def foo():
-    emit MyEvent("foo", 1000)()

--- a/compiler/tests/fixtures/compile_errors/emit_without_call.fe
+++ b/compiler/tests/fixtures/compile_errors/emit_without_call.fe
@@ -1,4 +1,0 @@
-contract Bar:
-
-  pub def test():
-    emit something

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -178,7 +178,8 @@ pub enum FuncStmt {
         msg: Option<Node<Expr>>,
     },
     Emit {
-        value: Node<Expr>,
+        name: Node<String>,
+        args: Node<Vec<Node<CallArg>>>,
     },
     Expr {
         value: Node<Expr>,

--- a/parser/tests/fixtures/parsers/emit_stmt.ron
+++ b/parser/tests/fixtures/parsers/emit_stmt.ron
@@ -1,19 +1,76 @@
-emit x
+emit Foo()
+emit Foo(1, 2)
 ---
 [
   Node(
     kind: Emit(
-      value: Node(
-        kind: Name("x"),
+      name: Node(
+        kind: "Foo",
         span: Span(
           start: 5,
-          end: 6,
+          end: 8,
+        ),
+      ),
+      args: Node(
+        kind: [],
+        span: Span(
+          start: 8,
+          end: 10,
         ),
       ),
     ),
     span: Span(
       start: 0,
-      end: 6,
+      end: 10,
+    ),
+  ),
+  Node(
+    kind: Emit(
+      name: Node(
+        kind: "Foo",
+        span: Span(
+          start: 16,
+          end: 19,
+        ),
+      ),
+      args: Node(
+        kind: [
+          Node(
+            kind: Arg(Node(
+              kind: Num("1"),
+              span: Span(
+                start: 20,
+                end: 21,
+              ),
+            )),
+            span: Span(
+              start: 20,
+              end: 21,
+            ),
+          ),
+          Node(
+            kind: Arg(Node(
+              kind: Num("2"),
+              span: Span(
+                start: 23,
+                end: 24,
+              ),
+            )),
+            span: Span(
+              start: 23,
+              end: 24,
+            ),
+          ),
+        ],
+        span: Span(
+          start: 19,
+          end: 25,
+        ),
+      ),
+    ),
+    span: Span(
+      start: 11,
+      end: 25,
     ),
   ),
 ]

--- a/parser/tests/fixtures/parsers/guest_book.ron
+++ b/parser/tests/fixtures/parsers/guest_book.ron
@@ -289,48 +289,40 @@ Node(
                   ),
                   Node(
                     kind: Emit(
-                      value: Node(
-                        kind: Call(
-                          func: Node(
-                            kind: Name("Signed"),
-                            span: Span(
-                              start: 237,
-                              end: 243,
-                            ),
-                          ),
-                          args: Node(
-                            kind: [
-                              Node(
-                                kind: Kwarg(Kwarg(
-                                  name: Node(
-                                    kind: "book_msg",
-                                    span: Span(
-                                      start: 244,
-                                      end: 252,
-                                    ),
-                                  ),
-                                  value: Node(
-                                    kind: Name("book_msg"),
-                                    span: Span(
-                                      start: 253,
-                                      end: 261,
-                                    ),
-                                  ),
-                                )),
+                      name: Node(
+                        kind: "Signed",
+                        span: Span(
+                          start: 237,
+                          end: 243,
+                        ),
+                      ),
+                      args: Node(
+                        kind: [
+                          Node(
+                            kind: Kwarg(Kwarg(
+                              name: Node(
+                                kind: "book_msg",
                                 span: Span(
                                   start: 244,
+                                  end: 252,
+                                ),
+                              ),
+                              value: Node(
+                                kind: Name("book_msg"),
+                                span: Span(
+                                  start: 253,
                                   end: 261,
                                 ),
                               ),
-                            ],
+                            )),
                             span: Span(
-                              start: 243,
-                              end: 262,
+                              start: 244,
+                              end: 261,
                             ),
                           ),
-                        ),
+                        ],
                         span: Span(
-                          start: 237,
+                          start: 243,
                           end: 262,
                         ),
                       ),

--- a/parser/tests/fixtures/parsers/small_stmt.ron
+++ b/parser/tests/fixtures/parsers/small_stmt.ron
@@ -1,6 +1,6 @@
 return
 assert x
-emit x
+emit Foo()
 pass
 break
 continue
@@ -38,45 +38,52 @@ x
   ),
   Node(
     kind: Emit(
-      value: Node(
-        kind: Name("x"),
+      name: Node(
+        kind: "Foo",
         span: Span(
           start: 21,
-          end: 22,
+          end: 24,
+        ),
+      ),
+      args: Node(
+        kind: [],
+        span: Span(
+          start: 24,
+          end: 26,
         ),
       ),
     ),
     span: Span(
       start: 16,
-      end: 22,
+      end: 26,
     ),
   ),
   Node(
     kind: Pass,
     span: Span(
-      start: 23,
-      end: 27,
+      start: 27,
+      end: 31,
     ),
   ),
   Node(
     kind: Break,
     span: Span(
-      start: 28,
-      end: 33,
+      start: 32,
+      end: 37,
     ),
   ),
   Node(
     kind: Continue,
     span: Span(
-      start: 34,
-      end: 42,
+      start: 38,
+      end: 46,
     ),
   ),
   Node(
     kind: Revert,
     span: Span(
-      start: 43,
-      end: 49,
+      start: 47,
+      end: 53,
     ),
   ),
   Node(
@@ -84,8 +91,8 @@ x
       target: Node(
         kind: Name("x"),
         span: Span(
-          start: 50,
-          end: 51,
+          start: 54,
+          end: 55,
         ),
       ),
       typ: Node(
@@ -93,21 +100,21 @@ x
           base: "bool",
         ),
         span: Span(
-          start: 53,
-          end: 57,
+          start: 57,
+          end: 61,
         ),
       ),
       value: Some(Node(
         kind: Name("y"),
         span: Span(
-          start: 60,
-          end: 61,
+          start: 64,
+          end: 65,
         ),
       )),
     ),
     span: Span(
-      start: 50,
-      end: 61,
+      start: 54,
+      end: 65,
     ),
   ),
   Node(
@@ -116,22 +123,22 @@ x
         Node(
           kind: Name("x"),
           span: Span(
-            start: 62,
-            end: 63,
+            start: 66,
+            end: 67,
           ),
         ),
       ],
       value: Node(
         kind: Name("y"),
         span: Span(
-          start: 66,
-          end: 67,
+          start: 70,
+          end: 71,
         ),
       ),
     ),
     span: Span(
-      start: 62,
-      end: 67,
+      start: 66,
+      end: 71,
     ),
   ),
   Node(
@@ -139,28 +146,28 @@ x
       target: Node(
         kind: Name("x"),
         span: Span(
-          start: 68,
-          end: 69,
+          start: 72,
+          end: 73,
         ),
       ),
       op: Node(
         kind: Add,
         span: Span(
-          start: 70,
-          end: 72,
+          start: 74,
+          end: 76,
         ),
       ),
       value: Node(
         kind: Name("y"),
         span: Span(
-          start: 73,
-          end: 74,
+          start: 77,
+          end: 78,
         ),
       ),
     ),
     span: Span(
-      start: 68,
-      end: 74,
+      start: 72,
+      end: 78,
     ),
   ),
   Node(
@@ -168,14 +175,14 @@ x
       value: Node(
         kind: Name("x"),
         span: Span(
-          start: 75,
-          end: 76,
+          start: 79,
+          end: 80,
         ),
       ),
     ),
     span: Span(
-      start: 75,
-      end: 76,
+      start: 79,
+      end: 80,
     ),
   ),
 ]


### PR DESCRIPTION
### What was wrong?

As explained in #337 our current AST allows any expression to follow the `emit` keyword and the analyzer ensures
that what follows actually is an event call. Clearly the analyzer is currently handling something that should rather be rejected at the parsing stage.

### How was it fixed?

1. The `emit` AST was changed to not take a `value` of `Expr` but rather a `name` of `String` and as well as a list of `CallArg`.
2. Parser, analyzer and lowering were changed accordingly
3. The analyzer error `EventInvocationExpected` was removed

### To-Do

- We should have parser tests for this but they are out of scope for this PR