### PR TITLE
Basic type inference of int literals and empty arrays

### DIFF
--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -40,7 +40,6 @@ impl Location {
             Type::String(_) => Ok(Location::Memory),
             Type::Struct(_) => Ok(Location::Memory),
             Type::Map(_) => Err(SemanticError::cannot_move()),
-            Type::Unit => Ok(Location::Value),
         }
     }
 }
@@ -88,7 +87,7 @@ impl From<Shared<ContractScope>> for ContractAttributes {
                     is_public: def.is_public,
                     name: name.clone(),
                     params: def.params.to_owned(),
-                    return_type: FixedSize::Unit,
+                    return_type: FixedSize::unit(),
                 })
             }
         }
@@ -159,7 +158,6 @@ impl ExpressionAttributes {
     pub fn into_loaded(mut self) -> Result<Self, SemanticError> {
         match self.typ {
             Type::Base(_) => {}
-            Type::Unit => {}
             Type::Contract(_) => {}
             _ => return Err(SemanticError::cannot_move()),
         }

--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -31,15 +31,14 @@ pub enum Location {
 impl Location {
     /// The expected location of a value with the given type when being
     /// assigned, returned, or passed.
-    pub fn assign_location(typ: Type) -> Result<Self, SemanticError> {
+    pub fn assign_location(typ: &FixedSize) -> Self {
         match typ {
-            Type::Base(_) => Ok(Location::Value),
-            Type::Contract(_) => Ok(Location::Value),
-            Type::Array(_) => Ok(Location::Memory),
-            Type::Tuple(_) => Ok(Location::Memory),
-            Type::String(_) => Ok(Location::Memory),
-            Type::Struct(_) => Ok(Location::Memory),
-            Type::Map(_) => Err(SemanticError::cannot_move()),
+            FixedSize::Base(_) => Location::Value,
+            FixedSize::Contract(_) => Location::Value,
+            FixedSize::Array(_) => Location::Memory,
+            FixedSize::Tuple(_) => Location::Memory,
+            FixedSize::String(_) => Location::Memory,
+            FixedSize::Struct(_) => Location::Memory,
         }
     }
 }

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -15,19 +15,12 @@ use crate::errors::{AnalyzerError, ErrorKind};
 use context::Context;
 use fe_common::files::SourceFileId;
 use fe_parser::ast as fe;
-use std::rc::Rc;
 
 /// Performs semantic analysis of the source program and returns a `Context`
 /// instance.
 pub fn analyze(module: &fe::Module, file_id: SourceFileId) -> Result<Context, AnalyzerError> {
-    let context = Context::new_shared(file_id);
-    let result = traversal::module::module(Rc::clone(&context), module);
-
-    // This should never panic.
-    let context = Rc::try_unwrap(context)
-        .map_err(|_| "more than one strong reference pointing to context")
-        .expect("failed to unwrap reference counter")
-        .into_inner();
+    let mut context = Context::new(file_id);
+    let result = traversal::module::module(&mut context, module);
 
     match result {
         Ok(()) => {

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -116,7 +116,6 @@ pub enum Type {
     String(FeString),
     Contract(Contract),
     Struct(Struct),
-    Unit,
 }
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
@@ -127,7 +126,6 @@ pub enum FixedSize {
     String(FeString),
     Contract(Contract),
     Struct(Struct),
-    Unit,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
@@ -136,6 +134,7 @@ pub enum Base {
     Bool,
     Byte,
     Address,
+    Unit,
 }
 
 #[derive(Copy, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, Eq, IntoStaticStr)]
@@ -273,6 +272,10 @@ impl Type {
         }
         false
     }
+
+    pub fn unit() -> Self {
+        Type::Base(Base::Unit)
+    }
 }
 
 impl From<FixedSize> for Type {
@@ -284,7 +287,6 @@ impl From<FixedSize> for Type {
             FixedSize::String(string) => Type::String(string),
             FixedSize::Contract(contract) => Type::Contract(contract),
             FixedSize::Struct(val) => Type::Struct(val),
-            FixedSize::Unit => Type::Unit,
         }
     }
 }
@@ -298,12 +300,17 @@ impl From<Base> for Type {
 impl FixedSize {
     /// Returns true if the type is `()`.
     pub fn is_unit(&self) -> bool {
-        self == &Self::Unit
+        self == &Self::Base(Base::Unit)
     }
 
     /// Creates an instance of bool.
     pub fn bool() -> Self {
         FixedSize::Base(Base::Bool)
+    }
+
+    /// Creates an instance of `()`.
+    pub fn unit() -> Self {
+        FixedSize::Base(Base::Unit)
     }
 }
 
@@ -339,7 +346,6 @@ impl TryFrom<Type> for FixedSize {
             Type::Struct(val) => Ok(FixedSize::Struct(val)),
             Type::Map(_) => Err(SemanticError::type_error()),
             Type::Contract(contract) => Ok(FixedSize::Contract(contract)),
-            Type::Unit => Ok(FixedSize::Unit),
         }
     }
 }
@@ -359,7 +365,6 @@ impl FeSized for FixedSize {
             FixedSize::String(string) => string.size(),
             FixedSize::Contract(contract) => contract.size(),
             FixedSize::Struct(val) => val.size(),
-            FixedSize::Unit => 0,
         }
     }
 }
@@ -390,6 +395,7 @@ impl FeSized for Base {
             Base::Bool => 1,
             Base::Byte => 1,
             Base::Address => 32,
+            Base::Unit => 0,
         }
     }
 }
@@ -433,7 +439,6 @@ impl AbiEncoding for FixedSize {
             FixedSize::String(string) => string.abi_json_name(),
             FixedSize::Contract(contract) => contract.abi_json_name(),
             FixedSize::Struct(val) => val.abi_json_name(),
-            FixedSize::Unit => panic!("unit is not encodable"),
         }
     }
 
@@ -445,7 +450,6 @@ impl AbiEncoding for FixedSize {
             FixedSize::String(string) => string.abi_selector_name(),
             FixedSize::Contract(contract) => contract.abi_selector_name(),
             FixedSize::Struct(val) => val.abi_selector_name(),
-            FixedSize::Unit => panic!("unit is not encodable"),
         }
     }
 
@@ -457,7 +461,6 @@ impl AbiEncoding for FixedSize {
             FixedSize::String(string) => string.abi_components(),
             FixedSize::Contract(contract) => contract.abi_components(),
             FixedSize::Struct(val) => val.abi_components(),
-            FixedSize::Unit => panic!("unit is not encodable"),
         }
     }
 
@@ -469,7 +472,6 @@ impl AbiEncoding for FixedSize {
             FixedSize::String(string) => string.abi_type(),
             FixedSize::Contract(contract) => contract.abi_type(),
             FixedSize::Struct(val) => val.abi_type(),
-            FixedSize::Unit => panic!("unit is not encodable"),
         }
     }
 }
@@ -492,6 +494,7 @@ impl AbiEncoding for Base {
             Base::Address => "address".to_string(),
             Base::Byte => "byte".to_string(),
             Base::Bool => "bool".to_string(),
+            Base::Unit => panic!("unit type is not abi encodable"),
         }
     }
 
@@ -504,98 +507,30 @@ impl AbiEncoding for Base {
     }
 
     fn abi_type(&self) -> AbiType {
-        match self {
-            Base::Bool => AbiType::Uint {
-                size: AbiUintSize {
-                    data_size: 1,
-                    padded_size: 32,
-                },
-            },
+        let (data_size, padded_size) = match self {
+            Base::Bool => (1, 32),
             Base::Numeric(size) => match size {
-                Integer::U256 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 32,
-                        padded_size: 32,
-                    },
-                },
-                Integer::U128 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 16,
-                        padded_size: 32,
-                    },
-                },
-                Integer::U64 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 8,
-                        padded_size: 32,
-                    },
-                },
-                Integer::U32 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 4,
-                        padded_size: 32,
-                    },
-                },
-                Integer::U16 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 2,
-                        padded_size: 32,
-                    },
-                },
-                Integer::U8 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 1,
-                        padded_size: 32,
-                    },
-                },
-                Integer::I256 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 32,
-                        padded_size: 32,
-                    },
-                },
-                Integer::I128 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 16,
-                        padded_size: 32,
-                    },
-                },
-                Integer::I64 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 8,
-                        padded_size: 32,
-                    },
-                },
-                Integer::I32 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 4,
-                        padded_size: 32,
-                    },
-                },
-                Integer::I16 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 2,
-                        padded_size: 32,
-                    },
-                },
-                Integer::I8 => AbiType::Uint {
-                    size: AbiUintSize {
-                        data_size: 1,
-                        padded_size: 32,
-                    },
-                },
+                Integer::U256 => (32, 32),
+                Integer::U128 => (16, 32),
+                Integer::U64 => (8, 32),
+                Integer::U32 => (4, 32),
+                Integer::U16 => (2, 32),
+                Integer::U8 => (1, 32),
+                Integer::I256 => (32, 32),
+                Integer::I128 => (16, 32),
+                Integer::I64 => (8, 32),
+                Integer::I32 => (4, 32),
+                Integer::I16 => (2, 32),
+                Integer::I8 => (1, 32),
             },
-            Base::Address => AbiType::Uint {
-                size: AbiUintSize {
-                    data_size: 32,
-                    padded_size: 32,
-                },
-            },
-            Base::Byte => AbiType::Uint {
-                size: AbiUintSize {
-                    data_size: 1,
-                    padded_size: 1,
-                },
+            Base::Address => (32, 32),
+            Base::Byte => (1, 1),
+            Base::Unit => panic!("unit type is not abi encodable"),
+        };
+        AbiType::Uint {
+            size: AbiUintSize {
+                data_size,
+                padded_size,
             },
         }
     }
@@ -746,7 +681,6 @@ impl SafeNames for FixedSize {
             FixedSize::String(string) => string.lower_snake(),
             FixedSize::Contract(contract) => contract.lower_snake(),
             FixedSize::Struct(val) => val.lower_snake(),
-            FixedSize::Unit => "unit".to_string(),
         }
     }
 }
@@ -769,6 +703,7 @@ impl SafeNames for Base {
             Base::Address => "address".to_string(),
             Base::Byte => "byte".to_string(),
             Base::Bool => "bool".to_string(),
+            Base::Unit => "unit".to_string(),
         }
     }
 }
@@ -820,7 +755,6 @@ impl fmt::Display for Type {
             Type::String(inner) => inner.fmt(f),
             Type::Contract(inner) => inner.fmt(f),
             Type::Struct(inner) => inner.fmt(f),
-            Type::Unit => write!(f, "()"),
         }
     }
 }
@@ -834,7 +768,6 @@ impl fmt::Display for FixedSize {
             FixedSize::String(inner) => inner.fmt(f),
             FixedSize::Contract(inner) => inner.fmt(f),
             FixedSize::Struct(inner) => inner.fmt(f),
-            FixedSize::Unit => write!(f, "()"),
         }
     }
 }
@@ -846,6 +779,7 @@ impl fmt::Display for Base {
             Base::Bool => "bool",
             Base::Byte => "byte",
             Base::Address => "address",
+            Base::Unit => "()",
         };
         write!(f, "{}", name)
     }

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -276,6 +276,51 @@ impl Type {
     pub fn unit() -> Self {
         Type::Base(Base::Unit)
     }
+
+    pub fn int(int_type: Integer) -> Self {
+        Type::Base(Base::Numeric(int_type))
+    }
+}
+
+pub trait TypeDowncast {
+    fn as_array(&self) -> Option<&Array>;
+    fn as_tuple(&self) -> Option<&Tuple>;
+    fn as_string(&self) -> Option<&FeString>;
+    fn as_map(&self) -> Option<&Map>;
+    fn as_int(&self) -> Option<Integer>;
+}
+
+impl TypeDowncast for Option<&Type> {
+    fn as_array(&self) -> Option<&Array> {
+        match self {
+            Some(Type::Array(inner)) => Some(inner),
+            _ => None,
+        }
+    }
+    fn as_tuple(&self) -> Option<&Tuple> {
+        match self {
+            Some(Type::Tuple(inner)) => Some(inner),
+            _ => None,
+        }
+    }
+    fn as_string(&self) -> Option<&FeString> {
+        match self {
+            Some(Type::String(inner)) => Some(inner),
+            _ => None,
+        }
+    }
+    fn as_map(&self) -> Option<&Map> {
+        match self {
+            Some(Type::Map(inner)) => Some(inner),
+            _ => None,
+        }
+    }
+    fn as_int(&self) -> Option<Integer> {
+        match self {
+            Some(Type::Base(Base::Numeric(int))) => Some(*int),
+            _ => None,
+        }
+    }
 }
 
 impl From<FixedSize> for Type {

--- a/analyzer/src/operations.rs
+++ b/analyzer/src/operations.rs
@@ -15,7 +15,6 @@ pub fn index(value: Type, index: Type) -> Result<Type, SemanticError> {
         Type::String(_) => Err(SemanticError::not_subscriptable()),
         Type::Contract(_) => Err(SemanticError::not_subscriptable()),
         Type::Struct(_) => Err(SemanticError::not_subscriptable()),
-        Type::Unit => Err(SemanticError::not_subscriptable()),
     }
 }
 

--- a/analyzer/src/traversal/assignments.rs
+++ b/analyzer/src/traversal/assignments.rs
@@ -17,9 +17,14 @@ pub fn assign(
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Assign { target, value } = &stmt.kind {
-        let target_attributes = expressions::expr(Rc::clone(&scope), context, target)?;
+        let target_attributes = expressions::expr(Rc::clone(&scope), context, target, None)?;
 
-        let value_attributes = expressions::expr(Rc::clone(&scope), context, value)?;
+        let value_attributes = expressions::expr(
+            Rc::clone(&scope),
+            context,
+            value,
+            Some(&target_attributes.typ),
+        )?;
         check_assign_target(context, target)?;
         if target_attributes.typ != value_attributes.typ {
             context.fancy_error(
@@ -97,8 +102,9 @@ pub fn aug_assign(
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::AugAssign { target, op, value } = &stmt.kind {
-        let target_attributes = expressions::expr(Rc::clone(&scope), context, target)?;
-        let value_attributes = expressions::expr(scope, context, value)?;
+        let target_attributes = expressions::expr(Rc::clone(&scope), context, target, None)?;
+        let value_attributes =
+            expressions::expr(scope, context, value, Some(&target_attributes.typ))?;
 
         operations::bin(&target_attributes.typ, &op.kind, &value_attributes.typ)?;
         return Ok(());

--- a/analyzer/src/traversal/declarations.rs
+++ b/analyzer/src/traversal/declarations.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 /// Gather context information for var declarations and check for type errors.
 pub fn var_decl(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
@@ -20,12 +20,12 @@ pub fn var_decl(
         };
         let declared_type = types::type_desc_fixed_size(
             &Scope::Block(Rc::clone(&scope)),
-            Rc::clone(&context),
+            context,
             &typ,
         )?;
         if let Some(value) = value {
             let value_attributes =
-                expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), value)?;
+                expressions::assignable_expr(Rc::clone(&scope), context, value)?;
 
             if Type::from(declared_type.clone()) != value_attributes.typ {
                 return Err(SemanticError::type_error());
@@ -33,7 +33,7 @@ pub fn var_decl(
         }
 
         scope.borrow_mut().add_var(&name, declared_type.clone())?;
-        context.borrow_mut().add_declaration(stmt, declared_type);
+        context.add_declaration(stmt, declared_type);
 
         return Ok(());
     }

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -25,43 +25,43 @@ use vec1::Vec1;
 /// Gather context information for expressions and check for type errors.
 pub fn expr(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     let attributes = match &exp.kind {
-        fe::Expr::Name(_) => expr_name(scope, Rc::clone(&context), exp),
-        fe::Expr::Num(_) => Ok(expr_num(Rc::clone(&context), exp)),
+        fe::Expr::Name(_) => expr_name(scope, context, exp),
+        fe::Expr::Num(_) => Ok(expr_num(context, exp)),
         fe::Expr::Bool(_) => expr_bool(exp),
-        fe::Expr::Subscript { .. } => expr_subscript(scope, Rc::clone(&context), exp),
-        fe::Expr::Attribute { .. } => expr_attribute(scope, Rc::clone(&context), exp),
-        fe::Expr::Ternary { .. } => expr_ternary(scope, Rc::clone(&context), exp),
-        fe::Expr::BoolOperation { .. } => expr_bool_operation(scope, Rc::clone(&context), exp),
-        fe::Expr::BinOperation { .. } => expr_bin_operation(scope, Rc::clone(&context), exp),
-        fe::Expr::UnaryOperation { .. } => expr_unary_operation(scope, Rc::clone(&context), exp),
-        fe::Expr::CompOperation { .. } => expr_comp_operation(scope, Rc::clone(&context), exp),
-        fe::Expr::Call { .. } => expr_call(scope, Rc::clone(&context), exp),
-        fe::Expr::List { .. } => expr_list(scope, Rc::clone(&context), exp),
-        fe::Expr::Tuple { .. } => expr_tuple(scope, Rc::clone(&context), exp),
+        fe::Expr::Subscript { .. } => expr_subscript(scope, context, exp),
+        fe::Expr::Attribute { .. } => expr_attribute(scope, context, exp),
+        fe::Expr::Ternary { .. } => expr_ternary(scope, context, exp),
+        fe::Expr::BoolOperation { .. } => expr_bool_operation(scope, context, exp),
+        fe::Expr::BinOperation { .. } => expr_bin_operation(scope, context, exp),
+        fe::Expr::UnaryOperation { .. } => expr_unary_operation(scope, context, exp),
+        fe::Expr::CompOperation { .. } => expr_comp_operation(scope, context, exp),
+        fe::Expr::Call { .. } => expr_call(scope, context, exp),
+        fe::Expr::List { .. } => expr_list(scope, context, exp),
+        fe::Expr::Tuple { .. } => expr_tuple(scope, context, exp),
         fe::Expr::Str(_) => expr_str(scope, exp),
         fe::Expr::Unit => Ok(ExpressionAttributes::new(Type::Unit, Location::Value)),
     }
     .map_err(|error| error.with_context(exp.span))?;
 
-    context.borrow_mut().add_expression(exp, attributes.clone());
+    context.add_expression(exp, attributes.clone());
 
     Ok(attributes)
 }
 
 pub fn expr_list(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::List { elts } = &exp.kind {
         // Assuming every element attribute should match the attribute of 0th element
         // of list.
         if let Some(first_elt) = elts.first() {
-            let first_attribute = expr(Rc::clone(&scope), Rc::clone(&context), first_elt)?;
+            let first_attribute = expr(Rc::clone(&scope), context, first_elt)?;
 
             // TODO: Right now we are only supporting Base type arrays
             // Potential we can support the tuples as well.
@@ -83,7 +83,7 @@ pub fn expr_list(
                     move_location: None,
                 }
             } else {
-                context.borrow_mut().error(
+                context.error(
                     "arrays can only hold primitive types",
                     first_elt.span,
                     format!(
@@ -95,9 +95,9 @@ pub fn expr_list(
             };
 
             for elt in elts.iter().skip(1) {
-                let next_attribute = expr(Rc::clone(&scope), Rc::clone(&context), elt)?;
+                let next_attribute = expr(Rc::clone(&scope), context, elt)?;
                 if next_attribute.typ != first_attribute.typ {
-                    context.borrow_mut().fancy_error(
+                    context.fancy_error(
                         "array elements must have same type",
                         vec![
                             Label::primary(
@@ -124,14 +124,12 @@ pub fn expr_list(
 /// Also ensures that the expression is on the stack.
 pub fn value_expr(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    let attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?.into_loaded()?;
+    let attributes = expr(Rc::clone(&scope), context, exp)?.into_loaded()?;
 
-    context
-        .borrow_mut()
-        .update_expression(exp, attributes.clone());
+    context.update_expression(exp, attributes.clone());
 
     Ok(attributes)
 }
@@ -141,12 +139,12 @@ pub fn value_expr(
 /// Also ensures that the expression is in the type's assigment location.
 pub fn assignable_expr(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     use Type::*;
 
-    let mut attributes = expr(Rc::clone(&scope), Rc::clone(&context), exp)?;
+    let mut attributes = expr(Rc::clone(&scope), context, exp)?;
     match &attributes.typ {
         Base(_) | Contract(_) | Unit => {
             if attributes.location != Location::Value {
@@ -155,7 +153,7 @@ pub fn assignable_expr(
         }
         Array(_) | Tuple(_) | String(_) | Struct(_) => {
             if attributes.final_location() != Location::Memory {
-                context.borrow_mut().fancy_error(
+                context.fancy_error(
                     "value must be copied to memory",
                     vec![Label::primary(exp.span, "this value is in storage")],
                     vec!["Hint: values located in storage can be copied to memory using the `to_mem` function.".into(),
@@ -166,7 +164,7 @@ pub fn assignable_expr(
             }
         }
         Map(_) => {
-            context.borrow_mut().error(
+            context.error(
                 "maps cannot reside in memory",
                 exp.span,
                 "this type can only be used in a contract field",
@@ -174,24 +172,21 @@ pub fn assignable_expr(
             return Err(SemanticError::fatal());
         }
     };
-    context
-        .borrow_mut()
-        .update_expression(exp, attributes.clone());
+    context.update_expression(exp, attributes.clone());
 
     Ok(attributes)
 }
 
 fn expr_tuple(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Tuple { elts } = &exp.kind {
         let types = elts
             .iter()
             .map(|elt| {
-                assignable_expr(Rc::clone(&scope), Rc::clone(&context), elt)
-                    .map(|attributes| attributes.typ)
+                assignable_expr(Rc::clone(&scope), context, elt).map(|attributes| attributes.typ)
             })
             .collect::<Result<Vec<_>, _>>()?;
         let tuple = Tuple {
@@ -216,7 +211,7 @@ fn expr_tuple(
 
 fn expr_name(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Name(name) = &exp.kind {
@@ -246,7 +241,7 @@ fn expr_name(
             )),
             Some(FixedSize::Unit) => Ok(ExpressionAttributes::new(Type::Unit, Location::Value)),
             None => {
-                context.borrow_mut().error(
+                context.error(
                     format!("cannot find value `{}` in this scope", name),
                     exp.span,
                     "undefined",
@@ -292,7 +287,7 @@ fn expr_bool(exp: &Node<fe::Expr>) -> Result<ExpressionAttributes, SemanticError
     unreachable!()
 }
 
-fn expr_num(context: Shared<Context>, exp: &Node<fe::Expr>) -> ExpressionAttributes {
+fn expr_num(context: &mut Context, exp: &Node<fe::Expr>) -> ExpressionAttributes {
     if let fe::Expr::Num(num) = &exp.kind {
         let num = to_bigint(num);
         validate_numeric_literal_fits_type(context, num, exp.span, Integer::U256);
@@ -304,11 +299,11 @@ fn expr_num(context: Shared<Context>, exp: &Node<fe::Expr>) -> ExpressionAttribu
 
 fn expr_subscript(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Subscript { value, index } = &exp.kind {
-        let value_attributes = expr(Rc::clone(&scope), Rc::clone(&context), value)?;
+        let value_attributes = expr(Rc::clone(&scope), context, value)?;
         let index_attributes = value_expr(scope, context, index)?;
 
         // performs type checking
@@ -328,7 +323,7 @@ fn expr_subscript(
 
 fn expr_attribute(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Attribute { value, attr } = &exp.kind {
@@ -453,12 +448,12 @@ fn expr_attribute_self(
 
 fn expr_bin_operation(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::BinOperation { left, op, right } = &exp.kind {
-        let left_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), left)?;
-        let right_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), right)?;
+        let left_attributes = value_expr(Rc::clone(&scope), context, left)?;
+        let right_attributes = value_expr(Rc::clone(&scope), context, right)?;
 
         return Ok(ExpressionAttributes::new(
             operations::bin(&left_attributes.typ, &op.kind, &right_attributes.typ)?,
@@ -471,16 +466,16 @@ fn expr_bin_operation(
 
 fn expr_unary_operation(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::UnaryOperation { op, operand } = &exp.kind {
-        let operand_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), operand)?;
+        let operand_attributes = value_expr(Rc::clone(&scope), context, operand)?;
 
         return match &op.kind {
             fe::UnaryOperator::USub => {
                 if !matches!(operand_attributes.typ, Type::Base(Base::Numeric(_))) {
-                    context.borrow_mut().error(
+                    context.error(
                         format!(
                             "cannot apply unary operator `-` to type `{}`",
                             operand_attributes.typ
@@ -501,7 +496,7 @@ fn expr_unary_operation(
             }
             fe::UnaryOperator::Not => {
                 if !matches!(operand_attributes.typ, Type::Base(Base::Bool)) {
-                    context.borrow_mut().error(
+                    context.error(
                         format!(
                             "cannot apply unary operator `not` to type `{}`",
                             operand_attributes.typ
@@ -527,7 +522,7 @@ fn expr_unary_operation(
 
 fn expr_call(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Call {
@@ -536,12 +531,7 @@ fn expr_call(
         args,
     } = &exp.kind
     {
-        return match expr_call_type(
-            Rc::clone(&scope),
-            Rc::clone(&context),
-            func,
-            generic_args.as_ref(),
-        )? {
+        return match expr_call_type(Rc::clone(&scope), context, func, generic_args.as_ref())? {
             CallType::BuiltinFunction { func: builtin } => {
                 expr_call_builtin_function(scope, context, builtin, func.span, args)
             }
@@ -563,16 +553,16 @@ fn expr_call(
 
 fn expr_call_builtin_function(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     typ: GlobalMethod,
     name_span: Span,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    let argument_attributes = expr_call_args(Rc::clone(&scope), Rc::clone(&context), args)?;
+    let argument_attributes = expr_call_args(Rc::clone(&scope), context, args)?;
     match typ {
         GlobalMethod::Keccak256 => {
-            validate_arg_count(Rc::clone(&context), typ.into(), name_span, args, 1);
-            validate_arg_labels(Rc::clone(&context), args, &[None]);
+            validate_arg_count(context, typ.into(), name_span, args, 1);
+            validate_arg_labels(context, args, &[None]);
 
             if !matches!(
                 argument_attributes.first().map(|attr| &attr.typ),
@@ -589,7 +579,7 @@ fn expr_call_builtin_function(
 }
 
 pub fn validate_arg_count(
-    context: Shared<Context>,
+    context: &mut Context,
     name: &str,
     name_span: Span,
     args: &Node<Vec<impl Spanned>>,
@@ -615,7 +605,7 @@ pub fn validate_arg_count(
             );
         }
 
-        context.borrow_mut().fancy_error(
+        context.fancy_error(
             format!(
                 "`{}` expects {} argument{}, but {} {} provided",
                 name,
@@ -632,7 +622,7 @@ pub fn validate_arg_count(
 }
 
 pub fn validate_arg_labels(
-    context: Shared<Context>,
+    context: &mut Context,
     args: &Node<Vec<Node<fe::CallArg>>>,
     labels: &[Option<&str>],
 ) {
@@ -649,7 +639,7 @@ pub fn validate_arg_labels(
                     } else {
                         vec![]
                     };
-                    context.borrow_mut().fancy_error(
+                    context.fancy_error(
                         "argument label mismatch",
                         vec![Label::primary(
                             actual_label.span,
@@ -662,7 +652,7 @@ pub fn validate_arg_labels(
             (Some(expected_label), None) => match &arg_val.kind {
                 fe::Expr::Name(var_name) if var_name == *expected_label => {}
                 _ => {
-                    context.borrow_mut().fancy_error(
+                    context.fancy_error(
                         "missing argument label",
                         vec![Label::primary(
                             Span::new(arg_val.span.start, arg_val.span.start),
@@ -676,7 +666,7 @@ pub fn validate_arg_labels(
                 }
             },
             (None, Some(actual_label)) => {
-                context.borrow_mut().error(
+                context.error(
                     "argument should not be labeled",
                     actual_label.span,
                     "remove this label",
@@ -689,15 +679,15 @@ pub fn validate_arg_labels(
 
 pub fn validate_arg_types(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     name: &str,
     args: &Node<Vec<Node<fe::CallArg>>>,
     params: &[(String, FixedSize)],
 ) -> Result<(), SemanticError> {
     for ((label, param_type), arg) in params.iter().zip(args.kind.iter()) {
-        let val_attrs = assignable_expr(Rc::clone(&scope), Rc::clone(&context), &arg.kind.value)?;
+        let val_attrs = assignable_expr(Rc::clone(&scope), context, &arg.kind.value)?;
         if param_type != &val_attrs.typ {
-            context.borrow_mut().type_error(
+            context.type_error(
                 format!("incorrect type for `{}` argument `{}`", name, label),
                 arg.kind.value.span,
                 param_type,
@@ -710,15 +700,15 @@ pub fn validate_arg_types(
 
 pub fn validate_named_args(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     name: &str,
     name_span: Span,
     args: &Node<Vec<Node<fe::CallArg>>>,
     params: &[(String, FixedSize)],
 ) -> Result<(), SemanticError> {
-    validate_arg_count(Rc::clone(&context), name, name_span, args, params.len());
+    validate_arg_count(context, name, name_span, args, params.len());
     validate_arg_labels(
-        Rc::clone(&context),
+        context,
         args,
         &params
             .iter()
@@ -731,14 +721,14 @@ pub fn validate_named_args(
 
 fn expr_call_struct_constructor(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     name_span: Span,
     typ: Struct,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     validate_named_args(
         Rc::clone(&scope),
-        Rc::clone(&context),
+        context,
         &typ.name,
         name_span,
         &args,
@@ -753,7 +743,7 @@ fn expr_call_struct_constructor(
 
 fn expr_call_type_constructor(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     name_span: Span,
     typ: Type,
     args: &Node<Vec<Node<fe::CallArg>>>,
@@ -763,36 +753,33 @@ fn expr_call_type_constructor(
     }
 
     // These all expect 1 arg, for now.
-    validate_arg_count(Rc::clone(&context), &format!("{}", typ), name_span, args, 1);
-    validate_arg_labels(Rc::clone(&context), args, &[None]);
+    validate_arg_count(context, &format!("{}", typ), name_span, args, 1);
+    validate_arg_labels(context, args, &[None]);
 
     let arg_attributes = args
         .kind
         .first()
-        .map(|arg| assignable_expr(Rc::clone(&scope), Rc::clone(&context), &arg.kind.value))
+        .map(|arg| assignable_expr(Rc::clone(&scope), context, &arg.kind.value))
         .transpose()?;
 
     match &typ {
         Type::String(string_type) => {
             if let Some(arg) = args.kind.first() {
-                validate_str_literal_fits_type(Rc::clone(&context), &arg.kind.value, string_type);
+                validate_str_literal_fits_type(context, &arg.kind.value, string_type);
             }
             Ok(ExpressionAttributes::new(typ, Location::Memory))
         }
         Type::Contract(_) => {
             if let Some(arg) = args.kind.first() {
                 if arg_attributes.unwrap().typ != Type::Base(Base::Address) {
-                    context
-                        .borrow_mut()
-                        .type_error("type mismatch", arg.span, Base::Address, &typ);
+                    context.type_error("type mismatch", arg.span, Base::Address, &typ);
                 }
             }
             Ok(ExpressionAttributes::new(typ, Location::Value))
         }
         Type::Base(Base::Numeric(int_type)) => {
             if let Some(arg) = args.kind.first() {
-                if let Some(num) = validate_is_numeric_literal(Rc::clone(&context), &arg.kind.value)
-                {
+                if let Some(num) = validate_is_numeric_literal(context, &arg.kind.value) {
                     // TODO: this is also called by expr() (via assignable_expr()),
                     //  to check if the literal fits in u256. If it doesn't, we'll get two errors.
                     validate_numeric_literal_fits_type(context, num, arg.span, *int_type);
@@ -820,18 +807,18 @@ fn expr_call_type_constructor(
 
 fn expr_call_args(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<Vec<ExpressionAttributes>, SemanticError> {
     args.kind
         .iter()
-        .map(|arg| assignable_expr(Rc::clone(&scope), Rc::clone(&context), &arg.kind.value))
+        .map(|arg| assignable_expr(Rc::clone(&scope), context, &arg.kind.value))
         .collect::<Result<Vec<_>, _>>()
 }
 
 fn expr_call_self_attribute(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     func_name: &str,
     name_span: Span,
     args: &Node<Vec<Node<fe::CallArg>>>,
@@ -848,20 +835,8 @@ fn expr_call_self_attribute(
         ..
     }) = called_func
     {
-        validate_arg_count(
-            Rc::clone(&context),
-            func_name,
-            name_span,
-            args,
-            params.len(),
-        );
-        validate_arg_types(
-            Rc::clone(&scope),
-            Rc::clone(&context),
-            func_name,
-            args,
-            &params,
-        )?;
+        validate_arg_count(context, func_name, name_span, args, params.len());
+        validate_arg_types(Rc::clone(&scope), context, func_name, args, &params)?;
 
         let return_location = match &return_type {
             FixedSize::Base(_) => Location::Value,
@@ -878,18 +853,16 @@ fn expr_call_self_attribute(
 
 fn expr_call_value_attribute(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     func: &Node<fe::Expr>,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Attribute { value, attr } = &func.kind {
-        let value_attributes = expr(Rc::clone(&scope), Rc::clone(&context), &value)?;
+        let value_attributes = expr(Rc::clone(&scope), context, &value)?;
 
         if let Type::Contract(contract) = &value_attributes.typ {
             // We must ensure the expression is loaded onto the stack.
-            context
-                .borrow_mut()
-                .update_expression(value, value_attributes.clone().into_loaded()?);
+            context.update_expression(value, value_attributes.clone().into_loaded()?);
             return expr_call_contract_attribute(
                 scope,
                 context,
@@ -901,7 +874,7 @@ fn expr_call_value_attribute(
         }
 
         // for now all of these function expect 0 arguments
-        validate_arg_count(Rc::clone(&context), &attr.kind, attr.span, args, 0);
+        validate_arg_count(context, &attr.kind, attr.span, args, 0);
 
         return match ValueMethod::from_str(&attr.kind)
             .map_err(|_| SemanticError::undefined_value())?
@@ -909,7 +882,7 @@ fn expr_call_value_attribute(
             ValueMethod::Clone => {
                 match value_attributes.location {
                     Location::Storage { .. } => {
-                        context.borrow_mut().fancy_error(
+                        context.fancy_error(
                             "`clone()` called on value in storage",
                             vec![
                                 Label::primary(value.span, "this value is in storage"),
@@ -919,7 +892,7 @@ fn expr_call_value_attribute(
                         );
                     }
                     Location::Value => {
-                        context.borrow_mut().fancy_error(
+                        context.fancy_error(
                             "`clone()` called on primitive type",
                             vec![
                                 Label::primary(value.span, "this value does not need to be cloned"),
@@ -936,7 +909,7 @@ fn expr_call_value_attribute(
                 match value_attributes.location {
                     Location::Storage { .. } => {}
                     Location::Value => {
-                        context.borrow_mut().fancy_error(
+                        context.fancy_error(
                             "`to_mem()` called on primitive type",
                             vec![
                                 Label::primary(
@@ -949,7 +922,7 @@ fn expr_call_value_attribute(
                         );
                     }
                     Location::Memory => {
-                        context.borrow_mut().fancy_error(
+                        context.fancy_error(
                             "`to_mem()` called on value in memory",
                             vec![
                                 Label::primary(value.span, "this value is in storage"),
@@ -1002,18 +975,18 @@ fn expr_call_value_attribute(
 
 fn expr_call_type_attribute(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     typ: Type,
     func_name: &str,
     name_span: Span,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, SemanticError> {
-    let arg_attributes = expr_call_args(Rc::clone(&scope), Rc::clone(&context), args)?;
+    let arg_attributes = expr_call_args(Rc::clone(&scope), context, args)?;
     let contract_name = scope.borrow().contract_scope().borrow().name.clone();
 
     match (typ, ContractTypeMethod::from_str(func_name)) {
         (Type::Contract(contract), Ok(ContractTypeMethod::Create2)) => {
-            validate_arg_count(Rc::clone(&context), func_name, name_span, args, 2);
+            validate_arg_count(context, func_name, name_span, args, 2);
 
             if contract_name == contract.name {
                 return Err(SemanticError::circular_dependency());
@@ -1038,7 +1011,7 @@ fn expr_call_type_attribute(
             }
         }
         (Type::Contract(contract), Ok(ContractTypeMethod::Create)) => {
-            validate_arg_count(Rc::clone(&context), func_name, name_span, args, 1);
+            validate_arg_count(context, func_name, name_span, args, 1);
 
             if contract_name == contract.name {
                 return Err(SemanticError::circular_dependency());
@@ -1065,7 +1038,7 @@ fn expr_call_type_attribute(
 
 fn expr_call_contract_attribute(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     contract: Contract,
     func_name: &str,
     name_span: Span,
@@ -1078,16 +1051,10 @@ fn expr_call_contract_attribute(
     {
         let return_type = function.return_type.to_owned();
 
-        validate_arg_count(
-            Rc::clone(&context),
-            func_name,
-            name_span,
-            args,
-            function.params.len(),
-        );
+        validate_arg_count(context, func_name, name_span, args, function.params.len());
         validate_arg_types(
             Rc::clone(&scope),
-            Rc::clone(&context),
+            context,
             func_name,
             args,
             &function.params,
@@ -1104,25 +1071,23 @@ fn expr_call_contract_attribute(
 
 fn expr_call_type(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     func: &Node<fe::Expr>,
     generic_args: Option<&Node<Vec<fe::GenericArg>>>,
 ) -> Result<CallType, SemanticError> {
     let call_type = match &func.kind {
-        fe::Expr::Name(name) => {
-            expr_name_call_type(scope, Rc::clone(&context), name, func.span, generic_args)
-        }
-        fe::Expr::Attribute { .. } => expr_attribute_call_type(scope, Rc::clone(&context), func),
+        fe::Expr::Name(name) => expr_name_call_type(scope, context, name, func.span, generic_args),
+        fe::Expr::Attribute { .. } => expr_attribute_call_type(scope, context, func),
         _ => Err(SemanticError::not_callable()),
     }?;
 
-    context.borrow_mut().add_call(func, call_type.clone());
+    context.add_call(func, call_type.clone());
     Ok(call_type)
 }
 
 fn expr_name_call_type(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     name: &str,
     name_span: Span,
     generic_args: Option<&Node<Vec<fe::GenericArg>>>,
@@ -1180,9 +1145,7 @@ fn expr_name_call_type(
             if let Some(typ) = scope.borrow().get_module_type_def(value) {
                 Ok(CallType::TypeConstructor { typ })
             } else {
-                context
-                    .borrow_mut()
-                    .error("undefined function", name_span, "undefined");
+                context.error("undefined function", name_span, "undefined");
                 Err(SemanticError::fatal())
             }
         }
@@ -1191,7 +1154,7 @@ fn expr_name_call_type(
 
 fn expr_attribute_call_type(
     scope: Shared<BlockScope>,
-    _context: Shared<Context>,
+    _context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<CallType, SemanticError> {
     if let fe::Expr::Attribute { value, attr } = &exp.kind {
@@ -1222,7 +1185,7 @@ fn expr_attribute_call_type(
     unreachable!()
 }
 
-fn validate_is_numeric_literal(context: Shared<Context>, value: &Node<fe::Expr>) -> Option<BigInt> {
+fn validate_is_numeric_literal(context: &mut Context, value: &Node<fe::Expr>) -> Option<BigInt> {
     if let fe::Expr::UnaryOperation { operand, op: _ } = &value.kind {
         if let fe::Expr::Num(num) = &operand.kind {
             return Some(-to_bigint(num));
@@ -1230,20 +1193,18 @@ fn validate_is_numeric_literal(context: Shared<Context>, value: &Node<fe::Expr>)
     } else if let fe::Expr::Num(num) = &value.kind {
         return Some(to_bigint(num));
     }
-    context
-        .borrow_mut()
-        .error("type mismatch", value.span, "expected a number literal");
+    context.error("type mismatch", value.span, "expected a number literal");
     None
 }
 
 fn validate_numeric_literal_fits_type(
-    context: Shared<Context>,
+    context: &mut Context,
     num: BigInt,
     span: Span,
     int_type: Integer,
 ) {
     if !int_type.fits(num) {
-        context.borrow_mut().error(
+        context.error(
             format!("literal out of range for `{}`", int_type),
             span,
             format!("does not fit into type `{}`", int_type),
@@ -1251,14 +1212,10 @@ fn validate_numeric_literal_fits_type(
     }
 }
 
-fn validate_str_literal_fits_type(
-    context: Shared<Context>,
-    arg_val: &Node<fe::Expr>,
-    typ: &FeString,
-) {
+fn validate_str_literal_fits_type(context: &mut Context, arg_val: &Node<fe::Expr>, typ: &FeString) {
     if let fe::Expr::Str(string) = &arg_val.kind {
         if string.len() > typ.max_size {
-            context.borrow_mut().error(
+            context.error(
                 "string capacity exceeded",
                 arg_val.span,
                 format!(
@@ -1269,24 +1226,22 @@ fn validate_str_literal_fits_type(
             );
         }
     } else {
-        context
-            .borrow_mut()
-            .error("type mismatch", arg_val.span, "expected a string literal");
+        context.error("type mismatch", arg_val.span, "expected a string literal");
     }
 }
 
 fn expr_comp_operation(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::CompOperation { left, op, right } = &exp.kind {
         // comparison operands should be moved to the stack
-        let left_attr = value_expr(Rc::clone(&scope), Rc::clone(&context), left)?;
-        let right_attr = value_expr(Rc::clone(&scope), Rc::clone(&context), right)?;
+        let left_attr = value_expr(Rc::clone(&scope), context, left)?;
+        let right_attr = value_expr(Rc::clone(&scope), context, right)?;
 
         if left_attr.typ != right_attr.typ {
-            context.borrow_mut().fancy_error(
+            context.fancy_error(
                 format!("`{}` operands must have the same type", op.kind),
                 vec![
                     Label::primary(left.span, format!("this has type `{}`", left_attr.typ)),
@@ -1311,7 +1266,7 @@ fn expr_comp_operation(
 
 fn expr_ternary(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::Ternary {
@@ -1321,19 +1276,18 @@ fn expr_ternary(
     } = &exp.kind
     {
         // test attributes should be stored as a value
-        let test_attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), test)?;
+        let test_attributes = value_expr(Rc::clone(&scope), context, test)?;
         // the return expressions should be stored in their default locations
         //
         // If, for example, one of the expressions is stored in memory and the other is
         // stored in storage, it's necessary that we move them to the same location.
         // This could be memory or the stack, depending on the type.
-        let if_expr_attributes = assignable_expr(Rc::clone(&scope), Rc::clone(&context), if_expr)?;
-        let else_expr_attributes =
-            assignable_expr(Rc::clone(&scope), Rc::clone(&context), else_expr)?;
+        let if_expr_attributes = assignable_expr(Rc::clone(&scope), context, if_expr)?;
+        let else_expr_attributes = assignable_expr(Rc::clone(&scope), context, else_expr)?;
 
         // Make sure the `test_attributes` is a boolean type.
         if Type::Base(Base::Bool) != test_attributes.typ {
-            context.borrow_mut().error(
+            context.error(
                 "`if` test expression must be a `bool`",
                 test.span,
                 format!("this has type `{}`; expected `bool`", test_attributes.typ),
@@ -1341,7 +1295,7 @@ fn expr_ternary(
         }
         // Should have the same return Type
         if if_expr_attributes.typ != else_expr_attributes.typ {
-            context.borrow_mut().fancy_error(
+            context.fancy_error(
                 "`if` and `else` values must have same type",
                 vec![
                     Label::primary(
@@ -1367,14 +1321,14 @@ fn expr_ternary(
 
 fn expr_bool_operation(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     exp: &Node<fe::Expr>,
 ) -> Result<ExpressionAttributes, SemanticError> {
     if let fe::Expr::BoolOperation { left, op, right } = &exp.kind {
         for operand in &[left, right] {
-            let attributes = value_expr(Rc::clone(&scope), Rc::clone(&context), operand)?;
+            let attributes = value_expr(Rc::clone(&scope), context, operand)?;
             if attributes.typ != Type::Base(Base::Bool) {
-                context.borrow_mut().error(
+                context.error(
                     format!("binary op `{}` operands must have type `bool`", op.kind),
                     operand.span,
                     format!("this has type `{}`; expected `bool`", attributes.typ),

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -43,7 +43,7 @@ pub fn expr(
         fe::Expr::List { .. } => expr_list(scope, context, exp),
         fe::Expr::Tuple { .. } => expr_tuple(scope, context, exp),
         fe::Expr::Str(_) => expr_str(scope, exp),
-        fe::Expr::Unit => Ok(ExpressionAttributes::new(Type::Unit, Location::Value)),
+        fe::Expr::Unit => Ok(ExpressionAttributes::new(Type::unit(), Location::Value)),
     }
     .map_err(|error| error.with_context(exp.span))?;
 
@@ -146,7 +146,7 @@ pub fn assignable_expr(
 
     let mut attributes = expr(Rc::clone(&scope), context, exp)?;
     match &attributes.typ {
-        Base(_) | Contract(_) | Unit => {
+        Base(_) | Contract(_) => {
             if attributes.location != Location::Value {
                 attributes.move_location = Some(Location::Value);
             }
@@ -239,7 +239,6 @@ fn expr_name(
                 Type::Struct(val),
                 Location::Memory,
             )),
-            Some(FixedSize::Unit) => Ok(ExpressionAttributes::new(Type::Unit, Location::Value)),
             None => {
                 context.error(
                     format!("cannot find value `{}` in this scope", name),

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -40,7 +40,7 @@ pub fn func_def(
                 )
             })
             .transpose()?
-            .unwrap_or(FixedSize::Unit);
+            .unwrap_or_else(FixedSize::unit);
 
         // `__init__` must not return any type other than `()`.
         if name == "__init__" && !return_type.is_unit() {
@@ -58,7 +58,7 @@ pub fn func_def(
                     ),
                 ],
             );
-            return_type = FixedSize::Unit;
+            return_type = FixedSize::unit();
         }
 
         let attributes: FunctionAttributes = contract_scope
@@ -395,7 +395,7 @@ fn func_return(
     if let fe::FuncStmt::Return { value } = &stmt.kind {
         let attributes = match value {
             Some(val) => expressions::assignable_expr(Rc::clone(&scope), context, val)?,
-            None => ExpressionAttributes::new(Type::Unit, Location::Value),
+            None => ExpressionAttributes::new(Type::unit(), Location::Value),
         };
 
         let host_func_def = scope

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 /// errors. Does not inspect the function body.
 pub fn func_def(
     contract_scope: Shared<ContractScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     def: &Node<fe::ContractStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::FuncDef {
@@ -27,7 +27,7 @@ pub fn func_def(
 
         let params = args
             .iter()
-            .map(|arg| func_def_arg(Rc::clone(&function_scope), Rc::clone(&context), arg))
+            .map(|arg| func_def_arg(Rc::clone(&function_scope), context, arg))
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut return_type = return_type_node
@@ -35,7 +35,7 @@ pub fn func_def(
             .map(|typ| {
                 types::type_desc_fixed_size(
                     &Scope::Block(Rc::clone(&function_scope)),
-                    Rc::clone(&context),
+                    context,
                     &typ,
                 )
             })
@@ -44,7 +44,7 @@ pub fn func_def(
 
         // `__init__` must not return any type other than `()`.
         if name == "__init__" && !return_type.is_unit() {
-            context.borrow_mut().fancy_error(
+            context.fancy_error(
                 "`__init__` function has incorrect return type",
                 vec![Label::primary(
                     return_type_node.as_ref().unwrap().span,
@@ -73,7 +73,7 @@ pub fn func_def(
             .to_owned()
             .into();
 
-        context.borrow_mut().add_function(def, attributes);
+        context.add_function(def, attributes);
 
         Ok(())
     } else {
@@ -84,7 +84,7 @@ pub fn func_def(
 /// Gather context information for a function body and check for type errors.
 pub fn func_body(
     contract_scope: Shared<ContractScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     def: &Node<fe::ContractStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::ContractStmt::FuncDef {
@@ -105,7 +105,7 @@ pub fn func_body(
         // If the return type is anything else, we do need to ensure that all code paths
         // return or revert.
         if !host_func_def.return_type.is_unit() && !all_paths_return_or_revert(&body) {
-            context.borrow_mut().fancy_error(
+            context.fancy_error(
                 "function body is missing a return or revert statement",
                 vec![
                     Label::primary(
@@ -124,7 +124,7 @@ pub fn func_body(
             );
         }
 
-        traverse_statements(Rc::clone(&host_func_def.scope), Rc::clone(&context), body)?;
+        traverse_statements(Rc::clone(&host_func_def.scope), context, body)?;
 
         Ok(())
     } else {
@@ -134,11 +134,11 @@ pub fn func_body(
 
 fn traverse_statements(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     body: &[Node<fe::FuncStmt>],
 ) -> Result<(), SemanticError> {
     for stmt in body.iter() {
-        func_stmt(Rc::clone(&scope), Rc::clone(&context), stmt)?
+        func_stmt(Rc::clone(&scope), context, stmt)?
     }
     Ok(())
 }
@@ -168,7 +168,7 @@ fn all_paths_return_or_revert(block: &[Node<fe::FuncStmt>]) -> bool {
 
 fn func_def_arg(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     arg: &Node<fe::FuncDefArg>,
 ) -> Result<(String, FixedSize), SemanticError> {
     let fe::FuncDefArg { name, typ } = &arg.kind;
@@ -179,7 +179,7 @@ fn func_def_arg(
 
 fn func_stmt(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     use fe::FuncStmt::*;
@@ -206,7 +206,7 @@ fn func_stmt(
 
 fn for_loop(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     match &stmt.kind {
@@ -215,11 +215,11 @@ fn for_loop(
             let body_scope = BlockScope::from_block_scope(BlockScopeType::Loop, Rc::clone(&scope));
             // Make sure iter is in the function scope & it should be an array.
 
-            let iter_type = expressions::expr(Rc::clone(&scope), Rc::clone(&context), &iter)?.typ;
+            let iter_type = expressions::expr(Rc::clone(&scope), context, &iter)?.typ;
             let target_type = if let Type::Array(array) = iter_type {
                 FixedSize::Base(array.inner)
             } else {
-                context.borrow_mut().type_error(
+                context.type_error(
                     "invalid `for` loop iterator type",
                     iter.span,
                     "array",
@@ -237,7 +237,7 @@ fn for_loop(
 
 fn loop_flow_statement(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) {
     if !scope.borrow().inherits_type(BlockScopeType::Loop) {
@@ -246,7 +246,7 @@ fn loop_flow_statement(
             fe::FuncStmt::Break => "break",
             _ => panic!(),
         };
-        context.borrow_mut().error(
+        context.error(
             format!("`{}` outside of a loop", stmt_name),
             stmt.span,
             format!("cannot `{}` outside of a `for` or `while` loop", stmt_name),
@@ -256,7 +256,7 @@ fn loop_flow_statement(
 
 fn if_statement(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     match &stmt.kind {
@@ -265,9 +265,9 @@ fn if_statement(
             body,
             or_else,
         } => {
-            let test_type = expressions::expr(Rc::clone(&scope), Rc::clone(&context), test)?.typ;
+            let test_type = expressions::expr(Rc::clone(&scope), context, test)?.typ;
             if test_type != Type::Base(Base::Bool) {
-                context.borrow_mut().type_error(
+                context.type_error(
                     "`if` statement condition is not bool",
                     test.span,
                     Base::Bool,
@@ -277,10 +277,10 @@ fn if_statement(
 
             let body_scope =
                 BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&scope));
-            traverse_statements(body_scope, Rc::clone(&context), body)?;
+            traverse_statements(body_scope, context, body)?;
             let or_else_scope =
                 BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&scope));
-            traverse_statements(or_else_scope, Rc::clone(&context), or_else)?;
+            traverse_statements(or_else_scope, context, or_else)?;
             Ok(())
         }
         _ => unreachable!(),
@@ -289,14 +289,14 @@ fn if_statement(
 
 fn while_loop(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     match &stmt.kind {
         fe::FuncStmt::While { test, body } => {
-            let test_type = expressions::expr(Rc::clone(&scope), Rc::clone(&context), &test)?.typ;
+            let test_type = expressions::expr(Rc::clone(&scope), context, &test)?.typ;
             if test_type != Type::Base(Base::Bool) {
-                context.borrow_mut().type_error(
+                context.type_error(
                     "`while` loop condition is not bool",
                     test.span,
                     Base::Bool,
@@ -305,7 +305,7 @@ fn while_loop(
             }
 
             let body_scope = BlockScope::from_block_scope(BlockScopeType::Loop, Rc::clone(&scope));
-            traverse_statements(body_scope, Rc::clone(&context), body)?;
+            traverse_statements(body_scope, context, body)?;
             Ok(())
         }
         _ => unreachable!(),
@@ -314,7 +314,7 @@ fn while_loop(
 
 fn expr(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Expr { value } = &stmt.kind {
@@ -326,22 +326,22 @@ fn expr(
 
 fn emit(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Emit { name, args } = &stmt.kind {
         if let Some(event) = scope.borrow().contract_event_def(&name.kind) {
-            context.borrow_mut().add_emit(stmt, event.clone());
+            context.add_emit(stmt, event.clone());
             expressions::validate_named_args(
                 Rc::clone(&scope),
-                Rc::clone(&context),
+                context,
                 &name.kind,
                 name.span,
                 args,
                 &event.fields,
             )?;
         } else {
-            context.borrow_mut().error(
+            context.error(
                 format!("undefined event: `{}`", name.kind),
                 name.span,
                 "undefined event",
@@ -356,13 +356,13 @@ fn emit(
 
 fn assert(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Assert { test, msg } = &stmt.kind {
-        let test_type = expressions::expr(Rc::clone(&scope), Rc::clone(&context), &test)?.typ;
+        let test_type = expressions::expr(Rc::clone(&scope), context, &test)?.typ;
         if test_type != Type::Base(Base::Bool) {
-            context.borrow_mut().type_error(
+            context.type_error(
                 "`assert` condition is not bool",
                 test.span,
                 Base::Bool,
@@ -371,9 +371,9 @@ fn assert(
         }
 
         if let Some(msg) = msg {
-            let msg_attributes = expressions::expr(scope, Rc::clone(&context), msg)?;
+            let msg_attributes = expressions::expr(scope, context, msg)?;
             if !matches!(msg_attributes.typ, Type::String(_)) {
-                context.borrow_mut().error(
+                context.error(
                     "`assert` reason must be a string",
                     msg.span,
                     format!("this has type `{}`; expected a string", msg_attributes.typ),
@@ -389,12 +389,12 @@ fn assert(
 
 fn func_return(
     scope: Shared<BlockScope>,
-    context: Shared<Context>,
+    context: &mut Context,
     stmt: &Node<fe::FuncStmt>,
 ) -> Result<(), SemanticError> {
     if let fe::FuncStmt::Return { value } = &stmt.kind {
         let attributes = match value {
-            Some(val) => expressions::assignable_expr(Rc::clone(&scope), Rc::clone(&context), val)?,
+            Some(val) => expressions::assignable_expr(Rc::clone(&scope), context, val)?,
             None => ExpressionAttributes::new(Type::Unit, Location::Value),
         };
 

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -9,7 +9,7 @@ use semver::{Version, VersionReq};
 use std::rc::Rc;
 
 /// Gather context information for a module and check for type errors.
-pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), SemanticError> {
+pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), SemanticError> {
     let scope = ModuleScope::new();
 
     let mut contracts = vec![];
@@ -17,20 +17,20 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
     for stmt in module.body.iter() {
         match &stmt.kind {
             fe::ModuleStmt::TypeDef { .. } => {
-                type_def(Rc::clone(&context), Rc::clone(&scope), stmt)?
+                type_def(context, Rc::clone(&scope), stmt)?
             }
             fe::ModuleStmt::Pragma { .. } => {
                 pragma_stmt(Rc::clone(&context), Rc::clone(&scope), stmt)
             }
             fe::ModuleStmt::StructDef { name, fields } => {
-                structs::struct_def(Rc::clone(&context), Rc::clone(&scope), &name.kind, fields)?
+                structs::struct_def(context, Rc::clone(&scope), &name.kind, fields)?
             }
             fe::ModuleStmt::ContractDef { .. } => {
                 // Collect contract statements and the scope that we create for them. After we
                 // have walked all contracts once, we walk over them again for a
                 // more detailed inspection.
                 let contract_scope =
-                    contracts::contract_def(Rc::clone(&scope), Rc::clone(&context), stmt)?;
+                    contracts::contract_def(Rc::clone(&scope), context, stmt)?;
                 contracts.push((stmt, contract_scope))
             }
             fe::ModuleStmt::FromImport { .. } => unimplemented!(),
@@ -40,17 +40,17 @@ pub fn module(context: Shared<Context>, module: &fe::Module) -> Result<(), Seman
 
     for (stmt, scope) in contracts.iter() {
         if let fe::ModuleStmt::ContractDef { .. } = stmt.kind {
-            contracts::contract_body(Rc::clone(&scope), Rc::clone(&context), stmt)?
+            contracts::contract_body(Rc::clone(&scope), context, stmt)?
         }
     }
 
-    context.borrow_mut().set_module(scope.into());
+    context.set_module(scope.into());
 
     Ok(())
 }
 
 fn type_def(
-    context: Shared<Context>,
+    context: &mut Context,
     scope: Shared<ModuleScope>,
     stmt: &Node<fe::ModuleStmt>,
 ) -> Result<(), SemanticError> {

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -8,7 +8,7 @@ use crate::Context;
 use std::rc::Rc;
 
 pub fn struct_def(
-    context: Shared<Context>,
+    context: &mut Context,
     module_scope: Shared<ModuleScope>,
     name: &str,
     fields: &[Node<Field>],
@@ -18,7 +18,7 @@ pub fn struct_def(
         let Field { name, typ, .. } = &field.kind;
         let field_type = type_desc(
             &Scope::Module(Rc::clone(&module_scope)),
-            Rc::clone(&context),
+            context,
             typ,
         )?;
         if let Type::Base(base_typ) = field_type {

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -16,11 +16,7 @@ pub fn struct_def(
     let mut val = Struct::new(name);
     for field in fields {
         let Field { name, typ, .. } = &field.kind;
-        let field_type = type_desc(
-            &Scope::Module(Rc::clone(&module_scope)),
-            context,
-            typ,
-        )?;
+        let field_type = type_desc(&Scope::Module(Rc::clone(&module_scope)), context, typ)?;
         if let Type::Base(base_typ) = field_type {
             val.add_field(&name.kind, &FixedSize::Base(base_typ))?;
         } else {

--- a/analyzer/src/traversal/types.rs
+++ b/analyzer/src/traversal/types.rs
@@ -121,7 +121,7 @@ pub fn type_desc(
             )
             .expect("tuple is empty"),
         }),
-        fe::TypeDesc::Unit => Type::Unit,
+        fe::TypeDesc::Unit => Type::unit(),
     };
 
     context.add_type_desc(desc, typ.clone());

--- a/compiler/src/lowering/mappers/functions.rs
+++ b/compiler/src/lowering/mappers/functions.rs
@@ -22,7 +22,7 @@ pub fn func_def(context: &Context, def: Node<fe::ContractStmt>) -> Node<fe::Cont
         // The return type is lowered if it exists. If there is no return type, we set it to the unit type.
         let lowered_return_type = return_type
             .map(|return_type| types::type_desc(context, return_type))
-            .unwrap_or_else(|| names::fixed_size_type_desc(&FixedSize::Unit).into_node());
+            .unwrap_or_else(|| names::fixed_size_type_desc(&FixedSize::unit()).into_node());
 
         let lowered_body = {
             let mut lowered_body = multiple_stmts(context, body);

--- a/compiler/src/lowering/names.rs
+++ b/compiler/src/lowering/names.rs
@@ -27,6 +27,7 @@ pub fn tuple_struct_name(tuple: &Tuple) -> fe::Expr {
 /// Maps a FixedSize type to its type description.
 pub fn fixed_size_type_desc(typ: &FixedSize) -> fe::TypeDesc {
     match typ {
+        FixedSize::Base(Base::Unit) => fe::TypeDesc::Unit,
         FixedSize::Base(base) => fe::TypeDesc::Base {
             base: base_type_name(base),
         },
@@ -34,7 +35,6 @@ pub fn fixed_size_type_desc(typ: &FixedSize) -> fe::TypeDesc {
             dimension: array.size,
             typ: fixed_size_type_desc(&array.inner.clone().into()).into_boxed_node(),
         },
-        FixedSize::Unit => fe::TypeDesc::Unit,
         FixedSize::Tuple(_) => todo!(),
         FixedSize::String(_) => todo!(),
         FixedSize::Contract(_) => todo!(),
@@ -61,6 +61,7 @@ fn base_type_name(typ: &Base) -> String {
         Base::Bool => "bool",
         Base::Byte => unimplemented!("byte should be removed"),
         Base::Address => "address",
+        Base::Unit => "unit",
     }
     .to_string()
 }

--- a/newsfragments/429.feature.md
+++ b/newsfragments/429.feature.md
@@ -1,0 +1,28 @@
+Types of integer literal are now inferred, rather than defaulting to `u256`.
+
+```
+contract C:
+
+  def f(x: u8) -> u16:
+    y: u8 = 100   # had to use u8(100) before
+    z: i8 = -129  # "literal out of range" error
+
+    return 1000   # had to use `return u16(1000)` before
+
+  def g():
+    self.f(50)
+```
+
+Similar inference is done for empty array literals. Previously, empty array
+literals caused a compiler crash, because the array element type couldn't
+be determined.
+```
+contract C:
+  def f(xs: u8[10]):
+    pass
+
+  def g():
+    self.f([])
+```
+(Note that array length mismatch is still a type error, so this code won't
+actually compile.)

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -319,6 +319,18 @@ impl fmt::Display for BinOperator {
     }
 }
 
+impl fmt::Display for UnaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use UnaryOperator::*;
+        match self {
+            Invert => write!(f, "~"),
+            Not => write!(f, "not"),
+            UAdd => write!(f, "+"),
+            USub => write!(f, "-"),
+        }
+    }
+}
+
 impl fmt::Display for CompOperator {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use CompOperator::*;

--- a/tests/fixtures/features/int_literal_coercion.fe
+++ b/tests/fixtures/features/int_literal_coercion.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    pub def bar() -> u32:
+        c: u32 = 30
+        c = 300
+        d: (u128, u64, u32) = (100, 200, c)
+        return d.item2

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -50,7 +50,8 @@ macro_rules! test_stmt {
 }
 
 test_stmt! { array_non_primitive, "x: (u8, u8)[10]" }
-test_stmt! { array_mixed_types, "x: u256[3] = [1, address(0), \"hi\"]" }
+test_stmt! { array_mixed_types, "x: u16[3] = [1, address(0), \"hi\"]" }
+test_stmt! { array_size_mismatch, "x: u8[3] = []\ny: u8[3] = [1, 2]" }
 test_stmt! { assert_reason_not_string, "assert true, 1" }
 test_stmt! { assign_int, "5 = 6" }
 test_stmt! { assign_call, "self.f() = 10" }
@@ -89,11 +90,11 @@ test_stmt! { overflow_i32_neg, "i32(-2147483649)" }
 test_stmt! { overflow_i32_pos, "i32(2147483648)" }
 test_stmt! { overflow_i64_neg, "i64(-9223372036854775809)" }
 test_stmt! { overflow_i64_pos, "i64(9223372036854775808)" }
-test_stmt! { overflow_i8_neg, "i8(-129)" }
-test_stmt! { overflow_i8_pos, "i8(128)" }
+test_stmt! { overflow_i8_neg, "x: i8 = -129" }
+test_stmt! { overflow_i8_pos, "x: i8 = 128" }
 test_stmt! { overflow_literal_too_big, "115792089237316195423570985008687907853269984665640564039457584007913129639936" }
 test_stmt! { overflow_literal_too_small, "-115792089237316195423570985008687907853269984665640564039457584007913129639936" }
-test_stmt! { overflow_u128_neg, "u128(-1)" }
+test_stmt! { overflow_u128_neg, "x: u128 = -1" }
 test_stmt! { overflow_u128_pos, "u128(340282366920938463463374607431768211456)" }
 test_stmt! { overflow_u16_neg, "u16(-1)" }
 test_stmt! { overflow_u16_pos, "u16(65536)" }
@@ -105,6 +106,7 @@ test_stmt! { overflow_u64_neg, "u64(-1)" }
 test_stmt! { overflow_u64_pos, "u64(18446744073709551616)" }
 test_stmt! { overflow_u8_neg, "u8(-1)" }
 test_stmt! { overflow_u8_pos, "u8(256)" }
+test_stmt! { overflow_u8_assignment, "x: u8 = 260" }
 test_stmt! { pow_with_signed_exponent, "base: i128\nexp: i128\nbase ** exp" }
 // Exponent can be unsigned but needs to be same size or smaller
 test_stmt! { pow_with_wrong_capacity, "base: i128\nexp: u256\nbase ** exp" }
@@ -114,8 +116,9 @@ test_stmt! { type_constructor_from_variable, "x: u8\ny: u16 = u16(x)" }
 test_stmt! { type_constructor_arg_count, "x: u8 = u8(1, 10)" }
 test_stmt! { unary_minus_on_bool, "x: bool = true\n-x" }
 test_stmt! { unary_not_on_int, "x: u256 = 10\nnot x" }
-test_stmt! { undefined_type, "x: foobar = 10" }
 test_stmt! { undefined_generic_type, "x: foobar<u256> = 10" }
+test_stmt! { undefined_name, "x: u16 = y\nz: u16 = y" }
+test_stmt! { undefined_type, "x: foobar = 10" }
 test_stmt! { unexpected_return, "return 1" }
 
 test_file! { bad_tuple_attr1 }

--- a/tests/src/features.rs
+++ b/tests/src/features.rs
@@ -244,6 +244,7 @@ fn test_assert() {
     case("radix_octal.fe", &[], uint_token(0o70)),
     case("radix_binary.fe", &[], uint_token(0b10)),
     case::map_tuple("map_tuple.fe", &[uint_token(1234)], uint_token(1234)),
+    case::int_literal_coercion("int_literal_coercion.fe", &[], uint_token(300)),
 )]
 fn test_method_return(fixture_file: &str, input: &[ethabi::Token], expected: ethabi::Token) {
     with_executor(&|mut executor| {

--- a/tests/src/snapshots/errors__array_size_mismatch.snap
+++ b/tests/src/snapshots/errors__array_size_mismatch.snap
@@ -1,0 +1,18 @@
+---
+source: analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: type mismatch
+  ┌─ [snippet]:3:14
+  │
+3 │   x: u8[3] = []
+  │              ^^ this has type `u8[0]`; expected type `u8[3]`
+
+error: type mismatch
+  ┌─ [snippet]:4:14
+  │
+4 │   y: u8[3] = [1, 2]
+  │              ^^^^^^ this has type `u8[2]`; expected type `u8[3]`
+
+

--- a/tests/src/snapshots/errors__overflow_u8_assignment.snap
+++ b/tests/src/snapshots/errors__overflow_u8_assignment.snap
@@ -3,10 +3,10 @@ source: analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: literal out of range for `i8`
+error: literal out of range for `u8`
   ┌─ [snippet]:3:11
   │
-3 │   x: i8 = 128
-  │           ^^^ does not fit into type `i8`
+3 │   x: u8 = 260
+  │           ^^^ does not fit into type `u8`
 
 

--- a/tests/src/snapshots/errors__undefined_name.snap
+++ b/tests/src/snapshots/errors__undefined_name.snap
@@ -1,0 +1,18 @@
+---
+source: analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: cannot find value `y` in this scope
+  ┌─ [snippet]:3:12
+  │
+3 │   x: u16 = y
+  │            ^ undefined
+
+error: cannot find value `y` in this scope
+  ┌─ [snippet]:4:12
+  │
+4 │   z: u16 = y
+  │            ^ undefined
+
+

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
@@ -313,12 +313,12 @@ note:
    ┌─ demos/erc20_token.fe:24:29
    │
 24 │         self._decimals = u8(18)
-   │                             ^^ attributes hash: 16797824492585953824
+   │                             ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
@@ -375,11 +375,13 @@ note:
    ┌─ demos/erc20_token.fe:25:9
    │
 25 │         self._mint(msg.sender, 1000000000000000000000000)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -618,11 +620,13 @@ note:
    ┌─ demos/erc20_token.fe:43:9
    │
 43 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -789,11 +793,13 @@ note:
    ┌─ demos/erc20_token.fe:50:9
    │
 50 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -990,11 +996,13 @@ note:
    ┌─ demos/erc20_token.fe:56:9
    │
 56 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -1163,11 +1171,13 @@ note:
    ┌─ demos/erc20_token.fe:57:9
    │
 57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -1350,11 +1360,13 @@ note:
    ┌─ demos/erc20_token.fe:61:9
    │
 61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -1537,11 +1549,13 @@ note:
    ┌─ demos/erc20_token.fe:65:9
    │
 65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -1723,11 +1737,13 @@ note:
    ┌─ demos/erc20_token.fe:72:9
    │
 72 │         self._before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -2193,11 +2209,13 @@ note:
    ┌─ demos/erc20_token.fe:81:9
    │
 81 │         self._before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -2605,11 +2623,13 @@ note:
    ┌─ demos/erc20_token.fe:90:9
    │
 90 │         self._before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -3362,7 +3382,7 @@ note:
 23 │ │         self._symbol = symbol
 24 │ │         self._decimals = u8(18)
 25 │ │         self._mint(msg.sender, 1000000000000000000000000)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 12781195277125811671
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 16507451754266593018
    │  
    = FunctionAttributes {
          is_public: true,
@@ -3385,7 +3405,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -3695,7 +3717,7 @@ note:
    · │
 75 │ │         self._balances[recipient] = self._balances[recipient] + value
 76 │ │         emit Transfer(from=sender, to=recipient, value=value)
-   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 17363926982505756183
+   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 5235743689364830446
    │  
    = FunctionAttributes {
          is_public: false,
@@ -3722,7 +3744,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -3735,7 +3759,7 @@ note:
    · │
 84 │ │         self._balances[account] = self._balances[account] + value
 85 │ │         emit Transfer(from=address(0), to=account, value=value)
-   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 1325051979785858305
+   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 4212583220897592452
    │  
    = FunctionAttributes {
          is_public: false,
@@ -3756,7 +3780,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -3769,7 +3795,7 @@ note:
    · │
 93 │ │         self._total_supply = self._total_supply - value
 94 │ │         emit Transfer(from=account, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 10306155239953339105
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 2235422051894015840
    │  
    = FunctionAttributes {
          is_public: false,
@@ -3790,7 +3816,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -3802,7 +3830,7 @@ note:
  99 │ │ 
 100 │ │         self._allowances[owner][spender] = value
 101 │ │         emit Approval(owner, spender, value)
-    │ ╰────────────────────────────────────────────^ attributes hash: 10525944821091525871
+    │ ╰────────────────────────────────────────────^ attributes hash: 422334171292144355
     │  
     = FunctionAttributes {
           is_public: false,
@@ -3829,7 +3857,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -3837,7 +3867,7 @@ note:
     │  
 103 │ ╭     def _setup_decimals(decimals_: u8):
 104 │ │         self._decimals = decimals_
-    │ ╰──────────────────────────────────^ attributes hash: 17687756789057869061
+    │ ╰──────────────────────────────────^ attributes hash: 10552040440503690559
     │  
     = FunctionAttributes {
           is_public: false,
@@ -3852,7 +3882,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -3860,7 +3892,7 @@ note:
     │  
 106 │ ╭     def _before_token_transfer(from: address, to: address, value: u256):
 107 │ │         pass
-    │ ╰────────────^ attributes hash: 13037046123086456523
+    │ ╰────────────^ attributes hash: 601366328933825474
     │  
     = FunctionAttributes {
           is_public: false,
@@ -3887,7 +3919,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -3900,7 +3934,7 @@ note:
     · │
 106 │ │     def _before_token_transfer(from: address, to: address, value: u256):
 107 │ │         pass
-    │ ╰────────────^ attributes hash: 4368831833896822203
+    │ ╰────────────^ attributes hash: 4956673513059637282
     │  
     = ContractAttributes {
           public_functions: [
@@ -4128,7 +4162,9 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
           ),
           events: [

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
@@ -47,7 +47,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -259,7 +261,7 @@ note:
 10 │ │         self.messages[msg.sender] = book_msg
 11 │ │ 
 12 │ │         emit Signed(book_msg=book_msg)
-   │ ╰──────────────────────────────────────^ attributes hash: 5981101296597642865
+   │ ╰──────────────────────────────────────^ attributes hash: 9582611576980218782
    │  
    = FunctionAttributes {
          is_public: true,
@@ -275,7 +277,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -314,7 +318,7 @@ note:
    · │
 14 │ │     pub def get_msg(addr: address) -> BookMsg:
 15 │ │         return self.messages[addr].to_mem()
-   │ ╰───────────────────────────────────────────^ attributes hash: 9538492214726090170
+   │ ╰───────────────────────────────────────────^ attributes hash: 15368480331433060906
    │  
    = ContractAttributes {
          public_functions: [
@@ -350,7 +354,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
@@ -114,7 +114,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -127,7 +129,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -255,7 +259,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -285,7 +291,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -314,13 +322,17 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "sync",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -1674,11 +1686,13 @@ note:
    ┌─ demos/uniswap.fe:95:9
    │
 95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -1744,11 +1758,13 @@ note:
    ┌─ demos/uniswap.fe:99:9
    │
 99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -2177,11 +2193,13 @@ note:
     ┌─ demos/uniswap.fe:106:9
     │
 106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -3236,7 +3254,7 @@ note:
     ┌─ demos/uniswap.fe:140:27
     │
 140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8306689668146703337
+    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3186366198341923168
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -3301,7 +3319,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -3314,7 +3334,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                   ],
               },
@@ -3913,11 +3935,13 @@ note:
     ┌─ demos/uniswap.fe:152:25
     │
 152 │                         self._mint(fee_to, liquidity)
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -4693,11 +4717,13 @@ note:
     ┌─ demos/uniswap.fe:173:13
     │
 173 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -4989,11 +5015,13 @@ note:
     ┌─ demos/uniswap.fe:179:9
     │
 179 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -5065,11 +5093,13 @@ note:
     ┌─ demos/uniswap.fe:180:9
     │
 180 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -6036,11 +6066,13 @@ note:
     ┌─ demos/uniswap.fe:203:9
     │
 203 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -6524,11 +6556,13 @@ note:
     ┌─ demos/uniswap.fe:209:9
     │
 209 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -8831,11 +8865,13 @@ note:
     ┌─ demos/uniswap.fe:253:9
     │
 253 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -9891,11 +9927,13 @@ note:
     ┌─ demos/uniswap.fe:268:9
     │
 268 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
-          location: Memory,
+          typ: Base(
+              Unit,
+          ),
+          location: Value,
           move_location: None,
       }
 
@@ -11120,7 +11158,7 @@ note:
     ┌─ demos/uniswap.fe:321:31
     │
 321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 749789108576145022
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -11246,7 +11284,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11276,7 +11316,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11305,13 +11347,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11392,7 +11438,7 @@ note:
     ┌─ demos/uniswap.fe:322:9
     │
 322 │         pair.initialize(token0, token1)
-    │         ^^^^ attributes hash: 749789108576145022
+    │         ^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -11518,7 +11564,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11548,7 +11596,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11577,13 +11627,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11692,10 +11746,12 @@ note:
     ┌─ demos/uniswap.fe:322:9
     │
 322 │         pair.initialize(token0, token1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11340536269963356597
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
     │
     = ExpressionAttributes {
-          typ: Unit,
+          typ: Base(
+              Unit,
+          ),
           location: Value,
           move_location: None,
       }
@@ -11797,7 +11853,7 @@ note:
     ┌─ demos/uniswap.fe:324:46
     │
 324 │         self.pairs[token0][token1] = address(pair)
-    │                                              ^^^^ attributes hash: 749789108576145022
+    │                                              ^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -11923,7 +11979,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11953,7 +12011,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -11982,13 +12042,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12176,7 +12240,7 @@ note:
     ┌─ demos/uniswap.fe:325:46
     │
 325 │         self.pairs[token1][token0] = address(pair)
-    │                                              ^^^^ attributes hash: 749789108576145022
+    │                                              ^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -12302,7 +12366,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12332,7 +12398,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12361,13 +12429,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12521,7 +12593,7 @@ note:
     ┌─ demos/uniswap.fe:326:53
     │
 326 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                                     ^^^^ attributes hash: 749789108576145022
+    │                                                     ^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -12647,7 +12719,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12677,7 +12751,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12706,13 +12782,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -12909,7 +12989,7 @@ note:
     ┌─ demos/uniswap.fe:329:55
     │
 329 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                                       ^^^^ attributes hash: 749789108576145022
+    │                                                       ^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -13035,7 +13115,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -13065,7 +13147,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -13094,13 +13178,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -13217,7 +13305,7 @@ note:
     ┌─ demos/uniswap.fe:330:24
     │
 330 │         return address(pair)
-    │                        ^^^^ attributes hash: 749789108576145022
+    │                        ^^^^ attributes hash: 1132705859373981687
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -13343,7 +13431,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -13373,7 +13463,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -13402,13 +13494,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -14111,13 +14207,15 @@ note:
    │  
 63 │ ╭     pub def __init__():
 64 │ │         self.factory = msg.sender
-   │ ╰─────────────────────────────────^ attributes hash: 10134238868280923582
+   │ ╰─────────────────────────────────^ attributes hash: 3035129065019296448
    │  
    = FunctionAttributes {
          is_public: true,
          name: "__init__",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -14175,7 +14273,7 @@ note:
 76 │ │         self.total_supply = self.total_supply + value
 77 │ │         self.balances[to] = self.balances[to] + value
 78 │ │         emit Transfer(from=address(0), to, value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 11812640435561676428
+   │ ╰─────────────────────────────────────────────────^ attributes hash: 15443469740899698302
    │  
    = FunctionAttributes {
          is_public: false,
@@ -14196,7 +14294,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -14206,7 +14306,7 @@ note:
 81 │ │         self.balances[from] = self.balances[from] - value
 82 │ │         self.total_supply = self.total_supply - value
 83 │ │         emit Transfer(from, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 5860083618676178729
+   │ ╰─────────────────────────────────────────────────^ attributes hash: 17962913940352130665
    │  
    = FunctionAttributes {
          is_public: false,
@@ -14227,7 +14327,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -14236,7 +14338,7 @@ note:
 85 │ ╭     def _approve(owner: address, spender: address, value: u256):
 86 │ │         self.allowances[owner][spender] = value
 87 │ │         emit Approval(owner, spender, value)
-   │ ╰────────────────────────────────────────────^ attributes hash: 10525944821091525871
+   │ ╰────────────────────────────────────────────^ attributes hash: 422334171292144355
    │  
    = FunctionAttributes {
          is_public: false,
@@ -14263,7 +14365,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -14273,7 +14377,7 @@ note:
 90 │ │         self.balances[from] = self.balances[from] - value
 91 │ │         self.balances[to] = self.balances[to] + value
 92 │ │         emit Transfer(from, to, value)
-   │ ╰──────────────────────────────────────^ attributes hash: 1168662896011493597
+   │ ╰──────────────────────────────────────^ attributes hash: 13745782628834436029
    │  
    = FunctionAttributes {
          is_public: false,
@@ -14300,7 +14404,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -14475,7 +14581,7 @@ note:
 118 │ │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
 119 │ │         self.token0 = token0
 120 │ │         self.token1 = token1
-    │ ╰────────────────────────────^ attributes hash: 10036853354460040729
+    │ ╰────────────────────────────^ attributes hash: 6029898335230722584
     │  
     = FunctionAttributes {
           is_public: true,
@@ -14494,7 +14600,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14507,7 +14615,7 @@ note:
     · │
 135 │ │         self.block_timestamp_last = block_timestamp
 136 │ │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 16195792106909731120
+    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 7299884525502940162
     │  
     = FunctionAttributes {
           is_public: false,
@@ -14546,7 +14654,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14668,7 +14778,7 @@ note:
     · │
 253 │ │         self._update(balance0, balance1, reserve0, reserve1)
 254 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13058644270313011387
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13894903424287666132
     │  
     = FunctionAttributes {
           is_public: true,
@@ -14697,7 +14807,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14709,7 +14821,7 @@ note:
 260 │ │ 
 261 │ │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
 262 │ │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 4624738249280070544
+    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 5235908045540984219
     │  
     = FunctionAttributes {
           is_public: true,
@@ -14722,7 +14834,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14732,13 +14846,15 @@ note:
 266 │ │         token0: ERC20 = ERC20(self.token0)
 267 │ │         token1: ERC20 = ERC20(self.token1)
 268 │ │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 8760164921434830532
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 5850979630449604761
     │  
     = FunctionAttributes {
           is_public: true,
           name: "sync",
           params: [],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14813,7 +14929,7 @@ note:
     │  
 300 │ ╭     pub def __init__(fee_to_setter: address):
 301 │ │        self.fee_to_setter = fee_to_setter
-    │ ╰─────────────────────────────────────────^ attributes hash: 7172151177252087884
+    │ ╰─────────────────────────────────────────^ attributes hash: 12436435812329240313
     │  
     = FunctionAttributes {
           is_public: true,
@@ -14826,7 +14942,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14919,7 +15037,7 @@ note:
 332 │ ╭     pub def set_fee_to(fee_to: address):
 333 │ │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
 334 │ │         self.fee_to = fee_to
-    │ ╰────────────────────────────^ attributes hash: 12890648541865675606
+    │ ╰────────────────────────────^ attributes hash: 13957803856706170765
     │  
     = FunctionAttributes {
           is_public: true,
@@ -14932,7 +15050,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -14941,7 +15061,7 @@ note:
 336 │ ╭     pub def set_fee_to_setter(fee_to_setter: address):
 337 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
 338 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 9123870829841798734
+    │ ╰──────────────────────────────────────────^ attributes hash: 4180541968382977460
     │  
     = FunctionAttributes {
           is_public: true,
@@ -14954,7 +15074,9 @@ note:
                   ),
               ),
           ],
-          return_type: Unit,
+          return_type: Base(
+              Unit,
+          ),
       }
 
 note: 
@@ -15885,7 +16007,7 @@ note:
     ┌─ demos/uniswap.fe:321:9
     │
 321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1220900674874998731
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 7884733282109801466
     │
     = Contract(
           Contract {
@@ -16010,7 +16132,9 @@ note:
                               ),
                           ),
                       ],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
@@ -16040,7 +16164,9 @@ note:
                               ),
                           ),
                       ],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
@@ -16069,13 +16195,17 @@ note:
                               ),
                           ),
                       ],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
                       name: "sync",
                       params: [],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
@@ -16158,7 +16288,7 @@ note:
 4 │ │ 
 5 │ │     pub def transfer(recipient: address, amount: u256) -> bool:
 6 │ │         return false
-  │ ╰────────────────────^ attributes hash: 8223504823133455958
+  │ ╰────────────────────^ attributes hash: 9114548470230238367
   │  
   = ContractAttributes {
         public_functions: [
@@ -16270,7 +16400,9 @@ note:
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -16283,7 +16415,9 @@ note:
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -16409,7 +16543,9 @@ note:
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -16439,7 +16575,9 @@ note:
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -16468,13 +16606,17 @@ note:
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "sync",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -16560,7 +16702,7 @@ note:
     · │
 282 │ │     def min(x: u256, y: u256) -> u256:
 283 │ │         return x if x < y else y
-    │ ╰────────────────────────────────^ attributes hash: 9232809846161970947
+    │ ╰────────────────────────────────^ attributes hash: 1073470112117261301
     │  
     = ContractAttributes {
           public_functions: [
@@ -16683,7 +16825,9 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
               FunctionAttributes {
                   is_public: true,
@@ -16713,7 +16857,9 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
               FunctionAttributes {
                   is_public: true,
@@ -16742,13 +16888,17 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
               FunctionAttributes {
                   is_public: true,
                   name: "sync",
                   params: [],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
               FunctionAttributes {
                   is_public: true,
@@ -16824,7 +16974,9 @@ note:
                   is_public: true,
                   name: "__init__",
                   params: [],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
           ),
           events: [
@@ -17154,7 +17306,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -17167,7 +17321,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                   ],
               },
@@ -17185,7 +17341,7 @@ note:
     · │
 337 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
 338 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 9161501736308064308
+    │ ╰──────────────────────────────────────────^ attributes hash: 6112704229203799669
     │  
     = ContractAttributes {
           public_functions: [
@@ -17247,7 +17403,9 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
               FunctionAttributes {
                   is_public: true,
@@ -17260,7 +17418,9 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
           ],
           init_function: Some(
@@ -17275,7 +17435,9 @@ note:
                           ),
                       ),
                   ],
-                  return_type: Unit,
+                  return_type: Base(
+                      Unit,
+                  ),
               },
           ),
           events: [
@@ -17492,7 +17654,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -17522,7 +17686,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -17551,13 +17717,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -17701,7 +17871,7 @@ note:
     ┌─ demos/uniswap.fe:140:27
     │
 140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^ attributes hash: 8392063984522607378
+    │                           ^^^^^^^^^^^^^^^^ attributes hash: 8456606813876647095
     │
     = TypeConstructor {
           typ: Contract(
@@ -17766,7 +17936,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -17779,7 +17951,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                   ],
               },
@@ -18724,7 +18898,7 @@ note:
     ┌─ demos/uniswap.fe:321:31
     │
 321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                               ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15173707327387249702
+    │                               ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6272831764403363833
     │
     = TypeAttribute {
           typ: Contract(
@@ -18850,7 +19024,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -18880,7 +19056,9 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -18909,13 +19087,17 @@ note:
                                   ),
                               ),
                           ],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
                           name: "sync",
                           params: [],
-                          return_type: Unit,
+                          return_type: Base(
+                              Unit,
+                          ),
                       },
                       FunctionAttributes {
                           is_public: true,
@@ -21723,7 +21905,7 @@ note:
     ┌─ demos/uniswap.fe:321:15
     │
 321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │               ^^^^^^^^^^^^^ attributes hash: 675782158511795747
+    │               ^^^^^^^^^^^^^ attributes hash: 8065529683655712314
     │
     = Contract(
           Contract {
@@ -21848,7 +22030,9 @@ note:
                               ),
                           ),
                       ],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
@@ -21878,7 +22062,9 @@ note:
                               ),
                           ),
                       ],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
@@ -21907,13 +22093,17 @@ note:
                               ),
                           ),
                       ],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,
                       name: "sync",
                       params: [],
-                      return_type: Unit,
+                      return_type: Base(
+                          Unit,
+                      ),
                   },
                   FunctionAttributes {
                       is_public: true,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
@@ -47,7 +47,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -243,7 +245,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: address, value: bytes[10]):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 478906740929164940
+  │ ╰─────────────────────────────^ attributes hash: 4945796714900412883
   │  
   = FunctionAttributes {
         is_public: true,
@@ -265,7 +267,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -278,7 +282,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: address, value: bytes[10]):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 8410219459608933701
+  │ ╰─────────────────────────────^ attributes hash: 3839650646182900780
   │  
   = ContractAttributes {
         public_functions: [
@@ -320,7 +324,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_005_assert.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_005_assert.snap
@@ -22,7 +22,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -45,7 +47,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -60,7 +64,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -244,7 +250,7 @@ note:
   │  
 2 │ ╭     pub def bar(baz: u256):
 3 │ │         assert baz > 5
-  │ ╰──────────────────────^ attributes hash: 3771050984671870939
+  │ ╰──────────────────────^ attributes hash: 15822262529719405181
   │  
   = FunctionAttributes {
         is_public: true,
@@ -259,7 +265,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -267,7 +275,7 @@ note:
   │  
 5 │ ╭     pub def revert_with_static_string(baz: u256):
 6 │ │         assert baz > 5, "Must be greater than five"
-  │ ╰───────────────────────────────────────────────────^ attributes hash: 949803207543601617
+  │ ╰───────────────────────────────────────────────────^ attributes hash: 17432662740340635293
   │  
   = FunctionAttributes {
         is_public: true,
@@ -282,7 +290,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -290,7 +300,7 @@ note:
   │  
 8 │ ╭     pub def revert_with(baz: u256, reason: String<1000>):
 9 │ │         assert baz > 5, reason
-  │ ╰──────────────────────────────^ attributes hash: 8362848128767449402
+  │ ╰──────────────────────────────^ attributes hash: 15346937376382820850
   │  
   = FunctionAttributes {
         is_public: true,
@@ -313,7 +323,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -326,7 +338,7 @@ note:
   · │
 8 │ │     pub def revert_with(baz: u256, reason: String<1000>):
 9 │ │         assert baz > 5, reason
-  │ ╰──────────────────────────────^ attributes hash: 18279959482144090337
+  │ ╰──────────────────────────────^ attributes hash: 3230845884331180109
   │  
   = ContractAttributes {
         public_functions: [
@@ -343,7 +355,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
             FunctionAttributes {
                 is_public: true,
@@ -366,7 +380,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
             FunctionAttributes {
                 is_public: true,
@@ -381,7 +397,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
@@ -123,11 +123,13 @@ note:
   ┌─ features/call_statement_with_args.fe:8:9
   │
 8 │         self.assign(100)
-  │         ^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+  │         ^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
   │
   = ExpressionAttributes {
-        typ: Unit,
-        location: Memory,
+        typ: Base(
+            Unit,
+        ),
+        location: Value,
         move_location: None,
     }
 
@@ -199,7 +201,7 @@ note:
   │  
 4 │ ╭     def assign(val: u256):
 5 │ │         self.baz[0] = val
-  │ ╰─────────────────────────^ attributes hash: 1203266608866525636
+  │ ╰─────────────────────────^ attributes hash: 430221338671783428
   │  
   = FunctionAttributes {
         is_public: false,
@@ -214,7 +216,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
@@ -107,11 +107,13 @@ note:
   ┌─ features/call_statement_without_args.fe:8:9
   │
 8 │         self.assign()
-  │         ^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+  │         ^^^^^^^^^^^^^ attributes hash: 13510039392732087821
   │
   = ExpressionAttributes {
-        typ: Unit,
-        location: Memory,
+        typ: Base(
+            Unit,
+        ),
+        location: Value,
         move_location: None,
     }
 
@@ -183,13 +185,15 @@ note:
   │  
 4 │ ╭     def assign():
 5 │ │         self.baz[0] = 100
-  │ ╰─────────────────────────^ attributes hash: 9582033157997918467
+  │ ╰─────────────────────────^ attributes hash: 12675432316673020112
   │  
   = FunctionAttributes {
         is_public: false,
         name: "assign",
         params: [],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
@@ -203,7 +203,7 @@ note:
   │  
 4 │ ╭     pub def __init__(baz: u256, bing: u256):
 5 │ │         self.bar[42] = baz + bing
-  │ ╰─────────────────────────────────^ attributes hash: 10600873716255629789
+  │ ╰─────────────────────────────────^ attributes hash: 9809353878122723186
   │  
   = FunctionAttributes {
         is_public: true,
@@ -226,7 +226,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -257,7 +259,7 @@ note:
   · │
 7 │ │     pub def read_bar() -> u256:
 8 │ │         return self.bar[42]
-  │ ╰───────────────────────────^ attributes hash: 176296086338423957
+  │ ╰───────────────────────────^ attributes hash: 12040919694487486401
   │  
   = ContractAttributes {
         public_functions: [
@@ -294,7 +296,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ),
         events: [],

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_015_create_contract_from_init.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_015_create_contract_from_init.snap
@@ -176,13 +176,15 @@ note:
   │  
 8 │ ╭     pub def __init__():
 9 │ │         self.foo_addr = address(Foo.create(0))
-  │ ╰──────────────────────────────────────────────^ attributes hash: 10134238868280923582
+  │ ╰──────────────────────────────────────────────^ attributes hash: 3035129065019296448
   │  
   = FunctionAttributes {
         is_public: true,
         name: "__init__",
         params: [],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -255,7 +257,7 @@ note:
    · │
 11 │ │     pub def get_foo_addr() -> address:
 12 │ │         return self.foo_addr
-   │ ╰────────────────────────────^ attributes hash: 2130015407891692482
+   │ ╰────────────────────────────^ attributes hash: 17693993461359681760
    │  
    = ContractAttributes {
          public_functions: [
@@ -273,7 +275,9 @@ note:
                  is_public: true,
                  name: "__init__",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ),
          events: [],

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_017_events.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_017_events.snap
@@ -26,7 +26,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -39,7 +41,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -61,13 +65,17 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "emit_nums",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -475,13 +483,15 @@ note:
    │  
 19 │ ╭     pub def emit_nums():
 20 │ │         emit Nums(num1=26, num2=42)
-   │ ╰───────────────────────────────────^ attributes hash: 5142136245848237202
+   │ ╰───────────────────────────────────^ attributes hash: 18215520939189548337
    │  
    = FunctionAttributes {
          is_public: true,
          name: "emit_nums",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -489,7 +499,7 @@ note:
    │  
 22 │ ╭     pub def emit_bases(addr: address):
 23 │ │         emit Bases(num=26, addr)
-   │ ╰────────────────────────────────^ attributes hash: 4675655585256261045
+   │ ╰────────────────────────────────^ attributes hash: 17638379303524345796
    │  
    = FunctionAttributes {
          is_public: true,
@@ -502,7 +512,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -510,7 +522,7 @@ note:
    │  
 25 │ ╭     pub def emit_mix(addr: address, my_bytes: bytes[100]):
 26 │ │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │ ╰──────────────────────────────────────────────────^ attributes hash: 3521292099077188868
+   │ ╰──────────────────────────────────────────────────^ attributes hash: 14039713244791060395
    │  
    = FunctionAttributes {
          is_public: true,
@@ -532,7 +544,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -543,7 +557,7 @@ note:
 30 │ │         addrs[0] = addr1
 31 │ │         addrs[1] = addr2
 32 │ │         emit Addresses(addrs)
-   │ ╰─────────────────────────────^ attributes hash: 3139577003742282823
+   │ ╰─────────────────────────────^ attributes hash: 13037764687780655657
    │  
    = FunctionAttributes {
          is_public: true,
@@ -562,7 +576,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -588,7 +604,7 @@ note:
    · │
 31 │ │         addrs[1] = addr2
 32 │ │         emit Addresses(addrs)
-   │ ╰─────────────────────────────^ attributes hash: 17863159823823136104
+   │ ╰─────────────────────────────^ attributes hash: 8487763690206504167
    │  
    = ContractAttributes {
          public_functions: [
@@ -609,7 +625,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -622,7 +640,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -644,13 +664,17 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "emit_nums",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_018_external_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_018_external_contract.snap
@@ -69,7 +69,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -150,7 +152,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -478,7 +482,7 @@ note:
    ┌─ features/external_contract.fe:24:20
    │
 24 │         foo: Foo = Foo(foo_address)
-   │                    ^^^^^^^^^^^^^^^^ attributes hash: 18356014201510878751
+   │                    ^^^^^^^^^^^^^^^^ attributes hash: 16886301623501386624
    │
    = ExpressionAttributes {
          typ: Contract(
@@ -545,7 +549,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -558,7 +564,7 @@ note:
    ┌─ features/external_contract.fe:25:9
    │
 25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^ attributes hash: 18356014201510878751
+   │         ^^^ attributes hash: 16886301623501386624
    │
    = ExpressionAttributes {
          typ: Contract(
@@ -625,7 +631,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -687,10 +695,12 @@ note:
    ┌─ features/external_contract.fe:25:9
    │
 25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11340536269963356597
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
+         typ: Base(
+             Unit,
+         ),
          location: Value,
          move_location: None,
      }
@@ -713,7 +723,7 @@ note:
    ┌─ features/external_contract.fe:32:20
    │
 32 │         foo: Foo = Foo(foo_address)
-   │                    ^^^^^^^^^^^^^^^^ attributes hash: 18356014201510878751
+   │                    ^^^^^^^^^^^^^^^^ attributes hash: 16886301623501386624
    │
    = ExpressionAttributes {
          typ: Contract(
@@ -780,7 +790,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -793,7 +805,7 @@ note:
    ┌─ features/external_contract.fe:33:16
    │
 33 │         return foo.build_array(a, b)
-   │                ^^^ attributes hash: 18356014201510878751
+   │                ^^^ attributes hash: 16886301623501386624
    │
    = ExpressionAttributes {
          typ: Contract(
@@ -860,7 +872,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -964,7 +978,7 @@ note:
   │  
 7 │ ╭     pub def emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
 8 │ │         emit MyEvent(my_num, my_addrs, my_string)
-  │ ╰─────────────────────────────────────────────────^ attributes hash: 5933194758192470687
+  │ ╰─────────────────────────────────────────────────^ attributes hash: 5642126450243024971
   │  
   = FunctionAttributes {
         is_public: true,
@@ -996,7 +1010,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -1051,7 +1067,7 @@ note:
    · │
 24 │ │         foo: Foo = Foo(foo_address)
 25 │ │         foo.emit_event(my_num, my_addrs, my_string)
-   │ ╰───────────────────────────────────────────────────^ attributes hash: 16534951539656982547
+   │ ╰───────────────────────────────────────────────────^ attributes hash: 10419898371504184233
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1089,7 +1105,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1160,7 +1178,7 @@ note:
    ┌─ features/external_contract.fe:24:9
    │
 24 │         foo: Foo = Foo(foo_address)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8627347501674821884
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5062774276835571497
    │
    = Contract(
          Contract {
@@ -1226,7 +1244,9 @@ note:
                              ),
                          ),
                      ],
-                     return_type: Unit,
+                     return_type: Base(
+                         Unit,
+                     ),
                  },
              ],
          },
@@ -1236,7 +1256,7 @@ note:
    ┌─ features/external_contract.fe:32:9
    │
 32 │         foo: Foo = Foo(foo_address)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8627347501674821884
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5062774276835571497
    │
    = Contract(
          Contract {
@@ -1302,7 +1322,9 @@ note:
                              ),
                          ),
                      ],
-                     return_type: Unit,
+                     return_type: Base(
+                         Unit,
+                     ),
                  },
              ],
          },
@@ -1318,7 +1340,7 @@ note:
    · │
 14 │ │         my_array[2] = b
 15 │ │         return my_array
-   │ ╰───────────────────────^ attributes hash: 11261423298995789029
+   │ ╰───────────────────────^ attributes hash: 5506265018671571882
    │  
    = ContractAttributes {
          public_functions: [
@@ -1382,7 +1404,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,
@@ -1499,7 +1523,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -1517,7 +1543,7 @@ note:
    · │
 32 │ │         foo: Foo = Foo(foo_address)
 33 │ │         return foo.build_array(a, b)
-   │ ╰────────────────────────────────────^ attributes hash: 14627458604945366717
+   │ ╰────────────────────────────────────^ attributes hash: 16068234830659304327
    │  
    = ContractAttributes {
          public_functions: [
@@ -1593,7 +1619,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,
@@ -1665,7 +1693,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -1677,7 +1707,7 @@ note:
    ┌─ features/external_contract.fe:24:20
    │
 24 │         foo: Foo = Foo(foo_address)
-   │                    ^^^ attributes hash: 1990501847882761040
+   │                    ^^^ attributes hash: 16020630380854771161
    │
    = TypeConstructor {
          typ: Contract(
@@ -1744,7 +1774,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -1763,7 +1795,7 @@ note:
    ┌─ features/external_contract.fe:32:20
    │
 32 │         foo: Foo = Foo(foo_address)
-   │                    ^^^ attributes hash: 1990501847882761040
+   │                    ^^^ attributes hash: 16020630380854771161
    │
    = TypeConstructor {
          typ: Contract(
@@ -1830,7 +1862,9 @@ note:
                                  ),
                              ),
                          ],
-                         return_type: Unit,
+                         return_type: Base(
+                             Unit,
+                         ),
                      },
                  ],
              },
@@ -2181,7 +2215,7 @@ note:
    ┌─ features/external_contract.fe:24:14
    │
 24 │         foo: Foo = Foo(foo_address)
-   │              ^^^ attributes hash: 4899098567064031318
+   │              ^^^ attributes hash: 13177979788212096402
    │
    = Contract(
          Contract {
@@ -2247,7 +2281,9 @@ note:
                              ),
                          ),
                      ],
-                     return_type: Unit,
+                     return_type: Base(
+                         Unit,
+                     ),
                  },
              ],
          },
@@ -2257,7 +2293,7 @@ note:
    ┌─ features/external_contract.fe:32:14
    │
 32 │         foo: Foo = Foo(foo_address)
-   │              ^^^ attributes hash: 4899098567064031318
+   │              ^^^ attributes hash: 13177979788212096402
    │
    = Contract(
          Contract {
@@ -2323,7 +2359,9 @@ note:
                              ),
                          ),
                      ],
-                     return_type: Unit,
+                     return_type: Base(
+                         Unit,
+                     ),
                  },
              ],
          },

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
@@ -80,7 +80,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -107,7 +109,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -582,7 +586,7 @@ note:
   │  
 8 │ ╭     pub def write_bar(a: address, b: address, value: u256):
 9 │ │         self.bar[a][b] = value
-  │ ╰──────────────────────────────^ attributes hash: 3782835354110485341
+  │ ╰──────────────────────────────^ attributes hash: 13446813489566530654
   │  
   = FunctionAttributes {
         is_public: true,
@@ -609,7 +613,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -648,7 +654,7 @@ note:
    │  
 14 │ ╭     pub def write_baz(a: address, b: u256, value: bool):
 15 │ │         self.baz[a][b] = value
-   │ ╰──────────────────────────────^ attributes hash: 4071428523554519660
+   │ ╰──────────────────────────────^ attributes hash: 5578425926724194078
    │  
    = FunctionAttributes {
          is_public: true,
@@ -675,7 +681,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -688,7 +696,7 @@ note:
    · │
 14 │ │     pub def write_baz(a: address, b: u256, value: bool):
 15 │ │         self.baz[a][b] = value
-   │ ╰──────────────────────────────^ attributes hash: 8827419361338718420
+   │ ╰──────────────────────────────^ attributes hash: 13752101938961302585
    │  
    = ContractAttributes {
          public_functions: [
@@ -763,7 +771,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -790,7 +800,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_029_numeric_sizes.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_029_numeric_sizes.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/src/analysis.rs
+source: analyzer/tests/analysis.rs
 expression: "build_snapshot(fixture, &src, &context)"
 
 ---
@@ -260,12 +260,12 @@ note:
   ┌─ features/numeric_sizes.fe:4:19
   │
 4 │         return u8(0)
-  │                   ^ attributes hash: 16797824492585953824
+  │                   ^ attributes hash: 6817314866882205962
   │
   = ExpressionAttributes {
         typ: Base(
             Numeric(
-                U256,
+                U8,
             ),
         ),
         location: Value,
@@ -292,12 +292,12 @@ note:
   ┌─ features/numeric_sizes.fe:7:20
   │
 7 │         return u16(0)
-  │                    ^ attributes hash: 16797824492585953824
+  │                    ^ attributes hash: 17931047209024117248
   │
   = ExpressionAttributes {
         typ: Base(
             Numeric(
-                U256,
+                U16,
             ),
         ),
         location: Value,
@@ -324,12 +324,12 @@ note:
    ┌─ features/numeric_sizes.fe:10:20
    │
 10 │         return u32(0)
-   │                    ^ attributes hash: 16797824492585953824
+   │                    ^ attributes hash: 5442387896079309831
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U32,
              ),
          ),
          location: Value,
@@ -356,12 +356,12 @@ note:
    ┌─ features/numeric_sizes.fe:13:20
    │
 13 │         return u64(0)
-   │                    ^ attributes hash: 16797824492585953824
+   │                    ^ attributes hash: 3044889006329355385
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U64,
              ),
          ),
          location: Value,
@@ -388,12 +388,12 @@ note:
    ┌─ features/numeric_sizes.fe:16:21
    │
 16 │         return u128(0)
-   │                     ^ attributes hash: 16797824492585953824
+   │                     ^ attributes hash: 9341420026351674595
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U128,
              ),
          ),
          location: Value,
@@ -468,12 +468,12 @@ note:
    ┌─ features/numeric_sizes.fe:22:19
    │
 22 │         return i8(-128)
-   │                   ^^^^ attributes hash: 17351186385905986417
+   │                   ^^^^ attributes hash: 9715536092457030614
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 I256,
+                 I8,
              ),
          ),
          location: Value,
@@ -516,12 +516,12 @@ note:
    ┌─ features/numeric_sizes.fe:25:20
    │
 25 │         return i16(-32768)
-   │                    ^^^^^^ attributes hash: 17351186385905986417
+   │                    ^^^^^^ attributes hash: 13584665093848691268
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 I256,
+                 I16,
              ),
          ),
          location: Value,
@@ -564,12 +564,12 @@ note:
    ┌─ features/numeric_sizes.fe:28:20
    │
 28 │         return i32(-2147483648)
-   │                    ^^^^^^^^^^^ attributes hash: 17351186385905986417
+   │                    ^^^^^^^^^^^ attributes hash: 13972995067286817043
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 I256,
+                 I32,
              ),
          ),
          location: Value,
@@ -612,12 +612,12 @@ note:
    ┌─ features/numeric_sizes.fe:31:20
    │
 31 │         return i64(-9223372036854775808)
-   │                    ^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
+   │                    ^^^^^^^^^^^^^^^^^^^^ attributes hash: 16198180549924123587
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 I256,
+                 I64,
              ),
          ),
          location: Value,
@@ -660,12 +660,12 @@ note:
    ┌─ features/numeric_sizes.fe:34:21
    │
 34 │         return i128(-170141183460469231731687303715884105728)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5494075259962106032
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 I256,
+                 I128,
              ),
          ),
          location: Value,
@@ -740,12 +740,12 @@ note:
    ┌─ features/numeric_sizes.fe:40:19
    │
 40 │         return u8(255)
-   │                   ^^^ attributes hash: 16797824492585953824
+   │                   ^^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -772,12 +772,12 @@ note:
    ┌─ features/numeric_sizes.fe:43:20
    │
 43 │         return u16(65535)
-   │                    ^^^^^ attributes hash: 16797824492585953824
+   │                    ^^^^^ attributes hash: 17931047209024117248
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U16,
              ),
          ),
          location: Value,
@@ -804,12 +804,12 @@ note:
    ┌─ features/numeric_sizes.fe:46:20
    │
 46 │         return u32(4294967295)
-   │                    ^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                    ^^^^^^^^^^ attributes hash: 5442387896079309831
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U32,
              ),
          ),
          location: Value,
@@ -836,12 +836,12 @@ note:
    ┌─ features/numeric_sizes.fe:49:20
    │
 49 │         return u64(18446744073709551615)
-   │                    ^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                    ^^^^^^^^^^^^^^^^^^^^ attributes hash: 3044889006329355385
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U64,
              ),
          ),
          location: Value,
@@ -868,12 +868,12 @@ note:
    ┌─ features/numeric_sizes.fe:52:21
    │
 52 │         return u128(340282366920938463463374607431768211455)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9341420026351674595
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U128,
              ),
          ),
          location: Value,
@@ -932,12 +932,12 @@ note:
    ┌─ features/numeric_sizes.fe:58:19
    │
 58 │         return i8(127)
-   │                   ^^^ attributes hash: 16797824492585953824
+   │                   ^^^ attributes hash: 9715536092457030614
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I8,
              ),
          ),
          location: Value,
@@ -964,12 +964,12 @@ note:
    ┌─ features/numeric_sizes.fe:61:20
    │
 61 │         return i16(32767)
-   │                    ^^^^^ attributes hash: 16797824492585953824
+   │                    ^^^^^ attributes hash: 13584665093848691268
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I16,
              ),
          ),
          location: Value,
@@ -996,12 +996,12 @@ note:
    ┌─ features/numeric_sizes.fe:64:20
    │
 64 │         return i32(2147483647)
-   │                    ^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                    ^^^^^^^^^^ attributes hash: 13972995067286817043
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I32,
              ),
          ),
          location: Value,
@@ -1028,12 +1028,12 @@ note:
    ┌─ features/numeric_sizes.fe:67:20
    │
 67 │         return i64(9223372036854775807)
-   │                    ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                    ^^^^^^^^^^^^^^^^^^^ attributes hash: 16198180549924123587
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I64,
              ),
          ),
          location: Value,
@@ -1060,12 +1060,12 @@ note:
    ┌─ features/numeric_sizes.fe:70:21
    │
 70 │         return i128(170141183460469231731687303715884105727)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5494075259962106032
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I128,
              ),
          ),
          location: Value,
@@ -1092,12 +1092,12 @@ note:
    ┌─ features/numeric_sizes.fe:73:21
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17351186385905986417
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I256,
              ),
          ),
          location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
@@ -21,7 +21,9 @@ ModuleAttributes {
                         is_public: true,
                         name: "renounceOwnership",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -34,7 +36,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -464,13 +468,15 @@ note:
   │  
 8 │ ╭   def __init__():
 9 │ │     self._owner = msg.sender
-  │ ╰────────────────────────────^ attributes hash: 16393739633064297277
+  │ ╰────────────────────────────^ attributes hash: 14570492547403311025
   │  
   = FunctionAttributes {
         is_public: false,
         name: "__init__",
         params: [],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -496,13 +502,15 @@ note:
 15 │ │     assert msg.sender == self._owner
 16 │ │     self._owner = address(0)
 17 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 12628352736240175616
+   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 10317366400091768963
    │  
    = FunctionAttributes {
          is_public: true,
          name: "renounceOwnership",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -513,7 +521,7 @@ note:
 21 │ │     assert newOwner != address(0)
 22 │ │     self._owner = newOwner
 23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 11843099122202862420
+   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 6796830737236095585
    │  
    = FunctionAttributes {
          is_public: true,
@@ -526,7 +534,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -539,7 +549,7 @@ note:
    · │
 22 │ │     self._owner = newOwner
 23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 10980029673205009560
+   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 17730541326400548227
    │  
    = ContractAttributes {
          public_functions: [
@@ -555,7 +565,9 @@ note:
                  is_public: true,
                  name: "renounceOwnership",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -568,7 +580,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_050_return_empty_tuple.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_050_return_empty_tuple.snap
@@ -13,37 +13,49 @@ ModuleAttributes {
                         is_public: true,
                         name: "explicit_return_a1",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "explicit_return_a2",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "explicit_return_b1",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "explicit_return_b2",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "implicit_a1",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "implicit_a2",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -56,10 +68,12 @@ note:
   ┌─ features/return_unit.fe:7:12
   │
 7 │     return ()
-  │            ^^ attributes hash: 11340536269963356597
+  │            ^^ attributes hash: 13510039392732087821
   │
   = ExpressionAttributes {
-        typ: Unit,
+        typ: Base(
+            Unit,
+        ),
         location: Value,
         move_location: None,
     }
@@ -68,10 +82,12 @@ note:
    ┌─ features/return_unit.fe:13:12
    │
 13 │     return ()
-   │            ^^ attributes hash: 11340536269963356597
+   │            ^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
+         typ: Base(
+             Unit,
+         ),
          location: Value,
          move_location: None,
      }
@@ -81,13 +97,15 @@ note:
   │  
 3 │ ╭   pub def explicit_return_a1():
 4 │ │     return
-  │ ╰──────────^ attributes hash: 18083434021587872568
+  │ ╰──────────^ attributes hash: 1876963790513669126
   │  
   = FunctionAttributes {
         is_public: true,
         name: "explicit_return_a1",
         params: [],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -95,13 +113,15 @@ note:
   │  
 6 │ ╭   pub def explicit_return_a2():
 7 │ │     return ()
-  │ ╰─────────────^ attributes hash: 10617058239827021938
+  │ ╰─────────────^ attributes hash: 3364218285822111877
   │  
   = FunctionAttributes {
         is_public: true,
         name: "explicit_return_a2",
         params: [],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -109,13 +129,15 @@ note:
    │  
  9 │ ╭   pub def explicit_return_b1() -> ():
 10 │ │     return
-   │ ╰──────────^ attributes hash: 10657930867196598530
+   │ ╰──────────^ attributes hash: 3119760715755557810
    │  
    = FunctionAttributes {
          is_public: true,
          name: "explicit_return_b1",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -123,13 +145,15 @@ note:
    │  
 12 │ ╭   pub def explicit_return_b2() -> ():
 13 │ │     return ()
-   │ ╰─────────────^ attributes hash: 6198315681164674556
+   │ ╰─────────────^ attributes hash: 3632662372498159713
    │  
    = FunctionAttributes {
          is_public: true,
          name: "explicit_return_b2",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -137,13 +161,15 @@ note:
    │  
 15 │ ╭   pub def implicit_a1():
 16 │ │     pass
-   │ ╰────────^ attributes hash: 9693705213771787825
+   │ ╰────────^ attributes hash: 17402243144066639029
    │  
    = FunctionAttributes {
          is_public: true,
          name: "implicit_a1",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -151,13 +177,15 @@ note:
    │  
 18 │ ╭   pub def implicit_a2() -> ():
 19 │ │     pass
-   │ ╰────────^ attributes hash: 9930524211417055242
+   │ ╰────────^ attributes hash: 13481222315964146038
    │  
    = FunctionAttributes {
          is_public: true,
          name: "implicit_a2",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -170,7 +198,7 @@ note:
    · │
 18 │ │   pub def implicit_a2() -> ():
 19 │ │     pass
-   │ ╰────────^ attributes hash: 18253823632002334586
+   │ ╰────────^ attributes hash: 12660317516329267343
    │  
    = ContractAttributes {
          public_functions: [
@@ -178,37 +206,49 @@ note:
                  is_public: true,
                  name: "explicit_return_a1",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "explicit_return_a2",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "explicit_return_b1",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "explicit_return_b2",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "implicit_a1",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "implicit_a2",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,
@@ -224,24 +264,30 @@ note:
   ┌─ features/return_unit.fe:9:35
   │
 9 │   pub def explicit_return_b1() -> ():
-  │                                   ^^ attributes hash: 7364705619221056123
+  │                                   ^^ attributes hash: 7530568563565570143
   │
-  = Unit
+  = Base(
+        Unit,
+    )
 
 note: 
    ┌─ features/return_unit.fe:12:35
    │
 12 │   pub def explicit_return_b2() -> ():
-   │                                   ^^ attributes hash: 7364705619221056123
+   │                                   ^^ attributes hash: 7530568563565570143
    │
-   = Unit
+   = Base(
+         Unit,
+     )
 
 note: 
    ┌─ features/return_unit.fe:18:28
    │
 18 │   pub def implicit_a2() -> ():
-   │                            ^^ attributes hash: 7364705619221056123
+   │                            ^^ attributes hash: 7530568563565570143
    │
-   = Unit
+   = Base(
+         Unit,
+     )
 
 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_056_return_i128_cast.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_056_return_i128_cast.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/src/analysis.rs
+source: analyzer/tests/analysis.rs
 expression: "build_snapshot(fixture, &src, &context)"
 
 ---
@@ -46,12 +46,12 @@ note:
   ┌─ features/return_i128_cast.fe:3:21
   │
 3 │         return i128(-3)
-  │                     ^^ attributes hash: 17351186385905986417
+  │                     ^^ attributes hash: 5494075259962106032
   │
   = ExpressionAttributes {
         typ: Base(
             Numeric(
-                I256,
+                I128,
             ),
         ),
         location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_079_return_u128_cast.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_079_return_u128_cast.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/src/analysis.rs
+source: analyzer/tests/analysis.rs
 expression: "build_snapshot(fixture, &src, &context)"
 
 ---
@@ -30,12 +30,12 @@ note:
   ┌─ features/return_u128_cast.fe:3:21
   │
 3 │         return u128(42)
-  │                     ^^ attributes hash: 16797824492585953824
+  │                     ^^ attributes hash: 9341420026351674595
   │
   = ExpressionAttributes {
         typ: Base(
             Numeric(
-                U256,
+                U128,
             ),
         ),
         location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_085_sized_vals_in_sto.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_085_sized_vals_in_sto.snap
@@ -13,7 +13,9 @@ ModuleAttributes {
                         is_public: true,
                         name: "emit_event",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -61,7 +63,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -79,7 +83,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -94,7 +100,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -491,7 +499,7 @@ note:
    │  
 11 │ ╭     pub def write_num(x: u256):
 12 │ │         self.num = x
-   │ ╰────────────────────^ attributes hash: 4723311554161287362
+   │ ╰────────────────────^ attributes hash: 3870046753883905095
    │  
    = FunctionAttributes {
          is_public: true,
@@ -506,7 +514,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -532,7 +542,7 @@ note:
    │  
 17 │ ╭     pub def write_nums(x: u256[42]):
 18 │ │         self.nums = x
-   │ ╰─────────────────────^ attributes hash: 13274737919563050399
+   │ ╰─────────────────────^ attributes hash: 3486766203781743725
    │  
    = FunctionAttributes {
          is_public: true,
@@ -550,7 +560,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -579,7 +591,7 @@ note:
    │  
 23 │ ╭     pub def write_str(x: String<26>):
 24 │ │         self.str = x
-   │ ╰────────────────────^ attributes hash: 8954082301525757861
+   │ ╰────────────────────^ attributes hash: 3276279393402660932
    │  
    = FunctionAttributes {
          is_public: true,
@@ -594,7 +606,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -624,13 +638,15 @@ note:
 32 │ │             nums=self.nums.to_mem(),
 33 │ │             str=self.str.to_mem()
 34 │ │         )
-   │ ╰─────────^ attributes hash: 3495533453674637575
+   │ ╰─────────^ attributes hash: 4747163906894849288
    │  
    = FunctionAttributes {
          is_public: true,
          name: "emit_event",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -643,7 +659,7 @@ note:
    · │
 33 │ │             str=self.str.to_mem()
 34 │ │         )
-   │ ╰─────────^ attributes hash: 6287727376829083665
+   │ ╰─────────^ attributes hash: 17206214854182202311
    │  
    = ContractAttributes {
          public_functions: [
@@ -651,7 +667,9 @@ note:
                  is_public: true,
                  name: "emit_event",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -699,7 +717,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -717,7 +737,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -732,7 +754,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_086_strings.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_086_strings.snap
@@ -326,7 +326,7 @@ note:
    │  
 11 │ ╭     pub def __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
 12 │ │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │ ╰─────────────────────────────────────────────────────────────────────────────────^ attributes hash: 7357528411609044749
+   │ ╰─────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13981111020481275043
    │  
    = FunctionAttributes {
          is_public: true,
@@ -371,7 +371,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -455,7 +457,7 @@ note:
    · │
 20 │ │     pub def return_casted_static_string() -> String<100>:
 21 │ │         return String<100>("foo")
-   │ ╰─────────────────────────────────^ attributes hash: 1334776889890751898
+   │ ╰─────────────────────────────────^ attributes hash: 16268845723743637357
    │  
    = ContractAttributes {
          public_functions: [
@@ -551,7 +553,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ),
          events: [

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
@@ -180,12 +180,12 @@ note:
    ┌─ features/structs.fe:14:22
    │
 14 │             rooms=u8(5),
-   │                      ^ attributes hash: 16797824492585953824
+   │                      ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -562,12 +562,12 @@ note:
    ┌─ features/structs.fe:19:42
    │
 19 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
+   │                                          ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -1078,12 +1078,12 @@ note:
    ┌─ features/structs.fe:25:42
    │
 25 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
+   │                                          ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -1594,12 +1594,12 @@ note:
    ┌─ features/structs.fe:31:42
    │
 31 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
+   │                                          ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -2106,12 +2106,12 @@ note:
    ┌─ features/structs.fe:36:42
    │
 36 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ attributes hash: 16797824492585953824
+   │                                          ^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -2294,12 +2294,12 @@ note:
    ┌─ features/structs.fe:38:34
    │
 38 │         self.my_house.rooms = u8(100)
-   │                                  ^^^ attributes hash: 16797824492585953824
+   │                                  ^^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -2608,12 +2608,12 @@ note:
    ┌─ features/structs.fe:41:42
    │
 41 │         assert self.my_house.rooms == u8(100)
-   │                                          ^^^ attributes hash: 16797824492585953824
+   │                                          ^^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -2756,12 +2756,12 @@ note:
    ┌─ features/structs.fe:48:22
    │
 48 │             rooms=u8(20),
-   │                      ^^ attributes hash: 16797824492585953824
+   │                      ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -3114,12 +3114,12 @@ note:
    ┌─ features/structs.fe:53:37
    │
 53 │         assert building.rooms == u8(20)
-   │                                     ^^ attributes hash: 16797824492585953824
+   │                                     ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -3522,12 +3522,12 @@ note:
    ┌─ features/structs.fe:59:29
    │
 59 │         building.rooms = u8(10)
-   │                             ^^ attributes hash: 16797824492585953824
+   │                             ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -3904,12 +3904,12 @@ note:
    ┌─ features/structs.fe:64:37
    │
 64 │         assert building.rooms == u8(10)
-   │                                     ^^ attributes hash: 16797824492585953824
+   │                                     ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -4048,12 +4048,12 @@ note:
    ┌─ features/structs.fe:71:22
    │
 71 │             rooms=u8(20),
-   │                      ^^ attributes hash: 16797824492585953824
+   │                      ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -4245,12 +4245,12 @@ note:
    ┌─ features/structs.fe:80:22
    │
 80 │             rooms=u8(20),
-   │                      ^^ attributes hash: 16797824492585953824
+   │                      ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
@@ -23,7 +23,9 @@ ModuleAttributes {
                         is_public: true,
                         name: "create_house",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -4430,13 +4432,15 @@ note:
    · │
 41 │ │         assert self.my_house.rooms == u8(100)
 42 │ │         assert self.my_house.vacant
-   │ ╰───────────────────────────────────^ attributes hash: 10817782358155661560
+   │ ╰───────────────────────────────────^ attributes hash: 12009841491257710086
    │  
    = FunctionAttributes {
          is_public: true,
          name: "create_house",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -4666,7 +4670,7 @@ note:
    · │
 82 │ │         )
 83 │ │         return keccak256(house.abi_encode())
-   │ ╰────────────────────────────────────────────^ attributes hash: 16703259830057426497
+   │ ╰────────────────────────────────────────────^ attributes hash: 3311199043119639431
    │  
    = ContractAttributes {
          public_functions: [
@@ -4684,7 +4688,9 @@ note:
                  is_public: true,
                  name: "create_house",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
@@ -49,7 +49,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -230,7 +232,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: u8, value: u8):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 2897055233776219835
+  │ ╰─────────────────────────────^ attributes hash: 8968390687644046085
   │  
   = FunctionAttributes {
         is_public: true,
@@ -253,7 +255,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -266,7 +270,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: u8, value: u8):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 9291818006446299071
+  │ ╰─────────────────────────────^ attributes hash: 10097728334127541592
   │  
   = ContractAttributes {
         public_functions: [
@@ -310,7 +314,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
@@ -49,7 +49,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -230,7 +232,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: u16, value: u16):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 11471608954978446699
+  │ ╰─────────────────────────────^ attributes hash: 11954065445549393040
   │  
   = FunctionAttributes {
         is_public: true,
@@ -253,7 +255,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -266,7 +270,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: u16, value: u16):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 17232832702720329584
+  │ ╰─────────────────────────────^ attributes hash: 2552723160601654412
   │  
   = ContractAttributes {
         public_functions: [
@@ -310,7 +314,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
@@ -49,7 +49,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -230,7 +232,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: u32, value: u32):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 13757565469597965916
+  │ ╰─────────────────────────────^ attributes hash: 2681720897893750627
   │  
   = FunctionAttributes {
         is_public: true,
@@ -253,7 +255,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -266,7 +270,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: u32, value: u32):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 10116138761331356536
+  │ ╰─────────────────────────────^ attributes hash: 5371633778108152681
   │  
   = ContractAttributes {
         public_functions: [
@@ -310,7 +314,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
@@ -49,7 +49,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -230,7 +232,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: u64, value: u64):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 1491333339964032061
+  │ ╰─────────────────────────────^ attributes hash: 2428008968283997795
   │  
   = FunctionAttributes {
         is_public: true,
@@ -253,7 +255,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -266,7 +270,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: u64, value: u64):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 13735277871154422535
+  │ ╰─────────────────────────────^ attributes hash: 12650034009405537088
   │  
   = ContractAttributes {
         public_functions: [
@@ -310,7 +314,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
@@ -49,7 +49,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -230,7 +232,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: u128, value: u128):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 7164863281079071239
+  │ ╰─────────────────────────────^ attributes hash: 17995441105429940633
   │  
   = FunctionAttributes {
         is_public: true,
@@ -253,7 +255,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -266,7 +270,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: u128, value: u128):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 4883751938912357307
+  │ ╰─────────────────────────────^ attributes hash: 3779653620560175745
   │  
   = ContractAttributes {
         public_functions: [
@@ -310,7 +314,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
@@ -49,7 +49,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -230,7 +232,7 @@ note:
   │  
 7 │ ╭     pub def write_bar(key: u256, value: u256):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 4145513212852308044
+  │ ╰─────────────────────────────^ attributes hash: 13939982015492517231
   │  
   = FunctionAttributes {
         is_public: true,
@@ -253,7 +255,9 @@ note:
                 ),
             ),
         ],
-        return_type: Unit,
+        return_type: Base(
+            Unit,
+        ),
     }
 
 note: 
@@ -266,7 +270,7 @@ note:
   · │
 7 │ │     pub def write_bar(key: u256, value: u256):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 3030546017647404527
+  │ ╰─────────────────────────────^ attributes hash: 10982861848565893921
   │  
   = ContractAttributes {
         public_functions: [
@@ -310,7 +314,9 @@ note:
                         ),
                     ),
                 ],
-                return_type: Unit,
+                return_type: Base(
+                    Unit,
+                ),
             },
         ],
         init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
@@ -808,12 +808,12 @@ note:
    ┌─ stress/abi_encoding_stress.fe:62:24
    │
 62 │             my_num2=u8(26),
-   │                        ^^ attributes hash: 16797824492585953824
+   │                        ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,
@@ -1076,12 +1076,12 @@ note:
    ┌─ stress/abi_encoding_stress.fe:69:32
    │
 69 │         my_struct.my_num2 = u8(42)
-   │                                ^^ attributes hash: 16797824492585953824
+   │                                ^^ attributes hash: 6817314866882205962
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 U8,
              ),
          ),
          location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
@@ -13,7 +13,9 @@ ModuleAttributes {
                         is_public: true,
                         name: "emit_my_event",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -211,7 +213,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -224,7 +228,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -240,7 +246,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -255,7 +263,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -270,7 +280,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -288,7 +300,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -1596,7 +1610,7 @@ note:
    │  
 23 │ ╭     pub def set_my_addrs(my_addrs: address[5]):
 24 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 12708309224674535663
+   │ ╰────────────────────────────────^ attributes hash: 14701522943662665464
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1612,7 +1626,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1639,7 +1655,7 @@ note:
    │  
 29 │ ╭     pub def set_my_u128(my_u128: u128):
 30 │ │         self.my_u128 = my_u128
-   │ ╰──────────────────────────────^ attributes hash: 17530708413772808696
+   │ ╰──────────────────────────────^ attributes hash: 10635070491814674598
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1654,7 +1670,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1680,7 +1698,7 @@ note:
    │  
 35 │ ╭     pub def set_my_string(my_string: String<10>):
 36 │ │         self.my_string = my_string
-   │ ╰──────────────────────────────────^ attributes hash: 3033660936924075855
+   │ ╰──────────────────────────────────^ attributes hash: 15141386370952016427
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1695,7 +1713,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1721,7 +1741,7 @@ note:
    │  
 41 │ ╭     pub def set_my_u8s(my_u8s: u8[255]):
 42 │ │         self.my_u8s = my_u8s
-   │ ╰────────────────────────────^ attributes hash: 7605717007273386303
+   │ ╰────────────────────────────^ attributes hash: 3951353961439842676
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1739,7 +1759,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1768,7 +1790,7 @@ note:
    │  
 47 │ ╭     pub def set_my_bool(my_bool: bool):
 48 │ │         self.my_bool = my_bool
-   │ ╰──────────────────────────────^ attributes hash: 1436793526906496838
+   │ ╰──────────────────────────────^ attributes hash: 9951927489494877708
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1781,7 +1803,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1805,7 +1829,7 @@ note:
    │  
 53 │ ╭     pub def set_my_bytes(my_bytes: bytes[100]):
 54 │ │         self.my_bytes = my_bytes
-   │ ╰────────────────────────────────^ attributes hash: 14296638220629361927
+   │ ╰────────────────────────────────^ attributes hash: 1603819576134687581
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1821,7 +1845,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1997,13 +2023,15 @@ note:
    · │
 81 │ │             my_bytes=self.my_bytes.to_mem()
 82 │ │         )
-   │ ╰─────────^ attributes hash: 9089586501468789190
+   │ ╰─────────^ attributes hash: 10533351548551667725
    │  
    = FunctionAttributes {
          is_public: true,
          name: "emit_my_event",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2016,7 +2044,7 @@ note:
    · │
 81 │ │             my_bytes=self.my_bytes.to_mem()
 82 │ │         )
-   │ ╰─────────^ attributes hash: 3267493635957601068
+   │ ╰─────────^ attributes hash: 424456335303037920
    │  
    = ContractAttributes {
          public_functions: [
@@ -2024,7 +2052,9 @@ note:
                  is_public: true,
                  name: "emit_my_event",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2222,7 +2252,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2235,7 +2267,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2251,7 +2285,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2266,7 +2302,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2281,7 +2319,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2299,7 +2339,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_101_data_copying_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_101_data_copying_stress.snap
@@ -76,7 +76,9 @@ ModuleAttributes {
                         is_public: true,
                         name: "emit_my_event",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -102,7 +104,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -143,7 +147,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -182,13 +188,17 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
                         name: "set_to_my_other_vals",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -1949,11 +1959,13 @@ note:
 69 │ │             self.my_string.to_mem(),
 70 │ │             self.my_u256.to_mem()
 71 │ │         )
-   │ ╰─────────^ attributes hash: 5074014468841562254
+   │ ╰─────────^ attributes hash: 13510039392732087821
    │  
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -2122,7 +2134,7 @@ note:
    · │
 24 │ │         self.my_u256 = my_u256
 25 │ │         self.my_other_u256 = my_other_u256
-   │ ╰──────────────────────────────────────────^ attributes hash: 16864902024724254016
+   │ ╰──────────────────────────────────────────^ attributes hash: 1560259300258650942
    │  
    = FunctionAttributes {
          is_public: true,
@@ -2161,7 +2173,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2170,13 +2184,15 @@ note:
 27 │ ╭     pub def set_to_my_other_vals():
 28 │ │         self.my_string = self.my_other_string
 29 │ │         self.my_u256 = self.my_other_u256
-   │ ╰─────────────────────────────────────────^ attributes hash: 383055877702058380
+   │ ╰─────────────────────────────────────────^ attributes hash: 16862758663013252212
    │  
    = FunctionAttributes {
          is_public: true,
          name: "set_to_my_other_vals",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2189,7 +2205,7 @@ note:
    · │
 43 │ │         assert my_2nd_array[3] == 50
 44 │ │         assert my_3rd_array[3] == 50
-   │ ╰────────────────────────────────────^ attributes hash: 12963554119915947050
+   │ ╰────────────────────────────────────^ attributes hash: 6476964505927014984
    │  
    = FunctionAttributes {
          is_public: true,
@@ -2207,7 +2223,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2345,13 +2363,15 @@ note:
 69 │ │             self.my_string.to_mem(),
 70 │ │             self.my_u256.to_mem()
 71 │ │         )
-   │ ╰─────────^ attributes hash: 9089586501468789190
+   │ ╰─────────^ attributes hash: 10533351548551667725
    │  
    = FunctionAttributes {
          is_public: true,
          name: "emit_my_event",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2359,7 +2379,7 @@ note:
    │  
 73 │ ╭     def emit_my_event_internal(some_string: String<42>, some_u256: u256):
 74 │ │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │ ╰──────────────────────────────────────────────────────────────^ attributes hash: 11329158825917724746
+   │ ╰──────────────────────────────────────────────────────────────^ attributes hash: 2034642201325374256
    │  
    = FunctionAttributes {
          is_public: false,
@@ -2382,7 +2402,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2390,7 +2412,7 @@ note:
    │  
 76 │ ╭     pub def set_my_addrs(my_addrs: address[3]):
 77 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 220845659595033400
+   │ ╰────────────────────────────────^ attributes hash: 12139699556071315906
    │  
    = FunctionAttributes {
          is_public: true,
@@ -2406,7 +2428,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -2480,7 +2504,7 @@ note:
    · │
 79 │ │     pub def get_my_second_addr() -> address:
 80 │ │         return self.my_addrs[1]
-   │ ╰───────────────────────────────^ attributes hash: 5097426127984065559
+   │ ╰───────────────────────────────^ attributes hash: 11054534901318549189
    │  
    = ContractAttributes {
          public_functions: [
@@ -2551,7 +2575,9 @@ note:
                  is_public: true,
                  name: "emit_my_event",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2577,7 +2603,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2618,7 +2646,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -2657,13 +2687,17 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
                  name: "set_to_my_other_vals",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
@@ -56,7 +56,9 @@ ModuleAttributes {
                         is_public: true,
                         name: "build_tuple_and_emit",
                         params: [],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -83,7 +85,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                     FunctionAttributes {
                         is_public: true,
@@ -248,7 +252,9 @@ ModuleAttributes {
                                 ),
                             ),
                         ],
-                        return_type: Unit,
+                        return_type: Base(
+                            Unit,
+                        ),
                     },
                 ],
             },
@@ -1130,11 +1136,13 @@ note:
    ┌─ stress/tuple_stress.fe:40:9
    │
 40 │         self.emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5074014468841562254
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13510039392732087821
    │
    = ExpressionAttributes {
-         typ: Unit,
-         location: Memory,
+         typ: Base(
+             Unit,
+         ),
+         location: Value,
          move_location: None,
      }
 
@@ -1390,7 +1398,7 @@ note:
    │  
 23 │ ╭     pub def emit_my_event(my_tuple: (u256, bool, address)):
 24 │ │         emit MyEvent(my_tuple)
-   │ ╰──────────────────────────────^ attributes hash: 10195864716275896975
+   │ ╰──────────────────────────────^ attributes hash: 11179766985792630760
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1417,7 +1425,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1426,7 +1436,7 @@ note:
 26 │ ╭     pub def set_my_sto_tuple(my_u256: u256, my_i32: i32):
 27 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
 28 │ │         self.my_sto_tuple = (my_u256, my_i32)
-   │ ╰─────────────────────────────────────────────^ attributes hash: 3417003893761463383
+   │ ╰─────────────────────────────────────────────^ attributes hash: 1596944400908148027
    │  
    = FunctionAttributes {
          is_public: true,
@@ -1449,7 +1459,9 @@ note:
                  ),
              ),
          ],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1491,13 +1503,15 @@ note:
    · │
 39 │ │         )
 40 │ │         self.emit_my_event(my_tuple)
-   │ ╰────────────────────────────────────^ attributes hash: 2667028644424766496
+   │ ╰────────────────────────────────────^ attributes hash: 693326251577398155
    │  
    = FunctionAttributes {
          is_public: true,
          name: "build_tuple_and_emit",
          params: [],
-         return_type: Unit,
+         return_type: Base(
+             Unit,
+         ),
      }
 
 note: 
@@ -1590,7 +1604,7 @@ note:
    · │
 42 │ │     pub def encode_my_tuple(my_tuple: (u256, bool, address)) -> bytes[96]:
 43 │ │         return my_tuple.abi_encode()
-   │ ╰────────────────────────────────────^ attributes hash: 14532587019825575010
+   │ ╰────────────────────────────────────^ attributes hash: 8500049769879482489
    │  
    = ContractAttributes {
          public_functions: [
@@ -1641,7 +1655,9 @@ note:
                  is_public: true,
                  name: "build_tuple_and_emit",
                  params: [],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -1668,7 +1684,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
              FunctionAttributes {
                  is_public: true,
@@ -1833,7 +1851,9 @@ note:
                          ),
                      ),
                  ],
-                 return_type: Unit,
+                 return_type: Base(
+                     Unit,
+                 ),
              },
          ],
          init_function: None,

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
@@ -683,12 +683,12 @@ note:
    ┌─ stress/tuple_stress.fe:27:86
    │
 27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                      ^ attributes hash: 16797824492585953824
+   │                                                                                      ^ attributes hash: 13972995067286817043
    │
    = ExpressionAttributes {
          typ: Base(
              Numeric(
-                 U256,
+                 I32,
              ),
          ),
          location: Value,

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__array_mixed_types.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__array_mixed_types.snap
@@ -3,20 +3,16 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: array elements must have same type
-  ┌─ [snippet]:3:17
+error: type mismatch
+  ┌─ [snippet]:3:19
   │
-3 │   x: u256[3] = [1, address(0), "hi"]
-  │                 ^  ---------- this has type `address`
-  │                 │   
-  │                 this has type `u256`
+3 │   x: u16[3] = [1, address(0), "hi"]
+  │                   ^^^^^^^^^^ this has type `address`; expected type `u16`
 
-error: array elements must have same type
-  ┌─ [snippet]:3:17
+error: type mismatch
+  ┌─ [snippet]:3:31
   │
-3 │   x: u256[3] = [1, address(0), "hi"]
-  │                 ^              ---- this has type `string<2>`
-  │                 │               
-  │                 this has type `u256`
+3 │   x: u16[3] = [1, address(0), "hi"]
+  │                               ^^^^ this has type `string<2>`; expected type `u16`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__array_size_mismatch.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__array_size_mismatch.snap
@@ -1,0 +1,18 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: type mismatch
+  ┌─ [snippet]:3:14
+  │
+3 │   x: u8[3] = []
+  │              ^^ this has type `u8[0]`; expected type `u8[3]`
+
+error: type mismatch
+  ┌─ [snippet]:4:14
+  │
+4 │   y: u8[3] = [1, 2]
+  │              ^^^^^^ this has type `u8[2]`; expected type `u8[3]`
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_add_uints.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_add_uints.snap
@@ -5,8 +5,5 @@ expression: "error_string(\"[snippet]\", &src)"
 ---
 
 
-TypeError on line 4
-pub def f():
-  a: u256 = 1
-  [31mb: u8 = 2[0m
-  a + b
+TypeError on line 5
+[31ma + b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_lshift_with_int.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_lshift_with_int.snap
@@ -5,8 +5,5 @@ expression: "error_string(\"[snippet]\", &src)"
 ---
 
 
-TypeError on line 4
-pub def f():
-  a: u256 = 1
-  [31mb: i256 = 2[0m
-  a << b
+TypeError on line 5
+[31ma << b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_pow_int.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_pow_int.snap
@@ -5,8 +5,5 @@ expression: "error_string(\"[snippet]\", &src)"
 ---
 
 
-TypeError on line 4
-pub def f():
-  a: u256 = 1
-  [31mb: i256 = 2[0m
-  a ** b
+SignedExponentNotAllowed on line 5
+[31ma ** b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_event_with_wrong_types.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_event_with_wrong_types.snap
@@ -25,10 +25,10 @@ error: incorrect type for `MyEvent` argument `val_1`
 7 │         emit MyEvent("foo", 1000)
   │                      ^^^^^ this has type `string<3>`; expected type `string<100>`
 
-error: incorrect type for `MyEvent` argument `val_2`
+error: literal out of range for `u8`
   ┌─ fixtures/compile_errors/call_event_with_wrong_types.fe:7:29
   │
 7 │         emit MyEvent("foo", 1000)
-  │                             ^^^^ this has type `u256`; expected type `u8`
+  │                             ^^^^ does not fit into type `u8`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_i256_neg.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_i256_neg.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/src/compile_errors.rs
+source: analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_i8_neg.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_i8_neg.snap
@@ -1,12 +1,12 @@
 ---
-source: tests/src/compile_errors.rs
+source: analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: literal out of range for `i8`
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:11
   │
-3 │   i8(-129)
-  │      ^^^^ does not fit into type `i8`
+3 │   x: i8 = -129
+  │           ^^^^ does not fit into type `i8`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_literal_too_small.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_literal_too_small.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/src/compile_errors.rs
+source: analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
@@ -8,5 +8,11 @@ error: literal out of range for `u256`
   │
 3 │   -115792089237316195423570985008687907853269984665640564039457584007913129639936
   │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not fit into type `u256`
+
+error: literal out of range for `i256`
+  ┌─ [snippet]:3:3
+  │
+3 │   -115792089237316195423570985008687907853269984665640564039457584007913129639936
+  │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not fit into type `i256`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_u128_neg.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_u128_neg.snap
@@ -1,12 +1,12 @@
 ---
-source: tests/src/compile_errors.rs
+source: analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: literal out of range for `u128`
-  ┌─ [snippet]:3:8
+  ┌─ [snippet]:3:13
   │
-3 │   u128(-1)
-  │        ^^ does not fit into type `u128`
+3 │   x: u128 = -1
+  │             ^^ does not fit into type `u128`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_u256_pos.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_u256_pos.snap
@@ -1,14 +1,8 @@
 ---
-source: tests/src/compile_errors.rs
+source: analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: literal out of range for `u256`
-  ┌─ [snippet]:3:8
-  │
-3 │   u256(115792089237316195423570985008687907853269984665640564039457584007913129639936)
-  │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ does not fit into type `u256`
-
 error: literal out of range for `u256`
   ┌─ [snippet]:3:8
   │

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_u8_assignment.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__overflow_u8_assignment.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: literal out of range for `u8`
+  ┌─ [snippet]:3:11
+  │
+3 │   x: u8 = 260
+  │           ^^^ does not fit into type `u8`
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__unary_not_on_int.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__unary_not_on_int.snap
@@ -7,6 +7,6 @@ error: cannot apply unary operator `not` to type `u256`
   ┌─ [snippet]:4:7
   │
 4 │   not x
-  │       ^ this has type `u256`; expected a `bool`
+  │       ^ this has type `u256`; expected type `bool`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__undefined_name.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__undefined_name.snap
@@ -1,0 +1,18 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: cannot find value `y` in this scope
+  ┌─ [snippet]:3:12
+  │
+3 │   x: u16 = y
+  │            ^ undefined
+
+error: cannot find value `y` in this scope
+  ┌─ [snippet]:4:12
+  │
+4 │   z: u16 = y
+  │            ^ undefined
+
+


### PR DESCRIPTION
### What was wrong?

Int literals can only be used where a u256 is expected unless they're wrapped in an explicit type constructor call. For example:
```
a: u8 = 100 # type error
def f(x: u8): ...
f(100) # type error
f(u8(100)) # ok
```
 
Also closes #256 (panic on `[]`).

### How was it fixed?

Some of the analyzer traversal fns now take an `expected_type` parameter. This is used to infer the type of int literals and the element type of arrays. Array size mismatch is still an error, so `x: u8[10] = []` is a type error, but at least it doesn't panic.

This isn't applied to strings. `x: string10 = "hi"` is still a type error. This will presumably require some work to not break compilation. This also doesn't coerce ints that aren't literals. Eg`y: u8 = ... \n x: u16 = y` is still a type error.

Tangential changes:
- Removed Shared wrapper from Context
- Moved the Unit type into Base, so empty arrays with no expected type can have inner type `Base::Unit` (this should only happen if the empty array is a standalone expr statement)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history