### PR TITLE
Updated solc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/solc-rust#9ba450f70534fa04d674534a50ae126f59eed163"
+source = "git+https://github.com/g-r-a-n-t/solc-rust#fcb910596c2b22d607970b2ba64229fe02e98e54"
 dependencies = [
  "bindgen",
  "cmake",


### PR DESCRIPTION
Fe build broke on my machine after updating to gcc 11 (specifically solc compilation). There was a recent commit in the solidity repo to fix the compiler errors. This PR bumps the version of solc-rust.