### PR TITLE
Allow generic arguments in `Expr::Call`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,7 @@ name = "fe-parser"
 version = "0.4.0-alpha"
 dependencies = [
  "fe-common",
+ "if_chain",
  "insta",
  "logos",
  "serde",
@@ -859,6 +860,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
 
 [[package]]
 name = "ignore"

--- a/analyzer/tests/fixtures/demos/erc20_token.fe
+++ b/analyzer/tests/fixtures/demos/erc20_token.fe
@@ -4,8 +4,8 @@ contract ERC20:
 
     _total_supply: u256
 
-    _name: string100
-    _symbol: string100
+    _name: String<100>
+    _symbol: String<100>
     _decimals: u8
 
     event Approval:
@@ -18,16 +18,16 @@ contract ERC20:
         idx to: address
         value: u256
 
-    pub def __init__(name: string100, symbol: string100):
+    pub def __init__(name: String<100>, symbol: String<100>):
         self._name = name
         self._symbol = symbol
         self._decimals = u8(18)
         self._mint(msg.sender, 1000000000000000000000000)
 
-    pub def name() -> string100:
+    pub def name() -> String<100>:
         return self._name.to_mem()
 
-    pub def symbol() -> string100:
+    pub def symbol() -> String<100>:
         return self._symbol.to_mem()
 
     pub def decimals() -> u8:

--- a/analyzer/tests/fixtures/features/assert.fe
+++ b/analyzer/tests/fixtures/features/assert.fe
@@ -5,5 +5,5 @@ contract Foo:
     pub def revert_with_static_string(baz: u256):
         assert baz > 5, "Must be greater than five"
 
-    pub def revert_with(baz: u256, reason: string1000):
+    pub def revert_with(baz: u256, reason: String<1000>):
         assert baz > 5, reason

--- a/analyzer/tests/fixtures/features/external_contract.fe
+++ b/analyzer/tests/fixtures/features/external_contract.fe
@@ -2,9 +2,9 @@ contract Foo:
     event MyEvent:
         my_num: u256
         my_addrs: address[5]
-        my_string: string11
+        my_string: String<11>
 
-    pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
+    pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
         emit MyEvent(my_num, my_addrs, my_string)
 
     pub def build_array(a: u256, b: u256) -> u256[3]:
@@ -19,7 +19,7 @@ contract FooProxy:
         foo_address: address,
         my_num: u256,
         my_addrs: address[5],
-        my_string: string11
+        my_string: String<11>
     ):
         foo: Foo = Foo(foo_address)
         foo.emit_event(my_num, my_addrs, my_string)

--- a/analyzer/tests/fixtures/features/sized_vals_in_sto.fe
+++ b/analyzer/tests/fixtures/features/sized_vals_in_sto.fe
@@ -1,12 +1,12 @@
 contract Foo:
     num: u256
     nums: u256[42]
-    str: string26
+    str: String<26>
 
     event MyEvent:
         num: u256
         nums: u256[42]
-        str: string26
+        str: String<26>
 
     pub def write_num(x: u256):
         self.num = x
@@ -20,10 +20,10 @@ contract Foo:
     pub def read_nums() -> u256[42]:
         return self.nums.to_mem()
 
-    pub def write_str(x: string26):
+    pub def write_str(x: String<26>):
         self.str = x
 
-    pub def read_str() -> string26:
+    pub def read_str() -> String<26>:
         return self.str.to_mem()
 
     pub def emit_event():

--- a/analyzer/tests/fixtures/features/strings.fe
+++ b/analyzer/tests/fixtures/features/strings.fe
@@ -1,21 +1,21 @@
 contract Foo:
     event MyEvent:
-        s2: string26
+        s2: String<26>
         u: u256
-        s1: string42
-        s3: string100
+        s1: String<42>
+        s3: String<100>
         a: address
-        s4: string13
-        s5: string100
+        s4: String<13>
+        s5: String<100>
 
-    pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-        emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+    pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+        emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
 
-    pub def bar(s1: string100, s2: string100) -> string100:
+    pub def bar(s1: String<100>, s2: String<100>) -> String<100>:
         return s2
 
-    pub def return_static_string() -> string43:
+    pub def return_static_string() -> String<43>:
         return "The quick brown fox jumps over the lazy dog"
 
-    pub def return_casted_static_string() -> string100:
-        return string100("foo")
+    pub def return_casted_static_string() -> String<100>:
+        return String<100>("foo")

--- a/analyzer/tests/fixtures/stress/abi_encoding_stress.fe
+++ b/analyzer/tests/fixtures/stress/abi_encoding_stress.fe
@@ -7,7 +7,7 @@ struct MyStruct:
 contract Foo:
     my_addrs: address[5]
     my_u128: u128
-    my_string: string10
+    my_string: String<10>
     my_u8s: u8[255]
     my_bool: bool
     my_bytes: bytes[100]
@@ -15,7 +15,7 @@ contract Foo:
     event MyEvent:
         my_addrs: address[5]
         my_u128: u128
-        my_string: string10
+        my_string: String<10>
         my_u8s: u8[255]
         my_bool: bool
         my_bytes: bytes[100]
@@ -32,10 +32,10 @@ contract Foo:
     pub def get_my_u128() -> u128:
         return self.my_u128
 
-    pub def set_my_string(my_string: string10):
+    pub def set_my_string(my_string: String<10>):
         self.my_string = my_string
 
-    pub def get_my_string() -> string10:
+    pub def get_my_string() -> String<10>:
         return self.my_string.to_mem()
 
     pub def set_my_u8s(my_u8s: u8[255]):

--- a/analyzer/tests/fixtures/stress/data_copying_stress.fe
+++ b/analyzer/tests/fixtures/stress/data_copying_stress.fe
@@ -1,6 +1,6 @@
 contract Foo:
-    my_string: string42
-    my_other_string: string42
+    my_string: String<42>
+    my_other_string: String<42>
 
     my_u256: u256
     my_other_u256: u256
@@ -10,12 +10,12 @@ contract Foo:
     my_addrs: address[3]
 
     event MyEvent:
-        my_string: string42
+        my_string: String<42>
         my_u256: u256
 
     pub def set_my_vals(
-        my_string: string42,
-        my_other_string: string42,
+        my_string: String<42>,
+        my_other_string: String<42>,
         my_u256: u256,
         my_other_u256: u256
     ):
@@ -70,7 +70,7 @@ contract Foo:
             self.my_u256.to_mem()
         )
 
-    def emit_my_event_internal(some_string: string42, some_u256: u256):
+    def emit_my_event_internal(some_string: String<42>, some_u256: u256):
         emit MyEvent(some_string, some_u256)
 
     pub def set_my_addrs(my_addrs: address[3]):

--- a/analyzer/tests/snapshots/analysis__case_001_erc20_token.snap
+++ b/analyzer/tests/snapshots/analysis__case_001_erc20_token.snap
@@ -3357,7 +3357,7 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:21:5
    │  
-21 │ ╭     pub def __init__(name: string100, symbol: string100):
+21 │ ╭     pub def __init__(name: String<100>, symbol: String<100>):
 22 │ │         self._name = name
 23 │ │         self._symbol = symbol
 24 │ │         self._decimals = u8(18)
@@ -3391,7 +3391,7 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:27:5
    │  
-27 │ ╭     pub def name() -> string100:
+27 │ ╭     pub def name() -> String<100>:
 28 │ │         return self._name.to_mem()
    │ ╰──────────────────────────────────^ attributes hash: 5720617903306357983
    │  
@@ -3409,7 +3409,7 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:30:5
    │  
-30 │ ╭     pub def symbol() -> string100:
+30 │ ╭     pub def symbol() -> String<100>:
 31 │ │         return self._symbol.to_mem()
    │ ╰────────────────────────────────────^ attributes hash: 11260969396255851957
    │  
@@ -4597,8 +4597,8 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:21:28
    │
-21 │     pub def __init__(name: string100, symbol: string100):
-   │                            ^^^^^^^^^ attributes hash: 17803113925034335199
+21 │     pub def __init__(name: String<100>, symbol: String<100>):
+   │                            ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -4607,10 +4607,10 @@ note:
      )
 
 note: 
-   ┌─ demos/erc20_token.fe:21:47
+   ┌─ demos/erc20_token.fe:21:49
    │
-21 │     pub def __init__(name: string100, symbol: string100):
-   │                                               ^^^^^^^^^ attributes hash: 17803113925034335199
+21 │     pub def __init__(name: String<100>, symbol: String<100>):
+   │                                                 ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -4621,8 +4621,8 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:27:23
    │
-27 │     pub def name() -> string100:
-   │                       ^^^^^^^^^ attributes hash: 17803113925034335199
+27 │     pub def name() -> String<100>:
+   │                       ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -4633,8 +4633,8 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:30:25
    │
-30 │     pub def symbol() -> string100:
-   │                         ^^^^^^^^^ attributes hash: 17803113925034335199
+30 │     pub def symbol() -> String<100>:
+   │                         ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -5096,8 +5096,8 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:7:12
   │
-7 │     _name: string100
-  │            ^^^^^^^^^ attributes hash: 17803113925034335199
+7 │     _name: String<100>
+  │            ^^^^^^^^^^^ attributes hash: 17803113925034335199
   │
   = String(
         FeString {
@@ -5108,8 +5108,8 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:8:14
   │
-8 │     _symbol: string100
-  │              ^^^^^^^^^ attributes hash: 17803113925034335199
+8 │     _symbol: String<100>
+  │              ^^^^^^^^^^^ attributes hash: 17803113925034335199
   │
   = String(
         FeString {

--- a/analyzer/tests/snapshots/analysis__case_005_assert.snap
+++ b/analyzer/tests/snapshots/analysis__case_005_assert.snap
@@ -288,7 +288,7 @@ note:
 note: 
   ┌─ features/assert.fe:8:5
   │  
-8 │ ╭     pub def revert_with(baz: u256, reason: string1000):
+8 │ ╭     pub def revert_with(baz: u256, reason: String<1000>):
 9 │ │         assert baz > 5, reason
   │ ╰──────────────────────────────^ attributes hash: 8362848128767449402
   │  
@@ -324,7 +324,7 @@ note:
 3 │ │         assert baz > 5
 4 │ │ 
   · │
-8 │ │     pub def revert_with(baz: u256, reason: string1000):
+8 │ │     pub def revert_with(baz: u256, reason: String<1000>):
 9 │ │         assert baz > 5, reason
   │ ╰──────────────────────────────^ attributes hash: 18279959482144090337
   │  
@@ -422,7 +422,7 @@ note:
 note: 
   ┌─ features/assert.fe:8:30
   │
-8 │     pub def revert_with(baz: u256, reason: string1000):
+8 │     pub def revert_with(baz: u256, reason: String<1000>):
   │                              ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -434,8 +434,8 @@ note:
 note: 
   ┌─ features/assert.fe:8:44
   │
-8 │     pub def revert_with(baz: u256, reason: string1000):
-  │                                            ^^^^^^^^^^ attributes hash: 18306761550294403845
+8 │     pub def revert_with(baz: u256, reason: String<1000>):
+  │                                            ^^^^^^^^^^^^ attributes hash: 18306761550294403845
   │
   = String(
         FeString {

--- a/analyzer/tests/snapshots/analysis__case_018_external_contract.snap
+++ b/analyzer/tests/snapshots/analysis__case_018_external_contract.snap
@@ -962,7 +962,7 @@ note:
 note: 
   ┌─ features/external_contract.fe:7:5
   │  
-7 │ ╭     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
+7 │ ╭     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
 8 │ │         emit MyEvent(my_num, my_addrs, my_string)
   │ ╰─────────────────────────────────────────────────^ attributes hash: 5933194758192470687
   │  
@@ -1851,8 +1851,8 @@ note:
 2 │ ╭     event MyEvent:
 3 │ │         my_num: u256
 4 │ │         my_addrs: address[5]
-5 │ │         my_string: string11
-  │ ╰───────────────────────────^ attributes hash: 7378635640628475731
+5 │ │         my_string: String<11>
+  │ ╰─────────────────────────────^ attributes hash: 7378635640628475731
   │  
   = EventDef {
         name: "MyEvent",
@@ -1915,8 +1915,8 @@ note:
 note: 
   ┌─ features/external_contract.fe:5:20
   │
-5 │         my_string: string11
-  │                    ^^^^^^^^ attributes hash: 635517298199288434
+5 │         my_string: String<11>
+  │                    ^^^^^^^^^^ attributes hash: 635517298199288434
   │
   = String(
         FeString {
@@ -1927,7 +1927,7 @@ note:
 note: 
   ┌─ features/external_contract.fe:7:32
   │
-7 │     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
+7 │     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
   │                                ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -1939,7 +1939,7 @@ note:
 note: 
   ┌─ features/external_contract.fe:7:48
   │
-7 │     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
+7 │     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
   │                                                ^^^^^^^^^^ attributes hash: 14952089586677068254
   │
   = Array(
@@ -1952,8 +1952,8 @@ note:
 note: 
   ┌─ features/external_contract.fe:7:71
   │
-7 │     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
-  │                                                                       ^^^^^^^^ attributes hash: 635517298199288434
+7 │     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
+  │                                                                       ^^^^^^^^^^ attributes hash: 635517298199288434
   │
   = String(
         FeString {
@@ -2038,8 +2038,8 @@ note:
 note: 
    ┌─ features/external_contract.fe:22:20
    │
-22 │         my_string: string11
-   │                    ^^^^^^^^ attributes hash: 635517298199288434
+22 │         my_string: String<11>
+   │                    ^^^^^^^^^^ attributes hash: 635517298199288434
    │
    = String(
          FeString {

--- a/analyzer/tests/snapshots/analysis__case_085_sized_vals_in_sto.snap
+++ b/analyzer/tests/snapshots/analysis__case_085_sized_vals_in_sto.snap
@@ -577,7 +577,7 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:23:5
    │  
-23 │ ╭     pub def write_str(x: string26):
+23 │ ╭     pub def write_str(x: String<26>):
 24 │ │         self.str = x
    │ ╰────────────────────^ attributes hash: 8954082301525757861
    │  
@@ -600,7 +600,7 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:26:5
    │  
-26 │ ╭     pub def read_str() -> string26:
+26 │ ╭     pub def read_str() -> String<26>:
 27 │ │         return self.str.to_mem()
    │ ╰────────────────────────────────^ attributes hash: 14969878574351140770
    │  
@@ -639,7 +639,7 @@ note:
  1 │ ╭ contract Foo:
  2 │ │     num: u256
  3 │ │     nums: u256[42]
- 4 │ │     str: string26
+ 4 │ │     str: String<26>
    · │
 33 │ │             self.str.to_mem()
 34 │ │         )
@@ -817,8 +817,8 @@ note:
 6 │ ╭     event MyEvent:
 7 │ │         num: u256
 8 │ │         nums: u256[42]
-9 │ │         str: string26
-  │ ╰─────────────────────^ attributes hash: 17206441778791770980
+9 │ │         str: String<26>
+  │ ╰───────────────────────^ attributes hash: 17206441778791770980
   │  
   = EventDef {
         name: "MyEvent",
@@ -885,8 +885,8 @@ note:
 note: 
   ┌─ features/sized_vals_in_sto.fe:9:14
   │
-9 │         str: string26
-  │              ^^^^^^^^ attributes hash: 14735093766067758717
+9 │         str: String<26>
+  │              ^^^^^^^^^^ attributes hash: 14735093766067758717
   │
   = String(
         FeString {
@@ -951,8 +951,8 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:23:26
    │
-23 │     pub def write_str(x: string26):
-   │                          ^^^^^^^^ attributes hash: 14735093766067758717
+23 │     pub def write_str(x: String<26>):
+   │                          ^^^^^^^^^^ attributes hash: 14735093766067758717
    │
    = String(
          FeString {
@@ -963,8 +963,8 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:26:27
    │
-26 │     pub def read_str() -> string26:
-   │                           ^^^^^^^^ attributes hash: 14735093766067758717
+26 │     pub def read_str() -> String<26>:
+   │                           ^^^^^^^^^^ attributes hash: 14735093766067758717
    │
    = String(
          FeString {
@@ -1002,8 +1002,8 @@ note:
 note: 
   ┌─ features/sized_vals_in_sto.fe:4:10
   │
-4 │     str: string26
-  │          ^^^^^^^^ attributes hash: 14735093766067758717
+4 │     str: String<26>
+  │          ^^^^^^^^^^ attributes hash: 14735093766067758717
   │
   = String(
         FeString {

--- a/analyzer/tests/snapshots/analysis__case_086_strings.snap
+++ b/analyzer/tests/snapshots/analysis__case_086_strings.snap
@@ -66,7 +66,7 @@ ModuleAttributes {
 note: 
    ┌─ features/strings.fe:12:22
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
    │                      ^^ attributes hash: 10420235251610747606
    │
    = ExpressionAttributes {
@@ -82,7 +82,7 @@ note:
 note: 
    ┌─ features/strings.fe:12:26
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
    │                          ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
@@ -98,7 +98,7 @@ note:
 note: 
    ┌─ features/strings.fe:12:29
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
    │                             ^^ attributes hash: 9569027785754553796
    │
    = ExpressionAttributes {
@@ -114,7 +114,7 @@ note:
 note: 
    ┌─ features/strings.fe:12:33
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
    │                                 ^^ attributes hash: 10521411858691425038
    │
    = ExpressionAttributes {
@@ -130,7 +130,7 @@ note:
 note: 
    ┌─ features/strings.fe:12:37
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
    │                                     ^ attributes hash: 513065555763557710
    │
    = ExpressionAttributes {
@@ -144,7 +144,7 @@ note:
 note: 
    ┌─ features/strings.fe:12:40
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
    │                                        ^^^^^^^^^^^^^^^ attributes hash: 15184264815905725710
    │
    = ExpressionAttributes {
@@ -158,10 +158,10 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:12:67
+   ┌─ features/strings.fe:12:69
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                                                   ^^^^^ attributes hash: 16852372960864427970
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
+   │                                                                     ^^^^^ attributes hash: 16852372960864427970
    │
    = ExpressionAttributes {
          typ: String(
@@ -176,8 +176,8 @@ note:
 note: 
    ┌─ features/strings.fe:12:57
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                                         ^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
+   │                                                         ^^^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
    │
    = ExpressionAttributes {
          typ: String(
@@ -222,10 +222,10 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:21:26
+   ┌─ features/strings.fe:21:28
    │
-21 │         return string100("foo")
-   │                          ^^^^^ attributes hash: 16852372960864427970
+21 │         return String<100>("foo")
+   │                            ^^^^^ attributes hash: 16852372960864427970
    │
    = ExpressionAttributes {
          typ: String(
@@ -240,8 +240,8 @@ note:
 note: 
    ┌─ features/strings.fe:21:16
    │
-21 │         return string100("foo")
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
+21 │         return String<100>("foo")
+   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 10521411858691425038
    │
    = ExpressionAttributes {
          typ: String(
@@ -256,8 +256,8 @@ note:
 note: 
    ┌─ features/strings.fe:12:9
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15379609340024909078
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15379609340024909078
    │
    = EventDef {
          name: "MyEvent",
@@ -324,9 +324,9 @@ note:
 note: 
    ┌─ features/strings.fe:11:5
    │  
-11 │ ╭     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-12 │ │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │ ╰─────────────────────────────────────────────────────────────────────────^ attributes hash: 7357528411609044749
+11 │ ╭     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+12 │ │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
+   │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 7357528411609044749
    │  
    = FunctionAttributes {
          is_public: true,
@@ -377,7 +377,7 @@ note:
 note: 
    ┌─ features/strings.fe:14:5
    │  
-14 │ ╭     pub def bar(s1: string100, s2: string100) -> string100:
+14 │ ╭     pub def bar(s1: String<100>, s2: String<100>) -> String<100>:
 15 │ │         return s2
    │ ╰─────────────────^ attributes hash: 1310249449051553929
    │  
@@ -412,7 +412,7 @@ note:
 note: 
    ┌─ features/strings.fe:17:5
    │  
-17 │ ╭     pub def return_static_string() -> string43:
+17 │ ╭     pub def return_static_string() -> String<43>:
 18 │ │         return "The quick brown fox jumps over the lazy dog"
    │ ╰────────────────────────────────────────────────────────────^ attributes hash: 16959256329822525068
    │  
@@ -430,9 +430,9 @@ note:
 note: 
    ┌─ features/strings.fe:20:5
    │  
-20 │ ╭     pub def return_casted_static_string() -> string100:
-21 │ │         return string100("foo")
-   │ ╰───────────────────────────────^ attributes hash: 17563008375114963269
+20 │ ╭     pub def return_casted_static_string() -> String<100>:
+21 │ │         return String<100>("foo")
+   │ ╰─────────────────────────────────^ attributes hash: 17563008375114963269
    │  
    = FunctionAttributes {
          is_public: true,
@@ -450,12 +450,12 @@ note:
    │  
  1 │ ╭ contract Foo:
  2 │ │     event MyEvent:
- 3 │ │         s2: string26
+ 3 │ │         s2: String<26>
  4 │ │         u: u256
    · │
-20 │ │     pub def return_casted_static_string() -> string100:
-21 │ │         return string100("foo")
-   │ ╰───────────────────────────────^ attributes hash: 1334776889890751898
+20 │ │     pub def return_casted_static_string() -> String<100>:
+21 │ │         return String<100>("foo")
+   │ ╰─────────────────────────────────^ attributes hash: 1334776889890751898
    │  
    = ContractAttributes {
          public_functions: [
@@ -631,8 +631,8 @@ note:
 note: 
    ┌─ features/strings.fe:12:57
    │
-12 │         emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
-   │                                                         ^^^^^^^^^ attributes hash: 7215139687200046467
+12 │         emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
+   │                                                         ^^^^^^ attributes hash: 7215139687200046467
    │
    = TypeConstructor {
          typ: String(
@@ -645,8 +645,8 @@ note:
 note: 
    ┌─ features/strings.fe:21:16
    │
-21 │         return string100("foo")
-   │                ^^^^^^^^^ attributes hash: 7215139687200046467
+21 │         return String<100>("foo")
+   │                ^^^^^^ attributes hash: 7215139687200046467
    │
    = TypeConstructor {
          typ: String(
@@ -660,13 +660,13 @@ note:
   ┌─ features/strings.fe:2:5
   │  
 2 │ ╭     event MyEvent:
-3 │ │         s2: string26
+3 │ │         s2: String<26>
 4 │ │         u: u256
-5 │ │         s1: string42
+5 │ │         s1: String<42>
   · │
-8 │ │         s4: string13
-9 │ │         s5: string100
-  │ ╰─────────────────────^ attributes hash: 15379609340024909078
+8 │ │         s4: String<13>
+9 │ │         s5: String<100>
+  │ ╰───────────────────────^ attributes hash: 15379609340024909078
   │  
   = EventDef {
         name: "MyEvent",
@@ -733,8 +733,8 @@ note:
 note: 
   ┌─ features/strings.fe:3:13
   │
-3 │         s2: string26
-  │             ^^^^^^^^ attributes hash: 14735093766067758717
+3 │         s2: String<26>
+  │             ^^^^^^^^^^ attributes hash: 14735093766067758717
   │
   = String(
         FeString {
@@ -757,8 +757,8 @@ note:
 note: 
   ┌─ features/strings.fe:5:13
   │
-5 │         s1: string42
-  │             ^^^^^^^^ attributes hash: 12783265608664719061
+5 │         s1: String<42>
+  │             ^^^^^^^^^^ attributes hash: 12783265608664719061
   │
   = String(
         FeString {
@@ -769,8 +769,8 @@ note:
 note: 
   ┌─ features/strings.fe:6:13
   │
-6 │         s3: string100
-  │             ^^^^^^^^^ attributes hash: 17803113925034335199
+6 │         s3: String<100>
+  │             ^^^^^^^^^^^ attributes hash: 17803113925034335199
   │
   = String(
         FeString {
@@ -791,8 +791,8 @@ note:
 note: 
   ┌─ features/strings.fe:8:13
   │
-8 │         s4: string13
-  │             ^^^^^^^^ attributes hash: 2814527799845147426
+8 │         s4: String<13>
+  │             ^^^^^^^^^^ attributes hash: 2814527799845147426
   │
   = String(
         FeString {
@@ -803,8 +803,8 @@ note:
 note: 
   ┌─ features/strings.fe:9:13
   │
-9 │         s5: string100
-  │             ^^^^^^^^^ attributes hash: 17803113925034335199
+9 │         s5: String<100>
+  │             ^^^^^^^^^^^ attributes hash: 17803113925034335199
   │
   = String(
         FeString {
@@ -815,8 +815,8 @@ note:
 note: 
    ┌─ features/strings.fe:11:26
    │
-11 │     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-   │                          ^^^^^^^^ attributes hash: 12783265608664719061
+11 │     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+   │                          ^^^^^^^^^^ attributes hash: 12783265608664719061
    │
    = String(
          FeString {
@@ -825,20 +825,20 @@ note:
      )
 
 note: 
-   ┌─ features/strings.fe:11:39
+   ┌─ features/strings.fe:11:41
    │
-11 │     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-   │                                       ^^^^^^^ attributes hash: 574436082528610497
+11 │     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+   │                                         ^^^^^^^ attributes hash: 574436082528610497
    │
    = Base(
          Address,
      )
 
 note: 
-   ┌─ features/strings.fe:11:52
+   ┌─ features/strings.fe:11:54
    │
-11 │     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-   │                                                    ^^^^^^^^ attributes hash: 14735093766067758717
+11 │     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+   │                                                      ^^^^^^^^^^ attributes hash: 14735093766067758717
    │
    = String(
          FeString {
@@ -847,10 +847,10 @@ note:
      )
 
 note: 
-   ┌─ features/strings.fe:11:65
+   ┌─ features/strings.fe:11:69
    │
-11 │     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-   │                                                                 ^^^^ attributes hash: 17942395924573474124
+11 │     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+   │                                                                     ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -859,10 +859,10 @@ note:
      )
 
 note: 
-   ┌─ features/strings.fe:11:75
+   ┌─ features/strings.fe:11:79
    │
-11 │     pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-   │                                                                           ^^^^^^^^^ attributes hash: 17803113925034335199
+11 │     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+   │                                                                               ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -873,8 +873,8 @@ note:
 note: 
    ┌─ features/strings.fe:14:21
    │
-14 │     pub def bar(s1: string100, s2: string100) -> string100:
-   │                     ^^^^^^^^^ attributes hash: 17803113925034335199
+14 │     pub def bar(s1: String<100>, s2: String<100>) -> String<100>:
+   │                     ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -883,10 +883,10 @@ note:
      )
 
 note: 
-   ┌─ features/strings.fe:14:36
+   ┌─ features/strings.fe:14:38
    │
-14 │     pub def bar(s1: string100, s2: string100) -> string100:
-   │                                    ^^^^^^^^^ attributes hash: 17803113925034335199
+14 │     pub def bar(s1: String<100>, s2: String<100>) -> String<100>:
+   │                                      ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -895,10 +895,10 @@ note:
      )
 
 note: 
-   ┌─ features/strings.fe:14:50
+   ┌─ features/strings.fe:14:54
    │
-14 │     pub def bar(s1: string100, s2: string100) -> string100:
-   │                                                  ^^^^^^^^^ attributes hash: 17803113925034335199
+14 │     pub def bar(s1: String<100>, s2: String<100>) -> String<100>:
+   │                                                      ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {
@@ -909,8 +909,8 @@ note:
 note: 
    ┌─ features/strings.fe:17:39
    │
-17 │     pub def return_static_string() -> string43:
-   │                                       ^^^^^^^^ attributes hash: 13742609200355297158
+17 │     pub def return_static_string() -> String<43>:
+   │                                       ^^^^^^^^^^ attributes hash: 13742609200355297158
    │
    = String(
          FeString {
@@ -921,8 +921,8 @@ note:
 note: 
    ┌─ features/strings.fe:20:46
    │
-20 │     pub def return_casted_static_string() -> string100:
-   │                                              ^^^^^^^^^ attributes hash: 17803113925034335199
+20 │     pub def return_casted_static_string() -> String<100>:
+   │                                              ^^^^^^^^^^^ attributes hash: 17803113925034335199
    │
    = String(
          FeString {

--- a/analyzer/tests/snapshots/analysis__case_100_abi_encoding_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_100_abi_encoding_stress.snap
@@ -1618,7 +1618,7 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:35:5
    │  
-35 │ ╭     pub def set_my_string(my_string: string10):
+35 │ ╭     pub def set_my_string(my_string: String<10>):
 36 │ │         self.my_string = my_string
    │ ╰──────────────────────────────────^ attributes hash: 3033660936924075855
    │  
@@ -1641,7 +1641,7 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:38:5
    │  
-38 │ ╭     pub def get_my_string() -> string10:
+38 │ ╭     pub def get_my_string() -> String<10>:
 39 │ │         return self.my_string.to_mem()
    │ ╰──────────────────────────────────────^ attributes hash: 707398757101008385
    │  
@@ -1934,7 +1934,7 @@ note:
  7 │ ╭ contract Foo:
  8 │ │     my_addrs: address[5]
  9 │ │     my_u128: u128
-10 │ │     my_string: string10
+10 │ │     my_string: String<10>
    · │
 81 │ │             self.my_bytes.to_mem()
 82 │ │         )
@@ -2462,7 +2462,7 @@ note:
 15 │ ╭     event MyEvent:
 16 │ │         my_addrs: address[5]
 17 │ │         my_u128: u128
-18 │ │         my_string: string10
+18 │ │         my_string: String<10>
 19 │ │         my_u8s: u8[255]
 20 │ │         my_bool: bool
 21 │ │         my_bytes: bytes[100]
@@ -2555,8 +2555,8 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:18:20
    │
-18 │         my_string: string10
-   │                    ^^^^^^^^ attributes hash: 3801988794903197532
+18 │         my_string: String<10>
+   │                    ^^^^^^^^^^ attributes hash: 3801988794903197532
    │
    = String(
          FeString {
@@ -2655,8 +2655,8 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:35:38
    │
-35 │     pub def set_my_string(my_string: string10):
-   │                                      ^^^^^^^^ attributes hash: 3801988794903197532
+35 │     pub def set_my_string(my_string: String<10>):
+   │                                      ^^^^^^^^^^ attributes hash: 3801988794903197532
    │
    = String(
          FeString {
@@ -2667,8 +2667,8 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:38:32
    │
-38 │     pub def get_my_string() -> string10:
-   │                                ^^^^^^^^ attributes hash: 3801988794903197532
+38 │     pub def get_my_string() -> String<10>:
+   │                                ^^^^^^^^^^ attributes hash: 3801988794903197532
    │
    = String(
          FeString {
@@ -2888,8 +2888,8 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:10:16
    │
-10 │     my_string: string10
-   │                ^^^^^^^^ attributes hash: 3801988794903197532
+10 │     my_string: String<10>
+   │                ^^^^^^^^^^ attributes hash: 3801988794903197532
    │
    = String(
          FeString {

--- a/analyzer/tests/snapshots/analysis__case_101_data_copying_stress.snap
+++ b/analyzer/tests/snapshots/analysis__case_101_data_copying_stress.snap
@@ -2116,8 +2116,8 @@ note:
    ┌─ stress/data_copying_stress.fe:16:5
    │  
 16 │ ╭     pub def set_my_vals(
-17 │ │         my_string: string42,
-18 │ │         my_other_string: string42,
+17 │ │         my_string: String<42>,
+18 │ │         my_other_string: String<42>,
 19 │ │         my_u256: u256,
    · │
 24 │ │         self.my_u256 = my_u256
@@ -2357,7 +2357,7 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:73:5
    │  
-73 │ ╭     def emit_my_event_internal(some_string: string42, some_u256: u256):
+73 │ ╭     def emit_my_event_internal(some_string: String<42>, some_u256: u256):
 74 │ │         emit MyEvent(some_string, some_u256)
    │ ╰────────────────────────────────────────────^ attributes hash: 11329158825917724746
    │  
@@ -2474,8 +2474,8 @@ note:
    ┌─ stress/data_copying_stress.fe:1:1
    │  
  1 │ ╭ contract Foo:
- 2 │ │     my_string: string42
- 3 │ │     my_other_string: string42
+ 2 │ │     my_string: String<42>
+ 3 │ │     my_other_string: String<42>
  4 │ │ 
    · │
 79 │ │     pub def get_my_second_addr() -> address:
@@ -2753,7 +2753,7 @@ note:
    ┌─ stress/data_copying_stress.fe:12:5
    │  
 12 │ ╭     event MyEvent:
-13 │ │         my_string: string42
+13 │ │         my_string: String<42>
 14 │ │         my_u256: u256
    │ ╰─────────────────────^ attributes hash: 9960040166005382103
    │  
@@ -2784,8 +2784,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:13:20
    │
-13 │         my_string: string42
-   │                    ^^^^^^^^ attributes hash: 12783265608664719061
+13 │         my_string: String<42>
+   │                    ^^^^^^^^^^ attributes hash: 12783265608664719061
    │
    = String(
          FeString {
@@ -2808,8 +2808,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:17:20
    │
-17 │         my_string: string42,
-   │                    ^^^^^^^^ attributes hash: 12783265608664719061
+17 │         my_string: String<42>,
+   │                    ^^^^^^^^^^ attributes hash: 12783265608664719061
    │
    = String(
          FeString {
@@ -2820,8 +2820,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:18:26
    │
-18 │         my_other_string: string42,
-   │                          ^^^^^^^^ attributes hash: 12783265608664719061
+18 │         my_other_string: String<42>,
+   │                          ^^^^^^^^^^ attributes hash: 12783265608664719061
    │
    = String(
          FeString {
@@ -2976,8 +2976,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:73:45
    │
-73 │     def emit_my_event_internal(some_string: string42, some_u256: u256):
-   │                                             ^^^^^^^^ attributes hash: 12783265608664719061
+73 │     def emit_my_event_internal(some_string: String<42>, some_u256: u256):
+   │                                             ^^^^^^^^^^ attributes hash: 12783265608664719061
    │
    = String(
          FeString {
@@ -2986,10 +2986,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:73:66
+   ┌─ stress/data_copying_stress.fe:73:68
    │
-73 │     def emit_my_event_internal(some_string: string42, some_u256: u256):
-   │                                                                  ^^^^ attributes hash: 17942395924573474124
+73 │     def emit_my_event_internal(some_string: String<42>, some_u256: u256):
+   │                                                                    ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -3023,8 +3023,8 @@ note:
 note: 
   ┌─ stress/data_copying_stress.fe:2:16
   │
-2 │     my_string: string42
-  │                ^^^^^^^^ attributes hash: 12783265608664719061
+2 │     my_string: String<42>
+  │                ^^^^^^^^^^ attributes hash: 12783265608664719061
   │
   = String(
         FeString {
@@ -3035,8 +3035,8 @@ note:
 note: 
   ┌─ stress/data_copying_stress.fe:3:22
   │
-3 │     my_other_string: string42
-  │                      ^^^^^^^^ attributes hash: 12783265608664719061
+3 │     my_other_string: String<42>
+  │                      ^^^^^^^^^^ attributes hash: 12783265608664719061
   │
   = String(
         FeString {

--- a/compiler/src/lowering/mappers/expressions.rs
+++ b/compiler/src/lowering/mappers/expressions.rs
@@ -51,8 +51,13 @@ pub fn expr(context: &Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
             op,
             right: boxed_expr(context, right),
         },
-        fe::Expr::Call { func, args } => fe::Expr::Call {
+        fe::Expr::Call {
+            func,
+            generic_args,
+            args,
+        } => fe::Expr::Call {
             func: boxed_expr(context, func),
+            generic_args,
             args: call_args(context, args),
         },
         fe::Expr::List { .. } => expr_list(context, exp),
@@ -130,6 +135,7 @@ fn expr_tuple(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
             // create type constructor call for the lowered tuple
             return fe::Expr::Call {
                 func: Box::new(Node::new(name, exp.span)),
+                generic_args: vec![],
                 args,
             };
         }
@@ -158,6 +164,7 @@ fn expr_list(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
                     attr: fn_name.into_node(),
                 }
                 .into_boxed_node(),
+                generic_args: vec![],
                 args,
             };
         }

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -76,7 +76,12 @@ pub fn call_arg(context: &Context, arg: &Node<fe::CallArg>) -> yul::Expression {
 }
 
 fn expr_call(context: &Context, exp: &Node<fe::Expr>) -> yul::Expression {
-    if let fe::Expr::Call { args, func } = &exp.kind {
+    if let fe::Expr::Call {
+        args,
+        generic_args: _,
+        func,
+    } = &exp.kind
+    {
         if let Some(call_type) = context.get_call(func) {
             let yul_args: Vec<yul::Expression> =
                 args.kind.iter().map(|val| call_arg(context, val)).collect();

--- a/compiler/tests/fixtures/compile_errors/call_event_with_wrong_types.fe
+++ b/compiler/tests/fixtures/compile_errors/call_event_with_wrong_types.fe
@@ -1,6 +1,6 @@
 contract Foo:
     event MyEvent:
-        val_1: string100
+        val_1: String<100>
         idx val_2: u8
 
     pub def foo():

--- a/compiler/tests/fixtures/compile_errors/string_capacity_mismatch.fe
+++ b/compiler/tests/fixtures/compile_errors/string_capacity_mismatch.fe
@@ -1,3 +1,3 @@
 contract Foo:
-    pub def bar() -> string3:
-        return string3("too long")
+    pub def bar() -> String<3>:
+        return String<3>("too long")

--- a/compiler/tests/fixtures/demos/erc20_token.fe
+++ b/compiler/tests/fixtures/demos/erc20_token.fe
@@ -4,8 +4,8 @@ contract ERC20:
 
     _total_supply: u256
 
-    _name: string100
-    _symbol: string100
+    _name: String<100>
+    _symbol: String<100>
     _decimals: u8
 
     event Approval:
@@ -18,16 +18,16 @@ contract ERC20:
         idx to: address
         value: u256
 
-    pub def __init__(name: string100, symbol: string100):
+    pub def __init__(name: String<100>, symbol: String<100>):
         self._name = name
         self._symbol = symbol
         self._decimals = u8(18)
         self._mint(msg.sender, 1000000000000000000000000)
 
-    pub def name() -> string100:
+    pub def name() -> String<100>:
         return self._name.to_mem()
 
-    pub def symbol() -> string100:
+    pub def symbol() -> String<100>:
         return self._symbol.to_mem()
 
     pub def decimals() -> u8:

--- a/compiler/tests/fixtures/features/assert.fe
+++ b/compiler/tests/fixtures/features/assert.fe
@@ -5,5 +5,5 @@ contract Foo:
     pub def revert_with_static_string(baz: u256):
         assert baz > 5, "Must be greater than five"
 
-    pub def revert_with(baz: u256, reason: string1000):
+    pub def revert_with(baz: u256, reason: String<1000>):
         assert baz > 5, reason

--- a/compiler/tests/fixtures/features/external_contract.fe
+++ b/compiler/tests/fixtures/features/external_contract.fe
@@ -2,9 +2,9 @@ contract Foo:
     event MyEvent:
         my_num: u256
         my_addrs: address[5]
-        my_string: string11
+        my_string: String<11>
 
-    pub def emit_event(my_num: u256, my_addrs: address[5], my_string: string11):
+    pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
         emit MyEvent(my_num, my_addrs, my_string)
 
     pub def build_array(a: u256, b: u256) -> u256[3]:
@@ -19,7 +19,7 @@ contract FooProxy:
         foo_address: address,
         my_num: u256,
         my_addrs: address[5],
-        my_string: string11
+        my_string: String<11>
     ):
         foo: Foo = Foo(foo_address)
         foo.emit_event(my_num, my_addrs, my_string)

--- a/compiler/tests/fixtures/features/sized_vals_in_sto.fe
+++ b/compiler/tests/fixtures/features/sized_vals_in_sto.fe
@@ -1,12 +1,12 @@
 contract Foo:
     num: u256
     nums: u256[42]
-    str: string26
+    str: String<26>
 
     event MyEvent:
         num: u256
         nums: u256[42]
-        str: string26
+        str: String<26>
 
     pub def write_num(x: u256):
         self.num = x
@@ -20,10 +20,10 @@ contract Foo:
     pub def read_nums() -> u256[42]:
         return self.nums.to_mem()
 
-    pub def write_str(x: string26):
+    pub def write_str(x: String<26>):
         self.str = x
 
-    pub def read_str() -> string26:
+    pub def read_str() -> String<26>:
         return self.str.to_mem()
 
     pub def emit_event():

--- a/compiler/tests/fixtures/features/strings.fe
+++ b/compiler/tests/fixtures/features/strings.fe
@@ -1,21 +1,21 @@
 contract Foo:
     event MyEvent:
-        s2: string26
+        s2: String<26>
         u: u256
-        s1: string42
-        s3: string100
+        s1: String<42>
+        s3: String<100>
         a: address
-        s4: string13
-        s5: string100
+        s4: String<13>
+        s5: String<100>
 
-    pub def __init__(s1: string42, a: address, s2: string26, u: u256, s3: string100):
-        emit MyEvent(s2, u, s1, s3, a, "static string", string100("foo"))
+    pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
+        emit MyEvent(s2, u, s1, s3, a, "static string", String<100>("foo"))
 
-    pub def bar(s1: string100, s2: string100) -> string100:
+    pub def bar(s1: String<100>, s2: String<100>) -> String<100>:
         return s2
 
-    pub def return_static_string() -> string43:
+    pub def return_static_string() -> String<43>:
         return "The quick brown fox jumps over the lazy dog"
 
-    pub def return_casted_static_string() -> string100:
-        return string100("foo")
+    pub def return_casted_static_string() -> String<100>:
+        return String<100>("foo")

--- a/compiler/tests/fixtures/stress/abi_encoding_stress.fe
+++ b/compiler/tests/fixtures/stress/abi_encoding_stress.fe
@@ -7,7 +7,7 @@ struct MyStruct:
 contract Foo:
     my_addrs: address[5]
     my_u128: u128
-    my_string: string10
+    my_string: String<10>
     my_u8s: u8[255]
     my_bool: bool
     my_bytes: bytes[100]
@@ -15,7 +15,7 @@ contract Foo:
     event MyEvent:
         my_addrs: address[5]
         my_u128: u128
-        my_string: string10
+        my_string: String<10>
         my_u8s: u8[255]
         my_bool: bool
         my_bytes: bytes[100]
@@ -32,10 +32,10 @@ contract Foo:
     pub def get_my_u128() -> u128:
         return self.my_u128
 
-    pub def set_my_string(my_string: string10):
+    pub def set_my_string(my_string: String<10>):
         self.my_string = my_string
 
-    pub def get_my_string() -> string10:
+    pub def get_my_string() -> String<10>:
         return self.my_string.to_mem()
 
     pub def set_my_u8s(my_u8s: u8[255]):

--- a/compiler/tests/fixtures/stress/data_copying_stress.fe
+++ b/compiler/tests/fixtures/stress/data_copying_stress.fe
@@ -1,6 +1,6 @@
 contract Foo:
-    my_string: string42
-    my_other_string: string42
+    my_string: String<42>
+    my_other_string: String<42>
 
     my_u256: u256
     my_other_u256: u256
@@ -10,12 +10,12 @@ contract Foo:
     my_addrs: address[3]
 
     event MyEvent:
-        my_string: string42
+        my_string: String<42>
         my_u256: u256
 
     pub def set_my_vals(
-        my_string: string42,
-        my_other_string: string42,
+        my_string: String<42>,
+        my_other_string: String<42>,
         my_u256: u256,
         my_other_u256: u256
     ):
@@ -70,7 +70,7 @@ contract Foo:
             self.my_u256.to_mem()
         )
 
-    def emit_my_event_internal(some_string: string42, some_u256: u256):
+    def emit_my_event_internal(some_string: String<42>, some_u256: u256):
         emit MyEvent(some_string, some_u256)
 
     pub def set_my_addrs(my_addrs: address[3]):

--- a/compiler/tests/fixtures/stress/external_calls.fe
+++ b/compiler/tests/fixtures/stress/external_calls.fe
@@ -1,11 +1,11 @@
 contract Foo:
     my_tuple: (u256, address)
-    my_string: string100
+    my_string: String<100>
 
-    pub def get_my_string() -> string100:
+    pub def get_my_string() -> String<100>:
         return self.my_string.to_mem()
 
-    pub def set_my_string(some_string: string100):
+    pub def set_my_string(some_string: String<100>):
         self.my_string = some_string
 
     pub def get_my_tuple() -> (u256, address):
@@ -14,12 +14,12 @@ contract Foo:
     pub def set_my_tuple(some_tuple: (u256, address)):
         self.my_tuple = some_tuple
 
-    pub def set_my_string_and_tuple(some_string: string100, some_tuple: (u256, address)):
+    pub def set_my_string_and_tuple(some_string: String<100>, some_tuple: (u256, address)):
         self.my_string = some_string
         self.my_tuple = some_tuple
 
-    pub def get_string() -> string10:
-        return string10("hi")
+    pub def get_string() -> String<10>:
+        return String<10>("hi")
 
     pub def get_array() -> u16[4]:
         return [u16(1), u16(2), u16(3), u16(257)]
@@ -34,10 +34,10 @@ contract FooProxy:
     pub def __init__(foo_addr: address):
         self.foo = Foo(foo_addr)
 
-    pub def call_set_my_string(some_string: string100):
+    pub def call_set_my_string(some_string: String<100>):
         self.foo.set_my_string(some_string)
 
-    pub def call_get_my_string() -> string100:
+    pub def call_get_my_string() -> String<100>:
         return self.foo.get_my_string()
 
     pub def call_set_my_tuple(some_tuple: (u256, address)):
@@ -46,10 +46,10 @@ contract FooProxy:
     pub def call_get_my_tuple() -> (u256, address):
         return self.foo.get_my_tuple()
 
-    pub def call_set_my_string_and_tuple(some_string: string100, some_tuple: (u256, address)):
+    pub def call_set_my_string_and_tuple(some_string: String<100>, some_tuple: (u256, address)):
         self.foo.set_my_string_and_tuple(some_string, some_tuple)
 
-    pub def call_get_string() -> string10:
+    pub def call_get_string() -> String<10>:
         return self.foo.get_string()
 
     pub def call_get_tuple() -> (u256, u256, bool):

--- a/newsfragments/379.feature.md
+++ b/newsfragments/379.feature.md
@@ -1,0 +1,8 @@
+1. Call expression can now accept generic arguments
+2. Replace `stringN` to `String<N>`
+
+Example:
+
+```
+s: String<10> = String<10>("HI")
+```

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1", features = ["derive"] }
 unescape = "0.1.0"
 uuid = { version = "0.8", features = ["v4", "stdweb"] }
 vec1 = { version = "1.8.0", features = ["serde"] }
+if_chain = "1.0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -216,6 +216,7 @@ pub enum Expr {
     },
     Call {
         func: Box<Node<Expr>>,
+        generic_args: Vec<Node<GenericArg>>,
         args: Node<Vec<Node<CallArg>>>,
     },
     List {

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -199,7 +199,7 @@ pub fn parse_opt_qualifier(par: &mut Parser, tk: TokenKind) -> Option<Span> {
 /// of `map<address, u256>`).
 /// # Panics
 /// Panics if the first token isn't `<`.
-fn parse_generic_args(par: &mut Parser) -> ParseResult<(Vec<Node<GenericArg>>, Span)> {
+pub fn parse_generic_args(par: &mut Parser) -> ParseResult<(Vec<Node<GenericArg>>, Span)> {
     use TokenKind::*;
     let mut span = par.assert(Lt).span;
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -3,6 +3,7 @@ use crate::node::Span;
 use logos::Logos;
 pub use token::{Token, TokenKind};
 
+#[derive(Clone)]
 pub struct Lexer<'a> {
     inner: logos::Lexer<'a, TokenKind>,
 }

--- a/parser/src/lexer/token.rs
+++ b/parser/src/lexer/token.rs
@@ -2,7 +2,7 @@ use crate::node::{Node, Span};
 use logos::Logos;
 use std::ops::Add;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Token<'a> {
     pub kind: TokenKind,
     pub text: &'a str,

--- a/parser/tests/cases/snapshots/cases__parse_ast__expr_attr2.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__expr_attr2.snap
@@ -57,6 +57,7 @@ Node(
         end: 9,
       ),
     ),
+    generic_args: [],
     args: Node(
       kind: [
         Node(

--- a/parser/tests/cases/snapshots/cases__parse_ast__expr_call1.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__expr_call1.snap
@@ -12,6 +12,7 @@ Node(
         end: 3,
       ),
     ),
+    generic_args: [],
     args: Node(
       kind: [],
       span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__expr_call2.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__expr_call2.snap
@@ -12,6 +12,7 @@ Node(
         end: 3,
       ),
     ),
+    generic_args: [],
     args: Node(
       kind: [
         Node(


### PR DESCRIPTION
### What was wrong?
fixes #379 

### How was it fixed?
1. Add `BTParser` which thinly wraps `Parser` and enables backtracking
2. Add `generic_args` to `ast::Expr::Call`
3. Add `if_chain` for improving readability

### To-Do
* https://github.com/ethereum/fe/issues/273

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
