### PR TITLE
Add support for pragma statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rstest",
+ "semver 1.0.0",
  "strum",
  "vec1",
 ]
@@ -720,6 +721,7 @@ dependencies = [
  "if_chain",
  "insta",
  "logos",
+ "semver 1.0.0",
  "serde",
  "unescape",
  "uuid",
@@ -1542,6 +1544,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
 
 [[package]]
 name = "semver-parser"

--- a/analyzer/Cargo.toml
+++ b/analyzer/Cargo.toml
@@ -15,6 +15,7 @@ num-bigint = "0.3.1"
 num-traits = "0.2.14"
 strum = { version = "0.20.0", features = ["derive"] }
 vec1 = "1.8.0"
+semver = "1.0.0"
 
 [dev-dependencies]
 insta = "1.7.1"

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -2,8 +2,10 @@ use crate::errors::SemanticError;
 use crate::namespace::scopes::{ModuleScope, Scope, Shared};
 use crate::traversal::{contracts, structs, types};
 use crate::Context;
+use fe_common::diagnostics::Label;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
+use semver::{Version, VersionReq};
 use std::rc::Rc;
 
 /// Gather context information for a module and check for type errors.
@@ -16,6 +18,9 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
         match &stmt.kind {
             fe::ModuleStmt::TypeDef { .. } => {
                 type_def(Rc::clone(&context), Rc::clone(&scope), stmt)?
+            }
+            fe::ModuleStmt::Pragma { .. } => {
+                pragma_stmt(Rc::clone(&context), Rc::clone(&scope), stmt)
             }
             fe::ModuleStmt::StructDef { name, fields } => {
                 structs::struct_def(Rc::clone(&context), Rc::clone(&scope), &name.kind, fields)?
@@ -47,13 +52,45 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
 fn type_def(
     context: Shared<Context>,
     scope: Shared<ModuleScope>,
-    def: &Node<fe::ModuleStmt>,
+    stmt: &Node<fe::ModuleStmt>,
 ) -> Result<(), SemanticError> {
-    if let fe::ModuleStmt::TypeDef { name, typ } = &def.kind {
+    if let fe::ModuleStmt::TypeDef { name, typ } = &stmt.kind {
         let typ = types::type_desc(&Scope::Module(Rc::clone(&scope)), context, &typ)?;
         scope.borrow_mut().add_type_def(&name.kind, typ)?;
         return Ok(());
     }
 
     unreachable!()
+}
+
+fn pragma_stmt(context: Shared<Context>, _scope: Shared<ModuleScope>, stmt: &Node<fe::ModuleStmt>) {
+    match &stmt.kind {
+        fe::ModuleStmt::Pragma {
+            version_requirement,
+        } => {
+            // This can't fail because the parser already validated it
+            let requirement =
+                VersionReq::parse(&version_requirement.kind).expect("Invalid version requirement");
+            let actual_version =
+                Version::parse(env!("CARGO_PKG_VERSION")).expect("Missing package version");
+
+            if !requirement.matches(&actual_version) {
+                context.borrow_mut().fancy_error(
+                    format!(
+                        "The current compiler version {} doesn't match the specified requirement",
+                        actual_version
+                    ),
+                    vec![Label::primary(
+                        version_requirement.span,
+                        "The specified version requirement",
+                    )],
+                    vec![format!(
+                        "Note: Use `pragma {}` to make the code compile",
+                        actual_version
+                    )],
+                );
+            }
+        }
+        _ => unreachable!(),
+    }
 }

--- a/compiler/src/lowering/mappers/module.rs
+++ b/compiler/src/lowering/mappers/module.rs
@@ -12,6 +12,7 @@ pub fn module(context: &Context, module: fe::Module) -> fe::Module {
         .body
         .into_iter()
         .map(|stmt| match &stmt.kind {
+            fe::ModuleStmt::Pragma { .. } => stmt,
             fe::ModuleStmt::TypeDef { .. } => stmt,
             fe::ModuleStmt::StructDef { .. } => stmt,
             fe::ModuleStmt::FromImport { .. } => stmt,

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -13,6 +13,7 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
         .iter()
         .fold(YulContracts::new(), |mut contracts, stmt| {
             match &stmt.kind {
+                fe::ModuleStmt::Pragma { .. } => {}
                 fe::ModuleStmt::TypeDef { .. } => {}
                 fe::ModuleStmt::ContractDef { name, .. } => {
                     // Map the set of created contract names to their Yul objects so they can be

--- a/docs/src/spec/index.md
+++ b/docs/src/spec/index.md
@@ -380,7 +380,25 @@ contract GuestBook:
 
 ### 4.1. Statements
 
-### 4.1.1 `revert` statement
+### 4.1.1 `pragma` statement
+
+
+> **<sup>Syntax</sup>**\
+> _PragmaStatement_ :\
+> &nbsp;&nbsp; `pragma` [_VersionRequirementExpression_]
+
+The pragma statement is denoted with the keyword `pragma`. Evaluating a `pragma`
+statement will cause the compiler to reject compilation if the version of the compiler does not conform to the given version requirement.
+
+An example of a `pragma` statement:
+
+```
+pragma ^0.1.0
+```
+
+The version requirement syntax is identical to the one that is used by cargo ([more info](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)).
+
+### 4.1.2 `revert` statement
 
 
 > **<sup>Syntax</sup>**\
@@ -397,7 +415,6 @@ def transfer(to : address, value : u256):
     if not self.in_whitelist(to):
         revert
     # more logic here
-```
 
 ### 4.2 Expressions
 

--- a/newsfragments/361.feature.md
+++ b/newsfragments/361.feature.md
@@ -1,0 +1,3 @@
+Support for `pragma` statement
+
+Example: `pragma ^0.1.0`

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -18,6 +18,7 @@ unescape = "0.1.0"
 uuid = { version = "0.8", features = ["v4", "stdweb"] }
 vec1 = { version = "1.8.0", features = ["serde"] }
 if_chain = "1.0.1"
+semver = "1.0.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -11,6 +11,9 @@ pub struct Module {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum ModuleStmt {
+    Pragma {
+        version_requirement: Node<String>,
+    },
     TypeDef {
         name: Node<String>,
         typ: Node<TypeDesc>,

--- a/parser/src/lexer/token.rs
+++ b/parser/src/lexer/token.rs
@@ -85,6 +85,8 @@ pub enum TokenKind {
     If,
     #[token("import")]
     Import,
+    #[token("pragma")]
+    Pragma,
     #[token("pass")]
     Pass,
     #[token("for")]
@@ -239,6 +241,7 @@ impl TokenKind {
             Idx => "idx",
             If => "if",
             Import => "import",
+            Pragma => "pragma",
             Pass => "pass",
             For => "for",
             Pub => "pub",

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -61,6 +61,7 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Return as wrapped back tracking parser
     pub fn as_bt_parser<'b>(&'b mut self) -> BTParser<'a, 'b> {
         BTParser::new(self)
     }

--- a/parser/tests/cases/errors.rs
+++ b/parser/tests/cases/errors.rs
@@ -33,6 +33,20 @@ macro_rules! test_parse_err {
 // These tests use the insta crate. insta will automatically generate the
 // snapshot file on the first run.
 
+test_parse_err! { contract_invalid_version_requirement, module::parse_module, true, r#"
+pragma 0.o
+contract C:
+  pass
+"#
+}
+
+test_parse_err! { contract_missing_version_requirement, module::parse_module, true, r#"
+pragma
+contract C:
+  pass
+"#
+}
+
 test_parse_err! { contract_bad_name, contracts::parse_contract_def, true, "contract 1X:\n x: u8" }
 test_parse_err! { contract_empty_body, module::parse_module, true, "contract X:\n \n \ncontract Y:\n x: u8" }
 test_parse_err! { contract_field_after_def, module::parse_module, false, r#"

--- a/parser/tests/cases/parse_ast.rs
+++ b/parser/tests/cases/parse_ast.rs
@@ -124,6 +124,10 @@ test_parse! { fn_def, |par| functions::parse_fn_def(par, None), "def foo21(x: bo
 test_parse! { event_def, types::parse_event_def, "event Foo:\n  x: address\n  idx y: u8" }
 test_parse! { empty_event_def, types::parse_event_def, "event Foo:\n  pass" }
 
+test_parse! { pragma1, module::parse_pragma, "pragma 0.1.0" }
+test_parse! { pragma2, module::parse_pragma, "pragma 0.1.0-alpha" }
+test_parse! { pragma3, module::parse_pragma, "pragma >= 1.2, < 1.5" }
+
 test_parse! { import_simple, module::parse_simple_import, "import foo as bar, baz, bing as bop" }
 test_parse! { struct_def, types::parse_struct_def, r#"struct S:
   x: address
@@ -150,6 +154,8 @@ test_parse! { empty_contract_def, contracts::parse_contract_def, r#"contract Foo
 "# }
 
 test_parse! { module_stmts, module::parse_module, r#"
+pragma 0.5.0
+
 import foo as bar, baz as bum
 
 type X = map<u8, u16>

--- a/parser/tests/cases/snapshots/cases__errors__contract_invalid_version_requirement.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_invalid_version_requirement.snap
@@ -1,0 +1,14 @@
+---
+source: parser/tests/cases/errors.rs
+expression: "err_string(stringify!(contract_invalid_version_requirement),\n           module::parse_module, true, r#\"\npragma 0.o\ncontract C:\n  pass\n\"#)"
+
+---
+error: failed to parse pragma statement: unexpected character 'o' while parsing minor version number
+  ┌─ contract_invalid_version_requirement:2:8
+  │
+2 │ pragma 0.o
+  │        ^^^ Invalid version requirement
+  │
+  = Example: `^0.5.0`
+
+

--- a/parser/tests/cases/snapshots/cases__errors__contract_missing_version_requirement.snap
+++ b/parser/tests/cases/snapshots/cases__errors__contract_missing_version_requirement.snap
@@ -1,0 +1,12 @@
+---
+source: parser/tests/cases/errors.rs
+expression: "err_string(stringify!(contract_missing_version_requirement),\n           module::parse_module, true, r#\"\npragma\ncontract C:\n  pass\n\"#)"
+
+---
+error: failed to parse pragma statement: missing version requirement
+  ┌─ contract_missing_version_requirement:2:1
+  │
+2 │ pragma
+  │ ^^^^^^
+
+

--- a/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -1,11 +1,26 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_stmts), module::parse_module,\n           r#\"\nimport foo as bar, baz as bum\n\ntype X = map<u8, u16>\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
+expression: "ast_string(stringify!(module_stmts), module::parse_module,\n           r#\"\npragma 0.5.0\n\nimport foo as bar, baz as bum\n\ntype X = map<u8, u16>\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
 
 ---
 Node(
   kind: Module(
     body: [
+      Node(
+        kind: Pragma(
+          version_requirement: Node(
+            kind: "0.5.0",
+            span: Span(
+              start: 8,
+              end: 13,
+            ),
+          ),
+        ),
+        span: Span(
+          start: 1,
+          end: 13,
+        ),
+      ),
       Node(
         kind: SimpleImport(
           names: [
@@ -15,22 +30,22 @@ Node(
                   Node(
                     kind: "foo",
                     span: Span(
-                      start: 8,
-                      end: 11,
+                      start: 22,
+                      end: 25,
                     ),
                   ),
                 ],
                 alias: Some(Node(
                   kind: "bar",
                   span: Span(
-                    start: 15,
-                    end: 18,
+                    start: 29,
+                    end: 32,
                   ),
                 )),
               ),
               span: Span(
-                start: 8,
-                end: 18,
+                start: 22,
+                end: 32,
               ),
             ),
             Node(
@@ -39,29 +54,29 @@ Node(
                   Node(
                     kind: "baz",
                     span: Span(
-                      start: 20,
-                      end: 23,
+                      start: 34,
+                      end: 37,
                     ),
                   ),
                 ],
                 alias: Some(Node(
                   kind: "bum",
                   span: Span(
-                    start: 27,
-                    end: 30,
+                    start: 41,
+                    end: 44,
                   ),
                 )),
               ),
               span: Span(
-                start: 20,
-                end: 30,
+                start: 34,
+                end: 44,
               ),
             ),
           ],
         ),
         span: Span(
-          start: 1,
-          end: 30,
+          start: 15,
+          end: 44,
         ),
       ),
       Node(
@@ -69,8 +84,8 @@ Node(
           name: Node(
             kind: "X",
             span: Span(
-              start: 37,
-              end: 38,
+              start: 51,
+              end: 52,
             ),
           ),
           typ: Node(
@@ -78,8 +93,8 @@ Node(
               base: Node(
                 kind: "map",
                 span: Span(
-                  start: 41,
-                  end: 44,
+                  start: 55,
+                  end: 58,
                 ),
               ),
               args: Node(
@@ -89,8 +104,8 @@ Node(
                       base: "u8",
                     ),
                     span: Span(
-                      start: 45,
-                      end: 47,
+                      start: 59,
+                      end: 61,
                     ),
                   )),
                   TypeDesc(Node(
@@ -98,26 +113,26 @@ Node(
                       base: "u16",
                     ),
                     span: Span(
-                      start: 49,
-                      end: 52,
+                      start: 63,
+                      end: 66,
                     ),
                   )),
                 ],
                 span: Span(
-                  start: 44,
-                  end: 53,
+                  start: 58,
+                  end: 67,
                 ),
               ),
             ),
             span: Span(
-              start: 41,
-              end: 53,
+              start: 55,
+              end: 67,
             ),
           ),
         ),
         span: Span(
-          start: 32,
-          end: 53,
+          start: 46,
+          end: 67,
         ),
       ),
       Node(
@@ -125,8 +140,8 @@ Node(
           name: Node(
             kind: "A",
             span: Span(
-              start: 64,
-              end: 65,
+              start: 78,
+              end: 79,
             ),
           ),
           fields: [
@@ -137,8 +152,8 @@ Node(
                 name: Node(
                   kind: "x",
                   span: Span(
-                    start: 81,
-                    end: 82,
+                    start: 95,
+                    end: 96,
                   ),
                 ),
                 typ: Node(
@@ -146,29 +161,29 @@ Node(
                     base: "u256",
                   ),
                   span: Span(
-                    start: 84,
-                    end: 88,
+                    start: 98,
+                    end: 102,
                   ),
                 ),
                 value: Some(Node(
                   kind: Num("10"),
                   span: Span(
-                    start: 91,
-                    end: 93,
+                    start: 105,
+                    end: 107,
                   ),
                 )),
               ),
               span: Span(
-                start: 71,
-                end: 88,
+                start: 85,
+                end: 102,
               ),
             ),
           ],
           body: [],
         ),
         span: Span(
-          start: 55,
-          end: 88,
+          start: 69,
+          end: 102,
         ),
       ),
       Node(
@@ -176,8 +191,8 @@ Node(
           name: Node(
             kind: "B",
             span: Span(
-              start: 104,
-              end: 105,
+              start: 118,
+              end: 119,
             ),
           ),
           fields: [
@@ -188,8 +203,8 @@ Node(
                 name: Node(
                   kind: "x",
                   span: Span(
-                    start: 115,
-                    end: 116,
+                    start: 129,
+                    end: 130,
                   ),
                 ),
                 typ: Node(
@@ -197,29 +212,29 @@ Node(
                     base: "X",
                   ),
                   span: Span(
-                    start: 118,
-                    end: 119,
+                    start: 132,
+                    end: 133,
                   ),
                 ),
                 value: None,
               ),
               span: Span(
-                start: 111,
-                end: 119,
+                start: 125,
+                end: 133,
               ),
             ),
           ],
           body: [],
         ),
         span: Span(
-          start: 95,
-          end: 119,
+          start: 109,
+          end: 133,
         ),
       ),
     ],
   ),
   span: Span(
     start: 1,
-    end: 119,
+    end: 133,
   ),
 )

--- a/parser/tests/cases/snapshots/cases__parse_ast__pragma1.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__pragma1.snap
@@ -1,0 +1,20 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(pragma1), module::parse_pragma, \"pragma 0.1.0\")"
+
+---
+Node(
+  kind: Pragma(
+    version_requirement: Node(
+      kind: "0.1.0",
+      span: Span(
+        start: 7,
+        end: 12,
+      ),
+    ),
+  ),
+  span: Span(
+    start: 0,
+    end: 12,
+  ),
+)

--- a/parser/tests/cases/snapshots/cases__parse_ast__pragma2.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__pragma2.snap
@@ -1,0 +1,20 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(pragma2), module::parse_pragma, \"pragma 0.1.0-alpha\")"
+
+---
+Node(
+  kind: Pragma(
+    version_requirement: Node(
+      kind: "0.1.0-alpha",
+      span: Span(
+        start: 7,
+        end: 18,
+      ),
+    ),
+  ),
+  span: Span(
+    start: 0,
+    end: 18,
+  ),
+)

--- a/parser/tests/cases/snapshots/cases__parse_ast__pragma3.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__pragma3.snap
@@ -1,0 +1,20 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(pragma3), module::parse_pragma, \"pragma >= 1.2, < 1.5\")"
+
+---
+Node(
+  kind: Pragma(
+    version_requirement: Node(
+      kind: ">=1.2,<1.5",
+      span: Span(
+        start: 7,
+        end: 20,
+      ),
+    ),
+  ),
+  span: Span(
+    start: 0,
+    end: 20,
+  ),
+)

--- a/tests/fixtures/compile_errors/invalid_compiler_version.fe
+++ b/tests/fixtures/compile_errors/invalid_compiler_version.fe
@@ -1,0 +1,4 @@
+pragma <=0.1.0
+
+contract foo:
+    pass

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -139,6 +139,7 @@ test_file! { emit_bad_args }
 test_file! { external_call_type_error }
 test_file! { external_call_wrong_number_of_params }
 test_file! { indexed_event }
+test_file! { invalid_compiler_version }
 test_file! { mismatch_return_type }
 test_file! { missing_return }
 test_file! { missing_return_in_else }

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_compiler_version.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_compiler_version.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: The current compiler version 0.5.0-alpha doesn't match the specified requirement
+  ┌─ fixtures/compile_errors/invalid_compiler_version.fe:1:8
+  │
+1 │ pragma <=0.1.0
+  │        ^^^^^^^ The specified version requirement
+  │
+  = Note: Use `pragma 0.5.0-alpha` to make the code compile
+
+


### PR DESCRIPTION
### What was wrong?

As described in #361 developers need to have a way to express that a piece of code can only be compiled with a compiler where the version matches a given requirement.

### How was it fixed?

- Added support for `pragma` keyword in the parser
- Version requirement is parsed using the `semver` crate
- The Analyzer checks the compiler version against the version requirement and raises a `WrongCompilerError` if needed.
