### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Fe had its first alpha release January 2021 and is now following a monthly relea
 
 ## Getting started
 
-- [Build the compiler](https://github.com/ethereum/fe/blob/master/docs/build.md)
+- [Build the compiler](https://github.com/ethereum/fe/blob/master/docs/src/development/build.md)
 - [Or download the binary release](https://github.com/ethereum/fe/releases)
 
 To compile Fe code:


### PR DESCRIPTION
### What was wrong?
The link to `build.md` was broken.


### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
