### PR TITLE
Dynamically sized return support for external calls

### DIFF
--- a/compiler/src/yul/runtime/functions/contracts.rs
+++ b/compiler/src/yul/runtime/functions/contracts.rs
@@ -59,8 +59,6 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
                     }
                 }
             } else {
-                let decoding_size =
-                    abi_operations::static_encode_size(vec![function.return_type.clone()]);
                 let decoding_operation = abi_operations::decode(
                     vec![function.return_type],
                     identifier_expression! { outstart },
@@ -73,9 +71,10 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
                         (let instart := alloc_mstoren([selector], 4))
                         (let insize := add(4, [encoding_size]))
                         (pop([encoding_operation]))
-                        (let outsize := [decoding_size])
+                        (pop((call((gas()), addr, 0, instart, insize, 0, 0))))
+                        (let outsize := returndatasize())
                         (let outstart := alloc(outsize))
-                        (pop((call((gas()), addr, 0, instart, insize, outstart, outsize))))
+                        (returndatacopy(outstart, 0, outsize))
                         (return_val := [decoding_operation])
                     }
                 }

--- a/compiler/tests/fixtures/stress/external_calls.fe
+++ b/compiler/tests/fixtures/stress/external_calls.fe
@@ -1,0 +1,63 @@
+contract Foo:
+    my_tuple: (u256, address)
+    my_string: string100
+
+    pub def get_my_string() -> string100:
+        return self.my_string.to_mem()
+
+    pub def set_my_string(some_string: string100):
+        self.my_string = some_string
+
+    pub def get_my_tuple() -> (u256, address):
+        return self.my_tuple.to_mem()
+
+    pub def set_my_tuple(some_tuple: (u256, address)):
+        self.my_tuple = some_tuple
+
+    pub def set_my_string_and_tuple(some_string: string100, some_tuple: (u256, address)):
+        self.my_string = some_string
+        self.my_tuple = some_tuple
+
+    pub def get_string() -> string10:
+        return string10("hi")
+
+    pub def get_array() -> u16[4]:
+        return [u16(1), u16(2), u16(3), u16(257)]
+
+    pub def get_tuple() -> (u256, u256, bool):
+        return (42, 26, false)
+
+
+contract FooProxy:
+    foo: Foo
+
+    pub def __init__(foo_addr: address):
+        self.foo = Foo(foo_addr)
+
+    pub def call_set_my_string(some_string: string100):
+        self.foo.set_my_string(some_string)
+
+    pub def call_get_my_string() -> string100:
+        return self.foo.get_my_string()
+
+    pub def call_set_my_tuple(some_tuple: (u256, address)):
+        self.foo.set_my_tuple(some_tuple)
+
+    pub def call_get_my_tuple() -> (u256, address):
+        return self.foo.get_my_tuple()
+
+    pub def call_set_my_string_and_tuple(some_string: string100, some_tuple: (u256, address)):
+        self.foo.set_my_string_and_tuple(some_string, some_tuple)
+
+    pub def call_get_string() -> string10:
+        return self.foo.get_string()
+
+    pub def call_get_tuple() -> (u256, u256, bool):
+        return self.foo.get_tuple()
+
+    pub def call_get_array():
+        my_array: u16[4] = self.foo.get_array()
+        assert my_array[0] == u16(1)
+        assert my_array[1] == u16(2)
+        assert my_array[2] == u16(3)
+        assert my_array[3] == u16(257)

--- a/newsfragments/415.feature.md
+++ b/newsfragments/415.feature.md
@@ -1,0 +1,1 @@
+External calls can now handle dynamically-sized return types.


### PR DESCRIPTION
### What was wrong?

closes #405 
closes #400 
closes #321 

I also noticed that there was a bug preventing us from calling functions on `contract` fields (e.g. `self.my_contract`).

### How was it fixed?

Used `returndatasize` and `returndatacopy` to deal with sizes that aren't known at compile-time (it's now much simpler).

See the note at the bottom of this [section](https://docs.soliditylang.org/en/v0.8.4/yul.html#evm-dialect):

> The call* instructions use the out and outsize parameters to define an area in memory where the return or failure data is placed. This area is written to depending on how many bytes the called contract returns. If it returns more data, only the first outsize bytes are written. You can access the rest of the data using the returndatacopy opcode. If it returns less data, then the remaining bytes are not touched at all. You need to use the returndatasize opcode to check which part of this memory area contains the return data. The remaining bytes will retain their values as of before the call.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
