### PR TITLE
Add tutorial that deploys and uses Guestbook on Görli

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 * [Quickstart](quickstart/index.md)
     * [Installation](quickstart/installation.md)
     * [Write your first contract](quickstart/first_contract.md)
+    * [Deploying a contract to a testnet](quickstart/deploy_contract.md)
 * [Development](development/index.md)
     * [Build & Test](development/build.md)
     * [Release](development/release.md)

--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -1,0 +1,117 @@
+## Deploy your contract.
+
+Since we have written our first contract now, how about we bring it to live and use it on an actual chain?
+
+Deploying such a demo contract to the Ethereum mainnet would be a waste of money but fortunately we have a few other options to choose from. For instance, we can use our very own local blockchain instance which is great for local development. Alternatively we can use a test network that provides developers shared infrastructure to deploy code without spending actual money on it.
+
+In this guide we will learn how to deploy and interact with our guest book on the popular [Görli testnet](https://goerli.net/).
+
+### Setting the stage with dapp.tools
+
+The Ethereum ecosystem provides a rich set of tools to assist smart contract developers in various ways when it comes to developing, testing, deploying and upgrading smart contracts. Fe is still a very young language and there are no tools yet that are tailored for the language. Having said that, most tooling should be flexible enough to work with Fe in some way that might feel slightly less integrated. For this guide we choose to use DappTools which is a very lightweight set of command line tools for managing smart contract development.
+
+To follow this guide, you will first need to head over to [dapp.tools](https://dapp.tools) and follow the installation steps.
+
+> Note: If you are a seasoned smart contract developer who uses different tools, feel free to follow the tutorial using your own toolchain.
+
+
+### Setting up a Görli user account
+
+To deploy our contract to the Görli testnet we will need to have an Ethereum account that has some GöETH. GöETH has no real value but it is still a resource that is needed as a basic line of defense against spamming the testnet. If you don't have any GöETH yet, you can request some from this [faucet](https://goerli-faucet.slock.it/)
+
+The next thing we need is to create a keystore file for our account so that dapp tools can sign messages via [`ethsign`](https://github.com/dapphub/dapptools/tree/master/src/ethsign).
+
+> **IMPORTANT**: It is good practice to **never** use an Ethereum account for a testnet that is also used for the actual Ethereum mainnet.
+
+To create the keystore file for your testnet account, you can use `ethsign` to import your private key. Run the following command and follow the instructions.
+
+```
+ethsign import --keystore ~/.ethereum/keystore/
+```
+
+### Making the deployment transaction
+
+Let's recall that we finished our guest book in the previous chapter with the following code.
+
+```python
+contract GuestBook:
+  messages: Map<address, String<100>>
+
+  pub def sign(book_msg: String<100>):
+      self.messages[msg.sender] = book_msg
+
+  pub def get_msg(addr: address) -> String<100>:
+      return self.messages[addr].to_mem()
+```
+
+If you haven't already, run `./fe guest_book.fe --overwrite` to obtain the bytecode that we want to deploy.
+
+To make the deployment, we will need to send a transaction to a node that participates in the Görli network. We can run our own node, sign up at Infura to use one of their nodes or find an open public node such as `https://goerli-light.eth.linkpool.io` which we will use to keep this tutorial as accessible as possible.
+
+Use the following command to deploy the contract. Please note that `<rpc-url>` needs to be replaced with the URL of the node that we connect to and `<our-eth-address>` needs to be replaced with the Ethereum address that we imported in the previous step.
+
+```
+$ ETH_RPC_URL=<rpc-url> ETH_FROM=<our-eth-address> seth send --create output/GuestBook/GuestBook.bin
+```
+
+What follows is the actual command and the response that was used when writing the tutorial.
+
+```
+$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io ETH_FROM=0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 seth send --create output/GuestBook/GuestBook.bin
+seth-send: warning: `ETH_GAS' not set; using default gas amount
+Ethereum account passphrase (not echoed): seth-send: Published transaction with 681 bytes of calldata.
+seth-send: 0x241ac045170d0612b67b2319fa08ed8be8b79568e00090c4f84146897b83760b
+seth-send: Waiting for transaction receipt...............................
+seth-send: Transaction included in block 4858224.
+0xcecd2be6d4d01ed7906f502be6321c3721f38bc6
+```
+
+As we can see in the output, our transaction [`0x241ac045170d0612b67b2319fa08ed8be8b79568e00090c4f84146897b83760b`](https://goerli.etherscan.io/tx/0x241ac045170d0612b67b2319fa08ed8be8b79568e00090c4f84146897b83760b) to deploy the contract is now included in the Görli blockchain. At the very end of the response we find [`0xcecd2be6d4d01ed7906f502be6321c3721f38bc6`](https://goerli.etherscan.io/address/0xcecd2be6d4d01ed7906f502be6321c3721f38bc6) which is the address where our contract is now deployed.
+
+### Signing the guest book
+
+Now that the guest book is live on the Görli network, everyone can send a transaction to sign it. We will sign it from the same address that was used to deploy the contract but there is nothing preventing anyone to sign it from any other address.
+
+The following command will send a transaction to call `sign(string)` with the message *"We <3 Fe"*.
+
+```
+ETH_RPC_URL=<rpc-url> ETH_FROM=<our-eth-address> seth send <contract-address> "sign(string)" '"We <3 Fe"'
+```
+
+What follows is again the actual command and the response that was used when writing the tutorial.
+
+```
+$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io ETH_FROM=0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 seth send 0xcecd2be6d4d01ed7906f502be6321c3721f38bc6 "sign(string)" '"We <3 Fe"'
+seth-send: warning: `ETH_GAS' not set; using default gas amount
+Ethereum account passphrase (not echoed): seth-send: Published transaction with 100 bytes of calldata.
+seth-send: 0xf61c042064a501939769b802d1455124b0f8665eb1b070c75c2815ca52bd8706
+seth-send: Waiting for transaction receipt.............
+seth-send: Transaction included in block 4858368.
+```
+
+Just as before, the response tells us the transaction hash [`0xf61c042064a501939769b802d1455124b0f8665eb1b070c75c2815ca52bd8706`](https://goerli.etherscan.io/tx/0xf61c042064a501939769b802d1455124b0f8665eb1b070c75c2815ca52bd8706) which we can inspect on Etherscan.
+
+### Reading the signatures
+
+The `get_msg(address)` API let's us read any signature for any address but it will give us an response of 100 zero bytes for any address that simply hasn't signed the guestbook.
+
+Since reading the messages doesn't change any state within the blochchain, we don't have to send and actual transaction. Instead we just perform a *call* against the local state of the node that we are querying.
+
+To do that run:
+
+```
+$ ETH_RPC_URL=<rpc-url> seth call <contract-address> "get_msg(address)" <address-to-check> | seth --to-ascii
+```
+
+Notice that the command doesn't need to provide `ETH_FROM` simply because we are not sending an actual transaction.
+
+```
+$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io seth call 0xcecd2be6d4d01ed7906f502be6321c3721f38bc6 "get_msg(address)" 0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 | seth --to-ascii
+We <3 Fe
+```
+
+As we can see in the last line of the output the signature for address `0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293` is in fact *We <3 Fe*.
+
+Congratulations! You've deployed real Fe code to a live network 🤖
+
+

--- a/docs/src/quickstart/first_contract.md
+++ b/docs/src/quickstart/first_contract.md
@@ -37,12 +37,12 @@ error: unexpected end of file
 
 Fe follows Pythonic block indentation rules and the compiler expects us to provide a block of indented code after `GuestBook:`.
 
-Let's expand the code by providing a [`map`](/docs/spec/index.html#51111-hashmap-types) where we can associate messages with Ethereum addresses. The messages will simply be [arrays](/docs/spec/index.html#5116-array-types) of a maximum of `100` bytes written as `bytes[100]`.
+Let's expand the code by providing a [`map`](/docs/spec/index.html#51111-hashmap-types) where we can associate messages with Ethereum addresses. The messages will simply be a [`string`](/docs/spec/index.html#51113-string-types) of a maximum length of `100` written as `string100`.
 The addresses are represented by the builtin [`address`](/docs/spec/index.html#51110-address-type) type.
 
 ```
 contract GuestBook:
-  messages: Map<address, bytes[100]>
+  messages: Map<address, String<100>>
 ```
 
 Execute `./fe guest_book.fe` again to recompile the file.
@@ -76,9 +76,9 @@ Let's focus on the functionality of our world changing application and add a met
 
 ```python
 contract GuestBook:
-  messages: Map<address, bytes[100]>
+  messages: Map<address, String<100>>
 
-  pub def sign(book_msg: bytes[100]):
+  pub def sign(book_msg: string100):
       self.messages[msg.sender] = book_msg
 ```
 
@@ -120,12 +120,12 @@ To make the guest book more useful we will also add a method `get_msg` to read e
 
 ```python
 contract GuestBook:
-  messages: Map<address, bytes[100]>
+  messages: Map<address, String<100>>
 
-  pub def sign(book_msg: bytes[100]):
+  pub def sign(book_msg: string100):
       self.messages[msg.sender] = book_msg
 
-  pub def get_msg(addr: address) -> bytes[100]:
+  pub def get_msg(addr: address) -> string100:
       return self.messages[addr]
 ```
 
@@ -134,7 +134,7 @@ However, we will hit another error as we try to recompile the current code.
 ```
 Unable to compile guest_book.fe.
 Analyzer error: CannotMove on line 8
-pub def get_msg(addr: address) -> bytes[100]:
+pub def get_msg(addr: address) -> string100:
       return self.messages[addr]
 ```
 
@@ -146,12 +146,12 @@ The code should compile fine when we change it accordingly.
 
 ```python
 contract GuestBook:
-  messages: Map<address, bytes[100]>
+  messages: Map<address, String<100>>
 
-  pub def sign(book_msg: bytes[100]):
+  pub def sign(book_msg: string100):
       self.messages[msg.sender] = book_msg
 
-  pub def get_msg(addr: address) -> bytes[100]:
+  pub def get_msg(addr: address) -> string100:
       return self.messages[addr].to_mem()
 ```
 

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -4,3 +4,4 @@ Let's get started with Fe! In this chapter you will learn how to install the Fe 
 
 * [Installation](installation.md)
 * [Writing your first contract](first_contract.md)
+* [Deploying a contract to a testnet](deploy_contract.md)

--- a/docs/src/spec/index.md
+++ b/docs/src/spec/index.md
@@ -529,6 +529,7 @@ The list of types is:
             * [Tuple]
             * [Array]
             * [Bytes]
+            * [String]
             * [Struct]
             * [Enum]
         * [HashMap]
@@ -635,11 +636,15 @@ Map<TKey,TValue>
 
 Where TKey is a base type and TValue is any data type.
 
-### 5.1.1.12. Bytes type
+### 5.1.1.12. Bytes types
 
 MISSING
 
-### 5.1.1.13. Event types
+### 5.1.1.13. String types
+
+MISSING
+
+### 5.1.1.14. Event types
 
 An *event type* is the type denoted by the name of an [`event` item].
 
@@ -805,5 +810,6 @@ Constant size values stored on the stack or in memory can be passed into and ret
 [Address]: #51110-address-types
 [HashMap]: #51111-hashmap-types
 [Bytes]: #51112-bytes-types
-[Event]: #51113-bytes-types
-  [event type]: #51113-bytes-types
+[String]: #51113-string-types
+[Event]: #51114-event-types
+  [event type]: #51114-event-types

--- a/website/index.html
+++ b/website/index.html
@@ -196,27 +196,27 @@
 
                       </div>
                       <code class="language-python flex-auto relative block text-white pt-4 pb-4 px-4 overflow-auto">
-
-# We can define type aliases using the `type` keyword
-type BookMsg = bytes[100]
-
 # The `contract` keyword defines a new contract type
 contract GuestBook:
-    pub guest_book: map&lt;address, BookMsg&gt;
+    # Strings are generic over a constant number
+    # that restricts its maximum size
+    messages: Map&lt;address, String&lt;100&gt;&gt;
 
     # Events can be defined on contract or module level
     event Signed:
-        book_msg: BookMsg
+        book_msg: String&lt;100&gt;
 
-    pub def sign(book_msg: BookMsg):
+    pub def sign(book_msg: String&lt;100&gt;):
         # All storage access is explicit using `self.&lt;some-key&gt;`
-        self.guest_book[msg.sender] = book_msg
+        self.messages[msg.sender] = book_msg
 
         # Emit the `Signed` event
         emit Signed(book_msg=book_msg)
 
-    pub def get_msg(addr: address) -> BookMsg:
-        return self.guest_book[addr].to_mem()
+    pub def get_msg(addr: address) -> String&lt;100&gt;:
+        # Copying data from storage to memory
+        # has to be done explicitly via `to_mem()`
+        return self.messages[addr].to_mem()
 </code>
                     </pre>
                   </div>

--- a/website/index.html
+++ b/website/index.html
@@ -111,7 +111,7 @@
       </div>
       <div class="text-center px-4 py-12 ">
         <p class="text-2xl text-gray-800 leading-7">Explore some advanced contracts written in Fe</p>
-        <a class="w-full mt-6 block bg-red-500 rounded px-6 py-3 text-lg text-gray-100 sm:w-auto sm:inline-block hover:bg-red-600 transition duration-200 ease-in-out shadow-lg" href="https://github.com/ethereum/fe/tree/master/compiler/tests/fixtures/demos">See examples &rarr;</a>
+        <a class="w-full mt-6 block bg-red-500 rounded px-6 py-3 text-lg text-gray-100 sm:w-auto sm:inline-block hover:bg-red-600 transition duration-200 ease-in-out shadow-lg" href="https://github.com/ethereum/fe/tree/master/tests/fixtures/demos">See examples &rarr;</a>
       </div>
     </section>
 
@@ -238,15 +238,15 @@ contract GuestBook:
             <h5 class="text-2xl tracking-tight mb-2">Read the docs &rarr;</h5>
             <p class="text-gray-700 leading-5">Learn to write Fe smart contracts</p>
           </a>
-          <a href="https://github.com/ethereum/fe/tree/master/compiler/tests/fixtures/demos" title="Read the docs" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
+          <a href="https://github.com/ethereum/fe/tree/master/tests/fixtures/demos" title="Check examples" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
             <h5 class="text-2xl tracking-tight mb-2">Check examples &rarr;</h5>
             <p class="text-gray-700 leading-5">Explore advanced contracts written in Fe</p>
           </a>
-          <a href="docs/development/index.html" title="Read the docs" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
+          <a href="docs/development/index.html" title="Contribute" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
             <h5 class="text-2xl tracking-tight mb-2">Contribute &rarr;</h5>
             <p class="text-gray-700 leading-5">Help improve Fe</p>
           </a>
-          <a href="https://discord.gg/ywpkAXFjZH" title="Read the docs" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
+          <a href="https://discord.gg/ywpkAXFjZH" title="Discuss" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
             <h5 class="text-2xl tracking-tight mb-2">Discuss &rarr;</h5>
             <p class="text-gray-700 leading-5">Discuss and explore with the community</p>
           </a>
@@ -267,7 +267,7 @@ contract GuestBook:
           <ul>
             <li><a class="block py-1 hover:text-white" href="docs/quickstart/index.html" title="Quickstart">Quickstart</a></li>
             <li><a class="block py-1 hover:text-white" href="/docs/index.html" title="Documentation">Documentation</a></li>
-            <li><a class="block py-1 hover:text-white" href="https://github.com/ethereum/fe/tree/master/compiler/tests/fixtures/demos" title="Playground">Examples</a></li>
+            <li><a class="block py-1 hover:text-white" href="https://github.com/ethereum/fe/tree/master/tests/fixtures/demos" title="Examples">Examples</a></li>
           </ul>
         </div>
         <div>


### PR DESCRIPTION
### What was wrong?

We need a tutorial that shows how to deploy Fe code and interact with it.

### How was it fixed?

Added a tutorial that takes the guest book, deploys it on Görli and interacts with it.

### To-Do

I want to expand with an additional section that explains how to get the code (and ABI) verified but that's currently blocked by #424. I'm waiting on Etherscan to get back with an response.
