### PR TITLE
Add parser error tests; fix parser unwrap() failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "winapi",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,10 +491,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -683,6 +708,7 @@ version = "0.3.0-alpha"
 dependencies = [
  "difference",
  "fe-common",
+ "insta",
  "logos",
  "regex",
  "ron",
@@ -919,6 +945,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "insta"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
+dependencies = [
+ "console",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "similar",
+ "uuid",
 ]
 
 [[package]]
@@ -1546,6 +1587,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha3"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1628,12 @@ name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
+name = "similar"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad1d488a557b235fc46dae55512ffbfc429d2482b08b4d9435ab07384ca8aec"
 
 [[package]]
 name = "smartstring"
@@ -1677,6 +1736,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2053,6 +2122,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yultsur"

--- a/common/src/diagnostics.rs
+++ b/common/src/diagnostics.rs
@@ -5,6 +5,7 @@ use term::termcolor::{BufferWriter, ColorChoice};
 
 pub type Diagnostic = CsDiagnostic<SourceFileId>;
 
+/// Print the given diagnostics to stderr.
 pub fn print_diagnostics(diagnostics: &[Diagnostic], files: &FileStore) {
     let writer = BufferWriter::stderr(ColorChoice::Auto);
     let mut buffer = writer.buffer();
@@ -15,4 +16,16 @@ pub fn print_diagnostics(diagnostics: &[Diagnostic], files: &FileStore) {
     }
     // If we use `writer` here, the output won't be captured by rust's test system.
     eprintln!("{}", std::str::from_utf8(buffer.as_slice()).unwrap());
+}
+
+/// Format the given diagnostics as a string.
+pub fn diagnostics_string(diagnostics: &[Diagnostic], files: &FileStore) -> String {
+    let writer = BufferWriter::stderr(ColorChoice::Never);
+    let mut buffer = writer.buffer();
+    let config = term::Config::default();
+
+    for diag in diagnostics {
+        term::emit(&mut buffer, &config, files, &diag).unwrap();
+    }
+    std::str::from_utf8(buffer.as_slice()).unwrap().to_string()
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 
 [dev-dependencies]
 difference = "2.0"
+insta = "1.7.1"
 ron = "0.5.1"
 serde_json = "1"
 wasm-bindgen-test = "0.3"

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -141,7 +141,7 @@ pub enum FuncStmt {
         value: Option<Node<Expr>>,
     },
     VarDecl {
-        target: Node<Expr>, // TODO: change to String
+        target: Node<Expr>,
         typ: Node<TypeDesc>,
         value: Option<Node<Expr>>,
     },

--- a/parser/src/grammar/expressions.rs
+++ b/parser/src/grammar/expressions.rs
@@ -73,7 +73,7 @@ pub fn parse_expr_with_min_bp(par: &mut Parser, min_bp: u8) -> ParseResult<Node<
                 break;
             }
 
-            let op_tok = par.next().unwrap();
+            let op_tok = par.next()?;
             let rhs = parse_expr_with_min_bp(par, rbp)?;
             expr_head = infix_op(expr_head, &op_tok, rhs);
             continue;
@@ -149,7 +149,7 @@ fn parse_expr_head(par: &mut Parser) -> ParseResult<Node<Expr>> {
     match par.peek_or_err()? {
         Name | Int | Hex | Text | True | False => {
             let tok = par.next()?;
-            Ok(atom(par, &tok)?)
+            Ok(atom(par, &tok))
         }
         Plus | Minus | Not | Tilde => {
             let op = par.next()?;
@@ -332,7 +332,7 @@ fn parse_expr_list(
 /* node building utils */
 
 /// Create an "atom" expr from the given `Token` (`Name`, `Num`, `Bool`, etc)
-fn atom(par: &mut Parser, tok: &Token) -> ParseResult<Node<Expr>> {
+fn atom(par: &mut Parser, tok: &Token) -> Node<Expr> {
     use TokenKind::*;
 
     let expr = match tok.kind {
@@ -344,12 +344,12 @@ fn atom(par: &mut Parser, tok: &Token) -> ParseResult<Node<Expr>> {
                 Expr::Str(vec![string])
             } else {
                 par.error(tok.span, "String contains an invalid escape sequence");
-                return Err(ParseFailed);
+                Expr::Str(vec![tok.text.into()])
             }
         }
         _ => panic!("Unexpected atom token: {:?}", tok),
     };
-    Ok(Node::new(expr, tok.span))
+    Node::new(expr, tok.span)
 }
 
 fn unescape_string(quoted_string: &str) -> Option<String> {

--- a/parser/src/grammar/functions.rs
+++ b/parser/src/grammar/functions.rs
@@ -1,7 +1,4 @@
-use super::expressions::{
-    parse_call_args,
-    parse_expr,
-};
+use super::expressions::{parse_call_args, parse_expr};
 use super::types::parse_type_desc;
 
 use crate::ast::{BinOperator, ContractStmt, FuncDefArg, FuncStmt, PubQualifier};
@@ -186,7 +183,7 @@ fn aug_assign_op(tk: TokenKind) -> Option<BinOperator> {
 /// # Panics
 /// Panics if the next token isn't one of the above.
 pub fn parse_single_word_stmt(par: &mut Parser) -> ParseResult<Node<FuncStmt>> {
-    let tok = par.next().unwrap();
+    let tok = par.next()?;
     par.expect_newline(tok.kind.symbol_str().unwrap())?;
     let stmt = match tok.kind {
         TokenKind::Continue => FuncStmt::Continue,

--- a/parser/src/grammar/module.rs
+++ b/parser/src/grammar/module.rs
@@ -32,7 +32,7 @@ pub fn parse_module(par: &mut Parser) -> ParseResult<Node<Module>> {
 
 /// Parse a [`ModuleStmt`].
 pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
-    match par.peek().unwrap() {
+    match par.peek_or_err()? {
         TokenKind::Import => parse_simple_import(par),
         TokenKind::Name if par.peeked_text() == "from" => parse_from_import(par),
         TokenKind::Contract => parse_contract_def(par),
@@ -40,15 +40,11 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
         TokenKind::Type => parse_type_def(par),
         TokenKind::Event => todo!("module-level event def"),
         _ => {
-            let tok = par.next().unwrap();
+            let tok = par.next()?;
             par.unexpected_token_error(
                 tok.span,
                 "failed to parse module",
                 vec!["Note: expected import, contract, struct, type, or event".into()],
-            );
-            par.error(
-                tok.span,
-                format!("Unexpected token when parsing module: `{:?}`", tok.kind),
             );
             Err(ParseFailed)
         }

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -146,7 +146,7 @@ pub fn parse_field(
     pub_qual: Option<Node<PubQualifier>>,
     const_qual: Option<Node<ConstQualifier>>,
 ) -> ParseResult<Node<Field>> {
-    let name = par.assert(TokenKind::Name);
+    let name = par.expect(TokenKind::Name, "failed to parse field definition")?;
     par.expect_with_notes(TokenKind::Colon, "failed to parse field definition", || {
         vec![
             "Note: field name must be followed by a colon and a type description".into(),

--- a/parser/src/lexer/token.rs
+++ b/parser/src/lexer/token.rs
@@ -208,7 +208,7 @@ impl TokenKind {
         let val = match self {
             Newline => "a newline",
             Dedent => "a dedent",
-            Name => "an identifier",
+            Name => "a name",
             Int => "a number",
             Hex => "a hexadecimal number",
             Text => "a string",

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -291,16 +291,13 @@ impl<'a> Parser<'a> {
         } else {
             self.fancy_error(
                 format!("failed to parse {} body", context_name),
-                vec![
-                    Label::primary(indent.span, "unexpected token".into()),
-                    Label::secondary(
-                        context_span + colon.as_ref(),
-                        format!(
-                            "the body of this {} must be indented and non-empty",
-                            context_name,
-                        ),
+                vec![Label::primary(
+                    context_span + colon.as_ref(),
+                    format!(
+                        "the body of this {} must be indented and non-empty",
+                        context_name,
                     ),
-                ],
+                )],
                 vec![],
             );
             Err(ParseFailed)

--- a/parser/tests/errors.rs
+++ b/parser/tests/errors.rs
@@ -1,0 +1,62 @@
+use fe_common::diagnostics::diagnostics_string;
+use fe_parser::grammar::{contracts, expressions, functions, module, types};
+
+use fe_parser::{ParseResult, Parser};
+use insta::assert_snapshot;
+
+pub fn err_string<F, T>(mut parse_fn: F, should_fail: bool, src: &str) -> String
+where
+    F: FnMut(&mut Parser) -> ParseResult<T>,
+    T: std::fmt::Debug,
+{
+    let mut files = fe_common::files::FileStore::new();
+    let id = files.add_file("[test snippet]", src);
+    let mut parser = Parser::new(src, id);
+
+    if should_fail != parse_fn(&mut parser).is_err() {
+        panic!(
+            "expected parsing to {}fail",
+            if should_fail { "" } else { "not " }
+        );
+    }
+    diagnostics_string(&parser.diagnostics, &files)
+}
+
+macro_rules! test_parse_err {
+    ($name:ident, $parse_fn:expr, $should_fail:expr, $string:expr) => {
+        #[test]
+        fn $name() {
+            let err = err_string($parse_fn, $should_fail, $string);
+            assert_snapshot!(err);
+        }
+    };
+}
+
+// These tests use the insta crate. insta will automatically generate the
+// snapshot file on the first run.
+
+test_parse_err! { contract_bad_name, contracts::parse_contract_def, true, "contract 1X:\n x: u8" }
+test_parse_err! { contract_empty_body, module::parse_module, true, "contract X:\n \n \ncontract Y:\n x: u8" }
+test_parse_err! { contract_field_after_def, module::parse_module, false, r#"
+contract C:
+  def f():
+    pass
+  x: u8
+"#
+}
+
+test_parse_err! { contract_pub_event, contracts::parse_contract_def, false, "contract C:\n pub event E:\n  x: u8" }
+test_parse_err! { contract_const_pub, contracts::parse_contract_def, false, "contract C:\n const pub x: u8" }
+test_parse_err! { contract_const_fn, contracts::parse_contract_def, false, "contract C:\n const def f():\n  pass" }
+test_parse_err! { emit_no_args, functions::parse_stmt, true, "emit x" }
+test_parse_err! { emit_expr, functions::parse_stmt, true, "emit x + 1" }
+test_parse_err! { emit_bad_call, functions::parse_stmt, true, "emit MyEvent(1)()" }
+test_parse_err! { expr_bad_prefix, expressions::parse_expr, true, "*x + 1" }
+test_parse_err! { for_no_in, functions::parse_stmt, true, "for x:\n pass" }
+test_parse_err! { fn_no_args, |par| functions::parse_fn_def(par, None), false, "def f:\n  return 5" }
+test_parse_err! { if_no_body, functions::parse_stmt, true, "if x:\nelse:\n x" }
+test_parse_err! { import_bad_name, module::parse_simple_import, true, "import x as 123" }
+test_parse_err! { module_bad_stmt, module::parse_module, true, "if x:\n y" }
+test_parse_err! { module_nonsense, module::parse_module, true, "))" }
+test_parse_err! { string_invalid_escape, expressions::parse_expr, false, r#""a string \c ""# }
+test_parse_err! { struct_bad_field_name, types::parse_struct_def, true, "struct f:\n pub def" }

--- a/parser/tests/snapshots/errors__contract_bad_name.snap
+++ b/parser/tests/snapshots/errors__contract_bad_name.snap
@@ -1,0 +1,14 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse contract definition
+  ┌─ [test snippet]:1:10
+  │
+1 │ contract 1X:
+  │          ^ Unexpected token. Expected a name
+  │
+  = Note: `contract` must be followed by a name, which must start with a letter and contain only letters, numbers, or underscores
+
+

--- a/parser/tests/snapshots/errors__contract_const_fn.snap
+++ b/parser/tests/snapshots/errors__contract_const_fn.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: `const` qualifier can't be used with function definitions
+  ┌─ [test snippet]:2:2
+  │
+2 │  const def f():
+  │  ^^^^^
+
+

--- a/parser/tests/snapshots/errors__contract_const_pub.snap
+++ b/parser/tests/snapshots/errors__contract_const_pub.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: `const pub` should be written `pub const`
+  ┌─ [test snippet]:2:2
+  │
+2 │  const pub x: u8
+  │  ^^^^^^^^^
+
+

--- a/parser/tests/snapshots/errors__contract_empty_body.snap
+++ b/parser/tests/snapshots/errors__contract_empty_body.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse contract definition body
+  ┌─ [test snippet]:1:1
+  │
+1 │ contract X:
+  │ ^^^^^^^^^^^ the body of this contract definition must be indented and non-empty
+
+

--- a/parser/tests/snapshots/errors__contract_field_after_def.snap
+++ b/parser/tests/snapshots/errors__contract_field_after_def.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: contract field definitions must come before any function or event definitions
+  ┌─ [test snippet]:5:3
+  │
+5 │   x: u8
+  │   ^^^^^
+
+

--- a/parser/tests/snapshots/errors__contract_pub_event.snap
+++ b/parser/tests/snapshots/errors__contract_pub_event.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: `pub` qualifier can't be used with event definitions
+  ┌─ [test snippet]:2:2
+  │
+2 │  pub event E:
+  │  ^^^
+
+

--- a/parser/tests/snapshots/errors__emit_bad_call.snap
+++ b/parser/tests/snapshots/errors__emit_bad_call.snap
@@ -1,0 +1,14 @@
+---
+source: parser/tests/errors.rs
+expression: "err_string(parse_emit_statement, true, \"emit MyEvent(1)()\")"
+
+---
+error: unexpected token while parsing emit statement
+  ┌─ [test snippet]:1:16
+  │
+1 │ emit MyEvent(1)()
+  │                ^ unexpected token
+  │
+  = expected a newline
+
+

--- a/parser/tests/snapshots/errors__emit_expr.snap
+++ b/parser/tests/snapshots/errors__emit_expr.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: "err_string(parse_emit_statement, true, \"emit x + 1\")"
+
+---
+error: failed to parse event invocation parameter list
+  ┌─ [test snippet]:1:8
+  │
+1 │ emit x + 1
+  │        ^ Unexpected token. Expected `(`
+
+

--- a/parser/tests/snapshots/errors__emit_no_args.snap
+++ b/parser/tests/snapshots/errors__emit_no_args.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: "err_string(parse_emit_statement, true, \"emit x\")"
+
+---
+error: unexpected end of file
+  ┌─ [test snippet]:1:7
+  │
+1 │ emit x
+  │       ^
+
+

--- a/parser/tests/snapshots/errors__emit_stmt.snap
+++ b/parser/tests/snapshots/errors__emit_stmt.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: "err_string(pemit, true, \"emit x\")"
+
+---
+error: unexpected end of file
+  ┌─ [test snippet]:1:7
+  │
+1 │ emit x
+  │       ^
+
+

--- a/parser/tests/snapshots/errors__expr_bad_postfix.snap
+++ b/parser/tests/snapshots/errors__expr_bad_postfix.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: unexpected end of file
+  ┌─ [test snippet]:1:4
+  │
+1 │ x++
+  │    ^
+
+

--- a/parser/tests/snapshots/errors__expr_bad_prefix.snap
+++ b/parser/tests/snapshots/errors__expr_bad_prefix.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: Unexpected token while parsing expression: `*`
+  ┌─ [test snippet]:1:1
+  │
+1 │ *x + 1
+  │ ^ unexpected token
+
+

--- a/parser/tests/snapshots/errors__fn_const_pub.snap
+++ b/parser/tests/snapshots/errors__fn_const_pub.snap
@@ -1,0 +1,18 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: `const pub` should be written `pub const`
+  ┌─ [test snippet]:2:2
+  │
+2 │  const pub def f():
+  │  ^^^^^^^^^
+
+error: `const` qualifier can't be used with function definitions
+  ┌─ [test snippet]:2:2
+  │
+2 │  const pub def f():
+  │  ^^^^^
+
+

--- a/parser/tests/snapshots/errors__fn_no_args.snap
+++ b/parser/tests/snapshots/errors__fn_no_args.snap
@@ -1,0 +1,17 @@
+---
+source: parser/tests/errors.rs
+expression: "err_string(|par| functions::parse_fn_def(par, None), false,\n           \"def f:\\n  return 5\")"
+
+---
+error: function definition requires a list of parameters
+  ┌─ [test snippet]:1:5
+  │
+1 │ def f:
+  │     ^ function name must be followed by `(`
+  │
+  = Note: if the function `f` takes no parameters, use an empty set of parentheses.
+  = Example: def f()
+  = Note: each parameter must have a name and a type.
+  = Example: def f(my_value: u256, x: bool)
+
+

--- a/parser/tests/snapshots/errors__for_no_in.snap
+++ b/parser/tests/snapshots/errors__for_no_in.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse `for` statement
+  ┌─ [test snippet]:1:6
+  │
+1 │ for x:
+  │      ^ Unexpected token. Expected `in`
+
+

--- a/parser/tests/snapshots/errors__if_no_body.snap
+++ b/parser/tests/snapshots/errors__if_no_body.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse `if` statement body
+  ┌─ [test snippet]:1:1
+  │
+1 │ if x:
+  │ ^^^^^ the body of this `if` statement must be indented and non-empty
+
+

--- a/parser/tests/snapshots/errors__import_bad_name.snap
+++ b/parser/tests/snapshots/errors__import_bad_name.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse import statement
+  ┌─ [test snippet]:1:13
+  │
+1 │ import x as 123
+  │             ^^^ Unexpected token. Expected a name
+
+

--- a/parser/tests/snapshots/errors__module_bad_stmt.snap
+++ b/parser/tests/snapshots/errors__module_bad_stmt.snap
@@ -1,0 +1,14 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse module
+  ┌─ [test snippet]:1:1
+  │
+1 │ if x:
+  │ ^^ unexpected token
+  │
+  = Note: expected import, contract, struct, type, or event
+
+

--- a/parser/tests/snapshots/errors__module_nonsense.snap
+++ b/parser/tests/snapshots/errors__module_nonsense.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: Unmatched right parenthesis
+  ┌─ [test snippet]:1:1
+  │
+1 │ ))
+  │ ^
+
+

--- a/parser/tests/snapshots/errors__string_invalid_escape.snap
+++ b/parser/tests/snapshots/errors__string_invalid_escape.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: String contains an invalid escape sequence
+  ┌─ [test snippet]:1:1
+  │
+1 │ "a string \c "
+  │ ^^^^^^^^^^^^^^
+
+

--- a/parser/tests/snapshots/errors__struct_bad_field_name.snap
+++ b/parser/tests/snapshots/errors__struct_bad_field_name.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/errors.rs
+expression: err
+
+---
+error: failed to parse field definition
+  ┌─ [test snippet]:2:6
+  │
+2 │  pub def
+  │      ^^^ Unexpected token. Expected a name
+
+


### PR DESCRIPTION
closes #366, closes #368

### What was wrong?

There were no tests for parser errors, and there were a couple cases where the parser was asserting something that it shouldn't, and thus panicking. (#366 and #368)

### How was it fixed?

:keyboard:

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
