### PR TITLE
Lower list expressions

### DIFF
--- a/analyzer/src/builtins.rs
+++ b/analyzer/src/builtins.rs
@@ -22,7 +22,7 @@ pub enum ContractTypeMethod {
     Create2,
 }
 
-#[derive(Debug, PartialEq, EnumString)]
+#[derive(strum::ToString, Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "lowercase")]
 pub enum Object {
     Block,

--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -2,7 +2,7 @@ use crate::builtins::GlobalMethod;
 use crate::errors::SemanticError;
 use crate::namespace::events::EventDef;
 use crate::namespace::scopes::{ContractFunctionDef, ContractScope, ModuleScope, Shared};
-use crate::namespace::types::{Contract, FixedSize, Struct, Tuple, Type};
+use crate::namespace::types::{Array, Contract, FixedSize, Struct, Tuple, Type};
 use fe_common::Span;
 use fe_parser::ast as fe;
 use fe_parser::node::{Node, NodeId};
@@ -49,6 +49,8 @@ pub struct ContractAttributes {
     pub init_function: Option<FunctionAttributes>,
     /// Events that have been defined by the user.
     pub events: Vec<EventDef>,
+    /// List expressions that the contract uses
+    pub list_expressions: BTreeSet<Array>,
     /// Static strings that the contract defines
     pub string_literals: BTreeSet<String>,
     /// Structs that have been defined by the user
@@ -116,6 +118,7 @@ impl From<Shared<ContractScope>> for ContractAttributes {
                 .values()
                 .map(|event| event.to_owned())
                 .collect::<Vec<EventDef>>(),
+            list_expressions: scope.borrow().list_expressions.clone(),
             string_literals: scope.borrow().string_defs.clone(),
             structs,
             external_contracts,

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -1,6 +1,6 @@
 use crate::errors::SemanticError;
 use crate::namespace::events::EventDef;
-use crate::namespace::types::{FixedSize, Tuple, Type};
+use crate::namespace::types::{Array, FixedSize, Tuple, Type};
 use std::cell::RefCell;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
@@ -41,6 +41,7 @@ pub struct ContractScope {
     pub event_defs: BTreeMap<String, EventDef>,
     pub field_defs: BTreeMap<String, ContractFieldDef>,
     pub function_defs: BTreeMap<String, ContractFunctionDef>,
+    pub list_expressions: BTreeSet<Array>,
     pub string_defs: BTreeSet<String>,
     pub created_contracts: BTreeSet<String>,
     num_fields: usize,
@@ -122,6 +123,7 @@ impl ContractScope {
             string_defs: BTreeSet::new(),
             interface: vec![],
             created_contracts: BTreeSet::new(),
+            list_expressions: BTreeSet::new(),
             num_fields: 0,
         }))
     }
@@ -208,6 +210,11 @@ impl ContractScope {
     /// contract.
     pub fn add_created_contract(&mut self, name: &str) {
         self.created_contracts.insert(name.to_owned());
+    }
+
+    /// Add the array type of a list expression that was used within the contract.
+    pub fn add_used_list_expression(&mut self, typ: Array) {
+        self.list_expressions.insert(typ);
     }
 }
 

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -357,6 +357,12 @@ impl From<Base> for Type {
     }
 }
 
+impl From<Base> for FixedSize {
+    fn from(value: Base) -> Self {
+        FixedSize::Base(value)
+    }
+}
+
 impl FixedSize {
     pub fn empty_tuple() -> Self {
         FixedSize::Tuple(Tuple::empty())

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -73,12 +73,20 @@ pub fn expr_list(
             // TODO: Right now we are only supporting Base type arrays
             // Potential we can support the tuples as well.
             if let Type::Base(base) = attribute_to_be_matched.typ {
+                let array_typ = Array {
+                    size: elts.len(),
+                    inner: base,
+                };
+
+                scope
+                    .borrow()
+                    .contract_scope()
+                    .borrow_mut()
+                    .add_used_list_expression(array_typ.clone());
+
                 return Ok(ExpressionAttributes {
-                    typ: Type::Array(Array {
-                        size: elts.len(),
-                        inner: base,
-                    }),
-                    location: attribute_to_be_matched.location,
+                    typ: Type::Array(array_typ),
+                    location: Location::Memory,
                     move_location: None,
                 });
             }

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -641,15 +641,17 @@ fn expr_call_self_attribute(
     func_name: &str,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
+    let called_func = scope
+        .borrow()
+        .contract_scope()
+        .borrow()
+        .function_def(func_name);
+
     if let Some(ContractFunctionDef {
         params,
         return_type,
         ..
-    }) = scope
-        .borrow()
-        .contract_scope()
-        .borrow()
-        .function_def(func_name)
+    }) = called_func
     {
         let argument_attributes = expr_call_args(Rc::clone(&scope), Rc::clone(&context), args)?;
 

--- a/analyzer/tests/snapshots/analysis__case_001_erc20_token.snap
+++ b/analyzer/tests/snapshots/analysis__case_001_erc20_token.snap
@@ -6067,6 +6067,7 @@ note:
                   ],
               },
           ],
+          list_expressions: {},
           string_literals: {},
           structs: [],
           external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_002_guest_book.snap
+++ b/analyzer/tests/snapshots/analysis__case_002_guest_book.snap
@@ -450,6 +450,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_003_uniswap.snap
+++ b/analyzer/tests/snapshots/analysis__case_003_uniswap.snap
@@ -25779,6 +25779,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [
@@ -26652,6 +26653,7 @@ note:
                   ],
               },
           ],
+          list_expressions: {},
           string_literals: {
               "UniswapV2: FORBIDDEN",
               "UniswapV2: INSUFFICIENT_INPUT_AMOUNT",
@@ -26952,6 +26954,7 @@ note:
                   ],
               },
           ],
+          list_expressions: {},
           string_literals: {
               "UniswapV2: FORBIDDEN",
               "UniswapV2: IDENTICAL_ADDRESSES",

--- a/analyzer/tests/snapshots/analysis__case_004_address_bytes10_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_004_address_bytes10_map.snap
@@ -386,6 +386,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_005_assert.snap
+++ b/analyzer/tests/snapshots/analysis__case_005_assert.snap
@@ -518,6 +518,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {
             "Must be greater than five",
         },

--- a/analyzer/tests/snapshots/analysis__case_006_aug_assign.snap
+++ b/analyzer/tests/snapshots/analysis__case_006_aug_assign.snap
@@ -2294,6 +2294,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_007_base_tuple.snap
+++ b/analyzer/tests/snapshots/analysis__case_007_base_tuple.snap
@@ -262,6 +262,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_008_call_statement_with_args.snap
+++ b/analyzer/tests/snapshots/analysis__case_008_call_statement_with_args.snap
@@ -339,6 +339,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_009_call_statement_with_args_2.snap
+++ b/analyzer/tests/snapshots/analysis__case_009_call_statement_with_args_2.snap
@@ -372,6 +372,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_010_call_statement_without_args.snap
+++ b/analyzer/tests/snapshots/analysis__case_010_call_statement_without_args.snap
@@ -298,6 +298,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_011_checked_arithmetic.snap
+++ b/analyzer/tests/snapshots/analysis__case_011_checked_arithmetic.snap
@@ -13353,6 +13353,7 @@ note:
           ],
           init_function: None,
           events: [],
+          list_expressions: {},
           string_literals: {},
           structs: [],
           external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_012_constructor.snap
+++ b/analyzer/tests/snapshots/analysis__case_012_constructor.snap
@@ -390,6 +390,7 @@ note:
             },
         ),
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_013_create2_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_013_create2_contract.snap
@@ -360,6 +360,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [
@@ -403,6 +404,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [

--- a/analyzer/tests/snapshots/analysis__case_014_create_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_014_create_contract.snap
@@ -327,6 +327,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [
@@ -369,6 +370,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [

--- a/analyzer/tests/snapshots/analysis__case_015_create_contract_from_init.snap
+++ b/analyzer/tests/snapshots/analysis__case_015_create_contract_from_init.snap
@@ -308,6 +308,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [
@@ -364,6 +365,7 @@ note:
              },
          ),
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [

--- a/analyzer/tests/snapshots/analysis__case_016_empty.snap
+++ b/analyzer/tests/snapshots/analysis__case_016_empty.snap
@@ -26,6 +26,7 @@ note:
         public_functions: [],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_017_events.snap
+++ b/analyzer/tests/snapshots/analysis__case_017_events.snap
@@ -980,6 +980,7 @@ note:
                  ],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_018_external_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_018_external_contract.snap
@@ -1912,6 +1912,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [
@@ -2097,6 +2098,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [

--- a/analyzer/tests/snapshots/analysis__case_019_for_loop_with_break.snap
+++ b/analyzer/tests/snapshots/analysis__case_019_for_loop_with_break.snap
@@ -609,6 +609,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_020_for_loop_with_continue.snap
+++ b/analyzer/tests/snapshots/analysis__case_020_for_loop_with_continue.snap
@@ -839,6 +839,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_021_for_loop_with_static_array.snap
+++ b/analyzer/tests/snapshots/analysis__case_021_for_loop_with_static_array.snap
@@ -531,6 +531,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_022_if_statement.snap
+++ b/analyzer/tests/snapshots/analysis__case_022_if_statement.snap
@@ -243,6 +243,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_023_if_statement_2.snap
+++ b/analyzer/tests/snapshots/analysis__case_023_if_statement_2.snap
@@ -259,6 +259,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_024_if_statement_with_block_declaration.snap
+++ b/analyzer/tests/snapshots/analysis__case_024_if_statement_with_block_declaration.snap
@@ -242,6 +242,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_025_keccak.snap
+++ b/analyzer/tests/snapshots/analysis__case_025_keccak.snap
@@ -435,6 +435,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_026_math.snap
+++ b/analyzer/tests/snapshots/analysis__case_026_math.snap
@@ -1150,6 +1150,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_027_multi_param.snap
+++ b/analyzer/tests/snapshots/analysis__case_027_multi_param.snap
@@ -461,6 +461,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_028_nested_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_028_nested_map.snap
@@ -973,6 +973,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_029_numeric_sizes.snap
+++ b/analyzer/tests/snapshots/analysis__case_029_numeric_sizes.snap
@@ -2673,6 +2673,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_030_ownable.snap
+++ b/analyzer/tests/snapshots/analysis__case_030_ownable.snap
@@ -844,6 +844,7 @@ note:
                  ],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_031_return_addition_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_031_return_addition_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_032_return_addition_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_032_return_addition_u128.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_033_return_addition_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_033_return_addition_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_034_return_array.snap
+++ b/analyzer/tests/snapshots/analysis__case_034_return_array.snap
@@ -243,6 +243,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_035_return_bitwiseand_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_035_return_bitwiseand_u128.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_036_return_bitwiseand_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_036_return_bitwiseand_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_037_return_bitwiseor_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_037_return_bitwiseor_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_038_return_bitwiseshl_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_038_return_bitwiseshl_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_039_return_bitwiseshr_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_039_return_bitwiseshr_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_040_return_bitwiseshr_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_040_return_bitwiseshr_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_041_return_bitwisexor_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_041_return_bitwisexor_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_042_return_bool_false.snap
+++ b/analyzer/tests/snapshots/analysis__case_042_return_bool_false.snap
@@ -89,6 +89,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_043_return_bool_inverted.snap
+++ b/analyzer/tests/snapshots/analysis__case_043_return_bool_inverted.snap
@@ -138,6 +138,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_044_return_bool_op_and.snap
+++ b/analyzer/tests/snapshots/analysis__case_044_return_bool_op_and.snap
@@ -184,6 +184,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_045_return_bool_op_or.snap
+++ b/analyzer/tests/snapshots/analysis__case_045_return_bool_op_or.snap
@@ -184,6 +184,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_046_return_bool_true.snap
+++ b/analyzer/tests/snapshots/analysis__case_046_return_bool_true.snap
@@ -89,6 +89,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_047_return_builtin_attributes.snap
+++ b/analyzer/tests/snapshots/analysis__case_047_return_builtin_attributes.snap
@@ -633,6 +633,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_048_return_division_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_048_return_division_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_049_return_division_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_049_return_division_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_050_return_empty_tuple.snap
+++ b/analyzer/tests/snapshots/analysis__case_050_return_empty_tuple.snap
@@ -329,6 +329,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_051_return_eq_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_051_return_eq_u256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_052_return_gt_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_052_return_gt_i256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_053_return_gt_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_053_return_gt_u256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_054_return_gte_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_054_return_gte_i256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_055_return_gte_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_055_return_gte_u256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_056_return_i128_cast.snap
+++ b/analyzer/tests/snapshots/analysis__case_056_return_i128_cast.snap
@@ -163,6 +163,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_057_return_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_057_return_i256.snap
@@ -131,6 +131,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_058_return_identity_u8.snap
+++ b/analyzer/tests/snapshots/analysis__case_058_return_identity_u8.snap
@@ -126,6 +126,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_059_return_identity_u16.snap
+++ b/analyzer/tests/snapshots/analysis__case_059_return_identity_u16.snap
@@ -126,6 +126,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_060_return_identity_u32.snap
+++ b/analyzer/tests/snapshots/analysis__case_060_return_identity_u32.snap
@@ -126,6 +126,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_061_return_identity_u64.snap
+++ b/analyzer/tests/snapshots/analysis__case_061_return_identity_u64.snap
@@ -126,6 +126,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_062_return_identity_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_062_return_identity_u128.snap
@@ -126,6 +126,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_063_return_identity_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_063_return_identity_u256.snap
@@ -126,6 +126,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_064_return_lt_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_064_return_lt_i256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_065_return_lt_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_065_return_lt_u128.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_066_return_lt_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_066_return_lt_u256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_067_return_lte_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_067_return_lte_i256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_068_return_lte_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_068_return_lte_u256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_069_return_mod_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_069_return_mod_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_070_return_mod_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_070_return_mod_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_071_return_msg_sig.snap
+++ b/analyzer/tests/snapshots/analysis__case_071_return_msg_sig.snap
@@ -155,6 +155,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_072_return_multiplication_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_072_return_multiplication_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_073_return_multiplication_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_073_return_multiplication_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_074_return_noteq_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_074_return_noteq_u256.snap
@@ -204,6 +204,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_075_return_pow_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_075_return_pow_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_076_return_pow_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_076_return_pow_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_077_return_subtraction_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_077_return_subtraction_i256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_078_return_subtraction_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_078_return_subtraction_u256.snap
@@ -214,6 +214,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_079_return_u128_cast.snap
+++ b/analyzer/tests/snapshots/analysis__case_079_return_u128_cast.snap
@@ -131,6 +131,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_080_return_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_080_return_u256.snap
@@ -99,6 +99,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_081_return_u256_from_called_fn.snap
+++ b/analyzer/tests/snapshots/analysis__case_081_return_u256_from_called_fn.snap
@@ -173,6 +173,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_082_return_u256_from_called_fn_with_args.snap
+++ b/analyzer/tests/snapshots/analysis__case_082_return_u256_from_called_fn_with_args.snap
@@ -1007,6 +1007,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_083_revert.snap
+++ b/analyzer/tests/snapshots/analysis__case_083_revert.snap
@@ -67,6 +67,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_084_self_address.snap
+++ b/analyzer/tests/snapshots/analysis__case_084_self_address.snap
@@ -89,6 +89,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_085_sized_vals_in_sto.snap
+++ b/analyzer/tests/snapshots/analysis__case_085_sized_vals_in_sto.snap
@@ -958,6 +958,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_086_strings.snap
+++ b/analyzer/tests/snapshots/analysis__case_086_strings.snap
@@ -815,6 +815,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {
              "The quick brown fox jumps over the lazy dog",
              "foo",

--- a/analyzer/tests/snapshots/analysis__case_087_structs.snap
+++ b/analyzer/tests/snapshots/analysis__case_087_structs.snap
@@ -6008,6 +6008,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [
              Struct {

--- a/analyzer/tests/snapshots/analysis__case_088_ternary_expression.snap
+++ b/analyzer/tests/snapshots/analysis__case_088_ternary_expression.snap
@@ -283,6 +283,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_089_two_contracts.snap
+++ b/analyzer/tests/snapshots/analysis__case_089_two_contracts.snap
@@ -496,6 +496,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [
@@ -565,6 +566,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [

--- a/analyzer/tests/snapshots/analysis__case_090_u8_u8_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_090_u8_u8_map.snap
@@ -379,6 +379,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_091_u16_u16_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_091_u16_u16_map.snap
@@ -379,6 +379,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_092_u32_u32_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_092_u32_u32_map.snap
@@ -379,6 +379,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_093_u64_u64_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_093_u64_u64_map.snap
@@ -379,6 +379,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_094_u128_u128_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_094_u128_u128_map.snap
@@ -379,6 +379,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_095_u256_u256_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_095_u256_u256_map.snap
@@ -379,6 +379,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_096_while_loop.snap
+++ b/analyzer/tests/snapshots/analysis__case_096_while_loop.snap
@@ -436,6 +436,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_097_while_loop_with_break.snap
+++ b/analyzer/tests/snapshots/analysis__case_097_while_loop_with_break.snap
@@ -325,6 +325,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_098_while_loop_with_break_2.snap
+++ b/analyzer/tests/snapshots/analysis__case_098_while_loop_with_break_2.snap
@@ -404,6 +404,7 @@ note:
         ],
         init_function: None,
         events: [],
+        list_expressions: {},
         string_literals: {},
         structs: [],
         external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_099_while_loop_with_continue.snap
+++ b/analyzer/tests/snapshots/analysis__case_099_while_loop_with_continue.snap
@@ -544,6 +544,7 @@ note:
          ],
          init_function: None,
          events: [],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_100_abi_encoding_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_100_abi_encoding_stress.snap
@@ -2831,6 +2831,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [
              Struct {

--- a/analyzer/tests/snapshots/analysis__case_101_data_copying_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_101_data_copying_stress.snap
@@ -3480,6 +3480,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/analyzer/tests/snapshots/analysis__case_102_tuple_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_102_tuple_stress.snap
@@ -2451,6 +2451,7 @@ note:
                  indexed_fields: [],
              },
          ],
+         list_expressions: {},
          string_literals: {},
          structs: [],
          external_contracts: [],

--- a/compiler/src/lowering/mappers/contracts.rs
+++ b/compiler/src/lowering/mappers/contracts.rs
@@ -1,9 +1,10 @@
 use fe_analyzer::context::Context;
+use fe_analyzer::namespace::types::{Array, FixedSize};
 
-use crate::lowering::mappers::functions;
-use crate::lowering::mappers::types;
+use crate::lowering::mappers::{functions, types};
+use crate::lowering::names;
+use crate::lowering::utils::ZeroSpanNode;
 use fe_parser::ast as fe;
-use fe_parser::ast::ContractStmt;
 use fe_parser::node::Node;
 
 /// Lowers a contract definition.
@@ -12,10 +13,20 @@ pub fn contract_def(context: &Context, stmt: Node<fe::ModuleStmt>) -> Node<fe::M
         let lowered_body = body
             .into_iter()
             .map(|stmt| match stmt.kind {
-                ContractStmt::EventDef { .. } => event_def(context, stmt),
-                ContractStmt::FuncDef { .. } => functions::func_def(context, stmt),
+                fe::ContractStmt::EventDef { .. } => event_def(context, stmt),
+                fe::ContractStmt::FuncDef { .. } => functions::func_def(context, stmt),
             })
             .collect();
+
+        let attributes = context.get_contract(stmt.id).expect("missing attributes");
+
+        let func_defs_from_list_expr = attributes
+            .list_expressions
+            .iter()
+            .map(|expr| list_expr_to_fn_def(expr).into_node())
+            .collect::<Vec<Node<fe::ContractStmt>>>();
+
+        let lowered_body = [lowered_body, func_defs_from_list_expr].concat();
 
         let lowered_fields = fields
             .into_iter()
@@ -74,4 +85,63 @@ fn event_def(context: &Context, stmt: Node<fe::ContractStmt>) -> Node<fe::Contra
     }
 
     unreachable!()
+}
+
+fn list_expr_to_fn_def(array: &Array) -> fe::ContractStmt {
+    // Built the AST nodes for the function arguments
+    let args = (0..array.size)
+        .map(|index| {
+            fe::FuncDefArg {
+                name: format!("val{}", index).into_node(),
+                typ: names::fixed_size_type_desc(&FixedSize::Base(array.inner.clone())).into_node(),
+            }
+            .into_node()
+        })
+        .collect::<Vec<_>>();
+
+    // Build the AST node for the array declaration
+    let var_decl_name = "generated_array";
+    let var_decl = fe::FuncStmt::VarDecl {
+        target: fe::VarDeclTarget::Name(var_decl_name.to_string()).into_node(),
+        typ: names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node(),
+        value: None,
+    }
+    .into_node();
+
+    // Build the AST nodes for the individual assignments of array slots
+    let assignments = (0..array.size)
+        .map(|index| {
+            fe::FuncStmt::Assign {
+                targets: vec![fe::Expr::Subscript {
+                    value: fe::Expr::Name(var_decl_name.to_string()).into_boxed_node(),
+                    slices: vec![fe::Slice::Index(
+                        fe::Expr::Num(index.to_string()).into_boxed_node(),
+                    )
+                    .into_node()]
+                    .into_node(),
+                }
+                .into_node()],
+                value: fe::Expr::Name(format!("val{}", index)).into_node(),
+            }
+            .into_node()
+        })
+        .collect::<Vec<_>>();
+
+    // Build the AST node for the return statement
+    let return_stmt = fe::FuncStmt::Return {
+        value: Some(fe::Expr::Name(var_decl_name.to_string()).into_node()),
+    }
+    .into_node();
+
+    let return_type =
+        Some(names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node());
+
+    // Put it all together in one AST node that holds the entire function definition
+    fe::ContractStmt::FuncDef {
+        pub_qual: None,
+        name: names::list_expr_generator_fn_name(array).into_node(),
+        args,
+        return_type,
+        body: [vec![var_decl], assignments, vec![return_stmt]].concat(),
+    }
 }

--- a/compiler/src/lowering/mappers/expressions.rs
+++ b/compiler/src/lowering/mappers/expressions.rs
@@ -1,4 +1,6 @@
-use crate::lowering::names::tuple_struct_name;
+use crate::lowering::names::{list_expr_generator_fn_name, tuple_struct_name};
+use crate::lowering::utils::ZeroSpanNode;
+use fe_analyzer::builtins::Object;
 use fe_analyzer::context::Context;
 use fe_analyzer::namespace::types::Type;
 use fe_parser::ast as fe;
@@ -53,7 +55,7 @@ pub fn expr(context: &Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
             func: boxed_expr(context, func),
             args: call_args(context, args),
         },
-        fe::Expr::List { .. } => unimplemented!(),
+        fe::Expr::List { .. } => expr_list(context, exp),
         fe::Expr::ListComp { .. } => unimplemented!(),
         fe::Expr::Tuple { .. } => expr_tuple(context, exp),
         fe::Expr::Str(_) => exp.kind,
@@ -156,6 +158,34 @@ fn expr_tuple(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
             // create type constructor call for the lowered tuple
             return fe::Expr::Call {
                 func: Box::new(Node::new(name, exp.span)),
+                args,
+            };
+        }
+    }
+
+    unreachable!()
+}
+
+fn expr_list(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
+    let attributes = context.get_expression(&exp).expect("missing attributes");
+
+    if let Type::Array(array) = &attributes.typ {
+        let fn_name = list_expr_generator_fn_name(array);
+
+        if let fe::Expr::List { elts } = exp.kind {
+            let args = elts
+                .into_iter()
+                .map(|list_val| fe::CallArg::Arg(list_val).into_node())
+                .collect::<Vec<_>>()
+                .into_node();
+
+            // Turn List Expression into a function call
+            return fe::Expr::Call {
+                func: fe::Expr::Attribute {
+                    value: fe::Expr::Name(Object::Self_.to_string()).into_boxed_node(),
+                    attr: fn_name.into_node(),
+                }
+                .into_boxed_node(),
                 args,
             };
         }

--- a/compiler/src/lowering/mod.rs
+++ b/compiler/src/lowering/mod.rs
@@ -5,6 +5,7 @@ use fe_analyzer::context::Context;
 
 mod mappers;
 mod names;
+mod utils;
 
 /// Lowers the Fe source AST to a Fe HIR AST.
 pub fn lower(context: &Context, module: FeModuleAst) -> FeModuleAst {

--- a/compiler/src/lowering/names.rs
+++ b/compiler/src/lowering/names.rs
@@ -1,5 +1,11 @@
-use fe_analyzer::namespace::types::{Base, FixedSize, Integer, SafeNames, Tuple};
+use crate::lowering::utils::ZeroSpanNode;
+use fe_analyzer::namespace::types::{Array, Base, FixedSize, Integer, SafeNames, Tuple};
 use fe_parser::ast as fe;
+
+/// The name of a lowered list expression generator function.
+pub fn list_expr_generator_fn_name(list_expr_type: &Array) -> String {
+    format!("list_expr_{}", list_expr_type.lower_snake())
+}
 
 /// The name of a lowered tuple struct definition.
 pub fn tuple_struct_string(tuple: &Tuple) -> String {
@@ -24,7 +30,10 @@ pub fn fixed_size_type_desc(typ: &FixedSize) -> fe::TypeDesc {
         FixedSize::Base(base) => fe::TypeDesc::Base {
             base: base_type_name(base),
         },
-        FixedSize::Array(_) => todo!(),
+        FixedSize::Array(array) => fe::TypeDesc::Array {
+            dimension: array.size,
+            typ: fixed_size_type_desc(&array.inner.clone().into()).into_boxed_node(),
+        },
         FixedSize::Tuple(_) => todo!(),
         FixedSize::String(_) => todo!(),
         FixedSize::Contract(_) => todo!(),

--- a/compiler/src/lowering/utils.rs
+++ b/compiler/src/lowering/utils.rs
@@ -1,0 +1,17 @@
+use fe_common::Span;
+use fe_parser::node::Node;
+
+/// A trait to turn any sized type into a `Node` with a span of zero.
+pub trait ZeroSpanNode: Sized {
+    /// Wrap the value in a `Node` with a span of zero.
+    fn into_node(self) -> Node<Self> {
+        Node::new(self, Span::zero())
+    }
+
+    /// Wrap the value in a boxed `Node` with a span of zero
+    fn into_boxed_node(self) -> Box<Node<Self>> {
+        Box::new(self.into_node())
+    }
+}
+
+impl<T> ZeroSpanNode for T {}

--- a/compiler/tests/cases/features.rs
+++ b/compiler/tests/cases/features.rs
@@ -143,6 +143,8 @@ fn test_assert() {
     case("return_u128_cast.fe", &[], uint_token(42)),
     case("return_i128_cast.fe", &[], int_token(-3)),
     case("return_msg_sig.fe", &[], bytes32_token("febb0f7e")),
+    case("return_sum_list_expression_1.fe", &[], uint_token(210)),
+    case("return_sum_list_expression_2.fe", &[], uint_token(210)),
     // binary operators
     case("return_addition_u256.fe", &[uint_token(42), uint_token(42)], uint_token(84)),
     case("return_addition_i256.fe", &[int_token(-42), int_token(-42)], int_token(-84)),

--- a/compiler/tests/cases/lowering/fixtures/list_expressions.fe
+++ b/compiler/tests/cases/lowering/fixtures/list_expressions.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def foo():
+        x: u256[3] = [10, 20, 30]

--- a/compiler/tests/cases/lowering/fixtures/list_expressions_lowered.fe
+++ b/compiler/tests/cases/lowering/fixtures/list_expressions_lowered.fe
@@ -1,0 +1,12 @@
+contract Foo:
+
+    pub def foo():
+        x: u256[3] = self.list_expr_array_u256_3(10, 20, 30)
+
+    def list_expr_array_u256_3(val0: u256, val1:u256, val2:u256) -> u256[3]:
+        generated_array: u256[3]
+        generated_array[0] = val0
+        generated_array[1] = val1
+        generated_array[2] = val2
+        return generated_array
+

--- a/compiler/tests/cases/lowering/mod.rs
+++ b/compiler/tests/cases/lowering/mod.rs
@@ -26,7 +26,12 @@ fn replace_spans(input: String) -> String {
     span_re.replace_all(&input, "[span omitted]").to_string()
 }
 
-#[rstest(fixture, case("aug_assign"), case("base_tuple"))]
+#[rstest(
+    fixture,
+    case("aug_assign"),
+    case("base_tuple"),
+    case("list_expressions")
+)]
 fn test_lowering(fixture: &str) {
     let src = fs::read_to_string(format!("tests/cases/lowering/fixtures/{}.fe", fixture))
         .expect("unable to src read fixture file");

--- a/compiler/tests/fixtures/features/return_sum_list_expression_1.fe
+++ b/compiler/tests/fixtures/features/return_sum_list_expression_1.fe
@@ -1,0 +1,8 @@
+contract Foo:
+
+    pub def bar() -> u256:
+        my_array: u256[20] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        sum: u256 = 0
+        for i in my_array:
+            sum = sum + i
+        return sum

--- a/compiler/tests/fixtures/features/return_sum_list_expression_2.fe
+++ b/compiler/tests/fixtures/features/return_sum_list_expression_2.fe
@@ -1,0 +1,10 @@
+contract Foo:
+
+    pub def bar() -> u256:
+        return self.count([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+
+    def count(values: u256[20]) -> u256:
+        sum: u256 = 0
+        for i in values:
+            sum = sum + i
+        return sum

--- a/newsfragments/388.feature.md
+++ b/newsfragments/388.feature.md
@@ -1,0 +1,11 @@
+Added support for list expressions.
+
+Example:
+
+```
+values: u256[3] = [10, 20, 30]
+
+# or anywhere else where expressions can be used such as in a call
+
+sum: u256 = self.sum([10, 20, 30])
+```


### PR DESCRIPTION
### What was wrong?

We do not yet support list expressions e.g. `[1, 2, 3]`

### How was it fixed?

1. List expressions are taken care of in the lowering pass. They are lowered to a function call where in the function we do an array declaration and individual assignments.
2. Added a blanket trait with `into_node()` and `into_boxed_node()` methods to make working without significant spans less annoying 
3. Added tests for the lowering as well as for the feature itself
