### PR TITLE
Capitalize Map type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following is a simple contract implemented in Fe.
 type BookMsg = bytes[100]
 
 contract GuestBook:
-    pub guest_book: map<address, BookMsg>
+    pub guest_book: Map<address, BookMsg>
 
     event Signed:
         book_msg: BookMsg

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -858,7 +858,7 @@ impl fmt::Display for Array {
 
 impl fmt::Display for Map {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "map<{}, {}>", self.key, self.value)
+        write!(f, "Map<{}, {}>", self.key, self.value)
     }
 }
 

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -189,7 +189,7 @@ pub fn assignable_expr(
         }
         Map(_) => {
             context.error(
-                "maps cannot reside in memory",
+                "Maps cannot reside in memory",
                 exp.span,
                 "this type can only be used in a contract field",
             );

--- a/analyzer/src/traversal/types.rs
+++ b/analyzer/src/traversal/types.rs
@@ -63,7 +63,7 @@ pub fn type_desc(
             }
         }
         fe::TypeDesc::Generic { base, args } => match base.kind.as_str() {
-            "map" => {
+            "Map" => {
                 validate_arg_count(context, &base.kind, base.span, &args, 2);
                 if args.kind.len() < 2 {
                     return Err(SemanticError::fatal());

--- a/docs/src/quickstart/first_contract.md
+++ b/docs/src/quickstart/first_contract.md
@@ -42,7 +42,7 @@ The addresses are represented by the builtin [`address`](/docs/spec/index.html#5
 
 ```
 contract GuestBook:
-  messages: map<address, bytes[100]>
+  messages: Map<address, bytes[100]>
 ```
 
 Execute `./fe guest_book.fe` again to recompile the file.
@@ -76,7 +76,7 @@ Let's focus on the functionality of our world changing application and add a met
 
 ```python
 contract GuestBook:
-  messages: map<address, bytes[100]>
+  messages: Map<address, bytes[100]>
 
   pub def sign(book_msg: bytes[100]):
       self.messages[msg.sender] = book_msg
@@ -120,7 +120,7 @@ To make the guest book more useful we will also add a method `get_msg` to read e
 
 ```python
 contract GuestBook:
-  messages: map<address, bytes[100]>
+  messages: Map<address, bytes[100]>
 
   pub def sign(book_msg: bytes[100]):
       self.messages[msg.sender] = book_msg
@@ -146,7 +146,7 @@ The code should compile fine when we change it accordingly.
 
 ```python
 contract GuestBook:
-  messages: map<address, bytes[100]>
+  messages: Map<address, bytes[100]>
 
   pub def sign(book_msg: bytes[100]):
       self.messages[msg.sender] = book_msg

--- a/docs/src/spec/index.md
+++ b/docs/src/spec/index.md
@@ -361,7 +361,7 @@ An example of a `contract`:
 
 ```
 contract GuestBook:
-    pub guest_book: map<address, bytes[100]>
+    pub guest_book: Map<address, bytes[100]>
 
     event Signed:
         idx book_msg: bytes[100]
@@ -630,7 +630,7 @@ Maps a key to a value.
 Example:
 
 ```
-map<TKey,TValue>
+Map<TKey,TValue>
 ```
 
 Where TKey is a base type and TValue is any data type.
@@ -705,8 +705,8 @@ Example:
 
 ``` python
 # contract scope
-bar: map<address, u256> # bar is assigned a static nonce by the compiler
-baz: map<address, map<address, u256>> # baz is assigned a static nonce by the compiler
+bar: Map<address, u256> # bar is assigned a static nonce by the compiler
+baz: Map<address, Map<address, u256>> # baz is assigned a static nonce by the compiler
 ```
 
 The expression `bar[0x00]` would resolve to the hash of both bar's nonce and the key value

--- a/fuzz/fixtures/fe/erc20.fe
+++ b/fuzz/fixtures/fe/erc20.fe
@@ -1,6 +1,6 @@
 contract ERC20:
-    _balances: map<address, u256>
-    _allowances: map<address, map<address, u256>>
+    _balances: Map<address, u256>
+    _allowances: Map<address, Map<address, u256>>
 
     _total_supply: u256
 

--- a/newsfragments/431.feature.md
+++ b/newsfragments/431.feature.md
@@ -1,0 +1,6 @@
+The Map type name is now capitalized. Example:
+
+```
+contract GuestBook:
+    guests: Map<address, String<100>>
+```

--- a/parser/src/grammar/contracts.rs
+++ b/parser/src/grammar/contracts.rs
@@ -20,7 +20,7 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
     let contract_tok = par.assert(Contract);
 
     // contract Foo:
-    //   x: map<address, u256>
+    //   x: Map<address, u256>
     //   pub y: u8
     //   const z: u256 = 10
     //

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -50,7 +50,7 @@ pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
     ))
 }
 
-/// Parse a type definition, e.g. `type MyMap = map<u8, address>`.
+/// Parse a type definition, e.g. `type MyMap = Map<u8, address>`.
 /// # Panics
 /// Panics if the next token isn't `type`.
 pub fn parse_type_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
@@ -60,7 +60,7 @@ pub fn parse_type_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
         vec![
             "Note: a type alias name must be followed by an equals sign and a type description"
                 .into(),
-            format!("Example: `type {} = map<address, u64>`", name.text),
+            format!("Example: `type {} = Map<address, u64>`", name.text),
         ]
     })?;
     let typ = parse_type_desc(par)?;
@@ -196,7 +196,7 @@ pub fn parse_opt_qualifier(par: &mut Parser, tk: TokenKind) -> Option<Span> {
 }
 
 /// Parse an angle-bracket-wrapped list of generic arguments (eg. the tail end
-/// of `map<address, u256>`).
+/// of `Map<address, u256>`).
 /// # Panics
 /// Panics if the first token isn't `<`.
 pub fn parse_generic_args(par: &mut Parser) -> ParseResult<Node<Vec<GenericArg>>> {
@@ -271,7 +271,7 @@ pub fn parse_generic_args(par: &mut Parser) -> ParseResult<Node<Vec<GenericArg>>
     Ok(Node::new(args, span))
 }
 
-/// Parse a type description, e.g. `u8` or `map<address, u256>`.
+/// Parse a type description, e.g. `u8` or `Map<address, u256>`.
 pub fn parse_type_desc(par: &mut Parser) -> ParseResult<Node<TypeDesc>> {
     use TokenKind::*;
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -30,7 +30,7 @@ pub struct Parser<'a> {
 
     /// Tokens that have been "peeked", or split from a larger token.
     /// Eg. `>>` may be split into two `>` tokens when parsing the end of a
-    /// generic type parameter list (eg. `map<u256, map<u256, address>>`).
+    /// generic type parameter list (eg. `Map<u256, Map<u256, address>>`).
     buffered: Vec<Token<'a>>,
 
     paren_stack: Vec<Span>,
@@ -150,7 +150,7 @@ impl<'a> Parser<'a> {
     /// Split the next token into two tokens, returning the first. Only supports
     /// splitting the `>>` token into two `>` tokens, specifically for
     /// parsing the closing angle bracket of a generic type argument list
-    /// (`map<x, map<y, z>>`).
+    /// (`Map<x, Map<y, z>>`).
     ///
     /// # Panics
     /// Panics if the next token isn't `>>`

--- a/parser/tests/cases/parse_ast.rs
+++ b/parser/tests/cases/parse_ast.rs
@@ -106,18 +106,18 @@ test_parse! { stmt_var_decl_name, functions::parse_stmt, "foo: u256" }
 test_parse! { stmt_var_decl_tuple, functions::parse_stmt, "(foo, bar): (u256, u256) = (10, 10)" }
 test_parse! { stmt_var_decl_tuples, functions::parse_stmt, "(a, (b, (c, d))): x" }
 
-test_parse! { type_def, types::parse_type_def, "type X = map<address, u256>" }
+test_parse! { type_def, types::parse_type_def, "type X = Map<address, u256>" }
 test_parse! { type_name, types::parse_type_desc, "MyType" }
 test_parse! { type_array, types::parse_type_desc, "address[25]" }
 test_parse! { type_3d, types::parse_type_desc, "u256[4][4][4]" }
 test_parse! { type_string, types::parse_type_desc, "string<100>" }
 test_parse! { type_generic, types::parse_type_desc, "foo<a, b<c>, d[10]>" }
 test_parse! { type_generic_int, types::parse_type_desc, "foo<1, 2>" }
-test_parse! { type_map1, types::parse_type_desc, "map<address, u256>" }
-test_parse! { type_map2, types::parse_type_desc, "map<address, map<u8, u256>>" }
-test_parse! { type_map3, types::parse_type_desc, "map<address, map<u8, map<u8, u8>>>" }
+test_parse! { type_map1, types::parse_type_desc, "Map<address, u256>" }
+test_parse! { type_map2, types::parse_type_desc, "Map<address, Map<u8, u256>>" }
+test_parse! { type_map3, types::parse_type_desc, "Map<address, Map<u8, Map<u8, u8>>>" }
 test_parse! { type_map4, types::parse_type_desc, "map < address , map < u8, u256 > >" }
-test_parse! { type_tuple, types::parse_type_desc, "(u8, u16, address, map<u8, u8>)" }
+test_parse! { type_tuple, types::parse_type_desc, "(u8, u16, address, Map<u8, u8>)" }
 test_parse! { type_unit, types::parse_type_desc, "()" }
 
 test_parse! { fn_def, |par| functions::parse_fn_def(par, None), "def foo21(x: bool, y: address,) -> bool:\n x"}
@@ -133,7 +133,7 @@ test_parse! { struct_def, types::parse_struct_def, r#"struct S:
   x: address
   pub y: u8
   const z: u8
-  pub const a: map<u8, foo>
+  pub const a: Map<u8, foo>
 "# }
 test_parse! { empty_struct_def, types::parse_struct_def, r#"struct S:
   pass
@@ -142,7 +142,7 @@ test_parse! { empty_struct_def, types::parse_struct_def, r#"struct S:
 test_parse! { contract_def, contracts::parse_contract_def, r#"contract Foo:
   x: address
   pub y: u8
-  pub const z: map<u8, address>
+  pub const z: Map<u8, address>
   pub def foo() -> u8:
     return 10
   event Bar:
@@ -158,7 +158,7 @@ pragma 0.5.0
 
 import foo as bar, baz as bum
 
-type X = map<u8, u16>
+type X = Map<u8, u16>
 
 contract A:
     pub const x: u256 = 10
@@ -171,7 +171,7 @@ test_parse! { guest_book, module::parse_module, r#"
 type BookMsg = bytes[100]
 
 contract GuestBook:
-    pub guest_book: map<address, BookMsg>
+    pub guest_book: Map<address, BookMsg>
 
     event Signed:
         idx book_msg: BookMsg

--- a/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(contract_def), contracts::parse_contract_def,\n           r#\"contract Foo:\n  x: address\n  pub y: u8\n  pub const z: map<u8, address>\n  pub def foo() -> u8:\n    return 10\n  event Bar:\n    idx from: address\n\"#)"
+expression: "ast_string(stringify!(contract_def), contracts::parse_contract_def,\n           r#\"contract Foo:\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n  pub def foo() -> u8:\n    return 10\n  event Bar:\n    idx from: address\n\"#)"
 
 ---
 Node(
@@ -81,7 +81,7 @@ Node(
           typ: Node(
             kind: Generic(
               base: Node(
-                kind: "map",
+                kind: "Map",
                 span: Span(
                   start: 54,
                   end: 57,

--- a/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(guest_book), module::parse_module,\n           r#\"\ntype BookMsg = bytes[100]\n\ncontract GuestBook:\n    pub guest_book: map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub def sign(book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg=book_msg)\n\n    pub def get_msg(addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
+expression: "ast_string(stringify!(guest_book), module::parse_module,\n           r#\"\ntype BookMsg = bytes[100]\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub def sign(book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg=book_msg)\n\n    pub def get_msg(addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
 
 ---
 Node(
@@ -63,7 +63,7 @@ Node(
                 typ: Node(
                   kind: Generic(
                     base: Node(
-                      kind: "map",
+                      kind: "Map",
                       span: Span(
                         start: 68,
                         end: 71,

--- a/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_stmts), module::parse_module,\n           r#\"\npragma 0.5.0\n\nimport foo as bar, baz as bum\n\ntype X = map<u8, u16>\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
+expression: "ast_string(stringify!(module_stmts), module::parse_module,\n           r#\"\npragma 0.5.0\n\nimport foo as bar, baz as bum\n\ntype X = Map<u8, u16>\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
 
 ---
 Node(
@@ -91,7 +91,7 @@ Node(
           typ: Node(
             kind: Generic(
               base: Node(
-                kind: "map",
+                kind: "Map",
                 span: Span(
                   start: 55,
                   end: 58,

--- a/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(struct_def), types::parse_struct_def,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  const z: u8\n  pub const a: map<u8, foo>\n\"#)"
+expression: "ast_string(stringify!(struct_def), types::parse_struct_def,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  const z: u8\n  pub const a: Map<u8, foo>\n\"#)"
 
 ---
 Node(
@@ -108,7 +108,7 @@ Node(
           typ: Node(
             kind: Generic(
               base: Node(
-                kind: "map",
+                kind: "Map",
                 span: Span(
                   start: 64,
                   end: 67,

--- a/parser/tests/cases/snapshots/cases__parse_ast__type_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__type_def.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(type_def), types::parse_type_def,\n           \"type X = map<address, u256>\")"
+expression: "ast_string(stringify!(type_def), types::parse_type_def,\n           \"type X = Map<address, u256>\")"
 
 ---
 Node(
@@ -15,7 +15,7 @@ Node(
     typ: Node(
       kind: Generic(
         base: Node(
-          kind: "map",
+          kind: "Map",
           span: Span(
             start: 9,
             end: 12,

--- a/parser/tests/cases/snapshots/cases__parse_ast__type_map1.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__type_map1.snap
@@ -1,12 +1,12 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(type_map1), types::parse_type_desc,\n           \"map<address, u256>\")"
+expression: "ast_string(stringify!(type_map1), types::parse_type_desc,\n           \"Map<address, u256>\")"
 
 ---
 Node(
   kind: Generic(
     base: Node(
-      kind: "map",
+      kind: "Map",
       span: Span(
         start: 0,
         end: 3,

--- a/parser/tests/cases/snapshots/cases__parse_ast__type_map2.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__type_map2.snap
@@ -1,12 +1,12 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(type_map2), types::parse_type_desc,\n           \"map<address, map<u8, u256>>\")"
+expression: "ast_string(stringify!(type_map2), types::parse_type_desc,\n           \"Map<address, Map<u8, u256>>\")"
 
 ---
 Node(
   kind: Generic(
     base: Node(
-      kind: "map",
+      kind: "Map",
       span: Span(
         start: 0,
         end: 3,
@@ -26,7 +26,7 @@ Node(
         TypeDesc(Node(
           kind: Generic(
             base: Node(
-              kind: "map",
+              kind: "Map",
               span: Span(
                 start: 13,
                 end: 16,

--- a/parser/tests/cases/snapshots/cases__parse_ast__type_map3.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__type_map3.snap
@@ -1,12 +1,12 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(type_map3), types::parse_type_desc,\n           \"map<address, map<u8, map<u8, u8>>>\")"
+expression: "ast_string(stringify!(type_map3), types::parse_type_desc,\n           \"Map<address, Map<u8, Map<u8, u8>>>\")"
 
 ---
 Node(
   kind: Generic(
     base: Node(
-      kind: "map",
+      kind: "Map",
       span: Span(
         start: 0,
         end: 3,
@@ -26,7 +26,7 @@ Node(
         TypeDesc(Node(
           kind: Generic(
             base: Node(
-              kind: "map",
+              kind: "Map",
               span: Span(
                 start: 13,
                 end: 16,
@@ -46,7 +46,7 @@ Node(
                 TypeDesc(Node(
                   kind: Generic(
                     base: Node(
-                      kind: "map",
+                      kind: "Map",
                       span: Span(
                         start: 21,
                         end: 24,

--- a/parser/tests/cases/snapshots/cases__parse_ast__type_tuple.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__type_tuple.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(type_tuple), types::parse_type_desc,\n           \"(u8, u16, address, map<u8, u8>)\")"
+expression: "ast_string(stringify!(type_tuple), types::parse_type_desc,\n           \"(u8, u16, address, Map<u8, u8>)\")"
 
 ---
 Node(
@@ -36,7 +36,7 @@ Node(
       Node(
         kind: Generic(
           base: Node(
-            kind: "map",
+            kind: "Map",
             span: Span(
               start: 19,
               end: 22,

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ The following is a simple contract implemented in Fe.
 type BookMsg = bytes[100]
 
 contract GuestBook:
-    pub guest_book: map<address, BookMsg>
+    pub guest_book: Map<address, BookMsg>
 
     event Signed:
         book_msg: BookMsg

--- a/tests/fixtures/compile_errors/missing_return.fe
+++ b/tests/fixtures/compile_errors/missing_return.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    baz: map<u256, u256>
+    baz: Map<u256, u256>
 
     pub def bar() -> u256:
         self.baz[0] = 1

--- a/tests/fixtures/demos/erc20_token.fe
+++ b/tests/fixtures/demos/erc20_token.fe
@@ -1,6 +1,6 @@
 contract ERC20:
-    _balances: map<address, u256>
-    _allowances: map<address, map<address, u256>>
+    _balances: Map<address, u256>
+    _allowances: Map<address, Map<address, u256>>
 
     _total_supply: u256
 

--- a/tests/fixtures/demos/guest_book.fe
+++ b/tests/fixtures/demos/guest_book.fe
@@ -1,7 +1,7 @@
 type BookMsg = bytes[100]
 
 contract GuestBook:
-    messages: map<address, BookMsg>
+    messages: Map<address, BookMsg>
 
     event Signed:
         book_msg: BookMsg

--- a/tests/fixtures/demos/uniswap.fe
+++ b/tests/fixtures/demos/uniswap.fe
@@ -9,11 +9,11 @@ contract UniswapV2Pair:
     # TODO: const support (https://github.com/ethereum/fe/issues/192)
     # const MINIMUM_LIQUIDITY: u256 = 1000
 
-    balances: map<address, u256>
-    allowances: map<address, map<address, u256>>
+    balances: Map<address, u256>
+    allowances: Map<address, Map<address, u256>>
     total_supply: u256
 
-    nonces: map<address, u256>
+    nonces: Map<address, u256>
 
     factory: address
     token0: address
@@ -286,7 +286,7 @@ contract UniswapV2Factory:
     fee_to: address
     fee_to_setter: address
 
-    pairs: map<address, map<address, address>>
+    pairs: Map<address, Map<address, address>>
 
     all_pairs: address[100]
     pair_counter: u256

--- a/tests/fixtures/features/address_bytes10_map.fe
+++ b/tests/fixtures/features/address_bytes10_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<address, bytes[10]>
+    pub bar: Map<address, bytes[10]>
 
     pub def read_bar(key: address) -> bytes[10]:
         return self.bar[key].to_mem()

--- a/tests/fixtures/features/call_statement_with_args.fe
+++ b/tests/fixtures/features/call_statement_with_args.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    baz: map<u256, u256>
+    baz: Map<u256, u256>
 
     def assign(val: u256):
         self.baz[0] = val

--- a/tests/fixtures/features/call_statement_with_args_2.fe
+++ b/tests/fixtures/features/call_statement_with_args_2.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    baz: map<u256, u256>
+    baz: Map<u256, u256>
 
     def assign(val: u256) -> u256:
         self.baz[0] = val

--- a/tests/fixtures/features/call_statement_without_args.fe
+++ b/tests/fixtures/features/call_statement_without_args.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    baz: map<u256, u256>
+    baz: Map<u256, u256>
 
     def assign():
         self.baz[0] = 100

--- a/tests/fixtures/features/constructor.fe
+++ b/tests/fixtures/features/constructor.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    bar: map<u256, u256>
+    bar: Map<u256, u256>
 
     pub def __init__(baz: u256, bing: u256):
         self.bar[42] = baz + bing

--- a/tests/fixtures/features/map_tuple.fe
+++ b/tests/fixtures/features/map_tuple.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    tuples: map<u256, (address, u256)>
+    tuples: Map<u256, (address, u256)>
 
     pub def bar(x: u256) -> u256:
         self.tuples[0] = (address(100), x)

--- a/tests/fixtures/features/nested_map.fe
+++ b/tests/fixtures/features/nested_map.fe
@@ -1,6 +1,6 @@
 contract Foo:
-    bar: map<address, map<address, u256>>
-    baz: map<address, map<u256, bool>>
+    bar: Map<address, Map<address, u256>>
+    baz: Map<address, Map<u256, bool>>
 
     pub def read_bar(a: address, b: address) -> u256:
         return self.bar[a][b]

--- a/tests/fixtures/features/return_u256_from_called_fn_with_args.fe
+++ b/tests/fixtures/features/return_u256_from_called_fn_with_args.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    baz: map<u256, u256>
+    baz: Map<u256, u256>
     pub def foo(val1: u256, val2: u256, val3: u256, val4: u256, val5: u256) -> u256:
         return val1 + val2 + val3 + val4 + val5
 

--- a/tests/fixtures/features/u128_u128_map.fe
+++ b/tests/fixtures/features/u128_u128_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<u128, u128>
+    pub bar: Map<u128, u128>
 
     pub def read_bar(key: u128) -> u128:
         return self.bar[key]

--- a/tests/fixtures/features/u16_u16_map.fe
+++ b/tests/fixtures/features/u16_u16_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<u16, u16>
+    pub bar: Map<u16, u16>
 
     pub def read_bar(key: u16) -> u16:
         return self.bar[key]

--- a/tests/fixtures/features/u256_u256_map.fe
+++ b/tests/fixtures/features/u256_u256_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<u256, u256>
+    pub bar: Map<u256, u256>
 
     pub def read_bar(key: u256) -> u256:
         return self.bar[key]

--- a/tests/fixtures/features/u32_u32_map.fe
+++ b/tests/fixtures/features/u32_u32_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<u32, u32>
+    pub bar: Map<u32, u32>
 
     pub def read_bar(key: u32) -> u32:
         return self.bar[key]

--- a/tests/fixtures/features/u64_u64_map.fe
+++ b/tests/fixtures/features/u64_u64_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<u64, u64>
+    pub bar: Map<u64, u64>
 
     pub def read_bar(key: u64) -> u64:
         return self.bar[key]

--- a/tests/fixtures/features/u8_u8_map.fe
+++ b/tests/fixtures/features/u8_u8_map.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    pub bar: map<u8, u8>
+    pub bar: Map<u8, u8>
 
     pub def read_bar(key: u8) -> u8:
         return self.bar[key]

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -57,12 +57,12 @@ test_stmt! { assign_int, "5 = 6" }
 test_stmt! { assign_call, "self.f() = 10" }
 test_stmt! { assign_type_mismatch, "x: u256 = 10\nx = address(0)" }
 test_stmt! { aug_assign_non_numeric, "a: u256 = 1\nb: bool = true\na += b" }
-test_stmt! { bad_map, "x: map<u8, u8, u8>" }
-test_stmt! { bad_map2, "x: map<address, 100>" }
-test_stmt! { bad_map3, "x: map<>" }
-test_stmt! { bad_map4, "x: map<y>" }
-test_stmt! { bad_map5, "x: map<map<u8, u8>, address>" }
-test_stmt! { bad_map6, "x: map<10, 20>" }
+test_stmt! { bad_map, "x: Map<u8, u8, u8>" }
+test_stmt! { bad_map2, "x: Map<address, 100>" }
+test_stmt! { bad_map3, "x: Map<>" }
+test_stmt! { bad_map4, "x: Map<y>" }
+test_stmt! { bad_map5, "x: Map<Map<u8, u8>, address>" }
+test_stmt! { bad_map6, "x: Map<10, 20>" }
 test_stmt! { binary_op_add_uints, "a: u256 = 1\nb: u8 = 2\na + b" }
 test_stmt! { binary_op_lshift_bool, "a: bool = true\nb: i256\na << b" }
 test_stmt! { binary_op_lshift_with_int, "a: u256 = 1\nb: i256 = 2\na << b" }

--- a/tests/src/lowering/fixtures/map_tuple.fe
+++ b/tests/src/lowering/fixtures/map_tuple.fe
@@ -1,5 +1,5 @@
 contract Foo:
-    tuples: map<u256, (address, u256)>
+    tuples: Map<u256, (address, u256)>
 
     pub def bar(x: u256) -> u256:
         self.tuples[0] = (address(100), x)

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
@@ -3928,8 +3928,8 @@ note:
     ┌─ demos/erc20_token.fe:1:1
     │  
   1 │ ╭ contract ERC20:
-  2 │ │     _balances: map<address, u256>
-  3 │ │     _allowances: map<address, map<address, u256>>
+  2 │ │     _balances: Map<address, u256>
+  3 │ │     _allowances: Map<address, Map<address, u256>>
   4 │ │ 
     · │
 106 │ │     def _before_token_transfer(from: address, to: address, value: u256):
@@ -5081,7 +5081,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:2:20
   │
-2 │     _balances: map<address, u256>
+2 │     _balances: Map<address, u256>
   │                    ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -5091,7 +5091,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:2:29
   │
-2 │     _balances: map<address, u256>
+2 │     _balances: Map<address, u256>
   │                             ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -5103,7 +5103,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:2:16
   │
-2 │     _balances: map<address, u256>
+2 │     _balances: Map<address, u256>
   │                ^^^^^^^^^^^^^^^^^^ attributes hash: 6830914040603267556
   │
   = Map(
@@ -5120,7 +5120,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:3:22
   │
-3 │     _allowances: map<address, map<address, u256>>
+3 │     _allowances: Map<address, Map<address, u256>>
   │                      ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -5130,7 +5130,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:3:35
   │
-3 │     _allowances: map<address, map<address, u256>>
+3 │     _allowances: Map<address, Map<address, u256>>
   │                                   ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -5140,7 +5140,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:3:44
   │
-3 │     _allowances: map<address, map<address, u256>>
+3 │     _allowances: Map<address, Map<address, u256>>
   │                                            ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -5152,7 +5152,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:3:31
   │
-3 │     _allowances: map<address, map<address, u256>>
+3 │     _allowances: Map<address, Map<address, u256>>
   │                               ^^^^^^^^^^^^^^^^^^ attributes hash: 6830914040603267556
   │
   = Map(
@@ -5169,7 +5169,7 @@ note:
 note: 
   ┌─ demos/erc20_token.fe:3:18
   │
-3 │     _allowances: map<address, map<address, u256>>
+3 │     _allowances: Map<address, Map<address, u256>>
   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 652293232820874660
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
@@ -312,7 +312,7 @@ note:
    ┌─ demos/guest_book.fe:3:1
    │  
  3 │ ╭ contract GuestBook:
- 4 │ │     messages: map<address, BookMsg>
+ 4 │ │     messages: Map<address, BookMsg>
  5 │ │ 
  6 │ │     event Signed:
    · │
@@ -492,7 +492,7 @@ note:
 note: 
   ┌─ demos/guest_book.fe:4:19
   │
-4 │     messages: map<address, BookMsg>
+4 │     messages: Map<address, BookMsg>
   │                   ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -502,7 +502,7 @@ note:
 note: 
   ┌─ demos/guest_book.fe:4:28
   │
-4 │     messages: map<address, BookMsg>
+4 │     messages: Map<address, BookMsg>
   │                            ^^^^^^^ attributes hash: 5134157185158150929
   │
   = Array(
@@ -515,7 +515,7 @@ note:
 note: 
   ┌─ demos/guest_book.fe:4:15
   │
-4 │     messages: map<address, BookMsg>
+4 │     messages: Map<address, BookMsg>
   │               ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10049485715821994445
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
@@ -20597,7 +20597,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:12:19
    │
-12 │     balances: map<address, u256>
+12 │     balances: Map<address, u256>
    │                   ^^^^^^^ attributes hash: 574436082528610497
    │
    = Base(
@@ -20607,7 +20607,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:12:28
    │
-12 │     balances: map<address, u256>
+12 │     balances: Map<address, u256>
    │                            ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
@@ -20619,7 +20619,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:12:15
    │
-12 │     balances: map<address, u256>
+12 │     balances: Map<address, u256>
    │               ^^^^^^^^^^^^^^^^^^ attributes hash: 6830914040603267556
    │
    = Map(
@@ -20636,7 +20636,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:13:21
    │
-13 │     allowances: map<address, map<address, u256>>
+13 │     allowances: Map<address, Map<address, u256>>
    │                     ^^^^^^^ attributes hash: 574436082528610497
    │
    = Base(
@@ -20646,7 +20646,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:13:34
    │
-13 │     allowances: map<address, map<address, u256>>
+13 │     allowances: Map<address, Map<address, u256>>
    │                                  ^^^^^^^ attributes hash: 574436082528610497
    │
    = Base(
@@ -20656,7 +20656,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:13:43
    │
-13 │     allowances: map<address, map<address, u256>>
+13 │     allowances: Map<address, Map<address, u256>>
    │                                           ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
@@ -20668,7 +20668,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:13:30
    │
-13 │     allowances: map<address, map<address, u256>>
+13 │     allowances: Map<address, Map<address, u256>>
    │                              ^^^^^^^^^^^^^^^^^^ attributes hash: 6830914040603267556
    │
    = Map(
@@ -20685,7 +20685,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:13:17
    │
-13 │     allowances: map<address, map<address, u256>>
+13 │     allowances: Map<address, Map<address, u256>>
    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 652293232820874660
    │
    = Map(
@@ -20719,7 +20719,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:16:17
    │
-16 │     nonces: map<address, u256>
+16 │     nonces: Map<address, u256>
    │                 ^^^^^^^ attributes hash: 574436082528610497
    │
    = Base(
@@ -20729,7 +20729,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:16:26
    │
-16 │     nonces: map<address, u256>
+16 │     nonces: Map<address, u256>
    │                          ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
@@ -20741,7 +20741,7 @@ note:
 note: 
    ┌─ demos/uniswap.fe:16:13
    │
-16 │     nonces: map<address, u256>
+16 │     nonces: Map<address, u256>
    │             ^^^^^^^^^^^^^^^^^^ attributes hash: 6830914040603267556
    │
    = Map(
@@ -21772,7 +21772,7 @@ note:
 note: 
     ┌─ demos/uniswap.fe:289:16
     │
-289 │     pairs: map<address, map<address, address>>
+289 │     pairs: Map<address, Map<address, address>>
     │                ^^^^^^^ attributes hash: 574436082528610497
     │
     = Base(
@@ -21782,7 +21782,7 @@ note:
 note: 
     ┌─ demos/uniswap.fe:289:29
     │
-289 │     pairs: map<address, map<address, address>>
+289 │     pairs: Map<address, Map<address, address>>
     │                             ^^^^^^^ attributes hash: 574436082528610497
     │
     = Base(
@@ -21792,7 +21792,7 @@ note:
 note: 
     ┌─ demos/uniswap.fe:289:38
     │
-289 │     pairs: map<address, map<address, address>>
+289 │     pairs: Map<address, Map<address, address>>
     │                                      ^^^^^^^ attributes hash: 574436082528610497
     │
     = Base(
@@ -21802,7 +21802,7 @@ note:
 note: 
     ┌─ demos/uniswap.fe:289:25
     │
-289 │     pairs: map<address, map<address, address>>
+289 │     pairs: Map<address, Map<address, address>>
     │                         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4628772786735305773
     │
     = Map(
@@ -21817,7 +21817,7 @@ note:
 note: 
     ┌─ demos/uniswap.fe:289:12
     │
-289 │     pairs: map<address, map<address, address>>
+289 │     pairs: Map<address, Map<address, address>>
     │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8166731215027904440
     │
     = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
@@ -276,7 +276,7 @@ note:
   ┌─ features/address_bytes10_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<address, bytes[10]>
+2 │ │     pub bar: Map<address, bytes[10]>
 3 │ │ 
 4 │ │     pub def read_bar(key: address) -> bytes[10]:
   · │
@@ -415,7 +415,7 @@ note:
 note: 
   ┌─ features/address_bytes10_map.fe:2:18
   │
-2 │     pub bar: map<address, bytes[10]>
+2 │     pub bar: Map<address, bytes[10]>
   │                  ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -425,7 +425,7 @@ note:
 note: 
   ┌─ features/address_bytes10_map.fe:2:27
   │
-2 │     pub bar: map<address, bytes[10]>
+2 │     pub bar: Map<address, bytes[10]>
   │                           ^^^^^ attributes hash: 16931239362436195516
   │
   = Base(
@@ -435,7 +435,7 @@ note:
 note: 
   ┌─ features/address_bytes10_map.fe:2:27
   │
-2 │     pub bar: map<address, bytes[10]>
+2 │     pub bar: Map<address, bytes[10]>
   │                           ^^^^^^^^^ attributes hash: 3890203001217727260
   │
   = Array(
@@ -448,7 +448,7 @@ note:
 note: 
   ┌─ features/address_bytes10_map.fe:2:14
   │
-2 │     pub bar: map<address, bytes[10]>
+2 │     pub bar: Map<address, bytes[10]>
   │              ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4759287443158325036
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
@@ -244,7 +244,7 @@ note:
   ┌─ features/call_statement_with_args.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     baz: map<u256, u256>
+2 │ │     baz: Map<u256, u256>
 3 │ │ 
 4 │ │     def assign(val: u256):
   · │
@@ -311,7 +311,7 @@ note:
 note: 
   ┌─ features/call_statement_with_args.fe:2:14
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │              ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -323,7 +323,7 @@ note:
 note: 
   ┌─ features/call_statement_with_args.fe:2:20
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -335,7 +335,7 @@ note:
 note: 
   ┌─ features/call_statement_with_args.fe:2:10
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │          ^^^^^^^^^^^^^^^ attributes hash: 3210256860376722957
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_009_call_statement_with_args_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_009_call_statement_with_args_2.snap
@@ -265,7 +265,7 @@ note:
    ┌─ features/call_statement_with_args_2.fe:1:1
    │  
  1 │ ╭ contract Foo:
- 2 │ │     baz: map<u256, u256>
+ 2 │ │     baz: Map<u256, u256>
  3 │ │ 
  4 │ │     def assign(val: u256) -> u256:
    · │
@@ -344,7 +344,7 @@ note:
 note: 
   ┌─ features/call_statement_with_args_2.fe:2:14
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │              ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -356,7 +356,7 @@ note:
 note: 
   ┌─ features/call_statement_with_args_2.fe:2:20
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -368,7 +368,7 @@ note:
 note: 
   ┌─ features/call_statement_with_args_2.fe:2:10
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │          ^^^^^^^^^^^^^^^ attributes hash: 3210256860376722957
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
@@ -219,7 +219,7 @@ note:
   ┌─ features/call_statement_without_args.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     baz: map<u256, u256>
+2 │ │     baz: Map<u256, u256>
 3 │ │ 
 4 │ │     def assign():
   · │
@@ -274,7 +274,7 @@ note:
 note: 
   ┌─ features/call_statement_without_args.fe:2:14
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │              ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -286,7 +286,7 @@ note:
 note: 
   ┌─ features/call_statement_without_args.fe:2:20
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -298,7 +298,7 @@ note:
 note: 
   ┌─ features/call_statement_without_args.fe:2:10
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │          ^^^^^^^^^^^^^^^ attributes hash: 3210256860376722957
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
@@ -253,7 +253,7 @@ note:
   ┌─ features/constructor.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     bar: map<u256, u256>
+2 │ │     bar: Map<u256, u256>
 3 │ │ 
 4 │ │     pub def __init__(baz: u256, bing: u256):
   · │
@@ -348,7 +348,7 @@ note:
 note: 
   ┌─ features/constructor.fe:2:14
   │
-2 │     bar: map<u256, u256>
+2 │     bar: Map<u256, u256>
   │              ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -360,7 +360,7 @@ note:
 note: 
   ┌─ features/constructor.fe:2:20
   │
-2 │     bar: map<u256, u256>
+2 │     bar: Map<u256, u256>
   │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -372,7 +372,7 @@ note:
 note: 
   ┌─ features/constructor.fe:2:10
   │
-2 │     bar: map<u256, u256>
+2 │     bar: Map<u256, u256>
   │          ^^^^^^^^^^^^^^^ attributes hash: 3210256860376722957
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
@@ -690,8 +690,8 @@ note:
    ┌─ features/nested_map.fe:1:1
    │  
  1 │ ╭ contract Foo:
- 2 │ │     bar: map<address, map<address, u256>>
- 3 │ │     baz: map<address, map<u256, bool>>
+ 2 │ │     bar: Map<address, Map<address, u256>>
+ 3 │ │     baz: Map<address, Map<u256, bool>>
  4 │ │ 
    · │
 14 │ │     pub def write_baz(a: address, b: u256, value: bool):
@@ -945,7 +945,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:2:14
   │
-2 │     bar: map<address, map<address, u256>>
+2 │     bar: Map<address, Map<address, u256>>
   │              ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -955,7 +955,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:2:27
   │
-2 │     bar: map<address, map<address, u256>>
+2 │     bar: Map<address, Map<address, u256>>
   │                           ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -965,7 +965,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:2:36
   │
-2 │     bar: map<address, map<address, u256>>
+2 │     bar: Map<address, Map<address, u256>>
   │                                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -977,7 +977,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:2:23
   │
-2 │     bar: map<address, map<address, u256>>
+2 │     bar: Map<address, Map<address, u256>>
   │                       ^^^^^^^^^^^^^^^^^^ attributes hash: 6830914040603267556
   │
   = Map(
@@ -994,7 +994,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:2:10
   │
-2 │     bar: map<address, map<address, u256>>
+2 │     bar: Map<address, Map<address, u256>>
   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 652293232820874660
   │
   = Map(
@@ -1016,7 +1016,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:3:14
   │
-3 │     baz: map<address, map<u256, bool>>
+3 │     baz: Map<address, Map<u256, bool>>
   │              ^^^^^^^ attributes hash: 574436082528610497
   │
   = Base(
@@ -1026,7 +1026,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:3:27
   │
-3 │     baz: map<address, map<u256, bool>>
+3 │     baz: Map<address, Map<u256, bool>>
   │                           ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -1038,7 +1038,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:3:33
   │
-3 │     baz: map<address, map<u256, bool>>
+3 │     baz: Map<address, Map<u256, bool>>
   │                                 ^^^^ attributes hash: 8311861578736502650
   │
   = Base(
@@ -1048,7 +1048,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:3:23
   │
-3 │     baz: map<address, map<u256, bool>>
+3 │     baz: Map<address, Map<u256, bool>>
   │                       ^^^^^^^^^^^^^^^ attributes hash: 8612757038189634989
   │
   = Map(
@@ -1065,7 +1065,7 @@ note:
 note: 
   ┌─ features/nested_map.fe:3:10
   │
-3 │     baz: map<address, map<u256, bool>>
+3 │     baz: Map<address, Map<u256, bool>>
   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12802517836116757582
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_082_return_u256_from_called_fn_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_082_return_u256_from_called_fn_with_args.snap
@@ -599,7 +599,7 @@ note:
    ┌─ features/return_u256_from_called_fn_with_args.fe:1:1
    │  
  1 │ ╭ contract Foo:
- 2 │ │     baz: map<u256, u256>
+ 2 │ │     baz: Map<u256, u256>
  3 │ │     pub def foo(val1: u256, val2: u256, val3: u256, val4: u256, val5: u256) -> u256:
  4 │ │         return val1 + val2 + val3 + val4 + val5
    · │
@@ -809,7 +809,7 @@ note:
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:2:14
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │              ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -821,7 +821,7 @@ note:
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:2:20
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -833,7 +833,7 @@ note:
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:2:10
   │
-2 │     baz: map<u256, u256>
+2 │     baz: Map<u256, u256>
   │          ^^^^^^^^^^^^^^^ attributes hash: 3210256860376722957
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
@@ -264,7 +264,7 @@ note:
   ┌─ features/u8_u8_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<u8, u8>
+2 │ │     pub bar: Map<u8, u8>
 3 │ │ 
 4 │ │     pub def read_bar(key: u8) -> u8:
   · │
@@ -379,7 +379,7 @@ note:
 note: 
   ┌─ features/u8_u8_map.fe:2:18
   │
-2 │     pub bar: map<u8, u8>
+2 │     pub bar: Map<u8, u8>
   │                  ^^ attributes hash: 1872326638020472004
   │
   = Base(
@@ -391,7 +391,7 @@ note:
 note: 
   ┌─ features/u8_u8_map.fe:2:22
   │
-2 │     pub bar: map<u8, u8>
+2 │     pub bar: Map<u8, u8>
   │                      ^^ attributes hash: 1872326638020472004
   │
   = Base(
@@ -403,7 +403,7 @@ note:
 note: 
   ┌─ features/u8_u8_map.fe:2:14
   │
-2 │     pub bar: map<u8, u8>
+2 │     pub bar: Map<u8, u8>
   │              ^^^^^^^^^^^ attributes hash: 15893437220884405684
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
@@ -264,7 +264,7 @@ note:
   ┌─ features/u16_u16_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<u16, u16>
+2 │ │     pub bar: Map<u16, u16>
 3 │ │ 
 4 │ │     pub def read_bar(key: u16) -> u16:
   · │
@@ -379,7 +379,7 @@ note:
 note: 
   ┌─ features/u16_u16_map.fe:2:18
   │
-2 │     pub bar: map<u16, u16>
+2 │     pub bar: Map<u16, u16>
   │                  ^^^ attributes hash: 547894393873242964
   │
   = Base(
@@ -391,7 +391,7 @@ note:
 note: 
   ┌─ features/u16_u16_map.fe:2:23
   │
-2 │     pub bar: map<u16, u16>
+2 │     pub bar: Map<u16, u16>
   │                       ^^^ attributes hash: 547894393873242964
   │
   = Base(
@@ -403,7 +403,7 @@ note:
 note: 
   ┌─ features/u16_u16_map.fe:2:14
   │
-2 │     pub bar: map<u16, u16>
+2 │     pub bar: Map<u16, u16>
   │              ^^^^^^^^^^^^^ attributes hash: 12146385998520654072
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
@@ -264,7 +264,7 @@ note:
   ┌─ features/u32_u32_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<u32, u32>
+2 │ │     pub bar: Map<u32, u32>
 3 │ │ 
 4 │ │     pub def read_bar(key: u32) -> u32:
   · │
@@ -379,7 +379,7 @@ note:
 note: 
   ┌─ features/u32_u32_map.fe:2:18
   │
-2 │     pub bar: map<u32, u32>
+2 │     pub bar: Map<u32, u32>
   │                  ^^^ attributes hash: 11356073382633174465
   │
   = Base(
@@ -391,7 +391,7 @@ note:
 note: 
   ┌─ features/u32_u32_map.fe:2:23
   │
-2 │     pub bar: map<u32, u32>
+2 │     pub bar: Map<u32, u32>
   │                       ^^^ attributes hash: 11356073382633174465
   │
   = Base(
@@ -403,7 +403,7 @@ note:
 note: 
   ┌─ features/u32_u32_map.fe:2:14
   │
-2 │     pub bar: map<u32, u32>
+2 │     pub bar: Map<u32, u32>
   │              ^^^^^^^^^^^^^ attributes hash: 4291380678104481154
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
@@ -264,7 +264,7 @@ note:
   ┌─ features/u64_u64_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<u64, u64>
+2 │ │     pub bar: Map<u64, u64>
 3 │ │ 
 4 │ │     pub def read_bar(key: u64) -> u64:
   · │
@@ -379,7 +379,7 @@ note:
 note: 
   ┌─ features/u64_u64_map.fe:2:18
   │
-2 │     pub bar: map<u64, u64>
+2 │     pub bar: Map<u64, u64>
   │                  ^^^ attributes hash: 17534999559619587862
   │
   = Base(
@@ -391,7 +391,7 @@ note:
 note: 
   ┌─ features/u64_u64_map.fe:2:23
   │
-2 │     pub bar: map<u64, u64>
+2 │     pub bar: Map<u64, u64>
   │                       ^^^ attributes hash: 17534999559619587862
   │
   = Base(
@@ -403,7 +403,7 @@ note:
 note: 
   ┌─ features/u64_u64_map.fe:2:14
   │
-2 │     pub bar: map<u64, u64>
+2 │     pub bar: Map<u64, u64>
   │              ^^^^^^^^^^^^^ attributes hash: 4568353499523922040
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
@@ -264,7 +264,7 @@ note:
   ┌─ features/u128_u128_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<u128, u128>
+2 │ │     pub bar: Map<u128, u128>
 3 │ │ 
 4 │ │     pub def read_bar(key: u128) -> u128:
   · │
@@ -379,7 +379,7 @@ note:
 note: 
   ┌─ features/u128_u128_map.fe:2:18
   │
-2 │     pub bar: map<u128, u128>
+2 │     pub bar: Map<u128, u128>
   │                  ^^^^ attributes hash: 14909107886776088983
   │
   = Base(
@@ -391,7 +391,7 @@ note:
 note: 
   ┌─ features/u128_u128_map.fe:2:24
   │
-2 │     pub bar: map<u128, u128>
+2 │     pub bar: Map<u128, u128>
   │                        ^^^^ attributes hash: 14909107886776088983
   │
   = Base(
@@ -403,7 +403,7 @@ note:
 note: 
   ┌─ features/u128_u128_map.fe:2:14
   │
-2 │     pub bar: map<u128, u128>
+2 │     pub bar: Map<u128, u128>
   │              ^^^^^^^^^^^^^^^ attributes hash: 12491373951574090365
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
@@ -264,7 +264,7 @@ note:
   ┌─ features/u256_u256_map.fe:1:1
   │  
 1 │ ╭ contract Foo:
-2 │ │     pub bar: map<u256, u256>
+2 │ │     pub bar: Map<u256, u256>
 3 │ │ 
 4 │ │     pub def read_bar(key: u256) -> u256:
   · │
@@ -379,7 +379,7 @@ note:
 note: 
   ┌─ features/u256_u256_map.fe:2:18
   │
-2 │     pub bar: map<u256, u256>
+2 │     pub bar: Map<u256, u256>
   │                  ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -391,7 +391,7 @@ note:
 note: 
   ┌─ features/u256_u256_map.fe:2:24
   │
-2 │     pub bar: map<u256, u256>
+2 │     pub bar: Map<u256, u256>
   │                        ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
@@ -403,7 +403,7 @@ note:
 note: 
   ┌─ features/u256_u256_map.fe:2:14
   │
-2 │     pub bar: map<u256, u256>
+2 │     pub bar: Map<u256, u256>
   │              ^^^^^^^^^^^^^^^ attributes hash: 3210256860376722957
   │
   = Map(

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `map` expects 2 arguments, but 3 were provided
+error: `Map` expects 2 arguments, but 3 were provided
   ┌─ [snippet]:3:6
   │
-3 │   x: map<u8, u8, u8>
+3 │   x: Map<u8, u8, u8>
   │      ^^^ --  --  -- supplied 3 arguments
   │      │            
   │      expects 2 arguments
@@ -15,4 +15,4 @@ error: `map` expects 2 arguments, but 3 were provided
 
 TypeError on line 3
 pub def f():
-  [31mx: map<u8, u8, u8>[0m
+  [31mx: Map<u8, u8, u8>[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map2.snap
@@ -6,7 +6,7 @@ expression: "error_string(\"[snippet]\", &src)"
 error: `map` key and value must be types
   ┌─ [snippet]:3:19
   │
-3 │   x: map<address, 100>
+3 │   x: Map<address, 100>
   │                   ^^^ this should be a type name
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map3.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map3.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `map` expects 2 arguments, but 0 were provided
+error: `Map` expects 2 arguments, but 0 were provided
   ┌─ [snippet]:3:6
   │
-3 │   x: map<>
+3 │   x: Map<>
   │      ^^^-- supplied 0 arguments
   │      │   
   │      expects 2 arguments

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map4.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map4.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `map` expects 2 arguments, but 1 was provided
+error: `Map` expects 2 arguments, but 1 was provided
   ┌─ [snippet]:3:6
   │
-3 │   x: map<y>
+3 │   x: Map<y>
   │      ^^^ - supplied 1 argument
   │      │    
   │      expects 2 arguments

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map5.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map5.snap
@@ -6,7 +6,7 @@ expression: "error_string(\"[snippet]\", &src)"
 error: `map` key must be a primitive type
   ┌─ [snippet]:3:10
   │
-3 │   x: map<map<u8, u8>, address>
+3 │   x: Map<Map<u8, u8>, address>
   │          ^^^^^^^^^^^ this can't be used as a map key
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map6.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map6.snap
@@ -6,13 +6,13 @@ expression: "error_string(\"[snippet]\", &src)"
 error: `map` key and value must be types
   ┌─ [snippet]:3:10
   │
-3 │   x: map<10, 20>
+3 │   x: Map<10, 20>
   │          ^^ this should be a type name
 
 error: `map` key and value must be types
   ┌─ [snippet]:3:14
   │
-3 │   x: map<10, 20>
+3 │   x: Map<10, 20>
   │              ^^ this should be a type name
 
 


### PR DESCRIPTION
### What was wrong?

Reference type names should be capitalized (we declared), and `map<k, v>` ain't.

### How was it fixed?

find and replace

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
