### PR TITLE
Panic if context.add_ methods are called twice.

### DIFF
--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -319,9 +319,27 @@ impl Context {
     }
 
     /// Attribute contextual information to an expression node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_expression(&mut self, node: &Node<fe::Expr>, attributes: ExpressionAttributes) {
         self.add_node(node);
-        self.expressions.insert(node.id, attributes);
+        expect_none(
+            self.expressions.insert(node.id, attributes),
+            "expression attributes already exist",
+        );
+    }
+
+    /// Update the expression attributes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry does not already exist for the node id.
+    pub fn update_expression(&mut self, node: &Node<fe::Expr>, attributes: ExpressionAttributes) {
+        self.expressions
+            .insert(node.id, attributes)
+            .expect("expression attributes do not exist");
     }
 
     /// Get information that has been attributed to an expression node.
@@ -330,9 +348,16 @@ impl Context {
     }
 
     /// Attribute contextual information to an emit statement node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_emit(&mut self, node: &Node<fe::FuncStmt>, event: EventDef) {
         self.add_node(node);
-        self.emits.insert(node.id, event);
+        expect_none(
+            self.emits.insert(node.id, event),
+            "emit statement attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to an emit statement node.
@@ -341,9 +366,16 @@ impl Context {
     }
 
     /// Attribute contextual information to a function definition node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_function(&mut self, node: &Node<fe::ContractStmt>, attributes: FunctionAttributes) {
         self.add_node(node);
-        self.functions.insert(node.id, attributes);
+        expect_none(
+            self.functions.insert(node.id, attributes),
+            "function attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to a function definition node.
@@ -352,9 +384,16 @@ impl Context {
     }
 
     /// Attribute contextual information to a declaration node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_declaration(&mut self, node: &Node<fe::FuncStmt>, typ: FixedSize) {
         self.add_node(node);
-        self.declarations.insert(node.id, typ);
+        expect_none(
+            self.declarations.insert(node.id, typ),
+            "declaration attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to a declaration node.
@@ -363,9 +402,16 @@ impl Context {
     }
 
     /// Attribute contextual information to a contract definition node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_contract(&mut self, node: &Node<fe::ModuleStmt>, attributes: ContractAttributes) {
         self.add_node(node);
-        self.contracts.insert(node.id, attributes);
+        expect_none(
+            self.contracts.insert(node.id, attributes),
+            "contract attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to a contract definition node.
@@ -374,9 +420,16 @@ impl Context {
     }
 
     /// Attribute contextual information to a call expression node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_call(&mut self, node: &Node<fe::Expr>, call_type: CallType) {
         self.add_node(node);
-        self.calls.insert(node.id, call_type);
+        expect_none(
+            self.calls.insert(node.id, call_type),
+            "call attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to a call expression node.
@@ -385,9 +438,16 @@ impl Context {
     }
 
     /// Attribute contextual information to an event definition node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_event(&mut self, node: &Node<fe::ContractStmt>, event: EventDef) {
         self.add_node(node);
-        self.events.insert(node.id, event);
+        expect_none(
+            self.events.insert(node.id, event),
+            "event attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to an event definition node.
@@ -396,9 +456,16 @@ impl Context {
     }
 
     /// Attribute contextual information to a type description node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an entry already exists for the node id.
     pub fn add_type_desc(&mut self, node: &Node<fe::TypeDesc>, typ: Type) {
         self.add_node(node);
-        self.type_descs.insert(node.id, typ);
+        expect_none(
+            self.type_descs.insert(node.id, typ),
+            "type desc attributes already exist",
+        );
     }
 
     /// Get information that has been attributed to a type description node.
@@ -502,5 +569,12 @@ impl Context {
                     .map(|attributes| (self.spans[node_id], attributes.to_owned()))
             })
             .collect::<Vec<_>>()
+    }
+}
+
+/// Temporary helper until `expect_none` is stable.
+fn expect_none<T>(item: Option<T>, msg: &str) {
+    if item.is_some() {
+        panic!("{}", msg)
     }
 }

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -64,7 +64,7 @@ pub fn expr_list(
             // Rationale - A list contains only one type of element.
             // No need to iterate the whole list if the first attribute doesn't match next
             // one.
-            for elt in elts.iter() {
+            for elt in elts.iter().skip(1) {
                 let next_attribute = expr(Rc::clone(&scope), Rc::clone(&context), elt)?;
                 validate_types_equal(&next_attribute, &attribute_to_be_matched)?;
             }
@@ -105,7 +105,9 @@ pub fn value_expr(
 ) -> Result<ExpressionAttributes, SemanticError> {
     let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.into_loaded()?;
 
-    context.borrow_mut().add_expression(exp, attributes.clone());
+    context
+        .borrow_mut()
+        .update_expression(exp, attributes.clone());
 
     Ok(attributes)
 }
@@ -120,7 +122,9 @@ pub fn assignable_expr(
 ) -> Result<ExpressionAttributes, SemanticError> {
     let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.into_assignable()?;
 
-    context.borrow_mut().add_expression(exp, attributes.clone());
+    context
+        .borrow_mut()
+        .update_expression(exp, attributes.clone());
 
     Ok(attributes)
 }

--- a/analyzer/tests/snapshots/analysis__case_001_erc20_token.snap
+++ b/analyzer/tests/snapshots/analysis__case_001_erc20_token.snap
@@ -326,22 +326,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:24:29
-   │
-24 │         self._decimals = u8(18)
-   │                             ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:24:26
    │
 24 │         self._decimals = u8(18)
@@ -366,36 +350,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:25:20
-   │
-25 │         self._mint(msg.sender, 1000000000000000000000000)
-   │                    ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:25:32
-   │
-25 │         self._mint(msg.sender, 1000000000000000000000000)
-   │                                ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -476,28 +430,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:28:16
-   │
-28 │         return self._name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 1366875787856227596
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 3,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:31:16
    │
 31 │         return self._symbol.to_mem()
@@ -540,28 +472,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:31:16
-   │
-31 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17260580191421820722
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 4,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:34:16
    │
 34 │         return self._decimals
@@ -576,50 +486,6 @@ note:
          location: Storage {
              nonce: Some(
                  5,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:34:16
-   │
-34 │         return self._decimals
-   │                ^^^^^^^^^^^^^^ attributes hash: 17806238794946045546
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 5,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:37:16
-   │
-37 │         return self._total_supply
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
              ),
          },
          move_location: Some(
@@ -689,40 +555,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:40:31
-   │
-40 │         return self._balances[account]
-   │                               ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:40:16
-   │
-40 │         return self._balances[account]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:40:16
    │
 40 │         return self._balances[account]
@@ -757,20 +589,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:43:24
-   │
-43 │         self._transfer(msg.sender, recipient, amount)
-   │                        ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:43:36
    │
 43 │         self._transfer(msg.sender, recipient, amount)
@@ -779,36 +597,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:43:36
-   │
-43 │         self._transfer(msg.sender, recipient, amount)
-   │                                    ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:43:47
-   │
-43 │         self._transfer(msg.sender, recipient, amount)
-   │                                               ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -861,20 +649,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:44:16
-   │
-44 │         return true
-   │                ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:47:16
    │
 47 │         return self._allowances[owner][spender]
@@ -901,20 +675,6 @@ note:
                  1,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:47:33
-   │
-47 │         return self._allowances[owner][spender]
-   │                                 ^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -970,40 +730,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:47:40
-   │
-47 │         return self._allowances[owner][spender]
-   │                                        ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:47:16
-   │
-47 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:47:16
    │
 47 │         return self._allowances[owner][spender]
@@ -1038,20 +764,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:50:23
-   │
-50 │         self._approve(msg.sender, spender, amount)
-   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:50:35
    │
 50 │         self._approve(msg.sender, spender, amount)
@@ -1060,36 +772,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:50:35
-   │
-50 │         self._approve(msg.sender, spender, amount)
-   │                                   ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:50:44
-   │
-50 │         self._approve(msg.sender, spender, amount)
-   │                                            ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -1124,20 +806,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:51:16
-   │
-51 │         return true
-   │                ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1200,20 +868,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:54:33
-   │
-54 │         assert self._allowances[sender][msg.sender] >= amount
-   │                                 ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:54:16
    │
 54 │         assert self._allowances[sender][msg.sender] >= amount
@@ -1251,20 +905,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:54:41
-   │
-54 │         assert self._allowances[sender][msg.sender] >= amount
-   │                                         ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:54:16
    │
 54 │         assert self._allowances[sender][msg.sender] >= amount
@@ -1282,42 +922,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:54:16
-   │
-54 │         assert self._allowances[sender][msg.sender] >= amount
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:54:56
-   │
-54 │         assert self._allowances[sender][msg.sender] >= amount
-   │                                                        ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1365,20 +969,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:56:24
-   │
-56 │         self._transfer(sender, recipient, amount)
-   │                        ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:56:32
    │
 56 │         self._transfer(sender, recipient, amount)
@@ -1387,36 +977,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:56:32
-   │
-56 │         self._transfer(sender, recipient, amount)
-   │                                ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:56:43
-   │
-56 │         self._transfer(sender, recipient, amount)
-   │                                           ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -1459,34 +1019,6 @@ note:
    │
 57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
    │                       ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:57:23
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                       ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:57:31
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                               ^^^^^^^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1555,20 +1087,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:57:60
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                                                            ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:57:43
    │
 57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
@@ -1606,40 +1124,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:57:68
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                                                                    ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:57:43
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:57:43
    │
 57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
@@ -1664,38 +1148,6 @@ note:
    │
 57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
    │                                                                                  ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:57:82
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                                                                                  ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:57:43
-   │
-57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - amount)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1754,52 +1206,10 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:58:16
-   │
-58 │         return true
-   │                ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:61:23
    │
 61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
    │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:61:23
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:61:35
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                   ^^^^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1868,20 +1278,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:61:61
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                                             ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:61:44
    │
 61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
@@ -1919,40 +1315,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:61:73
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                                                         ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:61:44
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:61:44
    │
 61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
@@ -1977,38 +1339,6 @@ note:
    │
 61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
    │                                                                                    ^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:61:84
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                                                                    ^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:61:44
-   │
-61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2067,52 +1397,10 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:62:16
-   │
-62 │         return true
-   │                ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:65:23
    │
 65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
    │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:65:23
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:65:35
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                   ^^^^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2181,20 +1469,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:65:61
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                                             ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:65:44
    │
 65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
@@ -2232,40 +1506,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:65:73
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                                                         ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:65:44
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:65:44
    │
 65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
@@ -2290,38 +1530,6 @@ note:
    │
 65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
    │                                                                                    ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:65:84
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                                                                    ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:65:44
-   │
-65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2380,34 +1588,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:66:16
-   │
-66 │         return true
-   │                ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:69:16
-   │
-69 │         assert sender != address(0)
-   │                ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:69:16
    │
 69 │         assert sender != address(0)
@@ -2432,36 +1612,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:69:34
-   │
-69 │         assert sender != address(0)
-   │                                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:69:26
-   │
-69 │         assert sender != address(0)
-   │                          ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -2510,20 +1660,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:70:16
-   │
-70 │         assert recipient != address(0)
-   │                ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:70:37
    │
 70 │         assert recipient != address(0)
@@ -2534,36 +1670,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:70:37
-   │
-70 │         assert recipient != address(0)
-   │                                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:70:29
-   │
-70 │         assert recipient != address(0)
-   │                             ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -2612,20 +1718,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:72:37
-   │
-72 │         self._before_token_transfer(sender, recipient, amount)
-   │                                     ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:72:45
    │
 72 │         self._before_token_transfer(sender, recipient, amount)
@@ -2634,36 +1726,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:72:45
-   │
-72 │         self._before_token_transfer(sender, recipient, amount)
-   │                                             ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:72:56
-   │
-72 │         self._before_token_transfer(sender, recipient, amount)
-   │                                                        ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -2741,20 +1803,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:74:24
-   │
-74 │         self._balances[sender] = self._balances[sender] - amount
-   │                        ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:74:9
    │
 74 │         self._balances[sender] = self._balances[sender] - amount
@@ -2812,20 +1860,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:74:49
-   │
-74 │         self._balances[sender] = self._balances[sender] - amount
-   │                                                 ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:74:34
    │
 74 │         self._balances[sender] = self._balances[sender] - amount
@@ -2843,42 +1877,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:74:34
-   │
-74 │         self._balances[sender] = self._balances[sender] - amount
-   │                                  ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:74:59
-   │
-74 │         self._balances[sender] = self._balances[sender] - amount
-   │                                                           ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -2935,20 +1933,6 @@ note:
                  0,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:75:24
-   │
-75 │         self._balances[recipient] = self._balances[recipient] + amount
-   │                        ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -3024,20 +2008,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:75:52
-   │
-75 │         self._balances[recipient] = self._balances[recipient] + amount
-   │                                                    ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:75:37
    │
 75 │         self._balances[recipient] = self._balances[recipient] + amount
@@ -3055,42 +2025,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:75:37
-   │
-75 │         self._balances[recipient] = self._balances[recipient] + amount
-   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:75:65
-   │
-75 │         self._balances[recipient] = self._balances[recipient] + amount
-   │                                                                 ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -3140,20 +2074,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:76:23
-   │
-76 │         emit Transfer(sender, recipient, amount)
-   │                       ^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:76:31
    │
 76 │         emit Transfer(sender, recipient, amount)
@@ -3162,36 +2082,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:76:31
-   │
-76 │         emit Transfer(sender, recipient, amount)
-   │                               ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:76:42
-   │
-76 │         emit Transfer(sender, recipient, amount)
-   │                                          ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -3228,20 +2118,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:79:16
-   │
-79 │         assert account != address(0)
-   │                ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:79:35
    │
 79 │         assert account != address(0)
@@ -3252,36 +2128,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:79:35
-   │
-79 │         assert account != address(0)
-   │                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:79:27
-   │
-79 │         assert account != address(0)
-   │                           ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -3332,36 +2178,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:81:45
-   │
-81 │         self._before_token_transfer(address(0), account, amount)
-   │                                             ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:81:37
-   │
-81 │         self._before_token_transfer(address(0), account, amount)
-   │                                     ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:81:37
    │
 81 │         self._before_token_transfer(address(0), account, amount)
@@ -3384,36 +2200,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:81:49
-   │
-81 │         self._before_token_transfer(address(0), account, amount)
-   │                                                 ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:81:58
-   │
-81 │         self._before_token_transfer(address(0), account, amount)
-   │                                                          ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -3494,44 +2280,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:83:30
-   │
-83 │         self._total_supply = self._total_supply + amount
-   │                              ^^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:83:51
-   │
-83 │         self._total_supply = self._total_supply + amount
-   │                                                   ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:83:51
    │
 83 │         self._total_supply = self._total_supply + amount
@@ -3585,20 +2333,6 @@ note:
                  0,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:84:24
-   │
-84 │         self._balances[account] = self._balances[account] + amount
-   │                        ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -3674,20 +2408,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:84:50
-   │
-84 │         self._balances[account] = self._balances[account] + amount
-   │                                                  ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:84:35
    │
 84 │         self._balances[account] = self._balances[account] + amount
@@ -3705,42 +2425,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:84:35
-   │
-84 │         self._balances[account] = self._balances[account] + amount
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:84:61
-   │
-84 │         self._balances[account] = self._balances[account] + amount
-   │                                                             ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -3792,54 +2476,10 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:85:31
-   │
-85 │         emit Transfer(address(0), account, amount)
-   │                               ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:85:23
    │
 85 │         emit Transfer(address(0), account, amount)
    │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:85:23
-   │
-85 │         emit Transfer(address(0), account, amount)
-   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:85:35
-   │
-85 │         emit Transfer(address(0), account, amount)
-   │                                   ^^^^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3880,36 +2520,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:85:44
-   │
-85 │         emit Transfer(address(0), account, amount)
-   │                                            ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:88:16
-   │
-88 │         assert account != address(0)
-   │                ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:88:16
    │
 88 │         assert account != address(0)
@@ -3934,36 +2544,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:88:35
-   │
-88 │         assert account != address(0)
-   │                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:88:27
-   │
-88 │         assert account != address(0)
-   │                           ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -4012,36 +2592,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:90:37
-   │
-90 │         self._before_token_transfer(account, address(0), amount)
-   │                                     ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:90:54
-   │
-90 │         self._before_token_transfer(account, address(0), amount)
-   │                                                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:90:54
    │
 90 │         self._before_token_transfer(account, address(0), amount)
@@ -4066,36 +2616,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:90:46
-   │
-90 │         self._before_token_transfer(account, address(0), amount)
-   │                                              ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:90:58
-   │
-90 │         self._before_token_transfer(account, address(0), amount)
-   │                                                          ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -4173,20 +2693,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:92:24
-   │
-92 │         self._balances[account] = self._balances[account] - amount
-   │                        ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:92:9
    │
 92 │         self._balances[account] = self._balances[account] - amount
@@ -4244,20 +2750,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:92:50
-   │
-92 │         self._balances[account] = self._balances[account] - amount
-   │                                                  ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:92:35
    │
 92 │         self._balances[account] = self._balances[account] - amount
@@ -4275,42 +2767,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:92:35
-   │
-92 │         self._balances[account] = self._balances[account] - amount
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:92:61
-   │
-92 │         self._balances[account] = self._balances[account] - amount
-   │                                                             ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -4388,44 +2844,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:93:30
-   │
-93 │         self._total_supply = self._total_supply - amount
-   │                              ^^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:93:51
-   │
-93 │         self._total_supply = self._total_supply - amount
-   │                                                   ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:93:51
    │
 93 │         self._total_supply = self._total_supply - amount
@@ -4472,20 +2890,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:94:23
-   │
-94 │         emit Transfer(account, address(0), amount)
-   │                       ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:94:40
    │
 94 │         emit Transfer(account, address(0), amount)
@@ -4496,36 +2900,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:94:40
-   │
-94 │         emit Transfer(account, address(0), amount)
-   │                                        ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:94:32
-   │
-94 │         emit Transfer(account, address(0), amount)
-   │                                ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -4562,36 +2936,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:94:44
-   │
-94 │         emit Transfer(account, address(0), amount)
-   │                                            ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:97:16
-   │
-97 │         assert owner != address(0)
-   │                ^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:97:16
    │
 97 │         assert owner != address(0)
@@ -4616,36 +2960,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:97:33
-   │
-97 │         assert owner != address(0)
-   │                                 ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:97:25
-   │
-97 │         assert owner != address(0)
-   │                         ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -4694,20 +3008,6 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:98:16
-   │
-98 │         assert spender != address(0)
-   │                ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/erc20_token.fe:98:35
    │
 98 │         assert spender != address(0)
@@ -4718,36 +3018,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:98:35
-   │
-98 │         assert spender != address(0)
-   │                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:98:27
-   │
-98 │         assert spender != address(0)
-   │                           ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -4826,20 +3096,6 @@ note:
       }
 
 note: 
-    ┌─ demos/erc20_token.fe:100:26
-    │
-100 │         self._allowances[owner][spender] = amount
-    │                          ^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/erc20_token.fe:100:9
     │
 100 │         self._allowances[owner][spender] = amount
@@ -4859,20 +3115,6 @@ note:
           location: Storage {
               nonce: None,
           },
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/erc20_token.fe:100:33
-    │
-100 │         self._allowances[owner][spender] = amount
-    │                                 ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
           move_location: None,
       }
 
@@ -4939,20 +3181,6 @@ note:
       }
 
 note: 
-    ┌─ demos/erc20_token.fe:101:23
-    │
-101 │         emit Approval(owner, spender, amount)
-    │                       ^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/erc20_token.fe:101:30
     │
 101 │         emit Approval(owner, spender, amount)
@@ -4961,36 +3189,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/erc20_token.fe:101:30
-    │
-101 │         emit Approval(owner, spender, amount)
-    │                              ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/erc20_token.fe:101:39
-    │
-101 │         emit Approval(owner, spender, amount)
-    │                                       ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_002_guest_book.snap
+++ b/analyzer/tests/snapshots/analysis__case_002_guest_book.snap
@@ -101,20 +101,6 @@ note:
      }
 
 note: 
-   ┌─ demos/guest_book.fe:10:25
-   │
-10 │         self.guest_book[msg.sender] = book_msg
-   │                         ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/guest_book.fe:10:9
    │
 10 │         self.guest_book[msg.sender] = book_msg
@@ -138,23 +124,6 @@ note:
    │
 10 │         self.guest_book[msg.sender] = book_msg
    │                                       ^^^^^^^^ attributes hash: 6578844474441717363
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 100,
-                 inner: Byte,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/guest_book.fe:12:30
-   │
-12 │         emit Signed(book_msg=book_msg)
-   │                              ^^^^^^^^ attributes hash: 6578844474441717363
    │
    = ExpressionAttributes {
          typ: Array(
@@ -225,20 +194,6 @@ note:
      }
 
 note: 
-   ┌─ demos/guest_book.fe:15:32
-   │
-15 │         return self.guest_book[addr].to_mem()
-   │                                ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/guest_book.fe:15:16
    │
 15 │         return self.guest_book[addr].to_mem()
@@ -255,27 +210,6 @@ note:
              nonce: None,
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ demos/guest_book.fe:15:16
-   │
-15 │         return self.guest_book[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16413446491870513894
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 100,
-                 inner: Byte,
-             },
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_003_uniswap.snap
+++ b/analyzer/tests/snapshots/analysis__case_003_uniswap.snap
@@ -482,36 +482,6 @@ note:
     }
 
 note: 
-  ┌─ demos/uniswap.fe:3:16
-  │
-3 │         return 0
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ demos/uniswap.fe:6:16
-  │
-6 │         return false
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ demos/uniswap.fe:6:16
   │
 6 │         return false
@@ -578,26 +548,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:67:16
-   │
-67 │         return self.factory
-   │                ^^^^^^^^^^^^ attributes hash: 1881084778906563551
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 4,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ demos/uniswap.fe:70:16
    │
 70 │         return self.token0
@@ -610,46 +560,6 @@ note:
          location: Storage {
              nonce: Some(
                  5,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:70:16
-   │
-70 │         return self.token0
-   │                ^^^^^^^^^^^ attributes hash: 14860769425885644190
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 5,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:73:16
-   │
-73 │         return self.token1
-   │                ^^^^^^^^^^^ attributes hash: 6731119893502442855
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 6,
              ),
          },
          move_location: Some(
@@ -720,44 +630,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:76:29
-   │
-76 │         self.total_supply = self.total_supply + value
-   │                             ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:76:49
-   │
-76 │         self.total_supply = self.total_supply + value
-   │                                                 ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:76:49
    │
 76 │         self.total_supply = self.total_supply + value
@@ -811,20 +683,6 @@ note:
                  0,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:77:23
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                       ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -900,20 +758,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:77:43
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                                           ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:77:29
    │
 77 │         self.balances[to] = self.balances[to] + value
@@ -931,42 +775,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:77:29
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:77:49
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                                                 ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1018,36 +826,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:78:31
-   │
-78 │         emit Transfer(address(0), to, value)
-   │                               ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:78:23
-   │
-78 │         emit Transfer(address(0), to, value)
-   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:78:23
    │
 78 │         emit Transfer(address(0), to, value)
@@ -1070,36 +848,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:78:35
-   │
-78 │         emit Transfer(address(0), to, value)
-   │                                   ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:78:39
-   │
-78 │         emit Transfer(address(0), to, value)
-   │                                       ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -1143,20 +891,6 @@ note:
                  0,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:81:23
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                       ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1232,20 +966,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:81:45
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                                             ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:81:31
    │
 81 │         self.balances[from] = self.balances[from] - value
@@ -1263,42 +983,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:81:31
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:81:53
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                                                     ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1376,44 +1060,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:82:29
-   │
-82 │         self.total_supply = self.total_supply - value
-   │                             ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:82:49
-   │
-82 │         self.total_supply = self.total_supply - value
-   │                                                 ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:82:49
    │
 82 │         self.total_supply = self.total_supply - value
@@ -1460,36 +1106,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:83:23
-   │
-83 │         emit Transfer(from, address(0), value)
-   │                       ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:83:37
-   │
-83 │         emit Transfer(from, address(0), value)
-   │                                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:83:37
    │
 83 │         emit Transfer(from, address(0), value)
@@ -1514,36 +1130,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:83:29
-   │
-83 │         emit Transfer(from, address(0), value)
-   │                             ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:83:41
-   │
-83 │         emit Transfer(from, address(0), value)
-   │                                         ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -1610,20 +1196,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:86:25
-   │
-86 │         self.allowances[owner][spender] = value
-   │                         ^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:86:9
    │
 86 │         self.allowances[owner][spender] = value
@@ -1643,20 +1215,6 @@ note:
          location: Storage {
              nonce: None,
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:86:32
-   │
-86 │         self.allowances[owner][spender] = value
-   │                                ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1723,20 +1281,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:87:23
-   │
-87 │         emit Approval(owner, spender, value)
-   │                       ^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:87:30
    │
 87 │         emit Approval(owner, spender, value)
@@ -1745,36 +1289,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:87:30
-   │
-87 │         emit Approval(owner, spender, value)
-   │                              ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:87:39
-   │
-87 │         emit Approval(owner, spender, value)
-   │                                       ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -1818,20 +1332,6 @@ note:
                  0,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:90:23
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                       ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1907,20 +1407,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:90:45
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                                             ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:90:31
    │
 90 │         self.balances[from] = self.balances[from] - value
@@ -1938,42 +1424,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:90:31
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:90:53
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                                                     ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -2030,20 +1480,6 @@ note:
                  0,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:91:23
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                       ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -2119,20 +1555,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:91:43
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                                           ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:91:29
    │
 91 │         self.balances[to] = self.balances[to] + value
@@ -2150,42 +1572,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:91:29
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:91:49
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                                                 ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -2235,20 +1621,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:92:23
-   │
-92 │         emit Transfer(from, to, value)
-   │                       ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:92:29
    │
 92 │         emit Transfer(from, to, value)
@@ -2257,36 +1629,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:92:29
-   │
-92 │         emit Transfer(from, to, value)
-   │                             ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:92:33
-   │
-92 │         emit Transfer(from, to, value)
-   │                                 ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -2323,20 +1665,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:95:23
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:95:35
    │
 95 │         self._approve(msg.sender, spender, value)
@@ -2345,36 +1673,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:95:35
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │                                   ^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:95:44
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │                                            ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -2427,34 +1725,6 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:96:16
-   │
-96 │         return true
-   │                ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:99:24
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │                        ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ demos/uniswap.fe:99:24
    │
 99 │         self._transfer(msg.sender, to, value)
@@ -2477,36 +1747,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:99:36
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │                                    ^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:99:40
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │                                        ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -2543,20 +1783,6 @@ note:
          location: Memory,
          move_location: None,
      }
-
-note: 
-    ┌─ demos/uniswap.fe:100:16
-    │
-100 │         return true
-    │                ^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
 
 note: 
     ┌─ demos/uniswap.fe:100:16
@@ -2617,20 +1843,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:103:32
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                                ^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:103:16
     │
 103 │         assert self.allowances[from][msg.sender] >= value
@@ -2668,20 +1880,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:103:38
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                                      ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:103:16
     │
 103 │         assert self.allowances[from][msg.sender] >= value
@@ -2699,42 +1897,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:103:16
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: None,
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:103:53
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                                                     ^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -2812,20 +1974,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:105:25
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                         ^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:105:9
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
@@ -2845,20 +1993,6 @@ note:
           location: Storage {
               nonce: None,
           },
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:105:31
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                               ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
           move_location: None,
       }
 
@@ -2939,20 +2073,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:105:61
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                                             ^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:105:45
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
@@ -2990,20 +2110,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:105:67
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                                                   ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:105:45
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
@@ -3021,42 +2127,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:105:45
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: None,
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:105:81
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                                                                 ^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -3106,20 +2176,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:106:24
-    │
-106 │         self._transfer(from, to, value)
-    │                        ^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:106:30
     │
 106 │         self._transfer(from, to, value)
@@ -3128,36 +2184,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:106:30
-    │
-106 │         self._transfer(from, to, value)
-    │                              ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:106:34
-    │
-106 │         self._transfer(from, to, value)
-    │                                  ^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -3192,20 +2218,6 @@ note:
               },
           ),
           location: Memory,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:107:16
-    │
-107 │         return true
-    │                ^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
           move_location: None,
       }
 
@@ -3263,20 +2275,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:110:30
-    │
-110 │         return self.balances[account]
-    │                              ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:110:16
     │
 110 │         return self.balances[account]
@@ -3290,48 +2288,6 @@ note:
           ),
           location: Storage {
               nonce: None,
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:110:16
-    │
-110 │         return self.balances[account]
-    │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: None,
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:113:17
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                 ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
           },
           move_location: Some(
               Value,
@@ -3375,50 +2331,6 @@ note:
           location: Storage {
               nonce: Some(
                   8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:113:32
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                                ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:113:47
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6371053836336388098
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  9,
               ),
           },
           move_location: Some(
@@ -3481,38 +2393,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:113:16
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4587792697801182575
-    │
-    = ExpressionAttributes {
-          typ: Tuple(
-              Tuple {
-                  items: [
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ],
-              },
-          ),
-          location: Memory,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:118:16
     │
 118 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
@@ -3524,40 +2404,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:118:16
-    │
-118 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:118:30
-    │
-118 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                              ^^^^^^^^^^^^ attributes hash: 1881084778906563551
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  4,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -3691,58 +2537,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:125:33
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                 ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:125:51
     │
 125 │         block_timestamp: u256 = block.timestamp % 2**32
     │                                                   ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:125:51
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                                   ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:125:54
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                                      ^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3787,58 +2585,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:125:51
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                                   ^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:125:33
     │
 125 │         block_timestamp: u256 = block.timestamp % 2**32
     │                                 ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:125:33
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                 ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:127:30
-    │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                              ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3886,44 +2636,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:127:48
-    │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                                ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6371053836336388098
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  9,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:127:30
-    │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -3985,64 +2697,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:130:43
-    │
-130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 415408777929039325
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  10,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:130:74
     │
 130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
     │                                                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:130:74
-    │
-130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:130:85
-    │
-130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                                     ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4087,58 +2745,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:130:73
-    │
-130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:130:97
     │
 130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
     │                                                                                                 ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:130:97
-    │
-130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                                                 ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:130:73
-    │
-130 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4225,64 +2835,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:131:43
-    │
-131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4883298818346038831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  11,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:131:74
     │
 131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
     │                                                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:131:74
-    │
-131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:131:85
-    │
-131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                                     ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4327,58 +2883,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:131:73
-    │
-131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:131:97
     │
 131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
     │                                                                                                 ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:131:97
-    │
-131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                                                 ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:131:73
-    │
-131 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4439,38 +2947,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:128:12
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:27
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                           ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:128:27
     │
 128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
@@ -4501,56 +2977,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:128:12
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:128:33
     │
 128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
     │                                 ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:33
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                 ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:45
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                             ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4593,20 +3023,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:128:33
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                 ^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:128:12
     │
 128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
@@ -4615,36 +3031,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:12
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:51
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                   ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -4677,36 +3063,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:63
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                               ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:128:51
-    │
-128 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                   ^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -4871,28 +3227,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:136:19
-    │
-136 │         emit Sync(self.reserve0, self.reserve1)
-    │                   ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:136:34
     │
 136 │         emit Sync(self.reserve0, self.reserve1)
@@ -4907,48 +3241,6 @@ note:
           location: Storage {
               nonce: Some(
                   8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:136:34
-    │
-136 │         emit Sync(self.reserve0, self.reserve1)
-    │                                  ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:140:44
-    │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                                            ^^^^^^^^^^^^ attributes hash: 1881084778906563551
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  4,
               ),
           },
           move_location: Some(
@@ -5090,34 +3382,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:140:27
-    │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:141:24
-    │
-141 │         fee_on: bool = fee_to != address(0)
-    │                        ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:141:24
     │
 141 │         fee_on: bool = fee_to != address(0)
@@ -5148,22 +3412,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:141:42
-    │
-141 │         fee_on: bool = fee_to != address(0)
-    │                                          ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:141:34
     │
 141 │         fee_on: bool = fee_to != address(0)
@@ -5172,34 +3420,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:141:34
-    │
-141 │         fee_on: bool = fee_to != address(0)
-    │                                  ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:141:24
-    │
-141 │         fee_on: bool = fee_to != address(0)
-    │                        ^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -5242,64 +3462,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:142:24
-    │
-142 │         k_last: u256 = self.k_last # gas savings
-    │                        ^^^^^^^^^^^ attributes hash: 12467918549696538113
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  12,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:145:42
     │
 145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
     │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:145:42
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:145:53
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                                     ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5344,38 +3510,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:145:42
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                          ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:145:32
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:145:32
     │
 145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
@@ -5396,38 +3530,6 @@ note:
     │
 146 │                 root_k_last: u256 = self.sqrt(k_last)
     │                                               ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:146:47
-    │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
-    │                                               ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:146:37
-    │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
-    │                                     ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5478,64 +3580,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:148:39
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                       ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  2,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:148:59
     │
 148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
     │                                                           ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:148:59
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                                           ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:148:39
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5580,58 +3628,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:148:68
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                                                    ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:148:39
     │
 148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
     │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:148:39
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:149:41
-    │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                         ^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5676,58 +3676,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:149:50
-    │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                                  ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:149:41
     │
 149 │                     denominator: u256 = root_k * 5 + root_k_last
     │                                         ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:149:41
-    │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                         ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:149:54
-    │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                                      ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5772,58 +3724,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:149:41
-    │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:150:39
     │
 150 │                     liquidity: u256 = numerator / denominator
     │                                       ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:150:39
-    │
-150 │                     liquidity: u256 = numerator / denominator
-    │                                       ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:150:51
-    │
-150 │                     liquidity: u256 = numerator / denominator
-    │                                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5868,22 +3772,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:150:39
-    │
-150 │                     liquidity: u256 = numerator / denominator
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:152:36
     │
 152 │                         self._mint(fee_to, liquidity)
@@ -5892,36 +3780,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:152:36
-    │
-152 │                         self._mint(fee_to, liquidity)
-    │                                    ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:152:44
-    │
-152 │                         self._mint(fee_to, liquidity)
-    │                                            ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -5964,38 +3822,6 @@ note:
     │
 151 │                     if liquidity > 0:
     │                        ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:151:24
-    │
-151 │                     if liquidity > 0:
-    │                        ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:151:36
-    │
-151 │                     if liquidity > 0:
-    │                                    ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6054,38 +3880,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:147:20
-    │
-147 │                 if root_k > root_k_last:
-    │                    ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:147:29
-    │
-147 │                 if root_k > root_k_last:
-    │                             ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:147:29
     │
 147 │                 if root_k > root_k_last:
@@ -6120,38 +3914,6 @@ note:
     │
 144 │             if k_last != 0:
     │                ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:144:16
-    │
-144 │             if k_last != 0:
-    │                ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:144:26
-    │
-144 │             if k_last != 0:
-    │                          ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6246,38 +4008,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:153:14
-    │
-153 │         elif k_last != 0:
-    │              ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:153:24
-    │
-153 │         elif k_last != 0:
-    │                        ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:153:24
     │
 153 │         elif k_last != 0:
@@ -6336,20 +4066,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:156:16
-    │
-156 │         return fee_on
-    │                ^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:160:35
     │
 160 │         MINIMUM_LIQUIDITY: u256 = 1000
@@ -6363,44 +4079,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:160:35
-    │
-160 │         MINIMUM_LIQUIDITY: u256 = 1000
-    │                                   ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:161:26
-    │
-161 │         reserve0: u256 = self.reserve0
-    │                          ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -6440,48 +4118,6 @@ note:
           location: Storage {
               nonce: Some(
                   8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:162:26
-    │
-162 │         reserve1: u256 = self.reserve1
-    │                          ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:163:32
-    │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                ^^^^^^^^^^^ attributes hash: 14860769425885644190
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  5,
               ),
           },
           move_location: Some(
@@ -6582,20 +4218,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:163:55
-    │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                                       ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:163:26
     │
 163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
@@ -6609,42 +4231,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:163:26
-    │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:164:32
-    │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                ^^^^^^^^^^^ attributes hash: 6731119893502442855
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  6,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -6740,56 +4326,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:164:55
-    │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                                       ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:164:26
     │
 164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
     │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:164:26
-    │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:165:25
-    │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                         ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6840,64 +4380,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:165:36
-    │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                                    ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:165:25
     │
 165 │         amount0: u256 = balance0 - self.reserve0
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:165:25
-    │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:166:25
-    │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                         ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6948,64 +4434,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:166:36
-    │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                                    ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:166:25
     │
 166 │         amount1: u256 = balance1 - self.reserve1
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:166:25
-    │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:168:39
-    │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                       ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7050,36 +4482,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:168:49
-    │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                                 ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:168:24
-    │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:168:24
     │
 168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
@@ -7113,44 +4515,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:169:30
-    │
-169 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │                              ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  2,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:170:27
-    │
-170 │         liquidity: u256 = 0
-    │                           ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -7202,38 +4566,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:172:35
-    │
-172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                   ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:172:45
-    │
-172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                             ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:172:45
     │
 172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
@@ -7266,58 +4598,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:172:35
-    │
-172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                   ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:172:25
     │
 172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:172:25
-    │
-172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:172:56
-    │
-172 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                                        ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7378,22 +4662,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:173:32
-    │
-173 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                                ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:173:24
     │
 173 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
@@ -7402,36 +4670,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:173:24
-    │
-173 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                        ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:173:36
-    │
-173 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                                    ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -7502,58 +4740,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:175:35
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                   ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:175:45
     │
 175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
     │                                             ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:45
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                             ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:34
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7598,58 +4788,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:175:61
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                             ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:175:34
     │
 175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
     │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:34
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:72
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                        ^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7694,38 +4836,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:175:82
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                                  ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:71
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:175:71
     │
 175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
@@ -7746,38 +4856,6 @@ note:
     │
 175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
     │                                                                                                  ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:98
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                                                  ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:175:71
-    │
-175 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7838,38 +4916,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:171:12
-    │
-171 │         if total_supply == 0:
-    │            ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:171:28
-    │
-171 │         if total_supply == 0:
-    │                            ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:171:28
     │
 171 │         if total_supply == 0:
@@ -7904,38 +4950,6 @@ note:
     │
 177 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
     │                ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:177:16
-    │
-177 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:177:28
-    │
-177 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                            ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8008,36 +5022,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:179:20
-    │
-179 │         self._mint(to, liquidity)
-    │                    ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:179:24
-    │
-179 │         self._mint(to, liquidity)
-    │                        ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:179:24
     │
 179 │         self._mint(to, liquidity)
@@ -8086,38 +5070,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:180:22
-    │
-180 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:180:32
-    │
-180 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:180:32
     │
 180 │         self._update(balance0, balance1, reserve0, reserve1)
@@ -8138,38 +5090,6 @@ note:
     │
 180 │         self._update(balance0, balance1, reserve0, reserve1)
     │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:180:42
-    │
-180 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:180:52
-    │
-180 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                                    ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8250,38 +5170,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:183:27
-    │
-183 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:183:38
-    │
-183 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:183:38
     │
 183 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
@@ -8342,36 +5230,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:185:19
-    │
-185 │         emit Mint(msg.sender, amount0, amount1)
-    │                   ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:185:31
-    │
-185 │         emit Mint(msg.sender, amount0, amount1)
-    │                               ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:185:31
     │
 185 │         emit Mint(msg.sender, amount0, amount1)
@@ -8392,38 +5250,6 @@ note:
     │
 185 │         emit Mint(msg.sender, amount0, amount1)
     │                                        ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:185:40
-    │
-185 │         emit Mint(msg.sender, amount0, amount1)
-    │                                        ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:186:16
-    │
-186 │         return liquidity
-    │                ^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8474,28 +5300,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:190:26
-    │
-190 │         reserve0: u256 = self.reserve0
-    │                          ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:191:26
     │
 191 │         reserve1: u256 = self.reserve1
@@ -8510,48 +5314,6 @@ note:
           location: Storage {
               nonce: Some(
                   8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:191:26
-    │
-191 │         reserve1: u256 = self.reserve1
-    │                          ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:192:31
-    │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │                               ^^^^^^^^^^^ attributes hash: 14860769425885644190
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  5,
               ),
           },
           move_location: Some(
@@ -8638,64 +5400,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:192:25
-    │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:193:31
     │
 193 │         token1: ERC20 = ERC20(self.token1)
@@ -8713,84 +5417,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:193:31
-    │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │                               ^^^^^^^^^^^ attributes hash: 6731119893502442855
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  6,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:193:25
-    │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -8924,36 +5550,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:194:43
-    │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:194:26
-    │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:194:26
     │
 194 │         balance0: u256 = token0.balanceOf(self.address)
@@ -9036,36 +5632,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:195:43
-    │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:195:26
-    │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -9127,40 +5693,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:196:41
-    │
-196 │         liquidity: u256 = self.balances[self.address]
-    │                                         ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:196:27
-    │
-196 │         liquidity: u256 = self.balances[self.address]
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: None,
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:196:27
     │
 196 │         liquidity: u256 = self.balances[self.address]
@@ -9185,38 +5717,6 @@ note:
     │
 198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
     │                                       ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:198:39
-    │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                       ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:198:49
-    │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                                 ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9259,42 +5759,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:198:24
-    │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:199:30
-    │
-199 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │                              ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  2,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:199:30
     │
 199 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
@@ -9321,38 +5785,6 @@ note:
     │
 200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
     │                          ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:200:26
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                          ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:200:38
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                                      ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9397,58 +5829,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:200:25
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:200:50
     │
 200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
     │                                                  ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:200:50
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                                                  ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:200:25
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9493,58 +5877,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:201:26
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                          ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:201:38
     │
 201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
     │                                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:201:38
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:201:25
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9589,58 +5925,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:201:50
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                                                  ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:201:25
     │
 201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:201:25
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:202:16
-    │
-202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9685,22 +5973,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:202:26
-    │
-202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                          ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:202:16
     │
 202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
@@ -9709,36 +5981,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:202:16
-    │
-202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:202:32
-    │
-202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -9771,36 +6013,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:202:42
-    │
-202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                          ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:202:32
-    │
-202 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                ^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -9859,36 +6071,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:203:20
-    │
-203 │         self._burn(self.address, liquidity)
-    │                    ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:203:34
-    │
-203 │         self._burn(self.address, liquidity)
-    │                                  ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -9999,36 +6181,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:204:25
-    │
-204 │         token0.transfer(to, amount0)
-    │                         ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:204:29
-    │
-204 │         token0.transfer(to, amount0)
-    │                             ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:204:29
     │
 204 │         token0.transfer(to, amount0)
@@ -10125,36 +6277,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:205:25
-    │
-205 │         token1.transfer(to, amount1)
-    │                         ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:205:29
-    │
-205 │         token1.transfer(to, amount1)
-    │                             ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -10279,20 +6401,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:206:37
-    │
-206 │         balance0 = token0.balanceOf(self.address)
-    │                                     ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:206:20
     │
 206 │         balance0 = token0.balanceOf(self.address)
@@ -10397,20 +6505,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:207:37
-    │
-207 │         balance1 = token1.balanceOf(self.address)
-    │                                     ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:207:20
     │
 207 │         balance1 = token1.balanceOf(self.address)
@@ -10443,38 +6537,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:209:22
-    │
-209 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:209:32
-    │
-209 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:209:32
     │
 209 │         self._update(balance0, balance1, reserve0, reserve1)
@@ -10495,38 +6557,6 @@ note:
     │
 209 │         self._update(balance0, balance1, reserve0, reserve1)
     │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:209:42
-    │
-209 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:209:52
-    │
-209 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                                    ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10607,38 +6637,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:212:27
-    │
-212 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:212:38
-    │
-212 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:212:38
     │
 212 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
@@ -10699,56 +6697,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:214:19
-    │
-214 │         emit Burn(msg.sender, amount0, amount1, to)
-    │                   ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:214:31
     │
 214 │         emit Burn(msg.sender, amount0, amount1, to)
     │                               ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:214:31
-    │
-214 │         emit Burn(msg.sender, amount0, amount1, to)
-    │                               ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:214:40
-    │
-214 │         emit Burn(msg.sender, amount0, amount1, to)
-    │                                        ^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10791,56 +6743,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:214:49
-    │
-214 │         emit Burn(msg.sender, amount0, amount1, to)
-    │                                                 ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:215:17
     │
 215 │         return (amount0, amount1)
     │                 ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:215:17
-    │
-215 │         return (amount0, amount1)
-    │                 ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:215:26
-    │
-215 │         return (amount0, amount1)
-    │                          ^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10896,69 +6802,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:215:16
-    │
-215 │         return (amount0, amount1)
-    │                ^^^^^^^^^^^^^^^^^^ attributes hash: 16683674341918319845
-    │
-    = ExpressionAttributes {
-          typ: Tuple(
-              Tuple {
-                  items: [
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ],
-              },
-          ),
-          location: Memory,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:221:16
     │
 221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
     │                ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:221:16
-    │
-221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:221:30
-    │
-221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                              ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -11001,36 +6848,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:221:16
-    │
-221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:221:35
-    │
-221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:221:35
     │
 221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
@@ -11057,36 +6874,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:221:49
-    │
-221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                                 ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:221:35
-    │
-221 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                   ^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -11159,50 +6946,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:222:26
-    │
-222 │         reserve0: u256 = self.reserve0
-    │                          ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:223:26
-    │
-223 │         reserve1: u256 = self.reserve1
-    │                          ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:223:26
     │
 223 │         reserve1: u256 = self.reserve1
@@ -11229,38 +6972,6 @@ note:
     │
 224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
     │                ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:224:16
-    │
-224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:224:30
-    │
-224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                              ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -11303,36 +7014,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:224:16
-    │
-224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:224:43
-    │
-224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                           ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:224:43
     │
 224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
@@ -11359,36 +7040,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:224:57
-    │
-224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                                         ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:224:43
-    │
-224 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -11459,26 +7110,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:226:31
-    │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │                               ^^^^^^^^^^^ attributes hash: 14860769425885644190
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  5,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:226:25
     │
 226 │         token0: ERC20 = ERC20(self.token0)
@@ -11534,84 +7165,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:226:25
-    │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:227:31
-    │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │                               ^^^^^^^^^^^ attributes hash: 6731119893502442855
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  6,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -11693,64 +7246,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:227:25
-    │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:230:16
     │
 230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
@@ -11759,78 +7254,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:230:16
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:230:30
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                              ^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
           ),
           location: Value,
           move_location: None,
@@ -11909,20 +7332,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:230:22
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                      ^^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:230:16
     │
 230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
@@ -11931,34 +7340,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:230:16
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:230:42
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                          ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
           ),
           location: Value,
           move_location: None,
@@ -12037,64 +7418,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:230:56
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                        ^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:230:48
     │
 230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
@@ -12103,34 +7426,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:230:48
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                ^^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:230:42
-    │
-230 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                          ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -12253,36 +7548,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:233:29
-    │
-233 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │                             ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:233:33
-    │
-233 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │                                 ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:233:33
     │
 233 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
@@ -12317,38 +7582,6 @@ note:
     │
 232 │         if amount0_out > 0:
     │            ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:232:12
-    │
-232 │         if amount0_out > 0:
-    │            ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:232:26
-    │
-232 │         if amount0_out > 0:
-    │                          ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -12463,36 +7696,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:235:29
-    │
-235 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │                             ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:235:33
-    │
-235 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │                                 ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:235:33
     │
 235 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
@@ -12527,38 +7730,6 @@ note:
     │
 234 │         if amount1_out > 0:
     │            ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:234:12
-    │
-234 │         if amount1_out > 0:
-    │            ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:234:26
-    │
-234 │         if amount1_out > 0:
-    │                          ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -12673,36 +7844,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:240:43
-    │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:240:26
-    │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:240:26
     │
 240 │         balance0: u256 = token0.balanceOf(self.address)
@@ -12791,36 +7932,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:241:43
-    │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:241:26
-    │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:241:26
     │
 241 │         balance1: u256 = token1.balanceOf(self.address)
@@ -12841,38 +7952,6 @@ note:
     │
 243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                                                   ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:67
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                   ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:78
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                              ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -12917,38 +7996,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:89
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                         ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:78
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                              ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:243:78
     │
 243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
@@ -12979,56 +8026,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:67
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:243:28
     │
 243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                            ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:28
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                            ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:40
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                        ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13073,58 +8074,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:51
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:243:39
     │
 243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:39
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:28
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13169,58 +8122,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:106
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                                          ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:243:28
     │
 243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:28
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:67
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                   ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13265,58 +8170,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:78
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                              ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:244:89
     │
 244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                                                                         ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:89
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                         ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:78
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                              ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13359,56 +8216,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:67
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:244:28
     │
 244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                            ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:28
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                            ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:40
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                        ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13453,58 +8264,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:51
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:244:39
     │
 244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:39
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:28
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13549,58 +8312,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:106
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                                          ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:244:28
     │
 244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:28
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:246:16
-    │
-246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13645,22 +8360,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:246:29
-    │
-246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                             ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:246:16
     │
 246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
@@ -13669,36 +8368,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:246:16
-    │
-246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:246:34
-    │
-246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                  ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
           ),
           location: Value,
           move_location: None,
@@ -13731,36 +8400,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:246:47
-    │
-246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                               ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:246:34
-    │
-246 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                  ^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
           ),
           location: Value,
           move_location: None,
@@ -13827,38 +8466,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:248:35
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                   ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:46
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                              ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:248:46
     │
 248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
@@ -13879,38 +8486,6 @@ note:
     │
 248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │                                   ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:35
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                   ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:53
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                     ^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -13955,58 +8530,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:248:66
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                                  ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:248:53
     │
 248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │                                                     ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:53
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                     ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:35
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14051,58 +8578,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:35
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                   ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:249:46
     │
 249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │                                              ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:46
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                              ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:35
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                   ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14147,58 +8626,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:53
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                     ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:249:66
     │
 249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │                                                                  ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:66
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                                  ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:53
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                     ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14243,58 +8674,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:35
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:251:16
     │
 251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:251:16
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:251:36
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                    ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14339,58 +8722,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:251:16
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:251:57
     │
 251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                                                         ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:251:57
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:251:68
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                                    ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14435,58 +8770,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:251:57
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:251:79
     │
 251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                                                                               ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:251:79
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                                               ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:251:57
-    │
-251 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14561,38 +8848,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:253:22
-    │
-253 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:253:32
-    │
-253 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:253:32
     │
 253 │         self._update(balance0, balance1, reserve0, reserve1)
@@ -14613,38 +8868,6 @@ note:
     │
 253 │         self._update(balance0, balance1, reserve0, reserve1)
     │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:253:42
-    │
-253 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:253:52
-    │
-253 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                                    ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14703,56 +8926,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:254:19
-    │
-254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                   ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:254:31
     │
 254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
     │                               ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:254:31
-    │
-254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                               ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:254:43
-    │
-254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                           ^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -14797,38 +8974,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:254:55
-    │
-254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:254:68
-    │
-254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                                    ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:254:68
     │
 254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
@@ -14856,40 +9001,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:254:81
-    │
-254 │         emit Swap(msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                                                 ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:258:31
-    │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │                               ^^^^^^^^^^^ attributes hash: 14860769425885644190
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  5,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -14971,64 +9082,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:258:25
-    │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:259:31
     │
 259 │         token1: ERC20 = ERC20(self.token1) # gas savings
@@ -15046,84 +9099,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:259:31
-    │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │                               ^^^^^^^^^^^ attributes hash: 6731119893502442855
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  6,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:259:25
-    │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -15257,20 +9232,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:261:25
-    │
-261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                         ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:261:29
     │
 261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
@@ -15343,36 +9304,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:261:46
-    │
-261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                                              ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:261:29
-    │
-261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:261:29
     │
 261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
@@ -15408,44 +9339,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:261:62
-    │
-261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                                                              ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:261:29
-    │
-261 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -15551,20 +9444,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:262:25
-    │
-262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                         ^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:262:29
     │
 262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
@@ -15637,36 +9516,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:262:46
-    │
-262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                                              ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:262:29
-    │
-262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:262:29
     │
 262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
@@ -15702,44 +9551,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:262:62
-    │
-262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                                                              ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:262:29
-    │
-262 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -15793,84 +9604,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:266:31
-    │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │                               ^^^^^^^^^^^ attributes hash: 14860769425885644190
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  5,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:266:25
-    │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:266:25
     │
 266 │         token0: ERC20 = ERC20(self.token0)
@@ -15946,84 +9679,6 @@ note:
           move_location: Some(
               Value,
           ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:267:31
-    │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │                               ^^^^^^^^^^^ attributes hash: 6731119893502442855
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  6,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:267:25
-    │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 15391172439059254871
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
       }
 
 note: 
@@ -16157,36 +9812,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:268:39
-    │
-268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                       ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:268:22
-    │
-268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:268:22
     │
 268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
@@ -16275,36 +9900,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:268:71
-    │
-268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                                       ^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:268:54
-    │
-268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:268:54
     │
 268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
@@ -16335,50 +9930,6 @@ note:
           location: Storage {
               nonce: Some(
                   7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:268:86
-    │
-268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                                                      ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  7,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:268:101
-    │
-268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                                                                     ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  8,
               ),
           },
           move_location: Some(
@@ -16473,38 +10024,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:274:23
-    │
-274 │             x: u256 = val / 2 + 1
-    │                       ^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:274:29
-    │
-274 │             x: u256 = val / 2 + 1
-    │                             ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:274:29
     │
 274 │             x: u256 = val / 2 + 1
@@ -16537,58 +10056,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:274:23
-    │
-274 │             x: u256 = val / 2 + 1
-    │                       ^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:274:33
     │
 274 │             x: u256 = val / 2 + 1
     │                                 ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:274:33
-    │
-274 │             x: u256 = val / 2 + 1
-    │                                 ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:274:23
-    │
-274 │             x: u256 = val / 2 + 1
-    │                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -16681,58 +10152,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:277:22
-    │
-277 │                 x = (val / x + x) / 2
-    │                      ^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:277:28
     │
 277 │                 x = (val / x + x) / 2
     │                            ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:277:28
-    │
-277 │                 x = (val / x + x) / 2
-    │                            ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:277:22
-    │
-277 │                 x = (val / x + x) / 2
-    │                      ^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -16777,58 +10200,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:277:32
-    │
-277 │                 x = (val / x + x) / 2
-    │                                ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:277:21
     │
 277 │                 x = (val / x + x) / 2
     │                     ^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:277:21
-    │
-277 │                 x = (val / x + x) / 2
-    │                     ^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:277:37
-    │
-277 │                 x = (val / x + x) / 2
-    │                                     ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -16877,38 +10252,6 @@ note:
     │
 275 │             while (x < z):
     │                    ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:275:20
-    │
-275 │             while (x < z):
-    │                    ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:275:24
-    │
-275 │             while (x < z):
-    │                        ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -16999,38 +10342,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:278:15
-    │
-278 │         elif (val != 0):
-    │               ^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:278:22
-    │
-278 │         elif (val != 0):
-    │                      ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:278:22
     │
 278 │         elif (val != 0):
@@ -17065,38 +10376,6 @@ note:
     │
 272 │         if (val > 3):
     │             ^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:272:13
-    │
-272 │         if (val > 3):
-    │             ^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:272:19
-    │
-272 │         if (val > 3):
-    │                   ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17155,58 +10434,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:280:16
-    │
-280 │         return z
-    │                ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:283:21
     │
 283 │         return x if x < y else y
     │                     ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:283:21
-    │
-283 │         return x if x < y else y
-    │                     ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:283:25
-    │
-283 │         return x if x < y else y
-    │                         ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17249,36 +10480,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:283:21
-    │
-283 │         return x if x < y else y
-    │                     ^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:283:16
-    │
-283 │         return x if x < y else y
-    │                ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:283:16
     │
 283 │         return x if x < y else y
@@ -17299,38 +10500,6 @@ note:
     │
 283 │         return x if x < y else y
     │                                ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:283:32
-    │
-283 │         return x if x < y else y
-    │                                ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:283:16
-    │
-283 │         return x if x < y else y
-    │                ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17411,46 +10580,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:304:16
-    │
-304 │         return self.fee_to
-    │                ^^^^^^^^^^^ attributes hash: 10848859084443309747
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  0,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:307:16
-    │
-307 │         return self.fee_to_setter
-    │                ^^^^^^^^^^^^^^^^^^ attributes hash: 7358142947426974590
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  1,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:307:16
     │
 307 │         return self.fee_to_setter
@@ -17493,60 +10622,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:310:16
-    │
-310 │         return self.pair_counter
-    │                ^^^^^^^^^^^^^^^^^ attributes hash: 1282759725205707727
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  4,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:313:16
     │
 313 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
     │                ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:313:16
-    │
-313 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:313:27
-    │
-313 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                           ^^^^^^^ attributes hash: 513065555763557710
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17615,34 +10694,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:38
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                      ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:315:48
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                                ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:315:48
     │
 315 │         token0: address = token_a if token_a < token_b else token_b
@@ -17671,52 +10722,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:38
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                      ^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:315:27
     │
 315 │         token0: address = token_a if token_a < token_b else token_b
     │                           ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:315:27
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                           ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:315:61
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                                             ^^^^^^^ attributes hash: 513065555763557710
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17755,52 +10764,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:27
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:316:38
     │
 316 │         token1: address = token_a if token_a > token_b else token_b
     │                                      ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:316:38
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                      ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:316:48
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                                ^^^^^^^ attributes hash: 513065555763557710
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17839,52 +10806,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:316:38
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                      ^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Bool,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:316:27
     │
 316 │         token1: address = token_a if token_a > token_b else token_b
     │                           ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:316:27
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                           ^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:316:61
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                                             ^^^^^^^ attributes hash: 513065555763557710
     │
     = ExpressionAttributes {
           typ: Base(
@@ -17923,34 +10848,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:316:27
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:317:16
-    │
-317 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:317:16
     │
 317 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
@@ -17975,36 +10872,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:317:34
-    │
-317 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                                  ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:317:26
-    │
-317 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                          ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
           ),
           location: Value,
           move_location: None,
@@ -18097,20 +10964,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:318:27
-    │
-318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                           ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:318:16
     │
 318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
@@ -18146,38 +10999,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:318:35
-    │
-318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                   ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:318:16
-    │
-318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15587646813440843004
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: None,
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:318:16
     │
 318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
@@ -18206,36 +11027,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:318:54
-    │
-318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                                      ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:318:46
-    │
-318 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                              ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
           ),
           location: Value,
           move_location: None,
@@ -18300,34 +11091,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:33
-    │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                 ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:320:41
-    │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                         ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:320:41
     │
 320 │         salt: u256 = keccak256((token0, token1).abi_encode())
@@ -18382,59 +11145,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:32
-    │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1242487606555163061
-    │
-    = ExpressionAttributes {
-          typ: Array(
-              Array {
-                  size: 64,
-                  inner: Byte,
-              },
-          ),
-          location: Memory,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:320:22
     │
 320 │         salt: u256 = keccak256((token0, token1).abi_encode())
     │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:320:22
-    │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:321:53
-    │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                     ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -18473,310 +11187,6 @@ note:
               Numeric(
                   U256,
               ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:321:56
-    │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                        ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:321:31
-    │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 2891139793169608093
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "approve",
-                          params: [
-                              (
-                                  "spender",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "burn",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "factory",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "get_reserves",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "initialize",
-                          params: [
-                              (
-                                  "token0",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "token1",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "mint",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "skim",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "swap",
-                          params: [
-                              (
-                                  "amount0_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "amount1_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "sync",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token0",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token1",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transferFrom",
-                          params: [
-                              (
-                                  "from",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
           ),
           location: Value,
           move_location: None,
@@ -19373,34 +11783,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:322:25
-    │
-322 │         pair.initialize(token0, token1)
-    │                         ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:322:33
-    │
-322 │         pair.initialize(token0, token1)
-    │                                 ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:322:33
     │
 322 │         pair.initialize(token0, token1)
@@ -19473,20 +11855,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:324:20
-    │
-324 │         self.pairs[token0][token1] = address(pair)
-    │                    ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:324:9
     │
 324 │         self.pairs[token0][token1] = address(pair)
@@ -19522,20 +11890,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:324:28
-    │
-324 │         self.pairs[token0][token1] = address(pair)
-    │                            ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:324:9
     │
 324 │         self.pairs[token0][token1] = address(pair)
@@ -19548,294 +11902,6 @@ note:
           location: Storage {
               nonce: None,
           },
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:324:46
-    │
-324 │         self.pairs[token0][token1] = address(pair)
-    │                                              ^^^^ attributes hash: 2891139793169608093
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "approve",
-                          params: [
-                              (
-                                  "spender",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "burn",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "factory",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "get_reserves",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "initialize",
-                          params: [
-                              (
-                                  "token0",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "token1",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "mint",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "skim",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "swap",
-                          params: [
-                              (
-                                  "amount0_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "amount1_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "sync",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token0",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token1",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transferFrom",
-                          params: [
-                              (
-                                  "from",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
           move_location: None,
       }
 
@@ -20184,20 +12250,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:325:20
-    │
-325 │         self.pairs[token1][token0] = address(pair)
-    │                    ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:325:9
     │
 325 │         self.pairs[token1][token0] = address(pair)
@@ -20233,20 +12285,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:325:28
-    │
-325 │         self.pairs[token1][token0] = address(pair)
-    │                            ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:325:9
     │
 325 │         self.pairs[token1][token0] = address(pair)
@@ -20259,294 +12297,6 @@ note:
           location: Storage {
               nonce: None,
           },
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:325:46
-    │
-325 │         self.pairs[token1][token0] = address(pair)
-    │                                              ^^^^ attributes hash: 2891139793169608093
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "approve",
-                          params: [
-                              (
-                                  "spender",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "burn",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "factory",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "get_reserves",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "initialize",
-                          params: [
-                              (
-                                  "token0",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "token1",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "mint",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "skim",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "swap",
-                          params: [
-                              (
-                                  "amount0_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "amount1_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "sync",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token0",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token1",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transferFrom",
-                          params: [
-                              (
-                                  "from",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
           move_location: None,
       }
 
@@ -20896,28 +12646,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:326:24
-    │
-326 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                        ^^^^^^^^^^^^^^^^^ attributes hash: 1282759725205707727
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  4,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
     ┌─ demos/uniswap.fe:326:9
     │
 326 │         self.all_pairs[self.pair_counter] = address(pair)
@@ -20930,294 +12658,6 @@ note:
           location: Storage {
               nonce: None,
           },
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:326:53
-    │
-326 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                                     ^^^^ attributes hash: 2891139793169608093
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "approve",
-                          params: [
-                              (
-                                  "spender",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "burn",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "factory",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "get_reserves",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "initialize",
-                          params: [
-                              (
-                                  "token0",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "token1",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "mint",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "skim",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "swap",
-                          params: [
-                              (
-                                  "amount0_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "amount1_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "sync",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token0",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token1",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transferFrom",
-                          params: [
-                              (
-                                  "from",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
           move_location: None,
       }
 
@@ -21566,44 +13006,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:327:29
-    │
-327 │         self.pair_counter = self.pair_counter + 1
-    │                             ^^^^^^^^^^^^^^^^^ attributes hash: 1282759725205707727
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  4,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:327:49
-    │
-327 │         self.pair_counter = self.pair_counter + 1
-    │                                                 ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:327:49
     │
 327 │         self.pair_counter = self.pair_counter + 1
@@ -21650,20 +13052,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:329:26
-    │
-329 │         emit PairCreated(token0, token1, address(pair), self.pair_counter)
-    │                          ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:329:34
     │
 329 │         emit PairCreated(token0, token1, address(pair), self.pair_counter)
@@ -21672,308 +13060,6 @@ note:
     = ExpressionAttributes {
           typ: Base(
               Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:329:34
-    │
-329 │         emit PairCreated(token0, token1, address(pair), self.pair_counter)
-    │                                  ^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:329:50
-    │
-329 │         emit PairCreated(token0, token1, address(pair), self.pair_counter)
-    │                                                  ^^^^ attributes hash: 2891139793169608093
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "approve",
-                          params: [
-                              (
-                                  "spender",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "burn",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "factory",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "get_reserves",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "initialize",
-                          params: [
-                              (
-                                  "token0",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "token1",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "mint",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "skim",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "swap",
-                          params: [
-                              (
-                                  "amount0_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "amount1_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "sync",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token0",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token1",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transferFrom",
-                          params: [
-                              (
-                                  "from",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
           ),
           location: Value,
           move_location: None,
@@ -22279,42 +13365,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:329:42
-    │
-329 │         emit PairCreated(token0, token1, address(pair), self.pair_counter)
-    │                                          ^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:329:57
-    │
-329 │         emit PairCreated(token0, token1, address(pair), self.pair_counter)
-    │                                                         ^^^^^^^^^^^^^^^^^ attributes hash: 1282759725205707727
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Storage {
-              nonce: Some(
-                  4,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -22628,308 +13678,6 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:330:24
-    │
-330 │         return address(pair)
-    │                        ^^^^ attributes hash: 2891139793169608093
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "approve",
-                          params: [
-                              (
-                                  "spender",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "burn",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "factory",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "get_reserves",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                      Base(
-                                          Numeric(
-                                              U256,
-                                          ),
-                                      ),
-                                  ],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "initialize",
-                          params: [
-                              (
-                                  "token0",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "token1",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "mint",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "skim",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "swap",
-                          params: [
-                              (
-                                  "amount0_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "amount1_out",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "sync",
-                          params: [],
-                          return_type: Tuple(
-                              Tuple {
-                                  items: [],
-                              },
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token0",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "token1",
-                          params: [],
-                          return_type: Base(
-                              Address,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transferFrom",
-                          params: [
-                              (
-                                  "from",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "to",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "value",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:330:16
-    │
-330 │         return address(pair)
-    │                ^^^^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ demos/uniswap.fe:330:16
     │
 330 │         return address(pair)
@@ -22955,40 +13703,6 @@ note:
           ),
           location: Value,
           move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:333:16
-    │
-333 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:333:30
-    │
-333 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                              ^^^^^^^^^^^^^^^^^^ attributes hash: 7358142947426974590
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Storage {
-              nonce: Some(
-                  1,
-              ),
-          },
-          move_location: Some(
-              Value,
-          ),
       }
 
 note: 
@@ -23078,34 +13792,6 @@ note:
     │
 337 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:337:16
-    │
-337 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^ attributes hash: 513065555763557710
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:337:30
-    │
-337 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                              ^^^^^^^^^^^^^ attributes hash: 513065555763557710
     │
     = ExpressionAttributes {
           typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_004_address_bytes10_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_004_address_bytes10_map.snap
@@ -101,20 +101,6 @@ note:
     }
 
 note: 
-  ┌─ features/address_bytes10_map.fe:5:25
-  │
-5 │         return self.bar[key].to_mem()
-  │                         ^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/address_bytes10_map.fe:5:16
   │
 5 │         return self.bar[key].to_mem()
@@ -131,27 +117,6 @@ note:
             nonce: None,
         },
         move_location: None,
-    }
-
-note: 
-  ┌─ features/address_bytes10_map.fe:5:16
-  │
-5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16692882328884997814
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 10,
-                inner: Byte,
-            },
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Memory,
-        ),
     }
 
 note: 
@@ -198,20 +163,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/address_bytes10_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_005_assert.snap
+++ b/analyzer/tests/snapshots/analysis__case_005_assert.snap
@@ -98,38 +98,6 @@ note:
     }
 
 note: 
-  ┌─ features/assert.fe:3:16
-  │
-3 │         assert baz > 5
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:3:22
-  │
-3 │         assert baz > 5
-  │                      ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/assert.fe:3:22
   │
 3 │         assert baz > 5
@@ -164,38 +132,6 @@ note:
   │
 6 │         assert baz > 5, "Must be greater than five"
   │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:6:16
-  │
-6 │         assert baz > 5, "Must be greater than five"
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:6:22
-  │
-6 │         assert baz > 5, "Must be greater than five"
-  │                      ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -258,38 +194,6 @@ note:
   │
 9 │         assert baz > 5, reason
   │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:9:16
-  │
-9 │         assert baz > 5, reason
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:9:22
-  │
-9 │         assert baz > 5, reason
-  │                      ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_006_aug_assign.snap
+++ b/analyzer/tests/snapshots/analysis__case_006_aug_assign.snap
@@ -416,22 +416,6 @@ note:
     }
 
 note: 
-  ┌─ features/aug_assign.fe:6:16
-  │
-6 │         return a
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/aug_assign.fe:9:9
   │
 9 │         a -= b
@@ -480,22 +464,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:10:16
-   │
-10 │         return a
-   │                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/aug_assign.fe:13:9
    │
 13 │         a *= b
@@ -516,22 +484,6 @@ note:
    │
 13 │         a *= b
    │              ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:14:16
-   │
-14 │         return a
-   │                ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -608,22 +560,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:18:16
-   │
-18 │         return a
-   │                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/aug_assign.fe:21:9
    │
 21 │         a %= b
@@ -644,22 +580,6 @@ note:
    │
 21 │         a %= b
    │              ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:22:16
-   │
-22 │         return a
-   │                ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -736,22 +656,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:26:16
-   │
-26 │         return a
-   │                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/aug_assign.fe:29:9
    │
 29 │         a <<= b
@@ -772,22 +676,6 @@ note:
    │
 29 │         a <<= b
    │               ^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:30:16
-   │
-30 │         return a
-   │                ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
@@ -864,22 +752,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:34:16
-   │
-34 │         return a
-   │                ^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/aug_assign.fe:37:9
    │
 37 │         a |= b
@@ -900,22 +772,6 @@ note:
    │
 37 │         a |= b
    │              ^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:38:16
-   │
-38 │         return a
-   │                ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
@@ -992,22 +848,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:42:16
-   │
-42 │         return a
-   │                ^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/aug_assign.fe:45:9
    │
 45 │         a &= b
@@ -1028,22 +868,6 @@ note:
    │
 45 │         a &= b
    │              ^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:46:16
-   │
-46 │         return a
-   │                ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1166,28 +990,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:51:16
-   │
-51 │         return self.my_num
-   │                ^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/aug_assign.fe:55:9
    │
 55 │         my_array[7] = a
@@ -1203,22 +1005,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:55:18
-   │
-55 │         my_array[7] = a
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1306,22 +1092,6 @@ note:
      }
 
 note: 
-   ┌─ features/aug_assign.fe:56:18
-   │
-56 │         my_array[7] += b
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/aug_assign.fe:56:9
    │
 56 │         my_array[7] += b
@@ -1386,40 +1156,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:57:25
-   │
-57 │         return my_array[7]
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/aug_assign.fe:57:16
-   │
-57 │         return my_array[7]
-   │                ^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_007_base_tuple.snap
+++ b/analyzer/tests/snapshots/analysis__case_007_base_tuple.snap
@@ -80,22 +80,6 @@ note:
     }
 
 note: 
-  ┌─ features/base_tuple.fe:3:17
-  │
-3 │         return (my_num, my_bool)
-  │                 ^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/base_tuple.fe:3:25
   │
 3 │         return (my_num, my_bool)
@@ -106,45 +90,6 @@ note:
             Bool,
         ),
         location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/base_tuple.fe:3:25
-  │
-3 │         return (my_num, my_bool)
-  │                         ^^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/base_tuple.fe:3:16
-  │
-3 │         return (my_num, my_bool)
-  │                ^^^^^^^^^^^^^^^^^ attributes hash: 11698647864115949400
-  │
-  = ExpressionAttributes {
-        typ: Tuple(
-            Tuple {
-                items: [
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                    Base(
-                        Bool,
-                    ),
-                ],
-            },
-        ),
-        location: Memory,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_008_call_statement_with_args.snap
+++ b/analyzer/tests/snapshots/analysis__case_008_call_statement_with_args.snap
@@ -70,22 +70,6 @@ note:
     }
 
 note: 
-  ┌─ features/call_statement_with_args.fe:5:18
-  │
-5 │         self.baz[0] = val
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/call_statement_with_args.fe:5:9
   │
 5 │         self.baz[0] = val
@@ -108,22 +92,6 @@ note:
   │
 5 │         self.baz[0] = val
   │                       ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_with_args.fe:8:21
-  │
-8 │         self.assign(100)
-  │                     ^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -208,42 +176,6 @@ note:
         ),
         location: Value,
         move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_with_args.fe:9:25
-  │
-9 │         return self.baz[0]
-  │                         ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_with_args.fe:9:16
-  │
-9 │         return self.baz[0]
-  │                ^^^^^^^^^^^ attributes hash: 9781479072077703403
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
     }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_009_call_statement_with_args_2.snap
+++ b/analyzer/tests/snapshots/analysis__case_009_call_statement_with_args_2.snap
@@ -70,22 +70,6 @@ note:
     }
 
 note: 
-  ┌─ features/call_statement_with_args_2.fe:5:18
-  │
-5 │         self.baz[0] = val
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/call_statement_with_args_2.fe:5:9
   │
 5 │         self.baz[0] = val
@@ -124,38 +108,6 @@ note:
   │
 6 │         return val
   │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_with_args_2.fe:6:16
-  │
-6 │         return val
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_with_args_2.fe:9:21
-  │
-9 │         self.assign(100)
-  │                     ^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -240,42 +192,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ features/call_statement_with_args_2.fe:10:25
-   │
-10 │         return self.baz[0]
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/call_statement_with_args_2.fe:10:16
-   │
-10 │         return self.baz[0]
-   │                ^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_010_call_statement_without_args.snap
+++ b/analyzer/tests/snapshots/analysis__case_010_call_statement_without_args.snap
@@ -70,22 +70,6 @@ note:
     }
 
 note: 
-  ┌─ features/call_statement_without_args.fe:5:18
-  │
-5 │         self.baz[0] = 100
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/call_statement_without_args.fe:5:9
   │
 5 │         self.baz[0] = 100
@@ -176,42 +160,6 @@ note:
         ),
         location: Value,
         move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_without_args.fe:9:25
-  │
-9 │         return self.baz[0]
-  │                         ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/call_statement_without_args.fe:9:16
-  │
-9 │         return self.baz[0]
-  │                ^^^^^^^^^^^ attributes hash: 9781479072077703403
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
     }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_011_checked_arithmetic.snap
+++ b/analyzer/tests/snapshots/analysis__case_011_checked_arithmetic.snap
@@ -1977,58 +1977,10 @@ note:
     }
 
 note: 
-  ┌─ features/checked_arithmetic.fe:4:16
-  │
-4 │         return left + right
-  │                ^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/checked_arithmetic.fe:4:23
   │
 4 │         return left + right
   │                       ^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/checked_arithmetic.fe:4:23
-  │
-4 │         return left + right
-  │                       ^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/checked_arithmetic.fe:4:16
-  │
-4 │         return left + right
-  │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -2073,38 +2025,6 @@ note:
     }
 
 note: 
-  ┌─ features/checked_arithmetic.fe:7:16
-  │
-7 │         return left + right
-  │                ^^^^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/checked_arithmetic.fe:7:23
-  │
-7 │         return left + right
-  │                       ^^^^^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/checked_arithmetic.fe:7:23
   │
 7 │         return left + right
@@ -2137,58 +2057,10 @@ note:
     }
 
 note: 
-  ┌─ features/checked_arithmetic.fe:7:16
-  │
-7 │         return left + right
-  │                ^^^^^^^^^^^^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
    ┌─ features/checked_arithmetic.fe:10:16
    │
 10 │         return left + right
    │                ^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:10:16
-   │
-10 │         return left + right
-   │                ^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:10:23
-   │
-10 │         return left + right
-   │                       ^^^^^ attributes hash: 3044889006329355385
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2233,58 +2105,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:10:16
-   │
-10 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:13:16
    │
 13 │         return left + right
    │                ^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:13:16
-   │
-13 │         return left + right
-   │                ^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:13:23
-   │
-13 │         return left + right
-   │                       ^^^^^ attributes hash: 5442387896079309831
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2329,58 +2153,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:13:16
-   │
-13 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:16:16
    │
 16 │         return left + right
    │                ^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:16:16
-   │
-16 │         return left + right
-   │                ^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:16:23
-   │
-16 │         return left + right
-   │                       ^^^^^ attributes hash: 17931047209024117248
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2425,58 +2201,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:16:16
-   │
-16 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:19:16
    │
 19 │         return left + right
    │                ^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:19:16
-   │
-19 │         return left + right
-   │                ^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:19:23
-   │
-19 │         return left + right
-   │                       ^^^^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2521,58 +2249,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:19:16
-   │
-19 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:22:16
    │
 22 │         return left + right
    │                ^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:22:16
-   │
-22 │         return left + right
-   │                ^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:22:23
-   │
-22 │         return left + right
-   │                       ^^^^^ attributes hash: 17351186385905986417
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2617,58 +2297,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:22:16
-   │
-22 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:25:16
    │
 25 │         return left + right
    │                ^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:25:16
-   │
-25 │         return left + right
-   │                ^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:25:23
-   │
-25 │         return left + right
-   │                       ^^^^^ attributes hash: 5494075259962106032
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2713,58 +2345,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:25:16
-   │
-25 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:28:16
    │
 28 │         return left + right
    │                ^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:28:16
-   │
-28 │         return left + right
-   │                ^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:28:23
-   │
-28 │         return left + right
-   │                       ^^^^^ attributes hash: 16198180549924123587
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2809,58 +2393,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:28:16
-   │
-28 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:31:16
    │
 31 │         return left + right
    │                ^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:31:16
-   │
-31 │         return left + right
-   │                ^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:31:23
-   │
-31 │         return left + right
-   │                       ^^^^^ attributes hash: 13972995067286817043
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2905,58 +2441,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:31:16
-   │
-31 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:34:16
    │
 34 │         return left + right
    │                ^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:34:16
-   │
-34 │         return left + right
-   │                ^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:34:23
-   │
-34 │         return left + right
-   │                       ^^^^^ attributes hash: 13584665093848691268
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3001,58 +2489,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:34:16
-   │
-34 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:37:16
    │
 37 │         return left + right
    │                ^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:37:16
-   │
-37 │         return left + right
-   │                ^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:37:23
-   │
-37 │         return left + right
-   │                       ^^^^^ attributes hash: 9715536092457030614
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3097,58 +2537,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:37:16
-   │
-37 │         return left + right
-   │                ^^^^^^^^^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:40:16
    │
 40 │         return left - right
    │                ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:40:16
-   │
-40 │         return left - right
-   │                ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:40:23
-   │
-40 │         return left - right
-   │                       ^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3193,58 +2585,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:40:16
-   │
-40 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:43:16
    │
 43 │         return left - right
    │                ^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:43:16
-   │
-43 │         return left - right
-   │                ^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:43:23
-   │
-43 │         return left - right
-   │                       ^^^^^ attributes hash: 9341420026351674595
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3289,58 +2633,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:43:16
-   │
-43 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:46:16
    │
 46 │         return left - right
    │                ^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:46:16
-   │
-46 │         return left - right
-   │                ^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:46:23
-   │
-46 │         return left - right
-   │                       ^^^^^ attributes hash: 3044889006329355385
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3385,58 +2681,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:46:16
-   │
-46 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:49:16
    │
 49 │         return left - right
    │                ^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:49:16
-   │
-49 │         return left - right
-   │                ^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:49:23
-   │
-49 │         return left - right
-   │                       ^^^^^ attributes hash: 5442387896079309831
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3481,58 +2729,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:49:16
-   │
-49 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:52:16
    │
 52 │         return left - right
    │                ^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:52:16
-   │
-52 │         return left - right
-   │                ^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:52:23
-   │
-52 │         return left - right
-   │                       ^^^^^ attributes hash: 17931047209024117248
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3577,58 +2777,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:52:16
-   │
-52 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:55:16
    │
 55 │         return left - right
    │                ^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:55:16
-   │
-55 │         return left - right
-   │                ^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:55:23
-   │
-55 │         return left - right
-   │                       ^^^^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3673,58 +2825,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:55:16
-   │
-55 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:58:16
    │
 58 │         return left - right
    │                ^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:58:16
-   │
-58 │         return left - right
-   │                ^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:58:23
-   │
-58 │         return left - right
-   │                       ^^^^^ attributes hash: 17351186385905986417
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3769,38 +2873,6 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:58:16
-   │
-58 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:61:16
-   │
-61 │         return left - right
-   │                ^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:61:16
    │
 61 │         return left - right
@@ -3821,38 +2893,6 @@ note:
    │
 61 │         return left - right
    │                       ^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:61:23
-   │
-61 │         return left - right
-   │                       ^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:61:16
-   │
-61 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 5494075259962106032
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3897,58 +2937,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:64:16
-   │
-64 │         return left - right
-   │                ^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:64:23
    │
 64 │         return left - right
    │                       ^^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:64:23
-   │
-64 │         return left - right
-   │                       ^^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:64:16
-   │
-64 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 16198180549924123587
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3993,58 +2985,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:67:16
-   │
-67 │         return left - right
-   │                ^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:67:23
    │
 67 │         return left - right
    │                       ^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:67:23
-   │
-67 │         return left - right
-   │                       ^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:67:16
-   │
-67 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 13972995067286817043
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4089,58 +3033,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:70:16
-   │
-70 │         return left - right
-   │                ^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:70:23
    │
 70 │         return left - right
    │                       ^^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:70:23
-   │
-70 │         return left - right
-   │                       ^^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:70:16
-   │
-70 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 13584665093848691268
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4185,58 +3081,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:73:16
-   │
-73 │         return left - right
-   │                ^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:73:23
    │
 73 │         return left - right
    │                       ^^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:73:23
-   │
-73 │         return left - right
-   │                       ^^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:73:16
-   │
-73 │         return left - right
-   │                ^^^^^^^^^^^^ attributes hash: 9715536092457030614
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4281,58 +3129,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:76:16
-   │
-76 │         return left / right
-   │                ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:76:23
    │
 76 │         return left / right
    │                       ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:76:23
-   │
-76 │         return left / right
-   │                       ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:76:16
-   │
-76 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4377,58 +3177,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:79:16
-   │
-79 │         return left / right
-   │                ^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:79:23
    │
 79 │         return left / right
    │                       ^^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:79:23
-   │
-79 │         return left / right
-   │                       ^^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:79:16
-   │
-79 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 9341420026351674595
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4473,58 +3225,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:82:16
-   │
-82 │         return left / right
-   │                ^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:82:23
    │
 82 │         return left / right
    │                       ^^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:82:23
-   │
-82 │         return left / right
-   │                       ^^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:82:16
-   │
-82 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 3044889006329355385
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4569,58 +3273,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:85:16
-   │
-85 │         return left / right
-   │                ^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:85:23
    │
 85 │         return left / right
    │                       ^^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:85:23
-   │
-85 │         return left / right
-   │                       ^^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:85:16
-   │
-85 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 5442387896079309831
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4665,58 +3321,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:88:16
-   │
-88 │         return left / right
-   │                ^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:88:23
    │
 88 │         return left / right
    │                       ^^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:88:23
-   │
-88 │         return left / right
-   │                       ^^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:88:16
-   │
-88 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 17931047209024117248
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4761,58 +3369,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:91:16
-   │
-91 │         return left / right
-   │                ^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:91:23
    │
 91 │         return left / right
    │                       ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:91:23
-   │
-91 │         return left / right
-   │                       ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:91:16
-   │
-91 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4857,58 +3417,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:94:16
-   │
-94 │         return left / right
-   │                ^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:94:23
    │
 94 │         return left / right
    │                       ^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:94:23
-   │
-94 │         return left / right
-   │                       ^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:94:16
-   │
-94 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 17351186385905986417
    │
    = ExpressionAttributes {
          typ: Base(
@@ -4953,38 +3465,6 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:97:16
-   │
-97 │         return left / right
-   │                ^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/checked_arithmetic.fe:97:23
-   │
-97 │         return left / right
-   │                       ^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/checked_arithmetic.fe:97:23
    │
 97 │         return left / right
@@ -5017,58 +3497,10 @@ note:
      }
 
 note: 
-   ┌─ features/checked_arithmetic.fe:97:16
-   │
-97 │         return left / right
-   │                ^^^^^^^^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
     ┌─ features/checked_arithmetic.fe:100:16
     │
 100 │         return left / right
     │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:100:16
-    │
-100 │         return left / right
-    │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:100:23
-    │
-100 │         return left / right
-    │                       ^^^^^ attributes hash: 16198180549924123587
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5113,58 +3545,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:100:16
-    │
-100 │         return left / right
-    │                ^^^^^^^^^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:103:16
     │
 103 │         return left / right
     │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:103:16
-    │
-103 │         return left / right
-    │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:103:23
-    │
-103 │         return left / right
-    │                       ^^^^^ attributes hash: 13972995067286817043
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5209,58 +3593,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:103:16
-    │
-103 │         return left / right
-    │                ^^^^^^^^^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:106:16
     │
 106 │         return left / right
     │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:106:16
-    │
-106 │         return left / right
-    │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:106:23
-    │
-106 │         return left / right
-    │                       ^^^^^ attributes hash: 13584665093848691268
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5305,58 +3641,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:106:16
-    │
-106 │         return left / right
-    │                ^^^^^^^^^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:109:16
     │
 109 │         return left / right
     │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:109:16
-    │
-109 │         return left / right
-    │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:109:23
-    │
-109 │         return left / right
-    │                       ^^^^^ attributes hash: 9715536092457030614
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5401,58 +3689,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:109:16
-    │
-109 │         return left / right
-    │                ^^^^^^^^^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:112:16
     │
 112 │         return left * right
     │                ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:112:16
-    │
-112 │         return left * right
-    │                ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:112:23
-    │
-112 │         return left * right
-    │                       ^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5497,58 +3737,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:112:16
-    │
-112 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:115:16
     │
 115 │         return left * right
     │                ^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:115:16
-    │
-115 │         return left * right
-    │                ^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:115:23
-    │
-115 │         return left * right
-    │                       ^^^^^ attributes hash: 9341420026351674595
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5593,58 +3785,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:115:16
-    │
-115 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:118:16
     │
 118 │         return left * right
     │                ^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:118:16
-    │
-118 │         return left * right
-    │                ^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:118:23
-    │
-118 │         return left * right
-    │                       ^^^^^ attributes hash: 3044889006329355385
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5689,58 +3833,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:118:16
-    │
-118 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:121:16
     │
 121 │         return left * right
     │                ^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:121:16
-    │
-121 │         return left * right
-    │                ^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:121:23
-    │
-121 │         return left * right
-    │                       ^^^^^ attributes hash: 5442387896079309831
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5785,58 +3881,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:121:16
-    │
-121 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:124:16
     │
 124 │         return left * right
     │                ^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:124:16
-    │
-124 │         return left * right
-    │                ^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:124:23
-    │
-124 │         return left * right
-    │                       ^^^^^ attributes hash: 17931047209024117248
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5881,58 +3929,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:124:16
-    │
-124 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:127:16
     │
 127 │         return left * right
     │                ^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:127:16
-    │
-127 │         return left * right
-    │                ^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:127:23
-    │
-127 │         return left * right
-    │                       ^^^^^ attributes hash: 6817314866882205962
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5977,58 +3977,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:127:16
-    │
-127 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:130:16
     │
 130 │         return left * right
     │                ^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:130:16
-    │
-130 │         return left * right
-    │                ^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:130:23
-    │
-130 │         return left * right
-    │                       ^^^^^ attributes hash: 17351186385905986417
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6073,58 +4025,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:130:16
-    │
-130 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:133:16
     │
 133 │         return left * right
     │                ^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:133:16
-    │
-133 │         return left * right
-    │                ^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:133:23
-    │
-133 │         return left * right
-    │                       ^^^^^ attributes hash: 5494075259962106032
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6169,58 +4073,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:133:16
-    │
-133 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:136:16
     │
 136 │         return left * right
     │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:136:16
-    │
-136 │         return left * right
-    │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:136:23
-    │
-136 │         return left * right
-    │                       ^^^^^ attributes hash: 16198180549924123587
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6265,58 +4121,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:136:16
-    │
-136 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:139:16
     │
 139 │         return left * right
     │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:139:16
-    │
-139 │         return left * right
-    │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:139:23
-    │
-139 │         return left * right
-    │                       ^^^^^ attributes hash: 13972995067286817043
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6361,58 +4169,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:139:16
-    │
-139 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:142:16
     │
 142 │         return left * right
     │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:142:16
-    │
-142 │         return left * right
-    │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:142:23
-    │
-142 │         return left * right
-    │                       ^^^^^ attributes hash: 13584665093848691268
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6457,58 +4217,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:142:16
-    │
-142 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:145:16
     │
 145 │         return left * right
     │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:145:16
-    │
-145 │         return left * right
-    │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:145:23
-    │
-145 │         return left * right
-    │                       ^^^^^ attributes hash: 9715536092457030614
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6553,58 +4265,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:145:16
-    │
-145 │         return left * right
-    │                ^^^^^^^^^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:148:16
     │
 148 │         return left % right
     │                ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:148:16
-    │
-148 │         return left % right
-    │                ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:148:23
-    │
-148 │         return left % right
-    │                       ^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6649,58 +4313,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:148:16
-    │
-148 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:151:16
     │
 151 │         return left % right
     │                ^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:151:16
-    │
-151 │         return left % right
-    │                ^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:151:23
-    │
-151 │         return left % right
-    │                       ^^^^^ attributes hash: 9341420026351674595
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6745,58 +4361,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:151:16
-    │
-151 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:154:16
     │
 154 │         return left % right
     │                ^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:154:16
-    │
-154 │         return left % right
-    │                ^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:154:23
-    │
-154 │         return left % right
-    │                       ^^^^^ attributes hash: 3044889006329355385
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6841,58 +4409,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:154:16
-    │
-154 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:157:16
     │
 157 │         return left % right
     │                ^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:157:16
-    │
-157 │         return left % right
-    │                ^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:157:23
-    │
-157 │         return left % right
-    │                       ^^^^^ attributes hash: 5442387896079309831
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6937,58 +4457,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:157:16
-    │
-157 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:160:16
     │
 160 │         return left % right
     │                ^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:160:16
-    │
-160 │         return left % right
-    │                ^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:160:23
-    │
-160 │         return left % right
-    │                       ^^^^^ attributes hash: 17931047209024117248
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7033,58 +4505,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:160:16
-    │
-160 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:163:16
     │
 163 │         return left % right
     │                ^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:163:16
-    │
-163 │         return left % right
-    │                ^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:163:23
-    │
-163 │         return left % right
-    │                       ^^^^^ attributes hash: 6817314866882205962
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7129,58 +4553,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:163:16
-    │
-163 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:166:16
     │
 166 │         return left % right
     │                ^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:166:16
-    │
-166 │         return left % right
-    │                ^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:166:23
-    │
-166 │         return left % right
-    │                       ^^^^^ attributes hash: 17351186385905986417
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7225,58 +4601,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:166:16
-    │
-166 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:169:16
     │
 169 │         return left % right
     │                ^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:169:16
-    │
-169 │         return left % right
-    │                ^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:169:23
-    │
-169 │         return left % right
-    │                       ^^^^^ attributes hash: 5494075259962106032
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7321,58 +4649,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:169:16
-    │
-169 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:172:16
     │
 172 │         return left % right
     │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:172:16
-    │
-172 │         return left % right
-    │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:172:23
-    │
-172 │         return left % right
-    │                       ^^^^^ attributes hash: 16198180549924123587
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7417,58 +4697,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:172:16
-    │
-172 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:175:16
     │
 175 │         return left % right
     │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:175:16
-    │
-175 │         return left % right
-    │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:175:23
-    │
-175 │         return left % right
-    │                       ^^^^^ attributes hash: 13972995067286817043
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7513,58 +4745,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:175:16
-    │
-175 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:178:16
     │
 178 │         return left % right
     │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:178:16
-    │
-178 │         return left % right
-    │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:178:23
-    │
-178 │         return left % right
-    │                       ^^^^^ attributes hash: 13584665093848691268
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7609,58 +4793,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:178:16
-    │
-178 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:181:16
     │
 181 │         return left % right
     │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:181:16
-    │
-181 │         return left % right
-    │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:181:23
-    │
-181 │         return left % right
-    │                       ^^^^^ attributes hash: 9715536092457030614
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7705,58 +4841,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:181:16
-    │
-181 │         return left % right
-    │                ^^^^^^^^^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:184:16
     │
 184 │         return left ** right
     │                ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:184:16
-    │
-184 │         return left ** right
-    │                ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:184:24
-    │
-184 │         return left ** right
-    │                        ^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7801,58 +4889,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:184:16
-    │
-184 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:187:16
     │
 187 │         return left ** right
     │                ^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:187:16
-    │
-187 │         return left ** right
-    │                ^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:187:24
-    │
-187 │         return left ** right
-    │                        ^^^^^ attributes hash: 9341420026351674595
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7897,58 +4937,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:187:16
-    │
-187 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:190:16
     │
 190 │         return left ** right
     │                ^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:190:16
-    │
-190 │         return left ** right
-    │                ^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:190:24
-    │
-190 │         return left ** right
-    │                        ^^^^^ attributes hash: 3044889006329355385
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7993,58 +4985,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:190:16
-    │
-190 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:193:16
     │
 193 │         return left ** right
     │                ^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:193:16
-    │
-193 │         return left ** right
-    │                ^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:193:24
-    │
-193 │         return left ** right
-    │                        ^^^^^ attributes hash: 5442387896079309831
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8089,58 +5033,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:193:16
-    │
-193 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:196:16
     │
 196 │         return left ** right
     │                ^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:196:16
-    │
-196 │         return left ** right
-    │                ^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:196:24
-    │
-196 │         return left ** right
-    │                        ^^^^^ attributes hash: 17931047209024117248
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8185,58 +5081,10 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:196:16
-    │
-196 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:199:16
     │
 199 │         return left ** right
     │                ^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:199:16
-    │
-199 │         return left ** right
-    │                ^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:199:24
-    │
-199 │         return left ** right
-    │                        ^^^^^ attributes hash: 6817314866882205962
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8281,22 +5129,6 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:199:16
-    │
-199 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:202:16
     │
 202 │         return left ** right
@@ -8306,38 +5138,6 @@ note:
           typ: Base(
               Numeric(
                   I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:202:16
-    │
-202 │         return left ** right
-    │                ^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:202:24
-    │
-202 │         return left ** right
-    │                        ^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
               ),
           ),
           location: Value,
@@ -8377,22 +5177,6 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:202:16
-    │
-202 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 17351186385905986417
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:205:16
     │
 205 │         return left ** right
@@ -8402,38 +5186,6 @@ note:
           typ: Base(
               Numeric(
                   I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:205:16
-    │
-205 │         return left ** right
-    │                ^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:205:24
-    │
-205 │         return left ** right
-    │                        ^^^^^ attributes hash: 9341420026351674595
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U128,
               ),
           ),
           location: Value,
@@ -8473,22 +5225,6 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:205:16
-    │
-205 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 5494075259962106032
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I128,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:208:16
     │
 208 │         return left ** right
@@ -8498,38 +5234,6 @@ note:
           typ: Base(
               Numeric(
                   I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:208:16
-    │
-208 │         return left ** right
-    │                ^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:208:24
-    │
-208 │         return left ** right
-    │                        ^^^^^ attributes hash: 3044889006329355385
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U64,
               ),
           ),
           location: Value,
@@ -8569,22 +5273,6 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:208:16
-    │
-208 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 16198180549924123587
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I64,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:211:16
     │
 211 │         return left ** right
@@ -8594,38 +5282,6 @@ note:
           typ: Base(
               Numeric(
                   I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:211:16
-    │
-211 │         return left ** right
-    │                ^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:211:24
-    │
-211 │         return left ** right
-    │                        ^^^^^ attributes hash: 5442387896079309831
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U32,
               ),
           ),
           location: Value,
@@ -8665,22 +5321,6 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:211:16
-    │
-211 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 13972995067286817043
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I32,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:214:16
     │
 214 │         return left ** right
@@ -8690,38 +5330,6 @@ note:
           typ: Base(
               Numeric(
                   I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:214:16
-    │
-214 │         return left ** right
-    │                ^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:214:24
-    │
-214 │         return left ** right
-    │                        ^^^^^ attributes hash: 17931047209024117248
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U16,
               ),
           ),
           location: Value,
@@ -8761,38 +5369,6 @@ note:
       }
 
 note: 
-    ┌─ features/checked_arithmetic.fe:214:16
-    │
-214 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 13584665093848691268
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I16,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:217:16
-    │
-217 │         return left ** right
-    │                ^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
     ┌─ features/checked_arithmetic.fe:217:16
     │
 217 │         return left ** right
@@ -8818,38 +5394,6 @@ note:
           typ: Base(
               Numeric(
                   U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:217:24
-    │
-217 │         return left ** right
-    │                        ^^^^^ attributes hash: 6817314866882205962
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U8,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ features/checked_arithmetic.fe:217:16
-    │
-217 │         return left ** right
-    │                ^^^^^^^^^^^^^ attributes hash: 9715536092457030614
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  I8,
               ),
           ),
           location: Value,

--- a/analyzer/tests/snapshots/analysis__case_012_constructor.snap
+++ b/analyzer/tests/snapshots/analysis__case_012_constructor.snap
@@ -70,22 +70,6 @@ note:
     }
 
 note: 
-  ┌─ features/constructor.fe:5:18
-  │
-5 │         self.bar[42] = baz + bing
-  │                  ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/constructor.fe:5:9
   │
 5 │         self.bar[42] = baz + bing
@@ -108,38 +92,6 @@ note:
   │
 5 │         self.bar[42] = baz + bing
   │                        ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/constructor.fe:5:24
-  │
-5 │         self.bar[42] = baz + bing
-  │                        ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/constructor.fe:5:30
-  │
-5 │         self.bar[42] = baz + bing
-  │                              ^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -224,42 +176,6 @@ note:
         ),
         location: Value,
         move_location: None,
-    }
-
-note: 
-  ┌─ features/constructor.fe:8:25
-  │
-8 │         return self.bar[42]
-  │                         ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/constructor.fe:8:16
-  │
-8 │         return self.bar[42]
-  │                ^^^^^^^^^^^^ attributes hash: 9781479072077703403
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
     }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_013_create2_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_013_create2_contract.snap
@@ -58,58 +58,10 @@ note:
     }
 
 note: 
-  ┌─ features/create2_contract.fe:3:16
-  │
-3 │         return 42
-  │                ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/create2_contract.fe:8:32
   │
 8 │         foo: Foo = Foo.create2(0, 52)
   │                                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create2_contract.fe:8:32
-  │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create2_contract.fe:8:35
-  │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                                   ^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -166,34 +118,6 @@ note:
     }
 
 note: 
-  ┌─ features/create2_contract.fe:8:20
-  │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                    ^^^^^^^^^^^^^^^^^^ attributes hash: 8552961459538575979
-  │
-  = ExpressionAttributes {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                functions: [
-                    FunctionAttributes {
-                        is_public: true,
-                        name: "get_my_num",
-                        params: [],
-                        return_type: Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    },
-                ],
-            },
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/create2_contract.fe:9:24
   │
 9 │         return address(foo)
@@ -216,48 +140,6 @@ note:
                     },
                 ],
             },
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create2_contract.fe:9:24
-  │
-9 │         return address(foo)
-  │                        ^^^ attributes hash: 8552961459538575979
-  │
-  = ExpressionAttributes {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                functions: [
-                    FunctionAttributes {
-                        is_public: true,
-                        name: "get_my_num",
-                        params: [],
-                        return_type: Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    },
-                ],
-            },
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create2_contract.fe:9:16
-  │
-9 │         return address(foo)
-  │                ^^^^^^^^^^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_014_create_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_014_create_contract.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract.fe:3:16
-  │
-3 │         return 42
-  │                ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/create_contract.fe:7:31
   │
 7 │         foo: Foo = Foo.create(0)
@@ -84,50 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create_contract.fe:7:31
-  │
-7 │         foo: Foo = Foo.create(0)
-  │                               ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create_contract.fe:7:20
-  │
-7 │         foo: Foo = Foo.create(0)
-  │                    ^^^^^^^^^^^^^ attributes hash: 8552961459538575979
-  │
-  = ExpressionAttributes {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                functions: [
-                    FunctionAttributes {
-                        is_public: true,
-                        name: "get_my_num",
-                        params: [],
-                        return_type: Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    },
-                ],
-            },
         ),
         location: Value,
         move_location: None,
@@ -184,48 +124,6 @@ note:
                     },
                 ],
             },
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create_contract.fe:8:24
-  │
-8 │         return address(foo)
-  │                        ^^^ attributes hash: 8552961459538575979
-  │
-  = ExpressionAttributes {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                functions: [
-                    FunctionAttributes {
-                        is_public: true,
-                        name: "get_my_num",
-                        params: [],
-                        return_type: Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    },
-                ],
-            },
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create_contract.fe:8:16
-  │
-8 │         return address(foo)
-  │                ^^^^^^^^^^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_015_create_contract_from_init.snap
+++ b/analyzer/tests/snapshots/analysis__case_015_create_contract_from_init.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract_from_init.fe:3:16
-  │
-3 │         return 42
-  │                ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/create_contract_from_init.fe:9:9
   │
 9 │         self.foo_addr = address(Foo.create(0))
@@ -102,50 +86,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:44
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                                            ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:33
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                                 ^^^^^^^^^^^^^ attributes hash: 8552961459538575979
-  │
-  = ExpressionAttributes {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                functions: [
-                    FunctionAttributes {
-                        is_public: true,
-                        name: "get_my_num",
-                        params: [],
-                        return_type: Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    },
-                ],
-            },
         ),
         location: Value,
         move_location: None,
@@ -192,26 +132,6 @@ note:
         location: Value,
         move_location: None,
     }
-
-note: 
-   ┌─ features/create_contract_from_init.fe:12:16
-   │
-12 │         return self.foo_addr
-   │                ^^^^^^^^^^^^^ attributes hash: 10848859084443309747
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
 
 note: 
    ┌─ features/create_contract_from_init.fe:12:16

--- a/analyzer/tests/snapshots/analysis__case_017_events.snap
+++ b/analyzer/tests/snapshots/analysis__case_017_events.snap
@@ -109,58 +109,10 @@ note:
      }
 
 note: 
-   ┌─ features/events.fe:20:19
-   │
-20 │         emit Nums(26, 42)
-   │                   ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/events.fe:20:23
    │
 20 │         emit Nums(26, 42)
    │                       ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:20:23
-   │
-20 │         emit Nums(26, 42)
-   │                       ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:23:20
-   │
-23 │         emit Bases(26, addr)
-   │                    ^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -203,20 +155,6 @@ note:
      }
 
 note: 
-   ┌─ features/events.fe:23:24
-   │
-23 │         emit Bases(26, addr)
-   │                        ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/events.fe:26:18
    │
 26 │         emit Mix(26, addr, 42, my_bytes)
@@ -227,36 +165,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:26:18
-   │
-26 │         emit Mix(26, addr, 42, my_bytes)
-   │                  ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:26:22
-   │
-26 │         emit Mix(26, addr, 42, my_bytes)
-   │                      ^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -289,39 +197,6 @@ note:
              ),
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:26:28
-   │
-26 │         emit Mix(26, addr, 42, my_bytes)
-   │                            ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:26:32
-   │
-26 │         emit Mix(26, addr, 42, my_bytes)
-   │                                ^^^^^^^^ attributes hash: 6578844474441717363
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 100,
-                 inner: Byte,
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -356,22 +231,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:30:15
-   │
-30 │         addrs[0] = addr1
-   │               ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -453,22 +312,6 @@ note:
      }
 
 note: 
-   ┌─ features/events.fe:31:15
-   │
-31 │         addrs[1] = addr2
-   │               ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/events.fe:31:9
    │
 31 │         addrs[1] = addr2
@@ -493,23 +336,6 @@ note:
              Address,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/events.fe:32:24
-   │
-32 │         emit Addresses(addrs)
-   │                        ^^^^^ attributes hash: 7002368435280568865
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 2,
-                 inner: Address,
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 

--- a/analyzer/tests/snapshots/analysis__case_018_external_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_018_external_contract.snap
@@ -184,22 +184,6 @@ note:
     }
 
 note: 
-  ┌─ features/external_contract.fe:8:22
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                      ^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/external_contract.fe:8:30
   │
 8 │         emit MyEvent(my_num, my_addrs, my_string)
@@ -210,39 +194,6 @@ note:
             Array {
                 size: 5,
                 inner: Address,
-            },
-        ),
-        location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/external_contract.fe:8:30
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                              ^^^^^^^^ attributes hash: 9740078941645877256
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 5,
-                inner: Address,
-            },
-        ),
-        location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/external_contract.fe:8:40
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                                        ^^^^^^^^^ attributes hash: 6861635195207119580
-  │
-  = ExpressionAttributes {
-        typ: String(
-            FeString {
-                max_size: 11,
             },
         ),
         location: Memory,
@@ -281,22 +232,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:12:18
-   │
-12 │         my_array[0] = a
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -384,22 +319,6 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:13:18
-   │
-13 │         my_array[1] = a * b
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/external_contract.fe:13:9
    │
 13 │         my_array[1] = a * b
@@ -420,38 +339,6 @@ note:
    │
 13 │         my_array[1] = a * b
    │                       ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:13:23
-   │
-13 │         my_array[1] = a * b
-   │                       ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:13:27
-   │
-13 │         my_array[1] = a * b
-   │                           ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -531,22 +418,6 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:14:18
-   │
-14 │         my_array[2] = b
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/external_contract.fe:14:9
    │
 14 │         my_array[2] = b
@@ -598,25 +469,6 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:15:16
-   │
-15 │         return my_array
-   │                ^^^^^^^^ attributes hash: 4935018943425161537
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 3,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/external_contract.fe:24:24
    │
 24 │         foo: Foo = Foo(foo_address)
@@ -625,104 +477,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:24:24
-   │
-24 │         foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:24:20
-   │
-24 │         foo: Foo = Foo(foo_address)
-   │                    ^^^^^^^^^^^^^^^^ attributes hash: 15112974837598546431
-   │
-   = ExpressionAttributes {
-         typ: Contract(
-             Contract {
-                 name: "Foo",
-                 functions: [
-                     FunctionAttributes {
-                         is_public: true,
-                         name: "build_array",
-                         params: [
-                             (
-                                 "a",
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                             ),
-                             (
-                                 "b",
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                             ),
-                         ],
-                         return_type: Array(
-                             Array {
-                                 size: 3,
-                                 inner: Numeric(
-                                     U256,
-                                 ),
-                             },
-                         ),
-                     },
-                     FunctionAttributes {
-                         is_public: true,
-                         name: "emit_event",
-                         params: [
-                             (
-                                 "my_num",
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                             ),
-                             (
-                                 "my_addrs",
-                                 Array(
-                                     Array {
-                                         size: 5,
-                                         inner: Address,
-                                     },
-                                 ),
-                             ),
-                             (
-                                 "my_string",
-                                 String(
-                                     FeString {
-                                         max_size: 11,
-                                     },
-                                 ),
-                             ),
-                         ],
-                         return_type: Tuple(
-                             Tuple {
-                                 items: [],
-                             },
-                         ),
-                     },
-                 ],
-             },
          ),
          location: Value,
          move_location: None,
@@ -913,22 +667,6 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:25:24
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │                        ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/external_contract.fe:25:32
    │
 25 │         foo.emit_event(my_num, my_addrs, my_string)
@@ -939,39 +677,6 @@ note:
              Array {
                  size: 5,
                  inner: Address,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:25:32
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │                                ^^^^^^^^ attributes hash: 9740078941645877256
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 5,
-                 inner: Address,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:25:42
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │                                          ^^^^^^^^^ attributes hash: 6861635195207119580
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 11,
              },
          ),
          location: Memory,
@@ -1019,104 +724,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:32:24
-   │
-32 │         foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:32:20
-   │
-32 │         foo: Foo = Foo(foo_address)
-   │                    ^^^^^^^^^^^^^^^^ attributes hash: 15112974837598546431
-   │
-   = ExpressionAttributes {
-         typ: Contract(
-             Contract {
-                 name: "Foo",
-                 functions: [
-                     FunctionAttributes {
-                         is_public: true,
-                         name: "build_array",
-                         params: [
-                             (
-                                 "a",
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                             ),
-                             (
-                                 "b",
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                             ),
-                         ],
-                         return_type: Array(
-                             Array {
-                                 size: 3,
-                                 inner: Numeric(
-                                     U256,
-                                 ),
-                             },
-                         ),
-                     },
-                     FunctionAttributes {
-                         is_public: true,
-                         name: "emit_event",
-                         params: [
-                             (
-                                 "my_num",
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                             ),
-                             (
-                                 "my_addrs",
-                                 Array(
-                                     Array {
-                                         size: 5,
-                                         inner: Address,
-                                     },
-                                 ),
-                             ),
-                             (
-                                 "my_string",
-                                 String(
-                                     FeString {
-                                         max_size: 11,
-                                     },
-                                 ),
-                             ),
-                         ],
-                         return_type: Tuple(
-                             Tuple {
-                                 items: [],
-                             },
-                         ),
-                     },
-                 ],
-             },
          ),
          location: Value,
          move_location: None,
@@ -1307,22 +914,6 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:33:32
-   │
-33 │         return foo.build_array(a, b)
-   │                                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/external_contract.fe:33:35
    │
 33 │         return foo.build_array(a, b)
@@ -1335,41 +926,6 @@ note:
              ),
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:33:35
-   │
-33 │         return foo.build_array(a, b)
-   │                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/external_contract.fe:33:16
-   │
-33 │         return foo.build_array(a, b)
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4935018943425161537
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 3,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 

--- a/analyzer/tests/snapshots/analysis__case_019_for_loop_with_break.snap
+++ b/analyzer/tests/snapshots/analysis__case_019_for_loop_with_break.snap
@@ -62,22 +62,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_break.fe:5:18
-  │
-5 │         my_array[0] = 5
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_break.fe:5:9
   │
 5 │         my_array[0] = 5
@@ -125,22 +109,6 @@ note:
             },
         ),
         location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/for_loop_with_break.fe:6:18
-  │
-6 │         my_array[1] = 10
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 
@@ -228,22 +196,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_break.fe:7:18
-  │
-7 │         my_array[2] = 15
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_break.fe:7:9
   │
 7 │         my_array[2] = 15
@@ -264,22 +216,6 @@ note:
   │
 7 │         my_array[2] = 15
   │                       ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/for_loop_with_break.fe:8:21
-  │
-8 │         sum: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -359,38 +295,6 @@ note:
      }
 
 note: 
-   ┌─ features/for_loop_with_break.fe:10:19
-   │
-10 │             sum = sum + i
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_break.fe:10:25
-   │
-10 │             sum = sum + i
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/for_loop_with_break.fe:10:25
    │
 10 │             sum = sum + i
@@ -439,38 +343,6 @@ note:
      }
 
 note: 
-   ┌─ features/for_loop_with_break.fe:11:16
-   │
-11 │             if sum == 15:
-   │                ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_break.fe:11:23
-   │
-11 │             if sum == 15:
-   │                       ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/for_loop_with_break.fe:11:23
    │
 11 │             if sum == 15:
@@ -495,22 +367,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_break.fe:13:16
-   │
-13 │         return sum
-   │                ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_020_for_loop_with_continue.snap
+++ b/analyzer/tests/snapshots/analysis__case_020_for_loop_with_continue.snap
@@ -62,22 +62,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_continue.fe:5:18
-  │
-5 │         my_array[0] = 2
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_continue.fe:5:9
   │
 5 │         my_array[0] = 2
@@ -125,22 +109,6 @@ note:
             },
         ),
         location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:6:18
-  │
-6 │         my_array[1] = 3
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 
@@ -228,22 +196,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_continue.fe:7:18
-  │
-7 │         my_array[2] = 5
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_continue.fe:7:9
   │
 7 │         my_array[2] = 5
@@ -291,22 +243,6 @@ note:
             },
         ),
         location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:8:18
-  │
-8 │         my_array[3] = 6
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 
@@ -394,22 +330,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_continue.fe:9:18
-  │
-9 │         my_array[4] = 9
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_continue.fe:9:9
   │
 9 │         my_array[4] = 9
@@ -440,22 +360,6 @@ note:
         location: Value,
         move_location: None,
     }
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:10:21
-   │
-10 │         sum: u256 = 0
-   │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
 
 note: 
    ┌─ features/for_loop_with_continue.fe:10:21
@@ -509,38 +413,6 @@ note:
      }
 
 note: 
-   ┌─ features/for_loop_with_continue.fe:12:16
-   │
-12 │             if i % 2 == 0:
-   │                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:12:20
-   │
-12 │             if i % 2 == 0:
-   │                    ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/for_loop_with_continue.fe:12:20
    │
 12 │             if i % 2 == 0:
@@ -561,38 +433,6 @@ note:
    │
 12 │             if i % 2 == 0:
    │                ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:12:16
-   │
-12 │             if i % 2 == 0:
-   │                ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:12:25
-   │
-12 │             if i % 2 == 0:
-   │                         ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -667,38 +507,6 @@ note:
      }
 
 note: 
-   ┌─ features/for_loop_with_continue.fe:14:19
-   │
-14 │             sum = sum + i
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:14:25
-   │
-14 │             sum = sum + i
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/for_loop_with_continue.fe:14:25
    │
 14 │             sum = sum + i
@@ -719,22 +527,6 @@ note:
    │
 14 │             sum = sum + i
    │                   ^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:15:16
-   │
-15 │         return sum
-   │                ^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_021_for_loop_with_static_array.snap
+++ b/analyzer/tests/snapshots/analysis__case_021_for_loop_with_static_array.snap
@@ -62,22 +62,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:5:18
-  │
-5 │         my_array[0] = 5
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_static_array.fe:5:9
   │
 5 │         my_array[0] = 5
@@ -125,22 +109,6 @@ note:
             },
         ),
         location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:6:18
-  │
-6 │         my_array[1] = 10
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 
@@ -228,22 +196,6 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:7:18
-  │
-7 │         my_array[2] = 15
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/for_loop_with_static_array.fe:7:9
   │
 7 │         my_array[2] = 15
@@ -264,22 +216,6 @@ note:
   │
 7 │         my_array[2] = 15
   │                       ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:8:21
-  │
-8 │         sum: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -359,38 +295,6 @@ note:
      }
 
 note: 
-   ┌─ features/for_loop_with_static_array.fe:10:19
-   │
-10 │             sum = sum + i
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_static_array.fe:10:25
-   │
-10 │             sum = sum + i
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/for_loop_with_static_array.fe:10:25
    │
 10 │             sum = sum + i
@@ -411,22 +315,6 @@ note:
    │
 10 │             sum = sum + i
    │                   ^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/for_loop_with_static_array.fe:11:16
-   │
-11 │         return sum
-   │                ^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_022_if_statement.snap
+++ b/analyzer/tests/snapshots/analysis__case_022_if_statement.snap
@@ -52,38 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/if_statement.fe:5:20
-  │
-5 │             return 1
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement.fe:7:20
-  │
-7 │             return 0
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/if_statement.fe:7:20
   │
 7 │             return 0
@@ -104,38 +72,6 @@ note:
   │
 4 │         if input > 5:
   │            ^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement.fe:4:12
-  │
-4 │         if input > 5:
-  │            ^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement.fe:4:20
-  │
-4 │         if input > 5:
-  │                    ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_023_if_statement_2.snap
+++ b/analyzer/tests/snapshots/analysis__case_023_if_statement_2.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/if_statement_2.fe:5:20
-  │
-5 │             return 1
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/if_statement_2.fe:7:20
   │
 7 │             assert true
@@ -86,38 +70,6 @@ note:
   │
 4 │         if val > 5:
   │            ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement_2.fe:4:12
-  │
-4 │         if val > 5:
-  │            ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement_2.fe:4:18
-  │
-4 │         if val > 5:
-  │                  ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -154,22 +106,6 @@ note:
   = ExpressionAttributes {
         typ: Base(
             Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement_2.fe:9:16
-  │
-9 │         return 0
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_024_if_statement_with_block_declaration.snap
+++ b/analyzer/tests/snapshots/analysis__case_024_if_statement_with_block_declaration.snap
@@ -43,38 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/if_statement_with_block_declaration.fe:5:23
-  │
-5 │             y: u256 = 1
-  │                       ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:6:20
-  │
-6 │             return y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/if_statement_with_block_declaration.fe:6:20
   │
 6 │             return y
@@ -95,38 +63,6 @@ note:
   │
 8 │             y: u256 = 1
   │                       ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:8:23
-  │
-8 │             y: u256 = 1
-  │                       ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:9:20
-  │
-9 │             return y
-  │                    ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_025_keccak.snap
+++ b/analyzer/tests/snapshots/analysis__case_025_keccak.snap
@@ -94,23 +94,6 @@ note:
     }
 
 note: 
-  ┌─ features/keccak.fe:4:26
-  │
-4 │         return keccak256(val)
-  │                          ^^^ attributes hash: 8598609981099527373
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 1,
-                inner: Byte,
-            },
-        ),
-        location: Memory,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/keccak.fe:4:16
   │
 4 │         return keccak256(val)
@@ -123,39 +106,6 @@ note:
             ),
         ),
         location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/keccak.fe:4:16
-  │
-4 │         return keccak256(val)
-  │                ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/keccak.fe:7:26
-  │
-7 │         return keccak256(val)
-  │                          ^^^ attributes hash: 2245312459861268279
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 3,
-                inner: Byte,
-            },
-        ),
-        location: Memory,
         move_location: None,
     }
 
@@ -193,22 +143,6 @@ note:
     }
 
 note: 
-  ┌─ features/keccak.fe:7:16
-  │
-7 │         return keccak256(val)
-  │                ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
    ┌─ features/keccak.fe:10:26
    │
 10 │         return keccak256(val)
@@ -222,39 +156,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/keccak.fe:10:26
-   │
-10 │         return keccak256(val)
-   │                          ^^^ attributes hash: 10306023770505947435
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 32,
-                 inner: Byte,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/keccak.fe:10:16
-   │
-10 │         return keccak256(val)
-   │                ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 

--- a/analyzer/tests/snapshots/analysis__case_026_math.snap
+++ b/analyzer/tests/snapshots/analysis__case_026_math.snap
@@ -111,38 +111,6 @@ note:
     }
 
 note: 
-  ┌─ features/math.fe:8:23
-  │
-8 │             x: u256 = val / 2 + 1
-  │                       ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:8:29
-  │
-8 │             x: u256 = val / 2 + 1
-  │                             ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/math.fe:8:29
   │
 8 │             x: u256 = val / 2 + 1
@@ -175,58 +143,10 @@ note:
     }
 
 note: 
-  ┌─ features/math.fe:8:23
-  │
-8 │             x: u256 = val / 2 + 1
-  │                       ^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/math.fe:8:33
   │
 8 │             x: u256 = val / 2 + 1
   │                                 ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:8:33
-  │
-8 │             x: u256 = val / 2 + 1
-  │                                 ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:8:23
-  │
-8 │             x: u256 = val / 2 + 1
-  │                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -319,58 +239,10 @@ note:
      }
 
 note: 
-   ┌─ features/math.fe:11:22
-   │
-11 │                 x = (val / x + x) / 2
-   │                      ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/math.fe:11:28
    │
 11 │                 x = (val / x + x) / 2
    │                            ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:11:28
-   │
-11 │                 x = (val / x + x) / 2
-   │                            ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:11:22
-   │
-11 │                 x = (val / x + x) / 2
-   │                      ^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -415,58 +287,10 @@ note:
      }
 
 note: 
-   ┌─ features/math.fe:11:32
-   │
-11 │                 x = (val / x + x) / 2
-   │                                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/math.fe:11:21
    │
 11 │                 x = (val / x + x) / 2
    │                     ^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:11:21
-   │
-11 │                 x = (val / x + x) / 2
-   │                     ^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:11:37
-   │
-11 │                 x = (val / x + x) / 2
-   │                                     ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -515,38 +339,6 @@ note:
   │
 9 │             while (x < z):
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:9:20
-  │
-9 │             while (x < z):
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:9:24
-  │
-9 │             while (x < z):
-  │                        ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -637,38 +429,6 @@ note:
      }
 
 note: 
-   ┌─ features/math.fe:12:15
-   │
-12 │         elif (val != 0):
-   │               ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:12:22
-   │
-12 │         elif (val != 0):
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/math.fe:12:22
    │
 12 │         elif (val != 0):
@@ -703,38 +463,6 @@ note:
   │
 6 │         if (val > 3):
   │             ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:6:13
-  │
-6 │         if (val > 3):
-  │             ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:6:19
-  │
-6 │         if (val > 3):
-  │                   ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -793,58 +521,10 @@ note:
      }
 
 note: 
-   ┌─ features/math.fe:14:16
-   │
-14 │         return z
-   │                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/math.fe:17:21
    │
 17 │         return x if x < y else y
    │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:17:21
-   │
-17 │         return x if x < y else y
-   │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:17:25
-   │
-17 │         return x if x < y else y
-   │                         ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -887,36 +567,6 @@ note:
      }
 
 note: 
-   ┌─ features/math.fe:17:21
-   │
-17 │         return x if x < y else y
-   │                     ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:17:16
-   │
-17 │         return x if x < y else y
-   │                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/math.fe:17:16
    │
 17 │         return x if x < y else y
@@ -937,38 +587,6 @@ note:
    │
 17 │         return x if x < y else y
    │                                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:17:32
-   │
-17 │         return x if x < y else y
-   │                                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/math.fe:17:16
-   │
-17 │         return x if x < y else y
-   │                ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_027_multi_param.snap
+++ b/analyzer/tests/snapshots/analysis__case_027_multi_param.snap
@@ -90,22 +90,6 @@ note:
     }
 
 note: 
-  ┌─ features/multi_param.fe:4:18
-  │
-4 │         my_array[0] = x
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/multi_param.fe:4:9
   │
 4 │         my_array[0] = x
@@ -153,22 +137,6 @@ note:
             },
         ),
         location: Memory,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/multi_param.fe:5:18
-  │
-5 │         my_array[1] = y
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 
@@ -256,22 +224,6 @@ note:
     }
 
 note: 
-  ┌─ features/multi_param.fe:6:18
-  │
-6 │         my_array[2] = z
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/multi_param.fe:6:9
   │
 6 │         my_array[2] = z
@@ -300,25 +252,6 @@ note:
             ),
         ),
         location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/multi_param.fe:7:16
-  │
-7 │         return my_array
-  │                ^^^^^^^^ attributes hash: 4935018943425161537
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 3,
-                inner: Numeric(
-                    U256,
-                ),
-            },
-        ),
-        location: Memory,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_028_nested_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_028_nested_map.snap
@@ -169,20 +169,6 @@ note:
     }
 
 note: 
-  ┌─ features/nested_map.fe:6:25
-  │
-6 │         return self.bar[a][b]
-  │                         ^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/nested_map.fe:6:16
   │
 6 │         return self.bar[a][b]
@@ -217,40 +203,6 @@ note:
         ),
         location: Value,
         move_location: None,
-    }
-
-note: 
-  ┌─ features/nested_map.fe:6:28
-  │
-6 │         return self.bar[a][b]
-  │                            ^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/nested_map.fe:6:16
-  │
-6 │         return self.bar[a][b]
-  │                ^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
     }
 
 note: 
@@ -318,20 +270,6 @@ note:
     }
 
 note: 
-  ┌─ features/nested_map.fe:9:18
-  │
-9 │         self.bar[a][b] = value
-  │                  ^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/nested_map.fe:9:9
   │
 9 │         self.bar[a][b] = value
@@ -351,20 +289,6 @@ note:
         location: Storage {
             nonce: None,
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/nested_map.fe:9:21
-  │
-9 │         self.bar[a][b] = value
-  │                     ^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
         move_location: None,
     }
 
@@ -461,20 +385,6 @@ note:
      }
 
 note: 
-   ┌─ features/nested_map.fe:12:25
-   │
-12 │         return self.baz[a][b]
-   │                         ^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/nested_map.fe:12:16
    │
 12 │         return self.baz[a][b]
@@ -511,40 +421,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ features/nested_map.fe:12:28
-   │
-12 │         return self.baz[a][b]
-   │                            ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/nested_map.fe:12:16
-   │
-12 │         return self.baz[a][b]
-   │                ^^^^^^^^^^^^^^ attributes hash: 11651497198297579333
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -610,20 +486,6 @@ note:
      }
 
 note: 
-   ┌─ features/nested_map.fe:15:18
-   │
-15 │         self.baz[a][b] = value
-   │                  ^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/nested_map.fe:15:9
    │
 15 │         self.baz[a][b] = value
@@ -643,22 +505,6 @@ note:
          location: Storage {
              nonce: None,
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/nested_map.fe:15:21
-   │
-15 │         self.baz[a][b] = value
-   │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 

--- a/analyzer/tests/snapshots/analysis__case_029_numeric_sizes.snap
+++ b/analyzer/tests/snapshots/analysis__case_029_numeric_sizes.snap
@@ -273,22 +273,6 @@ note:
     }
 
 note: 
-  ┌─ features/numeric_sizes.fe:4:19
-  │
-4 │         return u8(0)
-  │                   ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/numeric_sizes.fe:4:16
   │
 4 │         return u8(0)
@@ -298,38 +282,6 @@ note:
         typ: Base(
             Numeric(
                 U8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/numeric_sizes.fe:4:16
-  │
-4 │         return u8(0)
-  │                ^^^^^ attributes hash: 6817314866882205962
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/numeric_sizes.fe:7:20
-  │
-7 │         return u16(0)
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
             ),
         ),
         location: Value,
@@ -369,22 +321,6 @@ note:
     }
 
 note: 
-  ┌─ features/numeric_sizes.fe:7:16
-  │
-7 │         return u16(0)
-  │                ^^^^^^ attributes hash: 17931047209024117248
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
    ┌─ features/numeric_sizes.fe:10:20
    │
 10 │         return u32(0)
@@ -394,38 +330,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:10:20
-   │
-10 │         return u32(0)
-   │                    ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:10:16
-   │
-10 │         return u32(0)
-   │                ^^^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
              ),
          ),
          location: Value,
@@ -465,22 +369,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:13:20
-   │
-13 │         return u64(0)
-   │                    ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:13:16
    │
 13 │         return u64(0)
@@ -490,38 +378,6 @@ note:
          typ: Base(
              Numeric(
                  U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:13:16
-   │
-13 │         return u64(0)
-   │                ^^^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:16:21
-   │
-16 │         return u128(0)
-   │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
              ),
          ),
          location: Value,
@@ -561,58 +417,10 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:16:16
-   │
-16 │         return u128(0)
-   │                ^^^^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:19:21
    │
 19 │         return u256(0)
    │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:19:21
-   │
-19 │         return u256(0)
-   │                     ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:19:16
-   │
-19 │         return u256(0)
-   │                ^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -657,22 +465,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:22:20
-   │
-22 │         return i8(-128)
-   │                    ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:22:19
    │
 22 │         return i8(-128)
@@ -682,38 +474,6 @@ note:
          typ: Base(
              Numeric(
                  I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:22:19
-   │
-22 │         return i8(-128)
-   │                   ^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:22:16
-   │
-22 │         return i8(-128)
-   │                ^^^^^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
              ),
          ),
          location: Value,
@@ -753,22 +513,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:25:21
-   │
-25 │         return i16(-32768)
-   │                     ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:25:20
    │
 25 │         return i16(-32768)
@@ -778,38 +522,6 @@ note:
          typ: Base(
              Numeric(
                  I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:25:20
-   │
-25 │         return i16(-32768)
-   │                    ^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:25:16
-   │
-25 │         return i16(-32768)
-   │                ^^^^^^^^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
              ),
          ),
          location: Value,
@@ -849,22 +561,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:28:21
-   │
-28 │         return i32(-2147483648)
-   │                     ^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:28:20
    │
 28 │         return i32(-2147483648)
@@ -874,38 +570,6 @@ note:
          typ: Base(
              Numeric(
                  I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:28:20
-   │
-28 │         return i32(-2147483648)
-   │                    ^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:28:16
-   │
-28 │         return i32(-2147483648)
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
              ),
          ),
          location: Value,
@@ -945,22 +609,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:31:21
-   │
-31 │         return i64(-9223372036854775808)
-   │                     ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:31:20
    │
 31 │         return i64(-9223372036854775808)
@@ -970,38 +618,6 @@ note:
          typ: Base(
              Numeric(
                  I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:31:20
-   │
-31 │         return i64(-9223372036854775808)
-   │                    ^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:31:16
-   │
-31 │         return i64(-9223372036854775808)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
              ),
          ),
          location: Value,
@@ -1041,22 +657,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:34:22
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:34:21
    │
 34 │         return i128(-170141183460469231731687303715884105728)
@@ -1066,38 +666,6 @@ note:
          typ: Base(
              Numeric(
                  I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:34:21
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:34:16
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
              ),
          ),
          location: Value,
@@ -1137,58 +705,10 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:37:22
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:37:21
    │
 37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:37:21
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:37:16
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1233,22 +753,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:40:19
-   │
-40 │         return u8(255)
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:40:16
    │
 40 │         return u8(255)
@@ -1258,38 +762,6 @@ note:
          typ: Base(
              Numeric(
                  U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:40:16
-   │
-40 │         return u8(255)
-   │                ^^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:43:20
-   │
-43 │         return u16(65535)
-   │                    ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
              ),
          ),
          location: Value,
@@ -1329,22 +801,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:43:16
-   │
-43 │         return u16(65535)
-   │                ^^^^^^^^^^ attributes hash: 17931047209024117248
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:46:20
    │
 46 │         return u32(4294967295)
@@ -1354,38 +810,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:46:20
-   │
-46 │         return u32(4294967295)
-   │                    ^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:46:16
-   │
-46 │         return u32(4294967295)
-   │                ^^^^^^^^^^^^^^^ attributes hash: 5442387896079309831
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U32,
              ),
          ),
          location: Value,
@@ -1425,22 +849,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:49:20
-   │
-49 │         return u64(18446744073709551615)
-   │                    ^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:49:16
    │
 49 │         return u64(18446744073709551615)
@@ -1450,38 +858,6 @@ note:
          typ: Base(
              Numeric(
                  U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:49:16
-   │
-49 │         return u64(18446744073709551615)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3044889006329355385
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:52:21
-   │
-52 │         return u128(340282366920938463463374607431768211455)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
              ),
          ),
          location: Value,
@@ -1521,58 +897,10 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:52:16
-   │
-52 │         return u128(340282366920938463463374607431768211455)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9341420026351674595
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:55:21
    │
 55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:55:21
-   │
-55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:55:16
-   │
-55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1617,22 +945,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:58:19
-   │
-58 │         return i8(127)
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:58:16
    │
 58 │         return i8(127)
@@ -1642,38 +954,6 @@ note:
          typ: Base(
              Numeric(
                  I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:58:16
-   │
-58 │         return i8(127)
-   │                ^^^^^^^ attributes hash: 9715536092457030614
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:61:20
-   │
-61 │         return i16(32767)
-   │                    ^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
              ),
          ),
          location: Value,
@@ -1713,22 +993,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:61:16
-   │
-61 │         return i16(32767)
-   │                ^^^^^^^^^^ attributes hash: 13584665093848691268
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:64:20
    │
 64 │         return i32(2147483647)
@@ -1738,38 +1002,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:64:20
-   │
-64 │         return i32(2147483647)
-   │                    ^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:64:16
-   │
-64 │         return i32(2147483647)
-   │                ^^^^^^^^^^^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
              ),
          ),
          location: Value,
@@ -1809,22 +1041,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:67:20
-   │
-67 │         return i64(9223372036854775807)
-   │                    ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:67:16
    │
 67 │         return i64(9223372036854775807)
@@ -1834,38 +1050,6 @@ note:
          typ: Base(
              Numeric(
                  I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:67:16
-   │
-67 │         return i64(9223372036854775807)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16198180549924123587
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:70:21
-   │
-70 │         return i128(170141183460469231731687303715884105727)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
              ),
          ),
          location: Value,
@@ -1905,22 +1089,6 @@ note:
      }
 
 note: 
-   ┌─ features/numeric_sizes.fe:70:16
-   │
-70 │         return i128(170141183460469231731687303715884105727)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5494075259962106032
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/numeric_sizes.fe:73:21
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
@@ -1930,38 +1098,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:73:21
-   │
-73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:73:16
-   │
-73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I256,
              ),
          ),
          location: Value,

--- a/analyzer/tests/snapshots/analysis__case_030_ownable.snap
+++ b/analyzer/tests/snapshots/analysis__case_030_ownable.snap
@@ -104,26 +104,6 @@ note:
      }
 
 note: 
-   ┌─ features/ownable.fe:12:12
-   │
-12 │     return self._owner
-   │            ^^^^^^^^^^^ attributes hash: 10848859084443309747
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/ownable.fe:15:12
    │
 15 │     assert msg.sender == self._owner
@@ -135,40 +115,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:15:12
-   │
-15 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:15:26
-   │
-15 │     assert msg.sender == self._owner
-   │                          ^^^^^^^^^^^ attributes hash: 10848859084443309747
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -240,22 +186,6 @@ note:
      }
 
 note: 
-   ┌─ features/ownable.fe:16:27
-   │
-16 │     self._owner = address(0)
-   │                           ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/ownable.fe:16:19
    │
 16 │     self._owner = address(0)
@@ -284,20 +214,6 @@ note:
      }
 
 note: 
-   ┌─ features/ownable.fe:17:31
-   │
-17 │     emit OwnershipTransferred(msg.sender, address(0))
-   │                               ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/ownable.fe:17:51
    │
 17 │     emit OwnershipTransferred(msg.sender, address(0))
@@ -308,36 +224,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:17:51
-   │
-17 │     emit OwnershipTransferred(msg.sender, address(0))
-   │                                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:17:43
-   │
-17 │     emit OwnershipTransferred(msg.sender, address(0))
-   │                                           ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -369,40 +255,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:20:12
-   │
-20 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:20:26
-   │
-20 │     assert msg.sender == self._owner
-   │                          ^^^^^^^^^^^ attributes hash: 10848859084443309747
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -454,20 +306,6 @@ note:
      }
 
 note: 
-   ┌─ features/ownable.fe:21:12
-   │
-21 │     assert newOwner != address(0)
-   │            ^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/ownable.fe:21:32
    │
 21 │     assert newOwner != address(0)
@@ -478,36 +316,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:21:32
-   │
-21 │     assert newOwner != address(0)
-   │                                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:21:24
-   │
-21 │     assert newOwner != address(0)
-   │                        ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -578,34 +386,6 @@ note:
    │
 23 │     emit OwnershipTransferred(msg.sender, newOwner)
    │                               ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:23:31
-   │
-23 │     emit OwnershipTransferred(msg.sender, newOwner)
-   │                               ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/ownable.fe:23:43
-   │
-23 │     emit OwnershipTransferred(msg.sender, newOwner)
-   │                                           ^^^^^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_031_return_addition_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_031_return_addition_i256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_addition_i256.fe:3:16
-  │
-3 │         return x + y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_addition_i256.fe:3:20
   │
 3 │         return x + y
   │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_addition_i256.fe:3:20
-  │
-3 │         return x + y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_addition_i256.fe:3:16
-  │
-3 │         return x + y
-  │                ^^^^^ attributes hash: 17351186385905986417
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_032_return_addition_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_032_return_addition_u128.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_addition_u128.fe:3:16
-  │
-3 │         return x + y
-  │                ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_addition_u128.fe:3:20
   │
 3 │         return x + y
   │                    ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_addition_u128.fe:3:20
-  │
-3 │         return x + y
-  │                    ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_addition_u128.fe:3:16
-  │
-3 │         return x + y
-  │                ^^^^^ attributes hash: 9341420026351674595
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_033_return_addition_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_033_return_addition_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_addition_u256.fe:3:16
-  │
-3 │         return x + y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_addition_u256.fe:3:20
   │
 3 │         return x + y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_addition_u256.fe:3:20
-  │
-3 │         return x + y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_addition_u256.fe:3:16
-  │
-3 │         return x + y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_034_return_array.snap
+++ b/analyzer/tests/snapshots/analysis__case_034_return_array.snap
@@ -74,22 +74,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_array.fe:4:18
-  │
-4 │         my_array[3] = x
-  │                  ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_array.fe:4:9
   │
 4 │         my_array[3] = x
@@ -118,25 +102,6 @@ note:
             ),
         ),
         location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_array.fe:5:16
-  │
-5 │         return my_array
-  │                ^^^^^^^^ attributes hash: 9322500749845443226
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 5,
-                inner: Numeric(
-                    U256,
-                ),
-            },
-        ),
-        location: Memory,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_035_return_bitwiseand_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_035_return_bitwiseand_u128.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwiseand_u128.fe:3:16
-  │
-3 │         return x & y
-  │                ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwiseand_u128.fe:3:20
   │
 3 │         return x & y
   │                    ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseand_u128.fe:3:20
-  │
-3 │         return x & y
-  │                    ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseand_u128.fe:3:16
-  │
-3 │         return x & y
-  │                ^^^^^ attributes hash: 9341420026351674595
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_036_return_bitwiseand_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_036_return_bitwiseand_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwiseand_u256.fe:3:16
-  │
-3 │         return x & y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwiseand_u256.fe:3:20
   │
 3 │         return x & y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseand_u256.fe:3:20
-  │
-3 │         return x & y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseand_u256.fe:3:16
-  │
-3 │         return x & y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_037_return_bitwiseor_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_037_return_bitwiseor_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwiseor_u256.fe:3:16
-  │
-3 │         return x | y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwiseor_u256.fe:3:20
   │
 3 │         return x | y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseor_u256.fe:3:20
-  │
-3 │         return x | y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseor_u256.fe:3:16
-  │
-3 │         return x | y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_038_return_bitwiseshl_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_038_return_bitwiseshl_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwiseshl_u256.fe:3:16
-  │
-3 │         return x << y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwiseshl_u256.fe:3:21
   │
 3 │         return x << y
   │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseshl_u256.fe:3:21
-  │
-3 │         return x << y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseshl_u256.fe:3:16
-  │
-3 │         return x << y
-  │                ^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_039_return_bitwiseshr_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_039_return_bitwiseshr_i256.snap
@@ -60,22 +60,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwiseshr_i256.fe:3:16
-  │
-3 │         return x >> y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwiseshr_i256.fe:3:21
   │
 3 │         return x >> y
@@ -85,38 +69,6 @@ note:
         typ: Base(
             Numeric(
                 U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseshr_i256.fe:3:21
-  │
-3 │         return x >> y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseshr_i256.fe:3:16
-  │
-3 │         return x >> y
-  │                ^^^^^^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
             ),
         ),
         location: Value,

--- a/analyzer/tests/snapshots/analysis__case_040_return_bitwiseshr_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_040_return_bitwiseshr_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwiseshr_u256.fe:3:16
-  │
-3 │         return x >> y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwiseshr_u256.fe:3:21
   │
 3 │         return x >> y
   │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseshr_u256.fe:3:21
-  │
-3 │         return x >> y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwiseshr_u256.fe:3:16
-  │
-3 │         return x >> y
-  │                ^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_041_return_bitwisexor_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_041_return_bitwisexor_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bitwisexor_u256.fe:3:16
-  │
-3 │         return x ^ y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bitwisexor_u256.fe:3:20
   │
 3 │         return x ^ y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwisexor_u256.fe:3:20
-  │
-3 │         return x ^ y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bitwisexor_u256.fe:3:16
-  │
-3 │         return x ^ y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_042_return_bool_false.snap
+++ b/analyzer/tests/snapshots/analysis__case_042_return_bool_false.snap
@@ -39,20 +39,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_bool_false.fe:3:16
-  │
-3 │         return false
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bool_false.fe:2:5
   │  
 2 │ ╭     pub def bar() -> bool:

--- a/analyzer/tests/snapshots/analysis__case_043_return_bool_inverted.snap
+++ b/analyzer/tests/snapshots/analysis__case_043_return_bool_inverted.snap
@@ -46,34 +46,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_bool_inverted.fe:3:20
-  │
-3 │         return not some_condition
-  │                    ^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bool_inverted.fe:3:16
-  │
-3 │         return not some_condition
-  │                ^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bool_inverted.fe:3:16
   │
 3 │         return not some_condition

--- a/analyzer/tests/snapshots/analysis__case_044_return_bool_op_and.snap
+++ b/analyzer/tests/snapshots/analysis__case_044_return_bool_op_and.snap
@@ -52,52 +52,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bool_op_and.fe:3:16
-  │
-3 │         return x and y
-  │                ^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bool_op_and.fe:3:22
   │
 3 │         return x and y
   │                      ^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bool_op_and.fe:3:22
-  │
-3 │         return x and y
-  │                      ^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bool_op_and.fe:3:16
-  │
-3 │         return x and y
-  │                ^^^^^^^ attributes hash: 10866140763116710699
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_045_return_bool_op_or.snap
+++ b/analyzer/tests/snapshots/analysis__case_045_return_bool_op_or.snap
@@ -52,52 +52,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_bool_op_or.fe:3:16
-  │
-3 │         return x or y
-  │                ^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bool_op_or.fe:3:21
   │
 3 │         return x or y
   │                     ^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bool_op_or.fe:3:21
-  │
-3 │         return x or y
-  │                     ^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_bool_op_or.fe:3:16
-  │
-3 │         return x or y
-  │                ^^^^^^ attributes hash: 10866140763116710699
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_046_return_bool_true.snap
+++ b/analyzer/tests/snapshots/analysis__case_046_return_bool_true.snap
@@ -39,20 +39,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_bool_true.fe:3:16
-  │
-3 │         return true
-  │                ^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_bool_true.fe:2:5
   │  
 2 │ ╭     pub def bar() -> bool:

--- a/analyzer/tests/snapshots/analysis__case_047_return_builtin_attributes.snap
+++ b/analyzer/tests/snapshots/analysis__case_047_return_builtin_attributes.snap
@@ -115,56 +115,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_builtin_attributes.fe:3:16
-  │
-3 │         return block.coinbase
-  │                ^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_builtin_attributes.fe:6:16
   │
 6 │         return block.difficulty
   │                ^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_builtin_attributes.fe:6:16
-  │
-6 │         return block.difficulty
-  │                ^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_builtin_attributes.fe:9:16
-  │
-9 │         return block.number
-  │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -209,22 +163,6 @@ note:
      }
 
 note: 
-   ┌─ features/return_builtin_attributes.fe:12:16
-   │
-12 │         return block.timestamp
-   │                ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_builtin_attributes.fe:15:16
    │
 15 │         return chain.id
@@ -235,36 +173,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:15:16
-   │
-15 │         return chain.id
-   │                ^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:18:16
-   │
-18 │         return msg.sender
-   │                ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -301,22 +209,6 @@ note:
      }
 
 note: 
-   ┌─ features/return_builtin_attributes.fe:21:16
-   │
-21 │         return msg.value
-   │                ^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_builtin_attributes.fe:24:16
    │
 24 │         return tx.origin
@@ -325,36 +217,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:24:16
-   │
-24 │         return tx.origin
-   │                ^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:27:16
-   │
-27 │         return tx.gas_price
-   │                ^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_048_return_division_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_048_return_division_i256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_division_i256.fe:3:16
-  │
-3 │         return x / y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_division_i256.fe:3:20
   │
 3 │         return x / y
   │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_division_i256.fe:3:20
-  │
-3 │         return x / y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_division_i256.fe:3:16
-  │
-3 │         return x / y
-  │                ^^^^^ attributes hash: 17351186385905986417
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_049_return_division_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_049_return_division_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_division_u256.fe:3:16
-  │
-3 │         return x / y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_division_u256.fe:3:20
   │
 3 │         return x / y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_division_u256.fe:3:20
-  │
-3 │         return x / y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_division_u256.fe:3:16
-  │
-3 │         return x / y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_050_return_empty_tuple.snap
+++ b/analyzer/tests/snapshots/analysis__case_050_return_empty_tuple.snap
@@ -97,38 +97,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_empty_tuple.fe:7:12
-  │
-7 │     return ()
-  │            ^^ attributes hash: 2354569150226010475
-  │
-  = ExpressionAttributes {
-        typ: Tuple(
-            Tuple {
-                items: [],
-            },
-        ),
-        location: Memory,
-        move_location: None,
-    }
-
-note: 
-   ┌─ features/return_empty_tuple.fe:13:12
-   │
-13 │     return ()
-   │            ^^ attributes hash: 2354569150226010475
-   │
-   = ExpressionAttributes {
-         typ: Tuple(
-             Tuple {
-                 items: [],
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_empty_tuple.fe:13:12
    │
 13 │     return ()

--- a/analyzer/tests/snapshots/analysis__case_051_return_eq_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_051_return_eq_u256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_eq_u256.fe:3:16
-  │
-3 │         return x == y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_eq_u256.fe:3:21
   │
 3 │         return x == y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_eq_u256.fe:3:21
-  │
-3 │         return x == y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_eq_u256.fe:3:16
-  │
-3 │         return x == y
-  │                ^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_052_return_gt_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_052_return_gt_i256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_gt_i256.fe:3:16
-  │
-3 │         return x > y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_gt_i256.fe:3:20
   │
 3 │         return x > y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 I256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gt_i256.fe:3:20
-  │
-3 │         return x > y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gt_i256.fe:3:16
-  │
-3 │         return x > y
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_053_return_gt_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_053_return_gt_u256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_gt_u256.fe:3:16
-  │
-3 │         return x > y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_gt_u256.fe:3:20
   │
 3 │         return x > y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gt_u256.fe:3:20
-  │
-3 │         return x > y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gt_u256.fe:3:16
-  │
-3 │         return x > y
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_054_return_gte_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_054_return_gte_i256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_gte_i256.fe:3:16
-  │
-3 │         return x >= y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_gte_i256.fe:3:21
   │
 3 │         return x >= y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 I256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gte_i256.fe:3:21
-  │
-3 │         return x >= y
-  │                     ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gte_i256.fe:3:16
-  │
-3 │         return x >= y
-  │                ^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_055_return_gte_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_055_return_gte_u256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_gte_u256.fe:3:16
-  │
-3 │         return x >= y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_gte_u256.fe:3:21
   │
 3 │         return x >= y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gte_u256.fe:3:21
-  │
-3 │         return x >= y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_gte_u256.fe:3:16
-  │
-3 │         return x >= y
-  │                ^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_056_return_i128_cast.snap
+++ b/analyzer/tests/snapshots/analysis__case_056_return_i128_cast.snap
@@ -43,22 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_i128_cast.fe:3:22
-  │
-3 │         return i128(-3)
-  │                      ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_i128_cast.fe:3:21
   │
 3 │         return i128(-3)
@@ -68,38 +52,6 @@ note:
         typ: Base(
             Numeric(
                 I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_i128_cast.fe:3:21
-  │
-3 │         return i128(-3)
-  │                     ^^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_i128_cast.fe:3:16
-  │
-3 │         return i128(-3)
-  │                ^^^^^^^^ attributes hash: 5494075259962106032
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I128,
             ),
         ),
         location: Value,

--- a/analyzer/tests/snapshots/analysis__case_057_return_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_057_return_i256.snap
@@ -43,38 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_i256.fe:3:17
-  │
-3 │         return -3
-  │                 ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_i256.fe:3:16
-  │
-3 │         return -3
-  │                ^^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_i256.fe:3:16
   │
 3 │         return -3

--- a/analyzer/tests/snapshots/analysis__case_058_return_identity_u8.snap
+++ b/analyzer/tests/snapshots/analysis__case_058_return_identity_u8.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_identity_u8.fe:3:16
-  │
-3 │         return x
-  │                ^ attributes hash: 6817314866882205962
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_identity_u8.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u8) -> u8:

--- a/analyzer/tests/snapshots/analysis__case_059_return_identity_u16.snap
+++ b/analyzer/tests/snapshots/analysis__case_059_return_identity_u16.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_identity_u16.fe:3:16
-  │
-3 │         return x
-  │                ^ attributes hash: 17931047209024117248
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_identity_u16.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u16) -> u16:

--- a/analyzer/tests/snapshots/analysis__case_060_return_identity_u32.snap
+++ b/analyzer/tests/snapshots/analysis__case_060_return_identity_u32.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_identity_u32.fe:3:16
-  │
-3 │         return x
-  │                ^ attributes hash: 5442387896079309831
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U32,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_identity_u32.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u32) -> u32:

--- a/analyzer/tests/snapshots/analysis__case_061_return_identity_u64.snap
+++ b/analyzer/tests/snapshots/analysis__case_061_return_identity_u64.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_identity_u64.fe:3:16
-  │
-3 │         return x
-  │                ^ attributes hash: 3044889006329355385
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U64,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_identity_u64.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u64) -> u64:

--- a/analyzer/tests/snapshots/analysis__case_062_return_identity_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_062_return_identity_u128.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_identity_u128.fe:3:16
-  │
-3 │         return x
-  │                ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_identity_u128.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u128) -> u128:

--- a/analyzer/tests/snapshots/analysis__case_063_return_identity_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_063_return_identity_u256.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_identity_u256.fe:3:16
-  │
-3 │         return x
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_identity_u256.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u256) -> u256:

--- a/analyzer/tests/snapshots/analysis__case_064_return_lt_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_064_return_lt_i256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_lt_i256.fe:3:16
-  │
-3 │         return x < y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_lt_i256.fe:3:20
   │
 3 │         return x < y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 I256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lt_i256.fe:3:20
-  │
-3 │         return x < y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lt_i256.fe:3:16
-  │
-3 │         return x < y
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_065_return_lt_u128.snap
+++ b/analyzer/tests/snapshots/analysis__case_065_return_lt_u128.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_lt_u128.fe:3:16
-  │
-3 │         return x < y
-  │                ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_lt_u128.fe:3:20
   │
 3 │         return x < y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U128,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lt_u128.fe:3:20
-  │
-3 │         return x < y
-  │                    ^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lt_u128.fe:3:16
-  │
-3 │         return x < y
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_066_return_lt_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_066_return_lt_u256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_lt_u256.fe:3:16
-  │
-3 │         return x < y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_lt_u256.fe:3:20
   │
 3 │         return x < y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lt_u256.fe:3:20
-  │
-3 │         return x < y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lt_u256.fe:3:16
-  │
-3 │         return x < y
-  │                ^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_067_return_lte_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_067_return_lte_i256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_lte_i256.fe:3:16
-  │
-3 │         return x <= y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_lte_i256.fe:3:21
   │
 3 │         return x <= y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 I256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lte_i256.fe:3:21
-  │
-3 │         return x <= y
-  │                     ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lte_i256.fe:3:16
-  │
-3 │         return x <= y
-  │                ^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_068_return_lte_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_068_return_lte_u256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_lte_u256.fe:3:16
-  │
-3 │         return x <= y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_lte_u256.fe:3:21
   │
 3 │         return x <= y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lte_u256.fe:3:21
-  │
-3 │         return x <= y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_lte_u256.fe:3:16
-  │
-3 │         return x <= y
-  │                ^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_069_return_mod_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_069_return_mod_i256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_mod_i256.fe:3:16
-  │
-3 │         return x % y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_mod_i256.fe:3:20
   │
 3 │         return x % y
   │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_mod_i256.fe:3:20
-  │
-3 │         return x % y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_mod_i256.fe:3:16
-  │
-3 │         return x % y
-  │                ^^^^^ attributes hash: 17351186385905986417
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_070_return_mod_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_070_return_mod_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_mod_u256.fe:3:16
-  │
-3 │         return x % y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_mod_u256.fe:3:20
   │
 3 │         return x % y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_mod_u256.fe:3:20
-  │
-3 │         return x % y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_mod_u256.fe:3:16
-  │
-3 │         return x % y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_071_return_msg_sig.snap
+++ b/analyzer/tests/snapshots/analysis__case_071_return_msg_sig.snap
@@ -79,23 +79,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_msg_sig.fe:5:16
-  │
-5 │         return msg_sig
-  │                ^^^^^^^ attributes hash: 10306023770505947435
-  │
-  = ExpressionAttributes {
-        typ: Array(
-            Array {
-                size: 32,
-                inner: Byte,
-            },
-        ),
-        location: Memory,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_msg_sig.fe:2:5
   │  
 2 │ ╭     pub def bar() -> bytes[32]:

--- a/analyzer/tests/snapshots/analysis__case_072_return_multiplication_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_072_return_multiplication_i256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_multiplication_i256.fe:3:16
-  │
-3 │         return x * y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_multiplication_i256.fe:3:20
   │
 3 │         return x * y
   │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_multiplication_i256.fe:3:20
-  │
-3 │         return x * y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_multiplication_i256.fe:3:16
-  │
-3 │         return x * y
-  │                ^^^^^ attributes hash: 17351186385905986417
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_073_return_multiplication_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_073_return_multiplication_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_multiplication_u256.fe:3:16
-  │
-3 │         return x * y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_multiplication_u256.fe:3:20
   │
 3 │         return x * y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_multiplication_u256.fe:3:20
-  │
-3 │         return x * y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_multiplication_u256.fe:3:16
-  │
-3 │         return x * y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_074_return_noteq_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_074_return_noteq_u256.snap
@@ -58,22 +58,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_noteq_u256.fe:3:16
-  │
-3 │         return x != y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_noteq_u256.fe:3:21
   │
 3 │         return x != y
@@ -84,36 +68,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_noteq_u256.fe:3:21
-  │
-3 │         return x != y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_noteq_u256.fe:3:16
-  │
-3 │         return x != y
-  │                ^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_075_return_pow_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_075_return_pow_i256.snap
@@ -60,22 +60,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_pow_i256.fe:3:16
-  │
-3 │         return x ** y
-  │                ^ attributes hash: 9715536092457030614
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_pow_i256.fe:3:21
   │
 3 │         return x ** y
@@ -85,38 +69,6 @@ note:
         typ: Base(
             Numeric(
                 U8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_pow_i256.fe:3:21
-  │
-3 │         return x ** y
-  │                     ^ attributes hash: 6817314866882205962
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_pow_i256.fe:3:16
-  │
-3 │         return x ** y
-  │                ^^^^^^ attributes hash: 9715536092457030614
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I8,
             ),
         ),
         location: Value,

--- a/analyzer/tests/snapshots/analysis__case_076_return_pow_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_076_return_pow_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_pow_u256.fe:3:16
-  │
-3 │         return x ** y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_pow_u256.fe:3:21
   │
 3 │         return x ** y
   │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_pow_u256.fe:3:21
-  │
-3 │         return x ** y
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_pow_u256.fe:3:16
-  │
-3 │         return x ** y
-  │                ^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_077_return_subtraction_i256.snap
+++ b/analyzer/tests/snapshots/analysis__case_077_return_subtraction_i256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_subtraction_i256.fe:3:16
-  │
-3 │         return x - y
-  │                ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_subtraction_i256.fe:3:20
   │
 3 │         return x - y
   │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_subtraction_i256.fe:3:20
-  │
-3 │         return x - y
-  │                    ^ attributes hash: 17351186385905986417
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                I256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_subtraction_i256.fe:3:16
-  │
-3 │         return x - y
-  │                ^^^^^ attributes hash: 17351186385905986417
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_078_return_subtraction_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_078_return_subtraction_u256.snap
@@ -60,58 +60,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_subtraction_u256.fe:3:16
-  │
-3 │         return x - y
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_subtraction_u256.fe:3:20
   │
 3 │         return x - y
   │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_subtraction_u256.fe:3:20
-  │
-3 │         return x - y
-  │                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_subtraction_u256.fe:3:16
-  │
-3 │         return x - y
-  │                ^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_079_return_u128_cast.snap
+++ b/analyzer/tests/snapshots/analysis__case_079_return_u128_cast.snap
@@ -43,38 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_u128_cast.fe:3:21
-  │
-3 │         return u128(42)
-  │                     ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u128_cast.fe:3:16
-  │
-3 │         return u128(42)
-  │                ^^^^^^^^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_u128_cast.fe:3:16
   │
 3 │         return u128(42)

--- a/analyzer/tests/snapshots/analysis__case_080_return_u256.snap
+++ b/analyzer/tests/snapshots/analysis__case_080_return_u256.snap
@@ -43,22 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_u256.fe:3:16
-  │
-3 │         return 42
-  │                ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_u256.fe:2:5
   │  
 2 │ ╭     pub def bar() -> u256:

--- a/analyzer/tests/snapshots/analysis__case_081_return_u256_from_called_fn.snap
+++ b/analyzer/tests/snapshots/analysis__case_081_return_u256_from_called_fn.snap
@@ -53,38 +53,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_u256_from_called_fn.fe:5:16
-  │
-5 │         return self.foo()
-  │                ^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn.fe:8:16
-  │
-8 │         return 42
-  │                ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_u256_from_called_fn.fe:8:16
   │
 8 │         return 42

--- a/analyzer/tests/snapshots/analysis__case_082_return_u256_from_called_fn_with_args.snap
+++ b/analyzer/tests/snapshots/analysis__case_082_return_u256_from_called_fn_with_args.snap
@@ -104,58 +104,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:23
   │
 4 │         return val1 + val2 + val3 + val4 + val5
   │                       ^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:23
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                       ^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -200,58 +152,10 @@ note:
     }
 
 note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:30
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                              ^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
   │
 4 │         return val1 + val2 + val3 + val4 + val5
   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:37
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                                     ^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -296,38 +200,6 @@ note:
     }
 
 note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:44
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                                            ^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:44
   │
 4 │         return val1 + val2 + val3 + val4 + val5
@@ -348,38 +220,6 @@ note:
   │
 4 │         return val1 + val2 + val3 + val4 + val5
   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:7:16
-  │
-7 │         return 100
-  │                ^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -451,22 +291,6 @@ note:
      }
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:10:18
-   │
-10 │         self.baz[0] = 43
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
    │
 10 │         self.baz[0] = 43
@@ -517,58 +341,10 @@ note:
      }
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:25
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:28
    │
 11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
    │                            ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:28
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                            ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:31
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                               ^^^^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -613,58 +389,10 @@ note:
      }
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:43
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                           ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:48
    │
 11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
    │                                                ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:48
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:43
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                           ^^^^^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -736,22 +464,6 @@ note:
      }
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:61
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                             ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:52
    │
 11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
@@ -769,42 +481,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:52
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                    ^^^^^^^^^^^ attributes hash: 9781479072077703403
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_084_self_address.snap
+++ b/analyzer/tests/snapshots/analysis__case_084_self_address.snap
@@ -39,20 +39,6 @@ note:
     }
 
 note: 
-  ┌─ features/self_address.fe:3:16
-  │
-3 │         return self.address
-  │                ^^^^^^^^^^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/self_address.fe:2:5
   │  
 2 │ ╭     pub def my_address() -> address:

--- a/analyzer/tests/snapshots/analysis__case_085_sized_vals_in_sto.snap
+++ b/analyzer/tests/snapshots/analysis__case_085_sized_vals_in_sto.snap
@@ -178,28 +178,6 @@ note:
      }
 
 note: 
-   ┌─ features/sized_vals_in_sto.fe:15:16
-   │
-15 │         return self.num
-   │                ^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/sized_vals_in_sto.fe:18:9
    │
 18 │         self.nums = x
@@ -262,31 +240,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:21:16
-   │
-21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 2528791973804439794
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 42,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 1,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 
@@ -393,50 +346,6 @@ note:
      }
 
 note: 
-   ┌─ features/sized_vals_in_sto.fe:27:16
-   │
-27 │         return self.str.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ attributes hash: 8485417019611755295
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 26,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:31:13
-   │
-31 │             self.num,
-   │             ^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/sized_vals_in_sto.fe:31:13
    │
 31 │             self.num,
@@ -507,31 +416,6 @@ note:
      }
 
 note: 
-   ┌─ features/sized_vals_in_sto.fe:32:13
-   │
-32 │             self.nums.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^ attributes hash: 2528791973804439794
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 42,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 1,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ features/sized_vals_in_sto.fe:33:13
    │
 33 │             self.str.to_mem()
@@ -549,28 +433,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:33:13
-   │
-33 │             self.str.to_mem()
-   │             ^^^^^^^^^^^^^^^^^ attributes hash: 8485417019611755295
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 26,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_086_strings.snap
+++ b/analyzer/tests/snapshots/analysis__case_086_strings.snap
@@ -80,38 +80,6 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:12:22
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                      ^^ attributes hash: 10420235251610747606
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 26,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:12:26
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                          ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/strings.fe:12:26
    │
 12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
@@ -137,38 +105,6 @@ note:
          typ: String(
              FeString {
                  max_size: 42,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:12:29
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                             ^^ attributes hash: 9569027785754553796
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 42,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:12:33
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                 ^^ attributes hash: 10521411858691425038
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 100,
              },
          ),
          location: Memory,
@@ -206,36 +142,6 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:12:37
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                     ^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:12:40
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                        ^^^^^^^^^^^^^^^ attributes hash: 15184264815905725710
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 13,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/strings.fe:12:40
    │
 12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
@@ -268,58 +174,10 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:12:67
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                                                   ^^^^^ attributes hash: 16852372960864427970
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 3,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/strings.fe:12:57
    │
 12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
    │                                                         ^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:12:57
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                                         ^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:15:16
-   │
-15 │         return s2
-   │                ^^ attributes hash: 10521411858691425038
    │
    = ExpressionAttributes {
          typ: String(
@@ -364,22 +222,6 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:18:16
-   │
-18 │         return "The quick brown fox jumps over the lazy dog"
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 789892328184844625
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 43,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/strings.fe:21:26
    │
 21 │         return string100("foo")
@@ -389,38 +231,6 @@ note:
          typ: String(
              FeString {
                  max_size: 3,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:21:26
-   │
-21 │         return string100("foo")
-   │                          ^^^^^ attributes hash: 16852372960864427970
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 3,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/strings.fe:21:16
-   │
-21 │         return string100("foo")
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 100,
              },
          ),
          location: Memory,

--- a/analyzer/tests/snapshots/analysis__case_087_structs.snap
+++ b/analyzer/tests/snapshots/analysis__case_087_structs.snap
@@ -151,58 +151,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:12:19
-   │
-12 │             price=1,
-   │                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:13:18
    │
 13 │             size=2,
    │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:13:18
-   │
-13 │             size=2,
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:14:22
-   │
-14 │             rooms=u8(5),
-   │                      ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -241,36 +193,6 @@ note:
              Numeric(
                  U8,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:14:19
-   │
-14 │             rooms=u8(5),
-   │                   ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:15:20
-   │
-15 │             vacant=false
-   │                    ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
          ),
          location: Value,
          move_location: None,
@@ -407,44 +329,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:17:16
-   │
-17 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:17:39
-   │
-17 │         assert self.my_house.price == 1
-   │                                       ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:17:39
    │
 17 │         assert self.my_house.price == 1
@@ -540,44 +424,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:18:16
-   │
-18 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:18:38
-   │
-18 │         assert self.my_house.size == 2
-   │                                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -679,28 +525,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:19:16
-   │
-19 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 3920863001671643912
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:19:42
    │
 19 │         assert self.my_house.rooms == u8(5)
@@ -710,38 +534,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:19:42
-   │
-19 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:19:39
-   │
-19 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -842,40 +634,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:20:16
-   │
-20 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 5019499297016497421
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:20:40
-   │
-20 │         assert self.my_house.vacant == false
-   │                                        ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1057,44 +815,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:23:16
-   │
-23 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:23:38
-   │
-23 │         assert self.my_house.size == 50
-   │                                      ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:23:38
    │
 23 │         assert self.my_house.size == 50
@@ -1190,44 +910,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:24:16
-   │
-24 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:24:39
-   │
-24 │         assert self.my_house.price == 1
-   │                                       ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1329,28 +1011,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:25:16
-   │
-25 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 3920863001671643912
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:25:42
    │
 25 │         assert self.my_house.rooms == u8(5)
@@ -1360,38 +1020,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:25:42
-   │
-25 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:25:39
-   │
-25 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -1492,40 +1120,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:26:16
-   │
-26 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 5019499297016497421
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:26:40
-   │
-26 │         assert self.my_house.vacant == false
-   │                                        ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1707,44 +1301,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:29:16
-   │
-29 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:29:38
-   │
-29 │         assert self.my_house.size == 50
-   │                                      ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:29:38
    │
 29 │         assert self.my_house.size == 50
@@ -1840,44 +1396,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:30:16
-   │
-30 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:30:39
-   │
-30 │         assert self.my_house.price == 1000
-   │                                       ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1979,28 +1497,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:31:16
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 3920863001671643912
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:31:42
    │
 31 │         assert self.my_house.rooms == u8(5)
@@ -2010,38 +1506,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:31:42
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:31:39
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -2142,40 +1606,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:32:16
-   │
-32 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 5019499297016497421
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:32:40
-   │
-32 │         assert self.my_house.vacant == false
-   │                                        ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -2353,44 +1783,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:34:16
-   │
-34 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:34:38
-   │
-34 │         assert self.my_house.size == 50
-   │                                      ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:34:38
    │
 34 │         assert self.my_house.size == 50
@@ -2486,44 +1878,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:35:16
-   │
-35 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:35:39
-   │
-35 │         assert self.my_house.price == 1000
-   │                                       ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -2625,28 +1979,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:36:16
-   │
-36 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 3920863001671643912
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:36:42
    │
 36 │         assert self.my_house.rooms == u8(5)
@@ -2656,38 +1988,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:36:42
-   │
-36 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:36:39
-   │
-36 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -2871,22 +2171,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:38:34
-   │
-38 │         self.my_house.rooms = u8(100)
-   │                                  ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:38:31
    │
 38 │         self.my_house.rooms = u8(100)
@@ -2968,44 +2252,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:39:16
-   │
-39 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:39:38
-   │
-39 │         assert self.my_house.size == 50
-   │                                      ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -3107,44 +2353,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:40:16
-   │
-40 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:40:39
-   │
-40 │         assert self.my_house.price == 1000
-   │                                       ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:40:39
    │
 40 │         assert self.my_house.price == 1000
@@ -3243,28 +2451,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:41:16
-   │
-41 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 3920863001671643912
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:41:42
    │
 41 │         assert self.my_house.rooms == u8(100)
@@ -3274,38 +2460,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:41:42
-   │
-41 │         assert self.my_house.rooms == u8(100)
-   │                                          ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:41:39
-   │
-41 │         assert self.my_house.rooms == u8(100)
-   │                                       ^^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -3423,58 +2577,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:46:19
-   │
-46 │             price=300,
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:47:18
    │
 47 │             size=500,
    │                  ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:47:18
-   │
-47 │             size=500,
-   │                  ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:48:22
-   │
-48 │             rooms=u8(20),
-   │                      ^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -3519,22 +2625,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:48:19
-   │
-48 │             rooms=u8(20),
-   │                   ^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:49:20
    │
 49 │             vacant=true
@@ -3545,68 +2635,6 @@ note:
              Bool,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:49:20
-   │
-49 │             vacant=true
-   │                    ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:45:27
-   │  
-45 │           building: House = House(
-   │ ╭───────────────────────────^
-46 │ │             price=300,
-47 │ │             size=500,
-48 │ │             rooms=u8(20),
-49 │ │             vacant=true
-50 │ │         )
-   │ ╰─────────^ attributes hash: 7861995031096832649
-   │  
-   = ExpressionAttributes {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 fields: {
-                     "price": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "rooms": Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                     "size": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "vacant": Base(
-                         Bool,
-                     ),
-                 },
-                 order: [
-                     "price",
-                     "size",
-                     "rooms",
-                     "vacant",
-                 ],
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -3716,40 +2744,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:51:16
-   │
-51 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:51:33
-   │
-51 │         assert building.size == 500
-   │                                 ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -3843,40 +2837,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:52:16
-   │
-52 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:52:34
-   │
-52 │         assert building.price == 300
-   │                                  ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:52:34
    │
 52 │         assert building.price == 300
@@ -3967,24 +2927,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^ attributes hash: 16427982076128084429
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:53:37
    │
 53 │         assert building.rooms == u8(20)
@@ -3994,38 +2936,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:53:37
-   │
-53 │         assert building.rooms == u8(20)
-   │                                     ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:53:34
-   │
-53 │         assert building.rooms == u8(20)
-   │                                  ^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -4411,22 +3321,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:59:29
-   │
-59 │         building.rooms = u8(10)
-   │                             ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:59:26
    │
 59 │         building.rooms = u8(10)
@@ -4498,36 +3392,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:61:16
-   │
-61 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^ attributes hash: 16124721822221882146
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:61:35
-   │
-61 │         assert building.vacant == false
-   │                                   ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -4616,40 +3480,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ features/structs.fe:62:16
-   │
-62 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:62:34
-   │
-62 │         assert building.price == 1
-   │                                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -4743,40 +3573,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:63:16
-   │
-63 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:63:33
-   │
-63 │         assert building.size == 2
-   │                                 ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:63:33
    │
 63 │         assert building.size == 2
@@ -4867,24 +3663,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:64:16
-   │
-64 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^ attributes hash: 16427982076128084429
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:64:37
    │
 64 │         assert building.rooms == u8(10)
@@ -4894,38 +3672,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:64:37
-   │
-64 │         assert building.rooms == u8(10)
-   │                                     ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:64:34
-   │
-64 │         assert building.rooms == u8(10)
-   │                                  ^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
              ),
          ),
          location: Value,
@@ -5023,60 +3769,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:65:16
-   │
-65 │         return building.size
-   │                ^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ features/structs.fe:69:19
    │
 69 │             price=300,
    │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:69:19
-   │
-69 │             price=300,
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:70:18
-   │
-70 │             size=500,
-   │                  ^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -5121,38 +3817,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:71:22
-   │
-71 │             rooms=u8(20),
-   │                      ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:71:19
-   │
-71 │             rooms=u8(20),
-   │                   ^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:71:19
    │
 71 │             rooms=u8(20),
@@ -5179,68 +3843,6 @@ note:
              Bool,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:72:20
-   │
-72 │             vacant=true
-   │                    ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:68:24
-   │  
-68 │           house: House = House(
-   │ ╭────────────────────────^
-69 │ │             price=300,
-70 │ │             size=500,
-71 │ │             rooms=u8(20),
-72 │ │             vacant=true
-73 │ │         )
-   │ ╰─────────^ attributes hash: 7861995031096832649
-   │  
-   = ExpressionAttributes {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 fields: {
-                     "price": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "rooms": Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                     "size": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "vacant": Base(
-                         Bool,
-                     ),
-                 },
-                 order: [
-                     "price",
-                     "size",
-                     "rooms",
-                     "vacant",
-                 ],
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -5352,59 +3954,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:74:16
-   │
-74 │         return house.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 14553861407964170732
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 128,
-                 inner: Byte,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:78:19
    │
 78 │             price=300,
    │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:78:19
-   │
-78 │             price=300,
-   │                   ^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:79:18
-   │
-79 │             size=500,
-   │                  ^^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -5449,38 +4002,6 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:80:22
-   │
-80 │             rooms=u8(20),
-   │                      ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:80:19
-   │
-80 │             rooms=u8(20),
-   │                   ^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/structs.fe:80:19
    │
 80 │             rooms=u8(20),
@@ -5507,68 +4028,6 @@ note:
              Bool,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:81:20
-   │
-81 │             vacant=true
-   │                    ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:77:24
-   │  
-77 │           house: House = House(
-   │ ╭────────────────────────^
-78 │ │             price=300,
-79 │ │             size=500,
-80 │ │             rooms=u8(20),
-81 │ │             vacant=true
-82 │ │         )
-   │ ╰─────────^ attributes hash: 7861995031096832649
-   │  
-   = ExpressionAttributes {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 fields: {
-                     "price": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "rooms": Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                     "size": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "vacant": Base(
-                         Bool,
-                     ),
-                 },
-                 order: [
-                     "price",
-                     "size",
-                     "rooms",
-                     "vacant",
-                 ],
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -5676,39 +4135,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:83:26
-   │
-83 │         return keccak256(house.abi_encode())
-   │                          ^^^^^^^^^^^^^^^^^^ attributes hash: 14553861407964170732
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 128,
-                 inner: Byte,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/structs.fe:83:16
-   │
-83 │         return keccak256(house.abi_encode())
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 

--- a/analyzer/tests/snapshots/analysis__case_088_ternary_expression.snap
+++ b/analyzer/tests/snapshots/analysis__case_088_ternary_expression.snap
@@ -52,22 +52,6 @@ note:
     }
 
 note: 
-  ┌─ features/ternary_expression.fe:4:21
-  │
-4 │         return 1 if input > 5 else 0
-  │                     ^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/ternary_expression.fe:4:29
   │
 4 │         return 1 if input > 5 else 0
@@ -78,36 +62,6 @@ note:
             Numeric(
                 U256,
             ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/ternary_expression.fe:4:29
-  │
-4 │         return 1 if input > 5 else 0
-  │                             ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/ternary_expression.fe:4:21
-  │
-4 │         return 1 if input > 5 else 0
-  │                     ^^^^^^^^^ attributes hash: 10866140763116710699
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
         ),
         location: Value,
         move_location: None,
@@ -144,58 +98,10 @@ note:
     }
 
 note: 
-  ┌─ features/ternary_expression.fe:4:16
-  │
-4 │         return 1 if input > 5 else 0
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/ternary_expression.fe:4:36
   │
 4 │         return 1 if input > 5 else 0
   │                                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/ternary_expression.fe:4:36
-  │
-4 │         return 1 if input > 5 else 0
-  │                                    ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/ternary_expression.fe:4:16
-  │
-4 │         return 1 if input > 5 else 0
-  │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_089_two_contracts.snap
+++ b/analyzer/tests/snapshots/analysis__case_089_two_contracts.snap
@@ -80,36 +80,6 @@ note:
     }
 
 note: 
-  ┌─ features/two_contracts.fe:6:28
-  │
-6 │         return Bar(address(0)).bar()
-  │                            ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/two_contracts.fe:6:20
-  │
-6 │         return Bar(address(0)).bar()
-  │                    ^^^^^^^^^^ attributes hash: 513065555763557710
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Address,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/two_contracts.fe:6:20
   │
 6 │         return Bar(address(0)).bar()
@@ -178,38 +148,6 @@ note:
     }
 
 note: 
-  ┌─ features/two_contracts.fe:6:16
-  │
-6 │         return Bar(address(0)).bar()
-  │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/two_contracts.fe:9:16
-  │
-9 │         return 42
-  │                ^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/two_contracts.fe:9:16
   │
 9 │         return 42
@@ -236,36 +174,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/two_contracts.fe:16:28
-   │
-16 │         return Foo(address(0)).foo()
-   │                            ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/two_contracts.fe:16:20
-   │
-16 │         return Foo(address(0)).foo()
-   │                    ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
          ),
          location: Value,
          move_location: None,
@@ -328,38 +236,6 @@ note:
    │
 16 │         return Foo(address(0)).foo()
    │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/two_contracts.fe:16:16
-   │
-16 │         return Foo(address(0)).foo()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/two_contracts.fe:19:16
-   │
-19 │         return 26
-   │                ^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(

--- a/analyzer/tests/snapshots/analysis__case_090_u8_u8_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_090_u8_u8_map.snap
@@ -106,42 +106,6 @@ note:
     }
 
 note: 
-  ┌─ features/u8_u8_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ attributes hash: 6817314866882205962
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u8_u8_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ attributes hash: 1740598829751249486
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
-    }
-
-note: 
   ┌─ features/u8_u8_map.fe:5:16
   │
 5 │         return self.bar[key]
@@ -185,22 +149,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u8_u8_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 6817314866882205962
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_091_u16_u16_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_091_u16_u16_map.snap
@@ -106,42 +106,6 @@ note:
     }
 
 note: 
-  ┌─ features/u16_u16_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ attributes hash: 17931047209024117248
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u16_u16_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ attributes hash: 15869762792193778527
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
-    }
-
-note: 
   ┌─ features/u16_u16_map.fe:5:16
   │
 5 │         return self.bar[key]
@@ -185,22 +149,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u16_u16_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 17931047209024117248
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_092_u32_u32_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_092_u32_u32_map.snap
@@ -106,42 +106,6 @@ note:
     }
 
 note: 
-  ┌─ features/u32_u32_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ attributes hash: 5442387896079309831
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U32,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u32_u32_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ attributes hash: 15300787439658747760
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U32,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
-    }
-
-note: 
   ┌─ features/u32_u32_map.fe:5:16
   │
 5 │         return self.bar[key]
@@ -185,22 +149,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u32_u32_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 5442387896079309831
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U32,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_093_u64_u64_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_093_u64_u64_map.snap
@@ -106,42 +106,6 @@ note:
     }
 
 note: 
-  ┌─ features/u64_u64_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ attributes hash: 3044889006329355385
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U64,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u64_u64_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ attributes hash: 15688310892038921170
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U64,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
-    }
-
-note: 
   ┌─ features/u64_u64_map.fe:5:16
   │
 5 │         return self.bar[key]
@@ -185,22 +149,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u64_u64_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 3044889006329355385
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U64,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_094_u128_u128_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_094_u128_u128_map.snap
@@ -106,42 +106,6 @@ note:
     }
 
 note: 
-  ┌─ features/u128_u128_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u128_u128_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ attributes hash: 18138722145076203151
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
-    }
-
-note: 
   ┌─ features/u128_u128_map.fe:5:16
   │
 5 │         return self.bar[key]
@@ -185,22 +149,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u128_u128_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 9341420026351674595
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_095_u256_u256_map.snap
+++ b/analyzer/tests/snapshots/analysis__case_095_u256_u256_map.snap
@@ -106,42 +106,6 @@ note:
     }
 
 note: 
-  ┌─ features/u256_u256_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u256_u256_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ attributes hash: 9781479072077703403
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Storage {
-            nonce: None,
-        },
-        move_location: Some(
-            Value,
-        ),
-    }
-
-note: 
   ┌─ features/u256_u256_map.fe:5:16
   │
 5 │         return self.bar[key]
@@ -185,22 +149,6 @@ note:
                 0,
             ),
         },
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/u256_u256_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
         move_location: None,
     }
 

--- a/analyzer/tests/snapshots/analysis__case_096_while_loop.snap
+++ b/analyzer/tests/snapshots/analysis__case_096_while_loop.snap
@@ -43,22 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop.fe:3:21
-  │
-3 │         val: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop.fe:5:13
   │
 5 │             val = val + 1
@@ -79,38 +63,6 @@ note:
   │
 5 │             val = val + 1
   │                   ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop.fe:5:19
-  │
-5 │             val = val + 1
-  │                   ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop.fe:5:25
-  │
-5 │             val = val + 1
-  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -203,38 +155,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop.fe:6:16
-  │
-6 │             if val == 2:
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop.fe:6:23
-  │
-6 │             if val == 2:
-  │                       ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop.fe:6:23
   │
 6 │             if val == 2:
@@ -281,38 +201,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop.fe:4:15
-  │
-4 │         while val < 2:
-  │               ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop.fe:4:21
-  │
-4 │         while val < 2:
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop.fe:4:21
   │
 4 │         while val < 2:
@@ -337,22 +225,6 @@ note:
   = ExpressionAttributes {
         typ: Base(
             Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop.fe:8:16
-  │
-8 │         return val
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_097_while_loop_with_break.snap
+++ b/analyzer/tests/snapshots/analysis__case_097_while_loop_with_break.snap
@@ -43,22 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_break.fe:3:21
-  │
-3 │         val: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_break.fe:5:13
   │
 5 │             val = val + 1
@@ -79,38 +63,6 @@ note:
   │
 5 │             val = val + 1
   │                   ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break.fe:5:19
-  │
-5 │             val = val + 1
-  │                   ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break.fe:5:25
-  │
-5 │             val = val + 1
-  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -171,38 +123,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_break.fe:4:15
-  │
-4 │         while val < 2:
-  │               ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break.fe:4:21
-  │
-4 │         while val < 2:
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_break.fe:4:21
   │
 4 │         while val < 2:
@@ -227,22 +147,6 @@ note:
   = ExpressionAttributes {
         typ: Base(
             Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break.fe:7:16
-  │
-7 │         return val
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_098_while_loop_with_break_2.snap
+++ b/analyzer/tests/snapshots/analysis__case_098_while_loop_with_break_2.snap
@@ -43,22 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_break_2.fe:3:21
-  │
-3 │         val: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_break_2.fe:5:13
   │
 5 │             val = val + 1
@@ -79,38 +63,6 @@ note:
   │
 5 │             val = val + 1
   │                   ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:5:19
-  │
-5 │             val = val + 1
-  │                   ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:5:25
-  │
-5 │             val = val + 1
-  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -171,38 +123,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_break_2.fe:6:16
-  │
-6 │             if val == 1:
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:6:23
-  │
-6 │             if val == 1:
-  │                       ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_break_2.fe:6:23
   │
 6 │             if val == 1:
@@ -249,38 +169,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_break_2.fe:4:15
-  │
-4 │         while val < 2:
-  │               ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:4:21
-  │
-4 │         while val < 2:
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_break_2.fe:4:21
   │
 4 │         while val < 2:
@@ -305,22 +193,6 @@ note:
   = ExpressionAttributes {
         typ: Base(
             Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:8:16
-  │
-8 │         return val
-  │                ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
         ),
         location: Value,
         move_location: None,

--- a/analyzer/tests/snapshots/analysis__case_099_while_loop_with_continue.snap
+++ b/analyzer/tests/snapshots/analysis__case_099_while_loop_with_continue.snap
@@ -43,38 +43,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:3:19
-  │
-3 │         i: u256 = 0
-  │                   ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:4:25
-  │
-4 │         counter: u256 = 0
-  │                         ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_continue.fe:4:25
   │
 4 │         counter: u256 = 0
@@ -123,38 +91,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:7:17
-  │
-7 │             i = i + 1
-  │                 ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:7:21
-  │
-7 │             i = i + 1
-  │                     ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_continue.fe:7:21
   │
 7 │             i = i + 1
@@ -191,38 +127,6 @@ note:
   │
 8 │             if i == 1:
   │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:8:16
-  │
-8 │             if i == 1:
-  │                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:8:21
-  │
-8 │             if i == 1:
-  │                     ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -297,38 +201,6 @@ note:
      }
 
 note: 
-   ┌─ features/while_loop_with_continue.fe:10:23
-   │
-10 │             counter = counter + 1
-   │                       ^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ features/while_loop_with_continue.fe:10:33
-   │
-10 │             counter = counter + 1
-   │                                 ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ features/while_loop_with_continue.fe:10:33
    │
 10 │             counter = counter + 1
@@ -377,38 +249,6 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:6:15
-  │
-6 │         while i < 2:
-  │               ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:6:19
-  │
-6 │         while i < 2:
-  │                   ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/while_loop_with_continue.fe:6:19
   │
 6 │         while i < 2:
@@ -437,22 +277,6 @@ note:
         location: Value,
         move_location: None,
     }
-
-note: 
-   ┌─ features/while_loop_with_continue.fe:11:16
-   │
-11 │         return counter
-   │                ^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
 
 note: 
    ┌─ features/while_loop_with_continue.fe:11:16

--- a/analyzer/tests/snapshots/analysis__case_100_abi_encoding_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_100_abi_encoding_stress.snap
@@ -419,29 +419,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:27:16
-   │
-27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14222027602690501828
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 5,
-                 inner: Address,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:30:9
    │
 30 │         self.my_u128 = my_u128
@@ -475,28 +452,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:33:16
-   │
-33 │         return self.my_u128
-   │                ^^^^^^^^^^^^ attributes hash: 10067809958524075301
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 1,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -575,28 +530,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:39:16
-   │
-39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 980173007631351881
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 10,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 
@@ -712,31 +645,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:45:16
-   │
-45 │         return self.my_u8s.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 3855584261660153860
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 255,
-                 inner: Numeric(
-                     U8,
-                 ),
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 3,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:48:9
    │
 48 │         self.my_bool = my_bool
@@ -766,26 +674,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:51:16
-   │
-51 │         return self.my_bool
-   │                ^^^^^^^^^^^^ attributes hash: 11793743503936840609
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Storage {
-             nonce: Some(
-                 4,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -891,65 +779,10 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:57:16
-   │
-57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12051565540558389281
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 100,
-                 inner: Byte,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 5,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:61:20
    │
 61 │             my_num=42,
    │                    ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:61:20
-   │
-61 │             my_num=42,
-   │                    ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:62:24
-   │
-62 │             my_num2=u8(26),
-   │                        ^^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -994,22 +827,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:62:21
-   │
-62 │             my_num2=u8(26),
-   │                     ^^^^^^ attributes hash: 6817314866882205962
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:63:21
    │
 63 │             my_bool=true,
@@ -1018,36 +835,6 @@ note:
    = ExpressionAttributes {
          typ: Base(
              Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:63:21
-   │
-63 │             my_bool=true,
-   │                     ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:64:29
-   │
-64 │             my_addr=address(123456)
-   │                             ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
          ),
          location: Value,
          move_location: None,
@@ -1080,66 +867,6 @@ note:
              Address,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:64:21
-   │
-64 │             my_addr=address(123456)
-   │                     ^^^^^^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:60:16
-   │  
-60 │           return MyStruct(
-   │ ╭────────────────^
-61 │ │             my_num=42,
-62 │ │             my_num2=u8(26),
-63 │ │             my_bool=true,
-64 │ │             my_addr=address(123456)
-65 │ │         )
-   │ ╰─────────^ attributes hash: 4224724267794589733
-   │  
-   = ExpressionAttributes {
-         typ: Struct(
-             Struct {
-                 name: "MyStruct",
-                 fields: {
-                     "my_addr": Base(
-                         Address,
-                     ),
-                     "my_bool": Base(
-                         Bool,
-                     ),
-                     "my_num": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "my_num2": Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 },
-                 order: [
-                     "my_num",
-                     "my_num2",
-                     "my_bool",
-                     "my_addr",
-                 ],
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -1334,22 +1061,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:69:32
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │                                ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:69:29
    │
 69 │         my_struct.my_num2 = u8(42)
@@ -1504,22 +1215,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:71:37
-   │
-71 │         my_struct.my_addr = address(9999)
-   │                                     ^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:71:29
    │
 71 │         my_struct.my_addr = address(9999)
@@ -1530,46 +1225,6 @@ note:
              Address,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:72:16
-   │
-72 │         return my_struct
-   │                ^^^^^^^^^ attributes hash: 4224724267794589733
-   │
-   = ExpressionAttributes {
-         typ: Struct(
-             Struct {
-                 name: "MyStruct",
-                 fields: {
-                     "my_addr": Base(
-                         Address,
-                     ),
-                     "my_bool": Base(
-                         Bool,
-                     ),
-                     "my_num": Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     "my_num2": Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 },
-                 order: [
-                     "my_num",
-                     "my_num2",
-                     "my_bool",
-                     "my_addr",
-                 ],
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -1658,51 +1313,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:76:13
-   │
-76 │             self.my_addrs.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14222027602690501828
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 5,
-                 inner: Address,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:77:13
-   │
-77 │             self.my_u128,
-   │             ^^^^^^^^^^^^ attributes hash: 10067809958524075301
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 1,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:77:13
    │
 77 │             self.my_u128,
@@ -1742,28 +1352,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:78:13
-   │
-78 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 980173007631351881
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 10,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 
@@ -1837,51 +1425,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:79:13
-   │
-79 │             self.my_u8s.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^ attributes hash: 3855584261660153860
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 255,
-                 inner: Numeric(
-                     U8,
-                 ),
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 3,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:80:13
-   │
-80 │             self.my_bool,
-   │             ^^^^^^^^^^^^ attributes hash: 11793743503936840609
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Storage {
-             nonce: Some(
-                 4,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:80:13
    │
 80 │             self.my_bool,
@@ -1920,29 +1463,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:81:13
-   │
-81 │             self.my_bytes.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12051565540558389281
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 100,
-                 inner: Byte,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 5,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_101_data_copying_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_101_data_copying_stress.snap
@@ -461,44 +461,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:32:34
-   │
-32 │         my_2nd_array: u256[10] = my_array
-   │                                  ^^^^^^^^ attributes hash: 12880944358712268851
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 10,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:33:34
-   │
-33 │         my_3rd_array: u256[10] = my_2nd_array
-   │                                  ^^^^^^^^^^^^ attributes hash: 12880944358712268851
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 10,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:33:34
    │
 33 │         my_3rd_array: u256[10] = my_2nd_array
@@ -553,22 +515,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:35:25
-   │
-35 │         assert my_array[3] != 5
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:35:16
    │
 35 │         assert my_array[3] != 5
@@ -584,40 +530,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:35:16
-   │
-35 │         assert my_array[3] != 5
-   │                ^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:35:31
-   │
-35 │         assert my_array[3] != 5
-   │                               ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -666,22 +578,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:36:18
-   │
-36 │         my_array[3] = 5
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -769,22 +665,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:37:25
-   │
-37 │         assert my_array[3] == 5
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:37:16
    │
 37 │         assert my_array[3] == 5
@@ -800,40 +680,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:37:16
-   │
-37 │         assert my_array[3] == 5
-   │                ^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:37:31
-   │
-37 │         assert my_array[3] == 5
-   │                               ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -902,22 +748,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:38:29
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                             ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:38:16
    │
 38 │         assert my_2nd_array[3] == 5
@@ -933,40 +763,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:35
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1035,22 +831,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:39:29
-   │
-39 │         assert my_3rd_array[3] == 5
-   │                             ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:39:16
    │
 39 │         assert my_3rd_array[3] == 5
@@ -1066,40 +846,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:16
-   │
-39 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:35
-   │
-39 │         assert my_3rd_array[3] == 5
-   │                                   ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1148,22 +894,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:41:22
-   │
-41 │         my_3rd_array[3] = 50
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1251,22 +981,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:42:25
-   │
-42 │         assert my_array[3] == 50
-   │                         ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:42:16
    │
 42 │         assert my_array[3] == 50
@@ -1282,40 +996,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:16
-   │
-42 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:31
-   │
-42 │         assert my_array[3] == 50
-   │                               ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1384,22 +1064,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:43:29
-   │
-43 │         assert my_2nd_array[3] == 50
-   │                             ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:43:16
    │
 43 │         assert my_2nd_array[3] == 50
@@ -1415,40 +1079,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:16
-   │
-43 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:35
-   │
-43 │         assert my_2nd_array[3] == 50
-   │                                   ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1517,22 +1147,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:44:29
-   │
-44 │         assert my_3rd_array[3] == 50
-   │                             ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:44:16
    │
 44 │         assert my_3rd_array[3] == 50
@@ -1548,40 +1162,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:16
-   │
-44 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:35
-   │
-44 │         assert my_3rd_array[3] == 50
-   │                                   ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
      }
 
 note: 
@@ -1630,22 +1210,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:47:18
-   │
-47 │         my_array[3] = 5
-   │                  ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -1717,25 +1281,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:48:16
-   │
-48 │         return my_array
-   │                ^^^^^^^^ attributes hash: 12880944358712268851
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 10,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:51:16
    │
 51 │         return my_array.clone()
@@ -1752,27 +1297,6 @@ note:
          ),
          location: Memory,
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:51:16
-   │
-51 │         return my_array.clone()
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 10862398269442980722
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 10,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 
@@ -1853,22 +1377,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:26
-   │
-54 │         my_array.clone()[3] = 5
-   │                          ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:54:9
    │
 54 │         my_array.clone()[3] = 5
@@ -1920,25 +1428,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:55:16
-   │
-55 │         return my_array
-   │                ^^^^^^^^ attributes hash: 12880944358712268851
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 10,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:59:9
    │
 59 │         self.my_nums[0] = 42
@@ -1958,22 +1447,6 @@ note:
                  4,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:59:22
-   │
-59 │         self.my_nums[0] = 42
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -2067,22 +1540,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:60:22
-   │
-60 │         self.my_nums[1] = 26
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:60:9
    │
 60 │         self.my_nums[1] = 26
@@ -2136,22 +1593,6 @@ note:
                  4,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:61:22
-   │
-61 │         self.my_nums[2] = 0
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -2245,22 +1686,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:62:22
-   │
-62 │         self.my_nums[3] = 1
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:62:9
    │
 62 │         self.my_nums[3] = 1
@@ -2314,22 +1739,6 @@ note:
                  4,
              ),
          },
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:63:22
-   │
-63 │         self.my_nums[4] = 255
-   │                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -2470,25 +1879,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:65:16
-   │
-65 │         return my_nums_mem
-   │                ^^^^^^^^^^^ attributes hash: 9322500749845443226
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 5,
-                 inner: Numeric(
-                     U256,
-                 ),
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:69:13
    │
 69 │             self.my_string.to_mem(),
@@ -2506,28 +1896,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:69:13
-   │
-69 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14071116891056185972
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 42,
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
      }
 
 note: 
@@ -2595,28 +1963,6 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:70:13
-   │
-70 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 2,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ stress/data_copying_stress.fe:68:9
    │  
 68 │ ╭         self.emit_my_event_internal(
@@ -2648,38 +1994,6 @@ note:
              },
          ),
          location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:74:22
-   │
-74 │         emit MyEvent(some_string, some_u256)
-   │                      ^^^^^^^^^^^ attributes hash: 9569027785754553796
-   │
-   = ExpressionAttributes {
-         typ: String(
-             FeString {
-                 max_size: 42,
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:74:35
-   │
-74 │         emit MyEvent(some_string, some_u256)
-   │                                   ^^^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
          move_location: None,
      }
 
@@ -2772,40 +2086,6 @@ note:
          ),
          location: Value,
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:80:30
-   │
-80 │         return self.my_addrs[1]
-   │                              ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:80:16
-   │
-80 │         return self.my_addrs[1]
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 15587646813440843004
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Storage {
-             nonce: None,
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 

--- a/analyzer/tests/snapshots/analysis__case_102_tuple_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_102_tuple_stress.snap
@@ -316,36 +316,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:12:17
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                 ^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:12:25
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                         ^^^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:12:25
    │
 12 │         return (my_num, my_bool, my_address)
@@ -370,48 +340,6 @@ note:
              Address,
          ),
          location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:12:34
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                                  ^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:12:16
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14640869125644683951
-   │
-   = ExpressionAttributes {
-         typ: Tuple(
-             Tuple {
-                 items: [
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     Base(
-                         Bool,
-                     ),
-                     Base(
-                         Address,
-                     ),
-                 ],
-             },
-         ),
-         location: Memory,
          move_location: None,
      }
 
@@ -490,24 +418,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:15:16
-   │
-15 │         return my_tuple.item0
-   │                ^^^^^^^^^^^^^^ attributes hash: 11934894478308934606
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:18:16
    │
 18 │         return my_tuple.item1
@@ -533,22 +443,6 @@ note:
          ),
          location: Memory,
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:18:16
-   │
-18 │         return my_tuple.item1
-   │                ^^^^^^^^^^^^^^ attributes hash: 16124721822221882146
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -609,50 +503,6 @@ note:
          move_location: Some(
              Value,
          ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:21:16
-   │
-21 │         return my_tuple.item2
-   │                ^^^^^^^^^^^^^^ attributes hash: 4842680713810666204
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Memory,
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:24:22
-   │
-24 │         emit MyEvent(my_tuple)
-   │                      ^^^^^^^^ attributes hash: 14640869125644683951
-   │
-   = ExpressionAttributes {
-         typ: Tuple(
-             Tuple {
-                 items: [
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     Base(
-                         Bool,
-                     ),
-                     Base(
-                         Address,
-                     ),
-                 ],
-             },
-         ),
-         location: Memory,
-         move_location: None,
      }
 
 note: 
@@ -737,44 +587,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:16
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:48
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:27:48
    │
 27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
@@ -801,36 +613,6 @@ note:
              Numeric(
                  U256,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:43
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                           ^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:16
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
          ),
          location: Value,
          move_location: None,
@@ -904,44 +686,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:55
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17262025105149179489
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:86
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                      ^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:27:86
    │
 27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
@@ -968,36 +712,6 @@ note:
              Numeric(
                  I32,
              ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:82
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                  ^^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:55
-   │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
          ),
          location: Value,
          move_location: None,
@@ -1072,38 +786,6 @@ note:
          typ: Base(
              Numeric(
                  U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:28:30
-   │
-28 │         self.my_sto_tuple = (my_u256, my_i32)
-   │                              ^^^^^^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:28:39
-   │
-28 │         self.my_sto_tuple = (my_u256, my_i32)
-   │                                       ^^^^^^ attributes hash: 13972995067286817043
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 I32,
              ),
          ),
          location: Value,
@@ -1218,39 +900,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:31:16
-   │
-31 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 7737538719066505855
-   │
-   = ExpressionAttributes {
-         typ: Tuple(
-             Tuple {
-                 items: [
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     Base(
-                         Numeric(
-                             I32,
-                         ),
-                     ),
-                 ],
-             },
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Memory,
-         ),
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:34:24
    │
 34 │         my_num: u256 = self.my_sto_tuple.item0
@@ -1279,28 +928,6 @@ note:
              ),
          },
          move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:34:24
-   │
-34 │         my_num: u256 = self.my_sto_tuple.item0
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
      }
 
 note: 
@@ -1379,42 +1006,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:36:13
-   │
-36 │             self.my_sto_tuple.item0,
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Storage {
-             nonce: Some(
-                 0,
-             ),
-         },
-         move_location: Some(
-             Value,
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:37:13
-   │
-37 │             true and false,
-   │             ^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:37:13
    │
 37 │             true and false,
@@ -1433,34 +1024,6 @@ note:
    │
 37 │             true and false,
    │                      ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:37:22
-   │
-37 │             true and false,
-   │                      ^^^^^ attributes hash: 10866140763116710699
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Bool,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:37:13
-   │
-37 │             true and false,
-   │             ^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1501,36 +1064,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:38:21
-   │
-38 │             address(26)
-   │                     ^^ attributes hash: 16797824492585953824
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:38:13
-   │
-38 │             address(26)
-   │             ^^^^^^^^^^^ attributes hash: 513065555763557710
-   │
-   = ExpressionAttributes {
-         typ: Base(
-             Address,
-         ),
-         location: Value,
-         move_location: None,
-     }
-
-note: 
    ┌─ stress/tuple_stress.fe:38:13
    │
 38 │             address(26)
@@ -1555,67 +1088,6 @@ note:
 39 │ │         )
    │ ╰─────────^ attributes hash: 14640869125644683951
    │  
-   = ExpressionAttributes {
-         typ: Tuple(
-             Tuple {
-                 items: [
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     Base(
-                         Bool,
-                     ),
-                     Base(
-                         Address,
-                     ),
-                 ],
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:35:43
-   │  
-35 │           my_tuple: (u256, bool, address) = (
-   │ ╭───────────────────────────────────────────^
-36 │ │             self.my_sto_tuple.item0,
-37 │ │             true and false,
-38 │ │             address(26)
-39 │ │         )
-   │ ╰─────────^ attributes hash: 14640869125644683951
-   │  
-   = ExpressionAttributes {
-         typ: Tuple(
-             Tuple {
-                 items: [
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                     Base(
-                         Bool,
-                     ),
-                     Base(
-                         Address,
-                     ),
-                 ],
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:40:28
-   │
-40 │         self.emit_my_event(my_tuple)
-   │                            ^^^^^^^^ attributes hash: 14640869125644683951
-   │
    = ExpressionAttributes {
          typ: Tuple(
              Tuple {
@@ -1704,23 +1176,6 @@ note:
                          Address,
                      ),
                  ],
-             },
-         ),
-         location: Memory,
-         move_location: None,
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:43:16
-   │
-43 │         return my_tuple.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5235017701104600297
-   │
-   = ExpressionAttributes {
-         typ: Array(
-             Array {
-                 size: 96,
-                 inner: Byte,
              },
          ),
          location: Memory,

--- a/compiler/src/lowering/mappers/functions.rs
+++ b/compiler/src/lowering/mappers/functions.rs
@@ -118,14 +118,15 @@ fn aug_assign(
     op: Node<fe::BinOperator>,
     value: Node<fe::Expr>,
 ) -> Vec<fe::FuncStmt> {
-    let lowered_target = expressions::expr(context, target);
     let original_value_span = value.span;
-    let lowered_value = expressions::expr(context, value);
+    let lowered_target = expressions::expr(context, target.clone());
+    let lowered_lh_value = expressions::expr(context, target);
+    let lowered_rh_value = expressions::expr(context, value);
 
     let new_value_kind = fe::Expr::BinOperation {
-        left: Box::new(lowered_target.clone().new_id()),
+        left: Box::new(lowered_lh_value),
         op,
-        right: Box::new(lowered_value),
+        right: Box::new(lowered_rh_value),
     };
 
     let new_value = Node::new(new_value_kind, original_value_span);

--- a/compiler/tests/cases/lowering/fixtures/list_expressions_lowered.fe
+++ b/compiler/tests/cases/lowering/fixtures/list_expressions_lowered.fe
@@ -3,7 +3,7 @@ contract Foo:
     pub def foo():
         x: u256[3] = self.list_expr_array_u256_3(10, 20, 30)
 
-    def list_expr_array_u256_3(val0: u256, val1:u256, val2:u256) -> u256[3]:
+    def list_expr_array_u256_3(val0: u256, val1: u256, val2: u256) -> u256[3]:
         generated_array: u256[3]
         generated_array[0] = val0
         generated_array[1] = val1

--- a/newsfragments/392.internal.md
+++ b/newsfragments/392.internal.md
@@ -1,0 +1,1 @@
+Analyzer now disallows using `context.add_` methods to update attributes.


### PR DESCRIPTION
### What was wrong?

The context was letting us add attributes to the same ID multiple times.

### How was it fixed?

- added panics to each of the add methods
- fixed two spots that panicked

All of the snapshot noise is from there no longer being any duplicate expressions printouts.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
