### PR TITLE
Fixup formatting in release notes and tighten CI checks to prevent such in the future

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -33,7 +33,9 @@ Fe is moving fast. Read up on all the latest improvements.
   0x0000000000000000000000000000000000000000000000000000000000000020 // Data offset
   0x000000000000000000000000000000000000000000000000000000000000001a // String length
   0x4e6f7420656e6f7567682045746865722070726f76696465642e000000000000 // String data
-  ``` ([#288](https://github.com/ethereum/fe/issues/288))
+  ```
+  ([#288](https://github.com/ethereum/fe/issues/288))
+
 - Added support for augmented assignments.
 
   e.g.
@@ -83,7 +85,9 @@ Fe is moving fast. Read up on all the latest improvements.
       pub def bit_and(a: u8, b: u8) -> u8:
           a &= b
           return a
-  ``` ([#338](https://github.com/ethereum/fe/issues/338))
+  ```
+  ([#338](https://github.com/ethereum/fe/issues/338))
+
 - A new parser implementation, which provides more helpful error messages
   with fancy underlines and code context. ([#346](https://github.com/ethereum/fe/issues/346))
 - Added support for tuples with base type items.
@@ -98,7 +102,8 @@ Fe is moving fast. Read up on all the latest improvements.
           my_tuple: (u256, bool) = (my_num, my_bool)
           self.my_num = my_tuple.item0
           return my_tuple
-  ``` ([#352](https://github.com/ethereum/fe/issues/352))
+  ```
+  ([#352](https://github.com/ethereum/fe/issues/352))
 
 
 ### Bugfixes
@@ -118,7 +123,8 @@ Fe is moving fast. Read up on all the latest improvements.
       foo:Foo=Foo.create(0)
 
       return address(foo)
-  ``` ([#362](https://github.com/ethereum/fe/issues/362))
+  ```
+  ([#362](https://github.com/ethereum/fe/issues/362))
 
 
 ### Internal Changes - for Fe Contributors

--- a/newsfragments/4711.internal.md
+++ b/newsfragments/4711.internal.md
@@ -1,0 +1,1 @@
+Add CI check to ensure fragment files always end with a new line

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -29,14 +29,21 @@ assert num_args in {0, 1}
 if num_args == 1:
     assert sys.argv[1] in ('is-empty', )
 
-for fragment_file in THIS_DIR.iterdir():
+def ends_with_newline(file):
+    with open(file, 'r') as file:
+        return file.read().endswith('\n')
 
+for fragment_file in THIS_DIR.iterdir():
     if fragment_file.name in ALLOWED_FILES:
         continue
     elif num_args == 0:
         full_extension = "".join(fragment_file.suffixes)
         if full_extension not in ALLOWED_EXTENSIONS:
             raise Exception(f"Unexpected file: {fragment_file}")
+        elif not ends_with_newline(fragment_file):
+            raise Exception(
+                    f"Fragment files need to end with new line but { fragment_file.name } does not."
+                )
     elif sys.argv[1] == 'is-empty':
         raise Exception(f"Unexpected file: {fragment_file}")
     else:


### PR DESCRIPTION
Thanks for cutting the release yesterday @g-r-a-n-t. It also has exposed a small manual chore that I used to do these past releases. Basically, whenever we end a news fragment with a code block example it breaks the formatting with the issue link if there's not a new line after the code block.

I have fixed the formatting in the release notes (and on the release page) and added a check to our CI to simply always require us to end news fragment files with a new line.
