### PR TITLE
Missing `--workspace` option of `clippy`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-targets --all-features -- -D warnings
+        args: --workspace --all-targets --all-features -- -D warnings
 
   test:
     # Build & Test runs on all platforms

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ coverage:
 
 .PHONY: clippy
 clippy:
-	cargo clippy --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
+	cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
 
 .PHONY: rustfmt
 rustfmt:

--- a/analyzer/tests/analysis.rs
+++ b/analyzer/tests/analysis.rs
@@ -1,4 +1,3 @@
-use fe_analyzer;
 use fe_analyzer::context::Context;
 use fe_common::diagnostics::{diagnostics_string, Diagnostic, Label};
 use fe_common::files::{FileStore, SourceFileId};
@@ -153,12 +152,10 @@ fn build_diagnostics<T: Hash + Debug>(
     file_id: SourceFileId,
     spanned_attributes: &[(Span, T)],
 ) -> Vec<Diagnostic> {
-    let diagnostics = spanned_attributes
-        .into_iter()
+    spanned_attributes
+        .iter()
         .map(|(span, attributes)| build_attributes_diagnostic(file_id, span, attributes))
-        .collect::<Vec<_>>();
-
-    diagnostics
+        .collect::<Vec<_>>()
 }
 
 fn build_attributes_diagnostic<T: Hash + Debug>(

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -76,7 +76,6 @@ fn contract_def(
 #[cfg(test)]
 mod tests {
     use crate::abi::builder;
-    use fe_analyzer;
     use fe_parser::{grammar::module::parse_module, parse_code_chunk};
 
     #[test]

--- a/compiler/src/yul/names.rs
+++ b/compiler/src/yul/names.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn test_encode_name() {
         assert_eq!(
-            encode_name(&vec![
+            encode_name(&[
                 FixedSize::Base(U256),
                 FixedSize::Array(Array {
                     inner: Base::Byte,

--- a/compiler/tests/cases/compile_errors.rs
+++ b/compiler/tests/cases/compile_errors.rs
@@ -110,15 +110,10 @@ fn test_compile_errors(fixture_file: &str, expected_error: fe_analyzer::errors::
 
     match fe_compiler::compile(&src, id, true, false) {
         Err(error) => {
-            if error
-                .errors
-                .iter()
-                .find(|err| match err {
-                    ErrorKind::Analyzer(SemanticError { kind, .. }) => *kind == expected_error,
-                    _ => false,
-                })
-                .is_some()
-            {
+            if error.errors.iter().any(|err| match err {
+                ErrorKind::Analyzer(SemanticError { kind, .. }) => *kind == expected_error,
+                _ => false,
+            }) {
                 return;
             }
 

--- a/compiler/tests/cases/demo_uniswap.rs
+++ b/compiler/tests/cases/demo_uniswap.rs
@@ -268,19 +268,19 @@ fn uniswap_contracts() {
         token1_harness.test_function(
             &mut executor,
             "balanceOf",
-            &[bob.clone()],
+            &[bob],
             Some(&uint_token_from_dec_str("499999999999999999999000")),
         );
         token1_harness.test_function(
             &mut executor,
             "balanceOf",
-            &[alice.clone()],
+            &[alice],
             Some(&uint_token_from_dec_str("500000000000000000000292")),
         );
         token1_harness.test_function(
             &mut executor,
             "balanceOf",
-            &[pair_address.clone()],
+            &[pair_address],
             Some(&uint_token_from_dec_str("708")),
         );
     });

--- a/compiler/tests/cases/lowering/mod.rs
+++ b/compiler/tests/cases/lowering/mod.rs
@@ -12,7 +12,7 @@ use fe_common::utils::ron::{to_ron_string_pretty, Diff};
 fn lower_file(src: &str) -> fe::Module {
     let fe_module = parse_file(src);
     let context = fe_analyzer::analyze(&fe_module).expect("failed to get context");
-    lowering::lower(&context, fe_module.clone())
+    lowering::lower(&context, fe_module)
 }
 
 fn parse_file(src: &str) -> fe::Module {

--- a/parser/tests/cases/parse_ast.rs
+++ b/parser/tests/cases/parse_ast.rs
@@ -24,14 +24,14 @@ where
         if parser.diagnostics.is_empty() {
             eprintln!("parsing failed, but no diagnostics were generated. this should be fixed.");
             let next = parser.next();
-            if next.is_err() {
-                eprintln!("parser is at end of file");
-            } else {
+            if let Ok(tok) = next {
                 parser.error(
-                    next.unwrap().span,
+                    tok.span,
                     "this is the next token at time of parsing failure",
                 );
                 print_diagnostics(&parser.diagnostics, &files);
+            } else {
+                eprintln!("parser is at end of file");
             }
         } else {
             print_diagnostics(&parser.diagnostics, &files);


### PR DESCRIPTION
### What was wrong
Some files are not checked by `clippy` due to the missing `--workspace` option.

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
