### PR TITLE
Remove stub support for Ellipsis

### DIFF
--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -42,7 +42,6 @@ pub fn expr(
         fe::Expr::ListComp { .. } => unimplemented!(),
         fe::Expr::Tuple { .. } => expr_tuple(scope, Rc::clone(&context), exp),
         fe::Expr::Str(_) => expr_str(scope, exp),
-        fe::Expr::Ellipsis => unimplemented!(),
     }
     .map_err(|error| error.with_context(exp.span))?;
 

--- a/compiler/src/lowering/mappers/expressions.rs
+++ b/compiler/src/lowering/mappers/expressions.rs
@@ -54,7 +54,6 @@ pub fn expr(context: &Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
         // expressions before the Yul codegen pass, tho.
         fe::Expr::Tuple { .. } => exp.kind,
         fe::Expr::Str(_) => exp.kind,
-        fe::Expr::Ellipsis => unimplemented!(),
     };
 
     Node::new(lowered_kind, exp.span)

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -35,7 +35,6 @@ pub fn expr(context: &Context, exp: &Node<fe::Expr>) -> yul::Expression {
             fe::Expr::ListComp { .. } => unimplemented!(),
             fe::Expr::Tuple { .. } => expr_tuple(exp),
             fe::Expr::Str(_) => expr_str(exp),
-            fe::Expr::Ellipsis => unimplemented!(),
         };
 
         match (

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -239,7 +239,6 @@ pub enum Expr {
     Name(String),
     Num(String),
     Str(Vec<String>),
-    Ellipsis,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/parser/src/grammar/Fe.grammar
+++ b/parser/src/grammar/Fe.grammar
@@ -9,14 +9,12 @@ import_stmt: (simple_import | from_import) NEWLINE
 simple_import: 'import' (simple_import_name (',' simple_import_name)*)
 simple_import_name: dotted_name ['as' NAME]
 
-# Note: the ('.' | '...') is necessary because '...' is tokenized as a single
-# OP token (an ellipsis OP)
 from_import: from_import_parent_alt | from_import_sub_alt
 
-from_import_parent_alt: 'from' ('.' | '...')+ 'import' from_import_names
+from_import_parent_alt: 'from' '.'+ 'import' from_import_names
 from_import_sub_alt: 'from' from_import_sub_path 'import' from_import_names
 
-from_import_sub_path: ('.' | '...')* dotted_name
+from_import_sub_path: '.'* dotted_name
 from_import_names: '*' | '(' from_import_names_list ')' | from_import_names_list
 from_import_names_list: from_import_name (',' from_import_name)* [',']
 from_import_name: NAME ['as' NAME]

--- a/parser/src/lexer/token.rs
+++ b/parser/src/lexer/token.rs
@@ -193,8 +193,6 @@ pub enum TokenKind {
     LtLtEq,
     #[token(">>=")]
     GtGtEq,
-    #[token("...")]
-    Ellipsis,
     #[token("->")]
     Arrow,
 }
@@ -292,7 +290,6 @@ impl TokenKind {
             HatEq => "^=",
             LtLtEq => "<<=",
             GtGtEq => ">>=",
-            Ellipsis => "...",
             Arrow => "->",
             Error | Newline | Indent | Dedent | Name | Int | Hex | Text => return None,
         };


### PR DESCRIPTION
### What was wrong?

As mentioned in #279 we do have some stub code for the Ellipsis `...` syntax which we carried over from our Python heritage but don't actually plan to support.

### How was it fixed?

Removed all affected code