### PR TITLE
Allow hex/octal/binary radix numeric literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "codespan-reporting",
  "difference",
  "hex",
+ "num-traits",
  "ron",
  "serde",
  "tiny-keccak 2.0.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "fe-parser",
  "hex",
  "maplit",
+ "num-bigint",
  "once_cell",
  "primitive-types",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,8 +627,8 @@ dependencies = [
  "fe-parser",
  "hex",
  "insta",
- "lexical-core",
  "num-bigint",
+ "num-traits",
  "rstest",
  "strum",
  "vec1",
@@ -969,19 +969,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"

--- a/analyzer/Cargo.toml
+++ b/analyzer/Cargo.toml
@@ -12,8 +12,8 @@ fe-parser = {path = "../parser", version = "^0.4.0-alpha"}
 hex = "0.4"
 ansi_term = "0.12.1"
 num-bigint = "0.3.1"
+num-traits = "0.2.14"
 strum = { version = "0.20.0", features = ["derive"] }
-lexical-core = "0.7.6"
 vec1 = "1.8.0"
 
 [dev-dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,3 +13,4 @@ codespan-reporting = "0.11.1"
 serde = { version = "1", features = ["derive"] }
 ron = "0.5.1"
 difference = "2.0"
+num-traits = "0.2.14"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod diagnostics;
 pub mod files;
+pub mod numeric;
 mod span;
 pub mod utils;
 pub use span::Span;

--- a/common/src/numeric.rs
+++ b/common/src/numeric.rs
@@ -1,0 +1,83 @@
+/// A type that represents the radix of a numeric literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Radix {
+    Hexadecimal,
+    Decimal,
+    Octal,
+    Binary,
+}
+
+impl Radix {
+    /// Returns number representation of the radix.
+    pub fn as_num(self) -> u32 {
+        match self {
+            Self::Hexadecimal => 16,
+            Self::Decimal => 10,
+            Self::Octal => 8,
+            Self::Binary => 2,
+        }
+    }
+}
+
+/// A helper type to interpret a numeric literal represented by string.
+#[derive(Debug, Clone)]
+pub struct Literal<'a> {
+    /// The number part of the string.
+    num: &'a str,
+    /// The radix of the literal.
+    radix: Radix,
+    /// The radix part of the string.
+    prefix: Option<&'a str>,
+}
+
+impl<'a> Literal<'a> {
+    pub fn new(src: &'a str) -> Self {
+        debug_assert!(!src.is_empty());
+        debug_assert_ne!(src.chars().next(), Some('-'));
+        let (radix, prefix) = if src.len() < 2 {
+            (Radix::Decimal, None)
+        } else {
+            match &src[0..2] {
+                "0x" | "0X" => (Radix::Hexadecimal, Some(&src[..2])),
+                "0o" | "0O" => (Radix::Octal, Some(&src[..2])),
+                "0b" | "0B" => (Radix::Binary, Some(&src[..2])),
+                _ => (Radix::Decimal, None),
+            }
+        };
+
+        Self {
+            num: &src[prefix.map_or(0, |pref| pref.len())..],
+            radix,
+            prefix,
+        }
+    }
+
+    /// Parse the numeric literal to `T`.
+    pub fn parse<T: num_traits::Num>(&self) -> Result<T, T::FromStrRadixErr> {
+        T::from_str_radix(&self.num, self.radix.as_num())
+    }
+
+    /// Returns radix of the numeric literal.
+    pub fn radix(&self) -> Radix {
+        self.radix
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_radix() {
+        assert_eq!(Literal::new("0XFF").radix(), Radix::Hexadecimal);
+        assert_eq!(Literal::new("0xFF").radix(), Radix::Hexadecimal);
+        assert_eq!(Literal::new("0O77").radix(), Radix::Octal);
+        assert_eq!(Literal::new("0o77").radix(), Radix::Octal);
+        assert_eq!(Literal::new("0B77").radix(), Radix::Binary);
+        assert_eq!(Literal::new("0b77").radix(), Radix::Binary);
+        assert_eq!(Literal::new("1").radix(), Radix::Decimal);
+
+        // Invalid radix is treated as `Decimal`.
+        assert_eq!(Literal::new("0D15").radix(), Radix::Decimal);
+    }
+}

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -27,6 +27,7 @@ solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true }
 maplit = "1.0.2"
 once_cell = "1.5.2"
 vec1 = "1.8.0"
+num-bigint = "0.3.1"
 
 [dev-dependencies]
 evm-runtime = "0.18"

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -9,9 +9,11 @@ use fe_analyzer::builtins;
 use fe_analyzer::builtins::{ContractTypeMethod, GlobalMethod};
 use fe_analyzer::context::{CallType, Context, Location};
 use fe_analyzer::namespace::types::{Base, FeSized, FixedSize, Type};
+use fe_common::numeric;
 use fe_common::utils::keccak;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
+use num_bigint::BigInt;
 use std::convert::TryFrom;
 use std::str::FromStr;
 use yultsur::*;
@@ -296,6 +298,14 @@ fn expr_name(exp: &Node<fe::Expr>) -> yul::Expression {
 
 fn expr_num(exp: &Node<fe::Expr>) -> yul::Expression {
     if let fe::Expr::Num(num) = &exp.kind {
+        let literal = numeric::Literal::new(num);
+        let num = literal.parse::<BigInt>().expect("Invalid numeric literal");
+        let num = if matches!(literal.radix(), numeric::Radix::Decimal) {
+            format!("{}", num)
+        } else {
+            format!("{:#x}", num)
+        };
+
         return literal_expression! {(num)};
     }
 

--- a/compiler/tests/cases/compile_errors.rs
+++ b/compiler/tests/cases/compile_errors.rs
@@ -68,7 +68,6 @@ use rstest::rstest;
         "numeric_capacity_mismatch/literal_too_small.fe",
         NumericCapacityMismatch
     ),
-    case("numeric_capacity_mismatch/octal_number.fe", NumericCapacityMismatch),
     case("numeric_capacity_mismatch/u128_neg.fe", NumericCapacityMismatch),
     case("numeric_capacity_mismatch/u128_pos.fe", NumericCapacityMismatch),
     case("numeric_capacity_mismatch/u16_neg.fe", NumericCapacityMismatch),

--- a/compiler/tests/cases/features.rs
+++ b/compiler/tests/cases/features.rs
@@ -235,6 +235,10 @@ fn test_assert() {
     case("return_bool_op_or.fe", &[bool_token(true), bool_token(false)], bool_token(true)),
     case("return_bool_op_or.fe", &[bool_token(false), bool_token(true)], bool_token(true)),
     case("return_bool_op_or.fe", &[bool_token(false), bool_token(false)], bool_token(false)),
+    // radix
+    case("radix_hex.fe", &[], uint_token(0xfe)),
+    case("radix_octal.fe", &[], uint_token(0o70)),
+    case("radix_binary.fe", &[], uint_token(0b10)),
 )]
 fn test_method_return(fixture_file: &str, input: &[ethabi::Token], expected: ethabi::Token) {
     with_executor(&|mut executor| {

--- a/compiler/tests/fixtures/compile_errors/numeric_capacity_mismatch/octal_number.fe
+++ b/compiler/tests/fixtures/compile_errors/numeric_capacity_mismatch/octal_number.fe
@@ -1,3 +1,0 @@
-contract Foo:
-    pub def test() -> u8:
-        return u8(001)

--- a/compiler/tests/fixtures/features/radix_binary.fe
+++ b/compiler/tests/fixtures/features/radix_binary.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> u8:
+        return u8(0b10)

--- a/compiler/tests/fixtures/features/radix_hex.fe
+++ b/compiler/tests/fixtures/features/radix_hex.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> u8:
+        return u8(0xfe)

--- a/compiler/tests/fixtures/features/radix_octal.fe
+++ b/compiler/tests/fixtures/features/radix_octal.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar() -> u8:
+        return u8(0o70)

--- a/newsfragments/333.feature.md
+++ b/newsfragments/333.feature.md
@@ -1,0 +1,9 @@
+Add support for hexadecimal/octal/binary numeric literals.
+
+Example:
+
+```
+value_hex: u256 = 0xff
+value_octal: u256 = 0o77
+value_binary: u256 = 0b11
+```

--- a/parser/src/grammar/expressions.rs
+++ b/parser/src/grammar/expressions.rs
@@ -152,7 +152,7 @@ fn parse_expr_head(par: &mut Parser) -> ParseResult<Node<Expr>> {
     use TokenKind::*;
 
     match par.peek_or_err()? {
-        Name | Int | Hex | Text | True | False => {
+        Name | Int | Hex | Octal | Binary | Text | True | False => {
             let tok = par.next()?;
             Ok(atom(par, &tok))
         }
@@ -323,7 +323,7 @@ fn atom(par: &mut Parser, tok: &Token) -> Node<Expr> {
 
     let expr = match tok.kind {
         Name => Expr::Name(tok.text.to_owned()),
-        Int | Hex => Expr::Num(tok.text.to_owned()),
+        Int | Hex | Octal | Binary => Expr::Num(tok.text.to_owned()),
         True | False => Expr::Bool(tok.kind == True),
         Text => {
             if let Some(string) = unescape_string(tok.text) {

--- a/parser/src/lexer/token.rs
+++ b/parser/src/lexer/token.rs
@@ -45,6 +45,10 @@ pub enum TokenKind {
     Int,
     #[regex("0[xX][0-9a-fA-F]+")]
     Hex,
+    #[regex("0[oO][0-7]+")]
+    Octal,
+    #[regex("0[bB][0-1]+")]
+    Binary,
     // Float,
     #[regex(r#""([^"\\]|\\.)*""#)]
     #[regex(r#"'([^'\\]|\\.)*'"#)]
@@ -207,6 +211,8 @@ impl TokenKind {
             Name => "a name",
             Int => "a number",
             Hex => "a hexadecimal number",
+            Octal => "an octal number",
+            Binary => "a binary number",
             Text => "a string",
             _ => return self.symbol_str(),
         };
@@ -288,7 +294,9 @@ impl TokenKind {
             LtLtEq => "<<=",
             GtGtEq => ">>=",
             Arrow => "->",
-            Error | Newline | Indent | Dedent | Name | Int | Hex | Text => return None,
+            Error | Newline | Indent | Dedent | Name | Int | Hex | Octal | Binary | Text => {
+                return None
+            }
         };
         Some(val)
     }


### PR DESCRIPTION
### What was wrong?
closes #333 

### How was it fixed?
1. Added `common::numeric::Literal` to abstract string represented numeric literals.
2. Consistently use `BigInt` for semantic analysis, this approach is the same as `rustc` does (it holds `u128` for numeric integers).
2. Removed `lexical_core` because it doesn't provide `from_str_radix` like methods. And also, I think we don't need to check the details of `IntErrorKind` in almost all cases. This is because, looking at the definition of [`IntErrorKind`](https://doc.rust-lang.org/std/num/enum.IntErrorKind.html) in detail, `IntErrorKind::Empty` is the only error kind that we have to consider it an internal compiler error.

### To-Do
We may need to reconsider the usage of `BigInt`, I think it would be better to use [`U256`](https://docs.rs/primitive-types/0.9.0/primitive_types/struct.U256.html) because:
1. it provides more reliability than multiple-precision arithmetic.
2. it improves performance a little bit.

---
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
