### PR TITLE
Restrict var decl target to name or tuple

### DIFF
--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -14,7 +14,10 @@ pub fn var_decl(
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
-        let name = expressions::expr_name_string(target)?;
+        let name = match &target.kind {
+            fe::VarDeclTarget::Name(name) => name,
+            fe::VarDeclTarget::Tuple(_) => todo!("tuple destructuring variable declaration"),
+        };
         let declared_type =
             types::type_desc_fixed_size(Scope::Block(Rc::clone(&scope)), Rc::clone(&context), typ)?;
         if let Some(value) = value {

--- a/compiler/src/lowering/mappers/expressions.rs
+++ b/compiler/src/lowering/mappers/expressions.rs
@@ -55,8 +55,6 @@ pub fn expr(context: &Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
         },
         fe::Expr::List { .. } => unimplemented!(),
         fe::Expr::ListComp { .. } => unimplemented!(),
-        // We only accept empty tuples for now. We may want to completely eliminate tuple
-        // expressions before the Yul codegen pass, tho.
         fe::Expr::Tuple { .. } => expr_tuple(context, exp),
         fe::Expr::Str(_) => exp.kind,
     };

--- a/compiler/src/lowering/mappers/functions.rs
+++ b/compiler/src/lowering/mappers/functions.rs
@@ -49,11 +49,14 @@ fn func_stmt(context: &Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::FuncSt
         fe::FuncStmt::Return { value } => vec![fe::FuncStmt::Return {
             value: expressions::optional_expr(context, value),
         }],
-        fe::FuncStmt::VarDecl { target, typ, value } => vec![fe::FuncStmt::VarDecl {
-            target: expressions::expr(context, target),
-            typ: types::type_desc(context, typ),
-            value: expressions::optional_expr(context, value),
-        }],
+        fe::FuncStmt::VarDecl { target, typ, value } => match target.kind {
+            fe::VarDeclTarget::Name(_) => vec![fe::FuncStmt::VarDecl {
+                target,
+                typ: types::type_desc(context, typ),
+                value: expressions::optional_expr(context, value),
+            }],
+            fe::VarDeclTarget::Tuple(_) => todo!("tuple var decl lowering"),
+        },
         fe::FuncStmt::Assign { targets, value } => vec![fe::FuncStmt::Assign {
             targets: expressions::multiple_exprs(context, targets),
             value: expressions::expr(context, value),

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -11,7 +11,7 @@ pub fn var_decl(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement 
     let decl_type = context.get_declaration(stmt).expect("missing attributes");
 
     if let fe::FuncStmt::VarDecl { target, value, .. } = &stmt.kind {
-        let target = names::var_name(&expressions::expr_name_string(&target));
+        let target = names::var_name(var_decl_name(&target.kind));
 
         return if let Some(value) = value {
             let value = expressions::expr(context, &value);
@@ -28,6 +28,14 @@ pub fn var_decl(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement 
     }
 
     unreachable!()
+}
+
+fn var_decl_name(target: &fe::VarDeclTarget) -> &str {
+    if let fe::VarDeclTarget::Name(name) = target {
+        name
+    } else {
+        panic!("complex VarDeclTargets should be lowered to VarDeclTarget::Name")
+    }
 }
 
 #[cfg(test)]

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -309,10 +309,10 @@ pub fn slice_index(context: &Context, slice: &Node<fe::Slice>) -> yul::Expressio
 
 fn expr_tuple(exp: &Node<fe::Expr>) -> yul::Expression {
     if let fe::Expr::Tuple { elts } = &exp.kind {
-        if !elts.is_empty() {
-            todo!("Non empty Tuples aren't yet supported")
-        } else {
+        if elts.is_empty() {
             return literal_expression! {0x0};
+        } else {
+            panic!("Non-empty Tuples should be lowered to structs")
         }
     }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -129,15 +129,13 @@ pub struct FuncDefArg {
     pub typ: Node<TypeDesc>,
 }
 
-// TODO: `Node`s are very large. VarDecl is 328 bytes
-#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum FuncStmt {
     Return {
         value: Option<Node<Expr>>,
     },
     VarDecl {
-        target: Node<Expr>,
+        target: Node<VarDeclTarget>,
         typ: Node<TypeDesc>,
         value: Option<Node<Expr>>,
     },
@@ -181,6 +179,12 @@ pub enum FuncStmt {
     Break,
     Continue,
     Revert,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum VarDeclTarget {
+    Name(String),
+    Tuple(Vec<Node<VarDeclTarget>>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/parser/tests/cases/errors.rs
+++ b/parser/tests/cases/errors.rs
@@ -25,8 +25,7 @@ macro_rules! test_parse_err {
     ($name:ident, $parse_fn:expr, $should_fail:expr, $src:expr) => {
         #[test]
         fn $name() {
-            let err = err_string(stringify!($name), $parse_fn, $should_fail, $src);
-            assert_snapshot!(err);
+            assert_snapshot!(err_string(stringify!($name), $parse_fn, $should_fail, $src));
         }
     };
 }
@@ -57,5 +56,20 @@ test_parse_err! { if_no_body, functions::parse_stmt, true, "if x:\nelse:\n x" }
 test_parse_err! { import_bad_name, module::parse_simple_import, true, "import x as 123" }
 test_parse_err! { module_bad_stmt, module::parse_module, true, "if x:\n y" }
 test_parse_err! { module_nonsense, module::parse_module, true, "))" }
-test_parse_err! { string_invalid_escape, expressions::parse_expr, false, r#""a string \c ""# }
 test_parse_err! { struct_bad_field_name, types::parse_struct_def, true, "struct f:\n pub def" }
+test_parse_err! { stmt_vardecl_attr, functions::parse_stmt, true, "f.s : u" }
+test_parse_err! { stmt_vardecl_tuple, functions::parse_stmt, true, "(a, x+1) : u256" }
+test_parse_err! { stmt_vardecl_tuple_empty, functions::parse_stmt, true, "(a, ()) : u256" }
+test_parse_err! { stmt_vardecl_subscript, functions::parse_stmt, true, "a[1] : u256" }
+
+// assert_snapshot! doesn't like the invalid escape code
+#[test]
+fn string_invalid_escape() {
+    let err = err_string(
+        "string_invalid_escape",
+        expressions::parse_expr,
+        false,
+        r#""a string \c ""#,
+    );
+    assert_snapshot!(err);
+}

--- a/parser/tests/cases/parse_ast.rs
+++ b/parser/tests/cases/parse_ast.rs
@@ -102,6 +102,9 @@ test_parse! { stmt_if2, functions::parse_stmt, "if a:\n b \nelif c:\n d \nelif e
 test_parse! { stmt_while, functions::parse_stmt, "while a > 5:\n a -= 1" }
 test_parse! { stmt_for, functions::parse_stmt, "for a in b[0]:\n pass" }
 test_parse! { stmt_for_else, functions::parse_stmt, "for a in b:\n c\nelse:\n d" }
+test_parse! { stmt_var_decl_name, functions::parse_stmt, "foo: u256" }
+test_parse! { stmt_var_decl_tuple, functions::parse_stmt, "(foo, bar): (u256, u256) = (10, 10)" }
+test_parse! { stmt_var_decl_tuples, functions::parse_stmt, "(a, (b, (c, d))): x" }
 
 test_parse! { type_def, types::parse_type_def, "type X = map<address, u256>" }
 test_parse! { type_name, types::parse_type_desc, "MyType" }

--- a/parser/tests/cases/snapshots/cases__errors__contract_bad_name.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_bad_name.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(contract_bad_name), contracts::parse_contract_def, true,\n           \"contract 1X:\\n x: u8\")"
 
 ---
 error: failed to parse contract definition

--- a/parser/tests/cases/snapshots/cases__errors__contract_const_fn.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_const_fn.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(contract_const_fn), contracts::parse_contract_def,\n           false, \"contract C:\\n const def f():\\n  pass\")"
 
 ---
 error: `const` qualifier can't be used with function definitions

--- a/parser/tests/cases/snapshots/cases__errors__contract_const_pub.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_const_pub.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(contract_const_pub), contracts::parse_contract_def,\n           false, \"contract C:\\n const pub x: u8\")"
 
 ---
 error: `const pub` should be written `pub const`

--- a/parser/tests/cases/snapshots/cases__errors__contract_empty_body.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_empty_body.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(contract_empty_body), module::parse_module, true,\n           \"contract X:\\n \\n \\ncontract Y:\\n x: u8\")"
 
 ---
 error: failed to parse contract definition body

--- a/parser/tests/cases/snapshots/cases__errors__contract_field_after_def.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_field_after_def.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(contract_field_after_def), module::parse_module, false,\n           r#\"\ncontract C:\n  def f():\n    pass\n  x: u8\n\"#)"
 
 ---
 error: contract field definitions must come before any function or event definitions

--- a/parser/tests/cases/snapshots/cases__errors__contract_pub_event.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_pub_event.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(contract_pub_event), contracts::parse_contract_def,\n           false, \"contract C:\\n pub event E:\\n  x: u8\")"
 
 ---
 error: `pub` qualifier can't be used with event definitions

--- a/parser/tests/cases/snapshots/cases__errors__emit_bad_call.snap
+++ b/parser/tests/cases/snapshots/cases__errors__emit_bad_call.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(emit_bad_call), functions::parse_stmt, true,\n           \"emit MyEvent(1)()\")"
 
 ---
 error: unexpected token while parsing emit statement

--- a/parser/tests/cases/snapshots/cases__errors__emit_expr.snap
+++ b/parser/tests/cases/snapshots/cases__errors__emit_expr.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(emit_expr), functions::parse_stmt, true, \"emit x + 1\")"
 
 ---
 error: failed to parse event invocation parameter list

--- a/parser/tests/cases/snapshots/cases__errors__emit_no_args.snap
+++ b/parser/tests/cases/snapshots/cases__errors__emit_no_args.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(emit_no_args), functions::parse_stmt, true, \"emit x\")"
 
 ---
 error: unexpected end of file

--- a/parser/tests/cases/snapshots/cases__errors__expr_bad_prefix.snap
+++ b/parser/tests/cases/snapshots/cases__errors__expr_bad_prefix.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(expr_bad_prefix), expressions::parse_expr, true,\n           \"*x + 1\")"
 
 ---
 error: Unexpected token while parsing expression: `*`

--- a/parser/tests/cases/snapshots/cases__errors__fn_no_args.snap
+++ b/parser/tests/cases/snapshots/cases__errors__fn_no_args.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(fn_no_args), |par| functions::parse_fn_def(par, None),\n           false, \"def f:\\n  return 5\")"
 
 ---
 error: function definition requires a list of parameters

--- a/parser/tests/cases/snapshots/cases__errors__for_no_in.snap
+++ b/parser/tests/cases/snapshots/cases__errors__for_no_in.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(for_no_in), functions::parse_stmt, true,\n           \"for x:\\n pass\")"
 
 ---
 error: failed to parse `for` statement

--- a/parser/tests/cases/snapshots/cases__errors__if_no_body.snap
+++ b/parser/tests/cases/snapshots/cases__errors__if_no_body.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(if_no_body), functions::parse_stmt, true,\n           \"if x:\\nelse:\\n x\")"
 
 ---
 error: failed to parse `if` statement body

--- a/parser/tests/cases/snapshots/cases__errors__import_bad_name.snap
+++ b/parser/tests/cases/snapshots/cases__errors__import_bad_name.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(import_bad_name), module::parse_simple_import, true,\n           \"import x as 123\")"
 
 ---
 error: failed to parse import statement

--- a/parser/tests/cases/snapshots/cases__errors__module_bad_stmt.snap
+++ b/parser/tests/cases/snapshots/cases__errors__module_bad_stmt.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(module_bad_stmt), module::parse_module, true,\n           \"if x:\\n y\")"
 
 ---
 error: failed to parse module

--- a/parser/tests/cases/snapshots/cases__errors__module_nonsense.snap
+++ b/parser/tests/cases/snapshots/cases__errors__module_nonsense.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(module_nonsense), module::parse_module, true, \"))\")"
 
 ---
 error: Unmatched right parenthesis

--- a/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_attr.snap
+++ b/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_attr.snap
@@ -1,0 +1,15 @@
+---
+source: parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_attr), functions::parse_stmt, true,\n           \"f.s : u\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_attr:1:1
+  │
+1 │ f.s : u
+  │ ^^^ invalid variable declaration target
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_subscript.snap
+++ b/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_subscript.snap
@@ -1,0 +1,15 @@
+---
+source: parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_subscript), functions::parse_stmt, true,\n           \"a[1] : u256\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_subscript:1:1
+  │
+1 │ a[1] : u256
+  │ ^^^^ invalid variable declaration target
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple.snap
+++ b/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple.snap
@@ -1,0 +1,15 @@
+---
+source: parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_tuple), functions::parse_stmt, true,\n           \"(a, x+1) : u256\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_tuple:1:5
+  │
+1 │ (a, x+1) : u256
+  │     ^^^ invalid variable declaration target
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple_empty.snap
+++ b/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple_empty.snap
@@ -1,0 +1,15 @@
+---
+source: parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_tuple_empty), functions::parse_stmt, true,\n           \"(a, ()) : u256\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_tuple_empty:1:5
+  │
+1 │ (a, ()) : u256
+  │     ^^ invalid variable declaration target
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/parser/tests/cases/snapshots/cases__errors__struct_bad_field_name.snap
+++ b/parser/tests/cases/snapshots/cases__errors__struct_bad_field_name.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/errors.rs
-expression: err
+expression: "err_string(stringify!(struct_bad_field_name), types::parse_struct_def, true,\n           \"struct f:\\n pub def\")"
 
 ---
 error: failed to parse field definition

--- a/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_name.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_name.snap
@@ -1,0 +1,30 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_var_decl_name), functions::parse_stmt, \"foo: u256\")"
+
+---
+Node(
+  kind: VarDecl(
+    target: Node(
+      kind: Name("foo"),
+      span: Span(
+        start: 0,
+        end: 3,
+      ),
+    ),
+    typ: Node(
+      kind: Base(
+        base: "u256",
+      ),
+      span: Span(
+        start: 5,
+        end: 9,
+      ),
+    ),
+    value: None,
+  ),
+  span: Span(
+    start: 0,
+    end: 9,
+  ),
+)

--- a/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuple.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuple.snap
@@ -1,0 +1,87 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_var_decl_tuple), functions::parse_stmt,\n           \"(foo, bar): (u256, u256) = (10, 10)\")"
+
+---
+Node(
+  kind: VarDecl(
+    target: Node(
+      kind: Tuple([
+        Node(
+          kind: Name("foo"),
+          span: Span(
+            start: 1,
+            end: 4,
+          ),
+        ),
+        Node(
+          kind: Name("bar"),
+          span: Span(
+            start: 6,
+            end: 9,
+          ),
+        ),
+      ]),
+      span: Span(
+        start: 0,
+        end: 10,
+      ),
+    ),
+    typ: Node(
+      kind: Tuple(
+        items: [
+          Node(
+            kind: Base(
+              base: "u256",
+            ),
+            span: Span(
+              start: 13,
+              end: 17,
+            ),
+          ),
+          Node(
+            kind: Base(
+              base: "u256",
+            ),
+            span: Span(
+              start: 19,
+              end: 23,
+            ),
+          ),
+        ],
+      ),
+      span: Span(
+        start: 12,
+        end: 24,
+      ),
+    ),
+    value: Some(Node(
+      kind: Tuple(
+        elts: [
+          Node(
+            kind: Num("10"),
+            span: Span(
+              start: 28,
+              end: 30,
+            ),
+          ),
+          Node(
+            kind: Num("10"),
+            span: Span(
+              start: 32,
+              end: 34,
+            ),
+          ),
+        ],
+      ),
+      span: Span(
+        start: 27,
+        end: 35,
+      ),
+    )),
+  ),
+  span: Span(
+    start: 0,
+    end: 35,
+  ),
+)

--- a/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuples.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuples.snap
@@ -1,0 +1,75 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_var_decl_tuples), functions::parse_stmt,\n           \"(a, (b, (c, d))): x\")"
+
+---
+Node(
+  kind: VarDecl(
+    target: Node(
+      kind: Tuple([
+        Node(
+          kind: Name("a"),
+          span: Span(
+            start: 1,
+            end: 2,
+          ),
+        ),
+        Node(
+          kind: Tuple([
+            Node(
+              kind: Name("b"),
+              span: Span(
+                start: 5,
+                end: 6,
+              ),
+            ),
+            Node(
+              kind: Tuple([
+                Node(
+                  kind: Name("c"),
+                  span: Span(
+                    start: 9,
+                    end: 10,
+                  ),
+                ),
+                Node(
+                  kind: Name("d"),
+                  span: Span(
+                    start: 12,
+                    end: 13,
+                  ),
+                ),
+              ]),
+              span: Span(
+                start: 8,
+                end: 14,
+              ),
+            ),
+          ]),
+          span: Span(
+            start: 4,
+            end: 15,
+          ),
+        ),
+      ]),
+      span: Span(
+        start: 0,
+        end: 16,
+      ),
+    ),
+    typ: Node(
+      kind: Base(
+        base: "x",
+      ),
+      span: Span(
+        start: 18,
+        end: 19,
+      ),
+    ),
+    value: None,
+  ),
+  span: Span(
+    start: 0,
+    end: 19,
+  ),
+)


### PR DESCRIPTION
### What was wrong?

The ast and parser allowed any expr on the left-hand side of a variable declaration. The analyzer would panic on anything other than a name.

closes #351 

### How was it fixed?

Added a VarDeclTarget enum, with Name and Tuple variants. The parser now accepts names or non-empty tuples here, where the tuples can contain any VarDeclTarget (so `(a, (b, (c, d))): ...` is allowed). The analyzer and lowering phases are stubbed out with `todo!()`s.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
