### PR TITLE
Implement tuple destructuring 

### DIFF
--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -258,6 +258,8 @@ pub struct Context {
     pub module: Option<ModuleAttributes>,
     pub file_id: SourceFileId,
     pub diagnostics: Vec<Diagnostic>,
+    /// Holds fresh id for [`Context::make_unique_name`]
+    fresh_id: u64,
 }
 
 impl Context {
@@ -280,6 +282,7 @@ impl Context {
             module: None,
             file_id,
             diagnostics: Vec::new(),
+            fresh_id: 0,
         }
     }
 
@@ -580,6 +583,13 @@ impl Context {
                 .collect(),
             notes,
         });
+    }
+
+    /// Makes a unique name from the given name, keeping it as readable as possible.
+    pub fn make_unique_name(&mut self, name: &str) -> String {
+        let id = self.fresh_id;
+        self.fresh_id += 1;
+        format!("${}_{}", name, id)
     }
 }
 

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -1,5 +1,6 @@
 use crate::errors::SemanticError;
 use crate::namespace::scopes::{BlockScope, Scope, Shared};
+use crate::namespace::types::FixedSize;
 use crate::traversal::{expressions, types};
 use crate::Context;
 use fe_parser::ast as fe;
@@ -13,10 +14,6 @@ pub fn var_decl(
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
-        let name = match &target.kind {
-            fe::VarDeclTarget::Name(name) => name,
-            fe::VarDeclTarget::Tuple(_) => todo!("tuple destructuring variable declaration"),
-        };
         let declared_type =
             types::type_desc_fixed_size(&Scope::Block(Rc::clone(&scope)), context, &typ)?;
 
@@ -38,11 +35,32 @@ pub fn var_decl(
             }
         }
 
-        scope.borrow_mut().add_var(&name, declared_type.clone())?;
+        add_var(&scope, &target, declared_type.clone())?;
         context.add_declaration(stmt, declared_type);
-
         return Ok(());
     }
 
     unreachable!()
+}
+
+/// Add declared variables to the scope.
+fn add_var(
+    scope: &Shared<BlockScope>,
+    target: &Node<fe::VarDeclTarget>,
+    typ: FixedSize,
+) -> Result<(), SemanticError> {
+    match (&target.kind, typ) {
+        (fe::VarDeclTarget::Name(name), typ) => scope.borrow_mut().add_var(name, typ),
+        (fe::VarDeclTarget::Tuple(items), FixedSize::Tuple(items_ty)) => {
+            let items_ty = items_ty.items;
+            if items.len() != items_ty.as_vec().len() {
+                return Err(SemanticError::type_error());
+            }
+            for (item, item_ty) in items.iter().zip(items_ty.into_iter()) {
+                add_var(scope, item, item_ty)?;
+            }
+            Ok(())
+        }
+        _ => Err(SemanticError::type_error()),
+    }
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -35,7 +35,7 @@ pub fn compile(
     }
 
     // analyze source code
-    let context = match fe_analyzer::analyze(&fe_module, file_id) {
+    let mut context = match fe_analyzer::analyze(&fe_module, file_id) {
         Ok(_) if !errors.is_empty() => return Err(CompileError { errors }),
         Ok(context) => context,
         Err(err) => {
@@ -48,7 +48,7 @@ pub fn compile(
     let json_abis = abi::build(&context, &fe_module)?;
 
     // lower the AST
-    let lowered_fe_module = lowering::lower(&context, fe_module.clone());
+    let lowered_fe_module = lowering::lower(&mut context, fe_module.clone());
 
     // analyze the lowered AST
     let context =

--- a/compiler/src/lowering/mappers/contracts.rs
+++ b/compiler/src/lowering/mappers/contracts.rs
@@ -8,7 +8,7 @@ use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Lowers a contract definition.
-pub fn contract_def(context: &Context, stmt: Node<fe::ModuleStmt>) -> Node<fe::ModuleStmt> {
+pub fn contract_def(context: &mut Context, stmt: Node<fe::ModuleStmt>) -> Node<fe::ModuleStmt> {
     if let fe::ModuleStmt::ContractDef { name, fields, body } = stmt.kind {
         let lowered_body = body
             .into_iter()
@@ -46,7 +46,7 @@ pub fn contract_def(context: &Context, stmt: Node<fe::ModuleStmt>) -> Node<fe::M
     unreachable!()
 }
 
-fn contract_field(context: &Context, field: Node<fe::Field>) -> Node<fe::Field> {
+fn contract_field(context: &mut Context, field: Node<fe::Field>) -> Node<fe::Field> {
     Node::new(
         fe::Field {
             is_pub: field.kind.is_pub,
@@ -59,7 +59,7 @@ fn contract_field(context: &Context, field: Node<fe::Field>) -> Node<fe::Field> 
     )
 }
 
-fn event_def(context: &Context, stmt: Node<fe::ContractStmt>) -> Node<fe::ContractStmt> {
+fn event_def(context: &mut Context, stmt: Node<fe::ContractStmt>) -> Node<fe::ContractStmt> {
     if let fe::ContractStmt::EventDef { name, fields } = stmt.kind {
         let lowered_fields = fields
             .into_iter()

--- a/compiler/src/lowering/mappers/expressions.rs
+++ b/compiler/src/lowering/mappers/expressions.rs
@@ -7,7 +7,7 @@ use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Lowers an expression and all sub expressions.
-pub fn expr(context: &Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
+pub fn expr(context: &mut Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
     let span = exp.span;
 
     let lowered_kind = match exp.kind {
@@ -69,19 +69,19 @@ pub fn expr(context: &Context, exp: Node<fe::Expr>) -> Node<fe::Expr> {
 }
 
 /// Lowers and optional expression.
-pub fn optional_expr(context: &Context, exp: Option<Node<fe::Expr>>) -> Option<Node<fe::Expr>> {
+pub fn optional_expr(context: &mut Context, exp: Option<Node<fe::Expr>>) -> Option<Node<fe::Expr>> {
     exp.map(|exp| expr(context, exp))
 }
 
 /// Lowers a boxed expression.
 #[allow(clippy::boxed_local)]
-pub fn boxed_expr(context: &Context, exp: Box<Node<fe::Expr>>) -> Box<Node<fe::Expr>> {
+pub fn boxed_expr(context: &mut Context, exp: Box<Node<fe::Expr>>) -> Box<Node<fe::Expr>> {
     Box::new(expr(context, *exp))
 }
 
 /// Lowers call arguments
 pub fn call_args(
-    context: &Context,
+    context: &mut Context,
     args: Node<Vec<Node<fe::CallArg>>>,
 ) -> Node<Vec<Node<fe::CallArg>>> {
     let lowered_args = args
@@ -101,7 +101,7 @@ pub fn call_args(
     Node::new(lowered_args, args.span)
 }
 
-fn expr_tuple(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
+fn expr_tuple(context: &mut Context, exp: Node<fe::Expr>) -> fe::Expr {
     let attributes = context.get_expression(&exp).expect("missing attributes");
 
     if let Type::Tuple(tuple) = &attributes.typ {
@@ -137,7 +137,7 @@ fn expr_tuple(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
     unreachable!()
 }
 
-fn expr_list(context: &Context, exp: Node<fe::Expr>) -> fe::Expr {
+fn expr_list(context: &mut Context, exp: Node<fe::Expr>) -> fe::Expr {
     let attributes = context.get_expression(&exp).expect("missing attributes");
 
     if let Type::Array(array) = &attributes.typ {

--- a/compiler/src/lowering/mappers/functions.rs
+++ b/compiler/src/lowering/mappers/functions.rs
@@ -8,7 +8,7 @@ use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Lowers a function definition.
-pub fn func_def(context: &Context, def: Node<fe::ContractStmt>) -> Node<fe::ContractStmt> {
+pub fn func_def(context: &mut Context, def: Node<fe::ContractStmt>) -> Node<fe::ContractStmt> {
     if let fe::ContractStmt::FuncDef {
         is_pub,
         name,
@@ -17,8 +17,6 @@ pub fn func_def(context: &Context, def: Node<fe::ContractStmt>) -> Node<fe::Cont
         body,
     } = def.kind
     {
-        let attributes = context.get_function(def.id).expect("missing attributes");
-
         // The return type is lowered if it exists. If there is no return type, we set it to the unit type.
         let lowered_return_type = return_type
             .map(|return_type| types::type_desc(context, return_type))
@@ -26,6 +24,7 @@ pub fn func_def(context: &Context, def: Node<fe::ContractStmt>) -> Node<fe::Cont
 
         let lowered_body = {
             let mut lowered_body = multiple_stmts(context, body);
+            let attributes = context.get_function(def.id).expect("missing attributes");
             // append `return ()` to the body if there is no return
             if attributes.return_type.is_unit() && !is_last_statement_return(&lowered_body) {
                 lowered_body.push(
@@ -65,7 +64,7 @@ pub fn func_def(context: &Context, def: Node<fe::ContractStmt>) -> Node<fe::Cont
     }
 }
 
-fn func_stmt(context: &Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::FuncStmt>> {
+fn func_stmt(context: &mut Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::FuncStmt>> {
     let lowered_kinds = match stmt.kind {
         fe::FuncStmt::Return { value } => stmt_return(context, value),
         fe::FuncStmt::VarDecl { target, typ, value } => match target.kind {
@@ -74,7 +73,9 @@ fn func_stmt(context: &Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::FuncSt
                 typ: types::type_desc(context, typ),
                 value: expressions::optional_expr(context, value),
             }],
-            fe::VarDeclTarget::Tuple(_) => todo!("tuple var decl lowering"),
+            fe::VarDeclTarget::Tuple(_) => {
+                lower_tuple_destructuring(context, target, typ, value, stmt.span)
+            }
         },
         fe::FuncStmt::Assign { target, value } => vec![fe::FuncStmt::Assign {
             target: expressions::expr(context, target),
@@ -125,7 +126,10 @@ fn func_stmt(context: &Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::FuncSt
         .collect()
 }
 
-fn multiple_stmts(context: &Context, stmts: Vec<Node<fe::FuncStmt>>) -> Vec<Node<fe::FuncStmt>> {
+fn multiple_stmts(
+    context: &mut Context,
+    stmts: Vec<Node<fe::FuncStmt>>,
+) -> Vec<Node<fe::FuncStmt>> {
     stmts
         .into_iter()
         .map(|stmt| func_stmt(context, stmt))
@@ -134,7 +138,7 @@ fn multiple_stmts(context: &Context, stmts: Vec<Node<fe::FuncStmt>>) -> Vec<Node
 }
 
 fn stmt_aug_assign(
-    context: &Context,
+    context: &mut Context,
     target: Node<fe::Expr>,
     op: Node<fe::BinOperator>,
     value: Node<fe::Expr>,
@@ -159,7 +163,7 @@ fn stmt_aug_assign(
     }]
 }
 
-fn stmt_return(context: &Context, value: Option<Node<fe::Expr>>) -> Vec<fe::FuncStmt> {
+fn stmt_return(context: &mut Context, value: Option<Node<fe::Expr>>) -> Vec<fe::FuncStmt> {
     if let Some(value) = value {
         // lower a return statement that contains a value (e.g. `return true` or `return ()`)
         vec![fe::FuncStmt::Return {
@@ -178,5 +182,87 @@ fn is_last_statement_return(stmts: &[Node<fe::FuncStmt>]) -> bool {
         matches!(stmt.kind, fe::FuncStmt::Return { .. })
     } else {
         false
+    }
+}
+
+/// Lowers tuple desctructuring.
+///
+/// e.g.
+/// ```fe
+/// (x, y): (uint256, bool) = (1, true)
+/// ```
+/// will be lowered to
+/// ```fe
+/// $tmp_tuple_0: (uint256, bool) = (1, true)
+/// x: uint256 = $tmp_tuple_0.item0
+/// y: bool = $tmp_tuple_0.item1
+/// ```
+fn lower_tuple_destructuring(
+    context: &mut Context,
+    target: Node<fe::VarDeclTarget>,
+    typ: Node<fe::TypeDesc>,
+    value: Option<Node<fe::Expr>>,
+    span: fe_common::Span,
+) -> Vec<fe::FuncStmt> {
+    let mut stmts = vec![];
+    let tmp_tuple = context.make_unique_name("tmp_tuple");
+    stmts.push(fe::FuncStmt::VarDecl {
+        target: Node::new(fe::VarDeclTarget::Name(tmp_tuple.clone()), span),
+        typ: types::type_desc(context, typ.clone()),
+        value: expressions::optional_expr(context, value),
+    });
+
+    declare_tuple_items(
+        context,
+        target,
+        typ,
+        &tmp_tuple,
+        &mut vec![],
+        span,
+        &mut stmts,
+    );
+    stmts
+}
+
+fn declare_tuple_items(
+    context: &mut Context,
+    target: Node<fe::VarDeclTarget>,
+    typ: Node<fe::TypeDesc>,
+    tmp_tuple: &str,
+    indices: &mut Vec<usize>,
+    span: fe_common::Span,
+    stmts: &mut Vec<fe::FuncStmt>,
+) {
+    match target.kind {
+        fe::VarDeclTarget::Name(_) => {
+            let mut value = Node::new(fe::Expr::Name(tmp_tuple.to_string()), span);
+            for index in indices.iter() {
+                value = Node::new(
+                    fe::Expr::Attribute {
+                        value: value.into(),
+                        attr: Node::new(format!("item{}", index), span),
+                    },
+                    span,
+                );
+            }
+
+            stmts.push(fe::FuncStmt::VarDecl {
+                target,
+                typ,
+                value: expressions::optional_expr(context, Some(value)),
+            });
+        }
+
+        fe::VarDeclTarget::Tuple(items) => {
+            let items_typ = match typ.kind {
+                fe::TypeDesc::Tuple { items } => items,
+                _ => unreachable!(),
+            };
+            for (index, (target, typ)) in items.into_iter().zip(items_typ.into_iter()).enumerate() {
+                indices.push(index);
+                declare_tuple_items(context, target, typ, tmp_tuple, indices, span, stmts);
+                indices.pop().unwrap();
+            }
+        }
     }
 }

--- a/compiler/src/lowering/mappers/module.rs
+++ b/compiler/src/lowering/mappers/module.rs
@@ -7,7 +7,7 @@ use fe_parser::ast as fe;
 use fe_parser::node::{Node, Span};
 
 /// Lowers a module.
-pub fn module(context: &Context, module: fe::Module) -> fe::Module {
+pub fn module(context: &mut Context, module: fe::Module) -> fe::Module {
     let lowered_body = module
         .body
         .into_iter()

--- a/compiler/src/lowering/mappers/types.rs
+++ b/compiler/src/lowering/mappers/types.rs
@@ -5,7 +5,7 @@ use fe_common::Spanned;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
-pub fn type_desc(context: &Context, desc: Node<fe::TypeDesc>) -> Node<fe::TypeDesc> {
+pub fn type_desc(context: &mut Context, desc: Node<fe::TypeDesc>) -> Node<fe::TypeDesc> {
     let typ = context.get_type_desc(&desc).expect("missing attributes");
 
     match typ {

--- a/compiler/src/lowering/mod.rs
+++ b/compiler/src/lowering/mod.rs
@@ -8,6 +8,6 @@ mod names;
 mod utils;
 
 /// Lowers the Fe source AST to a Fe HIR AST.
-pub fn lower(context: &Context, module: FeModuleAst) -> FeModuleAst {
+pub fn lower(context: &mut Context, module: FeModuleAst) -> FeModuleAst {
     mappers::module::module(context, module)
 }

--- a/compiler/tests/cases/lowering/mod.rs
+++ b/compiler/tests/cases/lowering/mod.rs
@@ -1,0 +1,57 @@
+use fe_compiler::lowering;
+use fe_parser::ast as fe;
+use regex::Regex;
+use std::fs;
+
+use fe_common::files::SourceFileId;
+use rstest::rstest;
+
+use fe_common::assert_strings_eq;
+use fe_common::utils::ron::{to_ron_string_pretty, Diff};
+
+fn lower_file(src: &str) -> fe::Module {
+    let fe_module = parse_file(src);
+    let mut context = fe_analyzer::analyze(&fe_module).expect("failed to get context");
+    lowering::lower(&mut context, fe_module)
+}
+
+fn parse_file(src: &str) -> fe::Module {
+    fe_parser::parse_file(src, SourceFileId(0))
+        .expect("failed to parse file")
+        .0
+}
+
+fn replace_spans(input: String) -> String {
+    let span_re = Regex::new(r"span: Span\(\n\s*start: \d+,\n\s*end: \d+.\n\s*\),").unwrap();
+    span_re.replace_all(&input, "[span omitted]").to_string()
+}
+
+#[rstest(
+    fixture,
+    case("aug_assign"),
+    case("base_tuple"),
+    case("list_expressions"),
+    case("return_unit"),
+    case("unit_implicit"),
+    case("init"),
+    case("custom_empty_type")
+)]
+fn test_lowering(fixture: &str) {
+    let src = fs::read_to_string(format!("tests/cases/lowering/fixtures/{}.fe", fixture))
+        .expect("unable to src read fixture file");
+    let expected_lowered = fs::read_to_string(format!(
+        "tests/cases/lowering/fixtures/{}_lowered.fe",
+        fixture
+    ))
+    .expect("unable to read lowered fixture file");
+
+    let expected_lowered_ast = parse_file(&expected_lowered);
+    let actual_lowered_ast = lower_file(&src);
+
+    assert_strings_eq!(
+        replace_spans(to_ron_string_pretty(&expected_lowered_ast).unwrap()),
+        replace_spans(to_ron_string_pretty(&actual_lowered_ast).unwrap()),
+    );
+
+    fe_analyzer::analyze(&actual_lowered_ast).expect("analysis of the lowered module failed");
+}

--- a/newsfragments/376.feature.md
+++ b/newsfragments/376.feature.md
@@ -1,0 +1,8 @@
+Add support for tuple destructuring
+
+Example:
+
+```
+my_tuple: (u256, bool) = (42, true)
+(x, y): (u256, bool) = my_tuple
+```

--- a/tests/fixtures/features/tuple_destructuring.fe
+++ b/tests/fixtures/features/tuple_destructuring.fe
@@ -1,0 +1,11 @@
+contract Foo:
+    pub def bar() -> u256:
+        (x, y): (u256, bool) = (42, true)
+        return x
+
+    pub def baz(n: u256, b: bool) -> u256:
+        (x, y): (u256, bool) = self.make_tuple(n, b)
+        return x
+
+    def make_tuple(n: u256, b: bool) -> (u256, bool):
+        return (n, b)

--- a/tests/src/features.rs
+++ b/tests/src/features.rs
@@ -1262,3 +1262,17 @@ fn base_tuple() {
         );
     });
 }
+
+#[test]
+fn tuple_destructuring() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "tuple_destructuring.fe", "Foo", &[]);
+        harness.test_function(&mut executor, "bar", &[], Some(&uint_token(42)));
+        harness.test_function(
+            &mut executor,
+            "baz",
+            &[uint_token(1), bool_token(false)],
+            Some(&uint_token(1)),
+        );
+    });
+}


### PR DESCRIPTION
### What was wrong?
Fixes #376 

### How was it fixed?
As suggested in #376, implement tuple restructuring in the lowering pass.
e.g.
```
(x, y): (u256, bool) = (42, true)
```
is basically lowered to 
```
tmp_tuple: (u256, bool) = (42, true)
x: u256 = tmp_tuple.item0
y: bool = tmp_tuple.item1
```

The problem here is the possibility of name conflict of `tmp_tuple`, so we need to make a unique name for `tmp_tuple`. This is the same problem described in #377.
I tried to resolve the problem by prepending `$` which is a legal character in `yul` but illegal in `Fe`, and appending a fresh number to the name to avoid name conflict with another lowered variable. As a result, `tmp_tuple` above will be lowered to `$tmp_tuple_0` .

### To-Do
Rewrite lowering test if the above solution for name conflict is approved.

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
