### PR TITLE
Re-enable wasm tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,19 +113,19 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --features solc-backend --verbose
 
-  # wasm-test:
-  #     runs-on: ubuntu-latest
-  #     container: davesque/rust-wasm
-  #     steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
-  #     - name: Run WASM tests
-  #       run: wasm-pack test --node -- --workspace
+  wasm-test:
+      runs-on: ubuntu-latest
+      container: davesque/rust-wasm
+      steps:
+      - uses: actions/checkout@v2
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run WASM tests
+        run: wasm-pack test --node -- --workspace
 
   release:
     # Only run this when we push a tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "ctor"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,11 +721,13 @@ dependencies = [
  "fe-parser",
  "hex",
  "insta",
+ "pretty_assertions",
  "primitive-types",
  "rand",
  "regex",
  "rstest",
  "stringreader",
+ "wasm-bindgen-test",
  "yultsur",
 ]
 
@@ -721,6 +739,7 @@ dependencies = [
  "if_chain",
  "insta",
  "logos",
+ "pretty_assertions",
  "semver 1.0.0",
  "serde",
  "unescape",
@@ -995,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.50"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1211,6 +1230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1295,18 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cab0e7c02cf376875e9335e0ba1da535775beb5450d21e1dffca068818ed98b"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "primitive-types"
@@ -2016,9 +2056,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2026,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2041,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b8b767af23de6ac18bf2168b690bed2902743ddf0fb39252e36f9e2bfc63ea"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2053,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2063,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2076,15 +2116,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.73"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e972e914de63aa53bd84865e54f5c761bd274d48e5be3a6329a662c0386aa67a"
+checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -2096,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6153a8f9bf24588e9f25c87223414fff124049f68d3a442a0f0eab4768a8b6"
+checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ solc-backend = ["fe-compiler/solc-backend", "fe-compiler-tests/solc-backend"]
 clap = "2.33.3"
 fe-common = {path = "common", version = "^0.5.0-alpha"}
 fe-compiler = {path = "compiler", version = "^0.5.0-alpha"}
-fe-compiler-tests = {path = "tests", features = ["solc-backend"], version = "^0.4.0-alpha"}
+fe-compiler-tests = {path = "tests", version = "^0.4.0-alpha"}
 fe-parser = {path = "parser", version = "^0.5.0-alpha"}
 
 [dev-dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 bincode = "1.3.3"
 ethabi = "12.0"
-fe-compiler-test-utils = {path = "../test-utils", features = ["solc-backend"], version = "0.4.0-alpha"}
+fe-compiler-test-utils = {path = "../test-utils", version = "0.4.0-alpha"}
 libfuzzer-sys = "0.4"
 serde = {version = "1.0.125", features = ["derive"]}
 serde_json = "1.0.64"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -26,3 +26,4 @@ wasm-bindgen = "0.2"
 [dev-dependencies]
 insta = "1.7.1"
 wasm-bindgen-test = "0.3"
+pretty_assertions = "0.7.2"

--- a/parser/tests/cases/errors.rs
+++ b/parser/tests/cases/errors.rs
@@ -23,9 +23,24 @@ where
 
 macro_rules! test_parse_err {
     ($name:ident, $parse_fn:expr, $should_fail:expr, $src:expr) => {
+        #[cfg(not(target_arch = "wasm32"))]
         #[test]
         fn $name() {
             assert_snapshot!(err_string(stringify!($name), $parse_fn, $should_fail, $src));
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[wasm_bindgen_test::wasm_bindgen_test]
+        fn $name() {
+            let actual = err_string(stringify!($name), $parse_fn, $should_fail, $src);
+            let (_, expected) = include_str!(concat!(
+                "snapshots/cases__errors__",
+                stringify!($name),
+                ".snap"
+            ))
+            .rsplit_once("---\n")
+            .unwrap();
+            pretty_assertions::assert_eq!(actual.trim(), expected.trim());
         }
     };
 }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -11,7 +11,7 @@ ethabi = "12.0"
 evm = "0.18"
 evm-runtime = "0.18"
 fe-common = {path = "../common", version = "0.5.0-alpha"}
-fe-compiler = {path = "../compiler", features = ["solc-backend"], version = "0.5.0-alpha"}
+fe-compiler = {path = "../compiler", version = "0.5.0-alpha"}
 hex = "0.4"
 primitive-types = {version = "0.7", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -8,14 +8,14 @@ version = "0.4.0-alpha"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fe-compiler = {path = "../compiler", features = ["solc-backend"]}
+fe-compiler = {path = "../compiler"}
 # This fork contains the shorthand macros and some other necessary updates.
 ethabi = "12.0"
 evm = "0.18"
 evm-runtime = "0.18"
 fe-analyzer = {path = "../analyzer", version = "^0.5.0-alpha"}
 fe-common = {path = "../common", version = "^0.5.0-alpha"}
-fe-compiler-test-utils = {path = "../test-utils", features = ["solc-backend"]}
+fe-compiler-test-utils = {path = "../test-utils" }
 fe-parser = {path = "../parser", version = "^0.5.0-alpha"}
 hex = "0.4"
 primitive-types = {version = "0.7", default-features = false, features = ["rlp"]}
@@ -27,6 +27,8 @@ yultsur = {git = "https://github.com/g-r-a-n-t/yultsur"}
 
 [dev-dependencies]
 insta = "1.7.1"
+pretty_assertions = "0.7.2"
+wasm-bindgen-test = "0.3.24"
 
 [features]
 solc-backend = ["fe-compiler/solc-backend", "fe-compiler-test-utils/solc-backend"]


### PR DESCRIPTION
### What was wrong?

Tests don't run on wasm.

### How was it fixed?

Fixed the wasm32-unknown-unknown build (with solc-backend feature disabled), uncommented the wasm test config from the github workflow, and made some of the tests wasm-friendly.

I've only wasmified the tests that don't require solc, do use insta, and don't use rstest. So, the parser tests and the analyzer error tests. The other non-solc tests need to be refactored a bit to work on wasm, which I'd prefer to do as part of a future test cleanup pr.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
