### PR TITLE
Fill in Quickstart in Fe guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ build-website:
 	# Copy the entire website directory to target/website
 	cp -r website/ target/
 
+	# Fill version marker with current version
+	sed -i "s/{{FE_VERSION}}/$$(cargo pkgid | cut -d# -f2 | cut -d: -f2)/g" target/website/index.html
+
 	# Generate the compiler API docs
 	cargo doc --no-deps --workspace
 

--- a/analyzer/tests/fixtures/demos/guest_book.fe
+++ b/analyzer/tests/fixtures/demos/guest_book.fe
@@ -1,15 +1,15 @@
 type BookMsg = bytes[100]
 
 contract GuestBook:
-    pub guest_book: map<address, BookMsg>
+    messages: map<address, BookMsg>
 
     event Signed:
         book_msg: BookMsg
 
     pub def sign(book_msg: BookMsg):
-        self.guest_book[msg.sender] = book_msg
+        self.messages[msg.sender] = book_msg
 
         emit Signed(book_msg=book_msg)
 
     pub def get_msg(addr: address) -> BookMsg:
-        return self.guest_book[addr].to_mem()
+        return self.messages[addr].to_mem()

--- a/analyzer/tests/snapshots/analysis__case_002_guest_book.snap
+++ b/analyzer/tests/snapshots/analysis__case_002_guest_book.snap
@@ -63,8 +63,8 @@ ModuleAttributes {
 note: 
    ┌─ demos/guest_book.fe:10:9
    │
-10 │         self.guest_book[msg.sender] = book_msg
-   │         ^^^^^^^^^^^^^^^ attributes hash: 7171665311786934563
+10 │         self.messages[msg.sender] = book_msg
+   │         ^^^^^^^^^^^^^ attributes hash: 7171665311786934563
    │
    = ExpressionAttributes {
          typ: Map(
@@ -87,10 +87,10 @@ note:
      }
 
 note: 
-   ┌─ demos/guest_book.fe:10:25
+   ┌─ demos/guest_book.fe:10:23
    │
-10 │         self.guest_book[msg.sender] = book_msg
-   │                         ^^^^^^^^^^ attributes hash: 513065555763557710
+10 │         self.messages[msg.sender] = book_msg
+   │                       ^^^^^^^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(
@@ -103,8 +103,8 @@ note:
 note: 
    ┌─ demos/guest_book.fe:10:9
    │
-10 │         self.guest_book[msg.sender] = book_msg
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 453830748720542459
+10 │         self.messages[msg.sender] = book_msg
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 453830748720542459
    │
    = ExpressionAttributes {
          typ: Array(
@@ -120,10 +120,10 @@ note:
      }
 
 note: 
-   ┌─ demos/guest_book.fe:10:39
+   ┌─ demos/guest_book.fe:10:37
    │
-10 │         self.guest_book[msg.sender] = book_msg
-   │                                       ^^^^^^^^ attributes hash: 6578844474441717363
+10 │         self.messages[msg.sender] = book_msg
+   │                                     ^^^^^^^^ attributes hash: 6578844474441717363
    │
    = ExpressionAttributes {
          typ: Array(
@@ -156,8 +156,8 @@ note:
 note: 
    ┌─ demos/guest_book.fe:15:16
    │
-15 │         return self.guest_book[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^ attributes hash: 7171665311786934563
+15 │         return self.messages[addr].to_mem()
+   │                ^^^^^^^^^^^^^ attributes hash: 7171665311786934563
    │
    = ExpressionAttributes {
          typ: Map(
@@ -180,10 +180,10 @@ note:
      }
 
 note: 
-   ┌─ demos/guest_book.fe:15:32
+   ┌─ demos/guest_book.fe:15:30
    │
-15 │         return self.guest_book[addr].to_mem()
-   │                                ^^^^ attributes hash: 513065555763557710
+15 │         return self.messages[addr].to_mem()
+   │                              ^^^^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
          typ: Base(
@@ -196,8 +196,8 @@ note:
 note: 
    ┌─ demos/guest_book.fe:15:16
    │
-15 │         return self.guest_book[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 453830748720542459
+15 │         return self.messages[addr].to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 453830748720542459
    │
    = ExpressionAttributes {
          typ: Array(
@@ -215,8 +215,8 @@ note:
 note: 
    ┌─ demos/guest_book.fe:15:16
    │
-15 │         return self.guest_book[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16413446491870513894
+15 │         return self.messages[addr].to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16413446491870513894
    │
    = ExpressionAttributes {
          typ: Array(
@@ -260,7 +260,7 @@ note:
    ┌─ demos/guest_book.fe:9:5
    │  
  9 │ ╭     pub def sign(book_msg: BookMsg):
-10 │ │         self.guest_book[msg.sender] = book_msg
+10 │ │         self.messages[msg.sender] = book_msg
 11 │ │ 
 12 │ │         emit Signed(book_msg=book_msg)
    │ ╰──────────────────────────────────────^ attributes hash: 5066331849586951910
@@ -290,8 +290,8 @@ note:
    ┌─ demos/guest_book.fe:14:5
    │  
 14 │ ╭     pub def get_msg(addr: address) -> BookMsg:
-15 │ │         return self.guest_book[addr].to_mem()
-   │ ╰─────────────────────────────────────────────^ attributes hash: 14720587159970812425
+15 │ │         return self.messages[addr].to_mem()
+   │ ╰───────────────────────────────────────────^ attributes hash: 14720587159970812425
    │  
    = FunctionAttributes {
          is_public: true,
@@ -316,13 +316,13 @@ note:
    ┌─ demos/guest_book.fe:3:1
    │  
  3 │ ╭ contract GuestBook:
- 4 │ │     pub guest_book: map<address, BookMsg>
+ 4 │ │     messages: map<address, BookMsg>
  5 │ │ 
  6 │ │     event Signed:
    · │
 14 │ │     pub def get_msg(addr: address) -> BookMsg:
-15 │ │         return self.guest_book[addr].to_mem()
-   │ ╰─────────────────────────────────────────────^ attributes hash: 6562880586223247611
+15 │ │         return self.messages[addr].to_mem()
+   │ ╰───────────────────────────────────────────^ attributes hash: 6562880586223247611
    │  
    = ContractAttributes {
          public_functions: [
@@ -394,8 +394,8 @@ note:
 note: 
    ┌─ demos/guest_book.fe:15:16
    │
-15 │         return self.guest_book[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+15 │         return self.messages[addr].to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
    │
    = ValueAttribute
 
@@ -473,10 +473,10 @@ note:
      )
 
 note: 
-  ┌─ demos/guest_book.fe:4:21
+  ┌─ demos/guest_book.fe:4:15
   │
-4 │     pub guest_book: map<address, BookMsg>
-  │                     ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10049485715821994445
+4 │     messages: map<address, BookMsg>
+  │               ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10049485715821994445
   │
   = Map(
         Map {

--- a/docs/src/quickstart/first_contract.md
+++ b/docs/src/quickstart/first_contract.md
@@ -1,3 +1,159 @@
 ## Write your first Fe contract
 
-TODO
+Now that we have the compiler installed let's write our first contract. A contract contains the code that will be deployed to the Ethereum blockchain and resides at a specific address. 
+
+The code of the contract dictates how:
+  - it manipulates its own state
+  - interacts with other contracts
+  - exposes external APIs to be called from other contracts or users
+
+To keep things simple we will just write a basic *guestbook* where people can leave a message associated with their Ethereum address.
+
+>Note: Real code would not instrument the Ethereum blockchain in such a way as it is a waste of precious resources. This code is for demo purposes only.
+
+### Create a `guest_book.fe` file
+
+Fe code is written in files ending on the `.fe` file extension. Let's create a file `guest_book.fe` and put in the following content.
+
+python
+
+```python
+contract GuestBook:
+```
+
+Now, execute `./fe guest_book.fe` to compile the file.
+
+Oops, the compiler is telling us that it didn't expect our code to end here.
+
+```
+Unable to compile guest_book.fe.
+error: unexpected end of file
+  ┌─ guest_book.fe:1:20
+  │
+1 │ contract GuestBook:
+  │                    ^
+
+```
+
+Fe follows Pythonic block indentation rules and the compiler expects us to provide a block of indented code after `GuestBook:`.
+
+Let's expand the code by providing a [`map`](/docs/spec/index.html#51111-hashmap-types) where we can associate messages with Ethereum addresses. The messages will simply be [arrays](/docs/spec/index.html#5116-array-types) of a maximum of `100` bytes written as `bytes[100]`.
+The addresses are represented by the builtin [`address`](/docs/spec/index.html#51110-address-type) type.
+
+```
+contract GuestBook:
+  messages: map<address, bytes[100]>
+```
+
+Execute `./fe guest_book.fe` again to recompile the file.
+
+This time, the compiler tells us that it compiled our contract and that it has put the artifacts into a subdirectory called `output`.
+
+```
+Compiled guest_book.fe. Outputs in `output`
+```
+
+If we examine the `output` directory we'll find a subdirectory `GuestBook` with a `GuestBook_abi.json` and a `GuestBook.bin` file.
+
+```
+├── fe
+├── guest_book.fe
+└── output
+    └── GuestBook
+        ├── GuestBook_abi.json
+        └── GuestBook.bin
+```
+
+The `GuestBook_abi.json` is a JSON representation that describes the binary interface of our contract but since our contract doesn't yet expose anything useful its content for now resembles an empty array.
+
+The `GuestBook.bin` is slightly more interesting containing what looks like a gibberish of characters which in fact is the compiled binary contract code written in [hexadecimal](https://en.wikipedia.org/wiki/Hexadecimal) characters.
+
+We don't need to do anything further yet with these files that the compiler produces but they will become important when we get to the point where we want to deploy our code to the Ethereum blockchain.
+
+### Add a method to sign the guest book
+
+Let's focus on the functionality of our world changing application and add a method to sign the guestbook.
+
+```python
+contract GuestBook:
+  messages: map<address, bytes[100]>
+
+  pub def sign(book_msg: bytes[100]):
+      self.messages[msg.sender] = book_msg
+```
+
+The code should look familar to those of us that have written Python before except that in Fe every method that is defined without the [`pub`](/docs/spec/index.html#311-visibility-and-privacy) keyword becomes private. Since we want people to interact with our contract and call the `sign` method we have to prefix it with `pub`.
+
+Let's recompile the contract again and see what happens.
+
+```
+Failed to write output to directory: `output`. Error: Directory 'output' is not empty. Use --overwrite to overwrite.
+```
+
+Oops, the compiler is telling us that the `output` directory is a non-empty directory and plays it safe by asking us if we are sure that we want to overwrite it. We have to use the `--overwrite` flag to allow the compiler to overwrite it is that is stored in the `output` directory.
+
+Let's try it again with `./fe guest_book.fe --overwrite`.
+
+This time it worked and we can also see that the `GuestBook_abi.json` has become slightly more interesting.
+
+```json
+[
+  {
+    "name": "sign",
+    "type": "function",
+    "inputs": [
+      {
+        "name": "book_msg",
+        "type": "bytes100"
+      }
+    ],
+    "outputs": []
+  }
+]
+```
+
+Since our contract now has a public `sign` method the corresponding ABI has changed accordingly.
+
+### Add a method to read a message
+
+To make the guest book more useful we will also add a method `get_msg` to read entries from a given address.
+
+```python
+contract GuestBook:
+  messages: map<address, bytes[100]>
+
+  pub def sign(book_msg: bytes[100]):
+      self.messages[msg.sender] = book_msg
+
+  pub def get_msg(addr: address) -> bytes[100]:
+      return self.messages[addr]
+```
+
+However, we will hit another error as we try to recompile the current code.
+
+```
+Unable to compile guest_book.fe.
+Analyzer error: CannotMove on line 8
+pub def get_msg(addr: address) -> bytes[100]:
+      return self.messages[addr]
+```
+
+When we try to return a reference type such as an array from the storage of the contract we have to explicitly copy it to memory using the [`to_mem()`](/docs/spec/index.html#623-the-to_mem-function) function.
+
+> Note: In the future Fe will likely introduce immutable storage pointers which might affect these semantics.
+
+The code should compile fine when we change it accordingly.
+
+```python
+contract GuestBook:
+  messages: map<address, bytes[100]>
+
+  pub def sign(book_msg: bytes[100]):
+      self.messages[msg.sender] = book_msg
+
+  pub def get_msg(addr: address) -> bytes[100]:
+      return self.messages[addr].to_mem()
+```
+
+Congratulations! You finished your first little Fe project. 👏
+In the next chapter we will learn how to deploy our code and tweak it a bit further.

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -1,6 +1,6 @@
 ## Quickstart
 
-Get started with Fe.
+Let's get started with Fe! In this chapter you will learn how to install the Fe compiler and write your first contract.
 
 * [Installation](installation.md)
 * [Writing your first contract](first_contract.md)

--- a/docs/src/quickstart/installation.md
+++ b/docs/src/quickstart/installation.md
@@ -1,3 +1,42 @@
 ## Installation
 
-TODO
+At this point Fe is only available for **Linux** and **MacOS**.
+
+> Note: If you happen to be a Windows developer, consider getting involved
+> and help us to support the Windows platform. [Here would be a good place to start.](https://github.com/ethereum/fe/issues/62)
+
+### Download the compiler
+
+At this point Fe is only distributed via a single executable file linked from the [home page](../../). In the future we will make sure it can be installed through popular package managers such as `apt` or `homebrew`.
+
+Depending on your operating system, the file that you download is either named `fe_amd64` or `fe_mac`.
+
+> Note: We will rename the file to `fe` and assume that name for the rest of the guide. In the future when Fe can be installed via other mechanisms we can assume `fe` to become the canonical command name.
+
+### Add permission to execute
+
+In order to be able to execute the Fe compiler we will have to make the file *executable*. This can be done by navigating to the directory where the file is located and executing `chmod + x <filename>` (e.g. `chmod +x fe`).
+
+After we have set the proper permissions we should be able to run `./fe_amd64 --help` and an output that should be roughly compareable to:
+
+```
+Fe 0.4.0-alpha
+Compiler for the Fe language
+
+USAGE:
+    fe_amd64 [FLAGS] [OPTIONS] <input>
+
+FLAGS:
+    -h, --help         Prints help information
+        --optimize     Enables the Yul optimizer`
+        --overwrite    Overwrite contents of output directory`
+    -V, --version      Prints version information
+
+OPTIONS:
+    -e, --emit <emit>                Comma separated compile targets e.g. -e=bytecode,yul [default: abi,bytecode]
+                                     [possible values: abi, bytecode, ast, tokens, yul, loweredAst]
+    -o, --output-dir <output-dir>    The directory to store the compiler output e.g /tmp/output [default: output]
+
+ARGS:
+    <input>    The input source file to use e.g erc20.fe
+```

--- a/docs/src/spec/index.md
+++ b/docs/src/spec/index.md
@@ -774,19 +774,19 @@ Constant size values stored on the stack or in memory can be passed into and ret
 [Types]: #51-types
   [_Type_]: #51-types
   [type]: #51-types
-[Boolean]: #5111-boolean-type
-[Contract]: #5112-contract-type
+[Boolean]: #5111-boolean-types
+[Contract]: #5112-contract-types
 [Numeric]: #5113-numeric-type
 [Textual]: #5114-textual-types
-[Tuple]: #5115-tuple-type
-[Array]: #5116-array-type
+[Tuple]: #5115-tuple-types
+[Array]: #5116-array-types
 [Struct]: #5117-struct-types
   [struct type]: #5117-struct-types
-[Enum]: #5118-enum-type
-  [enumerated type]: #5118-enum-type
-[Function]: #5119-function-type
-[Address]: #51110-address-type
-[HashMap]: #51111-hashmap-type
-[Bytes]: #51112-bytes-type
-[Event]: #51113-bytes-type
-  [event type]: #51113-bytes-type
+[Enum]: #5118-enum-types
+  [enumerated type]: #5118-enum-types
+[Function]: #5119-function-types
+[Address]: #51110-address-types
+[HashMap]: #51111-hashmap-types
+[Bytes]: #51112-bytes-types
+[Event]: #51113-bytes-types
+  [event type]: #51113-bytes-types

--- a/newsfragments/403.doc.md
+++ b/newsfragments/403.doc.md
@@ -1,0 +1,1 @@
+Provide a Quickstart chapter in Fe Guide

--- a/website/index.html
+++ b/website/index.html
@@ -60,11 +60,23 @@
         <p class="text-lg sm:text-2xl text-gray-600 leading-6 sm:leading-8 mt-4">Create <span class="text-gray-900 font-semibold">decentralized applications</span> in a powerful, future-proof and <span class="text-gray-900 font-semibold">statically typed</span> language that is <span class="text-gray-900 font-semibold">easy to learn</span>.<p>
         <div class="mt-6 sm:mt-8 flex flex-wrap space-y-4 sm:space-y-0 sm:space-x-4 text-center">
           <a href="docs/quickstart/index.html" class="transition duration-200 ease-in-out w-full sm:w-auto text-lg sm:text-xl text-center bg-gray-900 rounded text-gray-100 py-3 px-6 hover:bg-gray-700 hover:text-white shadow-xl" title="Get started">Get started</a>
-          <a href="https://github.com/ethereum/fe/releases" class="w-full sm:w-auto px-6 py-3 bg-gray-300 text-gray-600 border border-gray-200 rounded hover:text-gray-900 leading-6 focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-gray-300 focus:outline-none transition-colors duration-200" title="Download">
+          <a id="download-linux" href="https://github.com/ethereum/fe/releases/download/v{{FE_VERSION}}/fe_amd64" class="w-full sm:w-auto px-6 py-3 bg-gray-300 text-gray-600 border border-gray-200 rounded hover:text-gray-900 leading-6 focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-gray-300 focus:outline-none transition-colors duration-200" title="Download">
             <svg xmlns="http://www.w3.org/2000/svg" class="float-left h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
               <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
             </svg>
-            &nbsp; Download
+            &nbsp; Download v{{FE_VERSION}} for Linux
+          </a>
+          <a id="download-mac" href="https://github.com/ethereum/fe/releases/download/v{{FE_VERSION}}/fe_mac" class="w-full sm:w-auto px-6 py-3 bg-gray-300 text-gray-600 border border-gray-200 rounded hover:text-gray-900 leading-6 focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-gray-300 focus:outline-none transition-colors duration-200" title="Download">
+            <svg xmlns="http://www.w3.org/2000/svg" class="float-left h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+            &nbsp; Download v{{FE_VERSION}} for Mac
+          </a>
+          <a id="download-unsupported" href="https://github.com/ethereum/fe/releases" class="w-full sm:w-auto px-6 py-3 bg-gray-300 text-gray-600 border border-gray-200 rounded hover:text-gray-900 leading-6 focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-gray-300 focus:outline-none transition-colors duration-200" title="Download">
+            <svg xmlns="http://www.w3.org/2000/svg" class="float-left h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+            &nbsp; Download v{{FE_VERSION}}
           </a>
         </div>
         <p>Fe is alpha software and not ready for production use!</p>
@@ -294,6 +306,37 @@ contract GuestBook:
     }
 
     menuBtn.addEventListener('click', toggleMenu)
+
+    let downloadLinux = document.querySelector('#download-linux');
+    let downloadMac = document.querySelector('#download-mac');
+    let downloadUnsupported = document.querySelector('#download-unsupported');
+
+    let buttons = {
+      'linux': downloadLinux,
+      'mac': downloadMac,
+      'windows': downloadUnsupported,
+      'unknown_os': downloadUnsupported
+    };
+
+    function enableDownloadFor(os) {
+      for (const key in buttons) {
+          buttons[key].classList.add('hidden');
+      }
+      buttons[os].classList.remove('hidden');
+    }
+
+    var detectedOS = "unknown_os";
+
+    if (navigator.appVersion.indexOf("Mac") != -1) {
+        detectedOS = "mac";
+    } else if (navigator.appVersion.indexOf("Win") != -1) {
+        detectedOS = "windows";
+    } else if (navigator.appVersion.indexOf("Linux") != -1) {
+        detectedOS = "linux";
+    }
+
+    enableDownloadFor(detectedOS);
+
   </script>
   <script src="https://unpkg.com/@highlightjs/cdn-assets@10.7.2/highlight.min.js"></script>
   <script src="https://unpkg.com/@highlightjs/cdn-assets@10.7.2/languages/python.min.js"></script>


### PR DESCRIPTION
### What was wrong?

A small collection of things around the website:
  - The download button is linking to the release page introducing an extra barrier before the actual file
  - We have some stubs in our Fe guide such as the Quickstart that needs to be filled in.
  - The guestbook example could be slightly improved

### How was it fixed?

1. The buttons now link to the actual binary. To do that the build pipeline reads the current compiler version and replaces a marker in the website. The website shows the correct button according to the users OS *unless* if we don't support the OS in which case we will link to the release page so that the user can see what kind of OS are supported.

2. The guestbook example makes the `map` private and renames it to be not repeat the contract name
3. Created Quickstart with Installation & First contract guide (deployment guide has yet to follow)
