### PR TITLE
Validate that tuple attributes are prefixed with 'item'

### DIFF
--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -366,9 +366,13 @@ fn expr_attribute(
 
 /// Pull the item index from the attribute string (e.g. "item4" -> "4").
 fn tuple_item_index(item: &str) -> Result<usize, SemanticError> {
-    item[4..]
-        .parse::<usize>()
-        .map_err(|_| SemanticError::undefined_value())
+    if item.len() < 5 || &item[..4] != "item" {
+        Err(SemanticError::undefined_value())
+    } else {
+        item[4..]
+            .parse::<usize>()
+            .map_err(|_| SemanticError::undefined_value())
+    }
 }
 
 fn expr_attribute_self(

--- a/compiler/tests/cases/compile_errors.rs
+++ b/compiler/tests/cases/compile_errors.rs
@@ -98,7 +98,9 @@ use rstest::rstest;
     case("binary_operations/add_uints.fe", TypeError),
     case("binary_operations/lshift_bool.fe", TypeError),
     case("binary_operations/lshift_with_int.fe", TypeError),
-    case("binary_operations/pow_int.fe", TypeError)
+    case("binary_operations/pow_int.fe", TypeError),
+    case("bad_tuple_attr1.fe", UndefinedValue),
+    case("bad_tuple_attr2.fe", UndefinedValue)
 )]
 fn test_compile_errors(fixture_file: &str, expected_error: fe_analyzer::errors::ErrorKind) {
     let mut files = FileStore::new();

--- a/compiler/tests/cases/lowering/mod.rs
+++ b/compiler/tests/cases/lowering/mod.rs
@@ -47,5 +47,7 @@ fn test_lowering(fixture: &str) {
     assert_strings_eq!(
         replace_spans(to_ron_string_pretty(&expected_lowered_ast).unwrap()),
         replace_spans(to_ron_string_pretty(&actual_lowered_ast).unwrap()),
-    )
+    );
+
+    fe_analyzer::analyze(&actual_lowered_ast).expect("analysis of the lowered module failed");
 }

--- a/compiler/tests/fixtures/compile_errors/bad_tuple_attr1.fe
+++ b/compiler/tests/fixtures/compile_errors/bad_tuple_attr1.fe
@@ -1,0 +1,6 @@
+# See ethereum/fe issue #396
+contract foo:
+    my_sto_tuple: (u256, i32)
+
+    pub def bar():
+        self.my_sto_tuple.iteo0

--- a/compiler/tests/fixtures/compile_errors/bad_tuple_attr2.fe
+++ b/compiler/tests/fixtures/compile_errors/bad_tuple_attr2.fe
@@ -1,0 +1,6 @@
+# See ethereum/fe issue #399
+contract foo:
+    my_sto_tuple: (u256, i32)
+
+    pub def bar:
+        self.my_sto_tuple.m

--- a/newsfragments/401.bugfix.md
+++ b/newsfragments/401.bugfix.md
@@ -1,0 +1,1 @@
+The analyzer will return an error if a tuple attribute is not of the form `item<index>`.


### PR DESCRIPTION
### What was wrong?

closes #396 and closes #399

### How was it fixed?

We weren't verifying that tuple attributes started with "item", which resulted in undefined attributes such as `iteo0` making it to the post-lowering analysis stage.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
