### PR TITLE
Migrate remaining old style errors

### DIFF
--- a/analyzer/src/builtins.rs
+++ b/analyzer/src/builtins.rs
@@ -14,7 +14,7 @@ pub enum GlobalMethod {
     Keccak256,
 }
 
-#[derive(Debug, PartialEq, EnumString)]
+#[derive(strum::ToString, Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "snake_case")]
 pub enum ContractTypeMethod {
     Create,

--- a/analyzer/src/constants.rs
+++ b/analyzer/src/constants.rs
@@ -1,0 +1,1 @@
+pub const MAX_INDEXED_EVENT_FIELDS: usize = 3;

--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -1,5 +1,5 @@
 use crate::builtins::GlobalMethod;
-use crate::errors::SemanticError;
+use crate::errors::CannotMove;
 use crate::namespace::events::EventDef;
 use crate::namespace::scopes::{ContractFunctionDef, ContractScope, ModuleScope, Shared};
 use crate::namespace::types::{Array, Contract, FixedSize, Struct, Tuple, Type};
@@ -154,11 +154,11 @@ impl ExpressionAttributes {
     }
 
     /// Adds a move to value, if it is in storage or memory.
-    pub fn into_loaded(mut self) -> Result<Self, SemanticError> {
+    pub fn into_loaded(mut self) -> Result<Self, CannotMove> {
         match self.typ {
             Type::Base(_) => {}
             Type::Contract(_) => {}
-            _ => return Err(SemanticError::cannot_move()),
+            _ => return Err(CannotMove),
         }
 
         if self.location != Location::Value {

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -4,6 +4,10 @@ use ansi_term::Color::Red;
 use fe_common::diagnostics::Diagnostic;
 use fe_parser::node::Span;
 
+/// Error to be returned from APIs that should reject duplicate definitions
+#[derive(Debug)]
+pub struct AlreadyDefined;
+
 #[derive(Debug)]
 pub struct AnalyzerError {
     pub diagnostics: Vec<Diagnostic>,
@@ -13,7 +17,6 @@ pub struct AnalyzerError {
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum ErrorKind {
-    AlreadyDefined,
     CannotMove,
     NotCallable,
     NotSubscriptable,
@@ -75,14 +78,6 @@ impl SemanticError {
     pub fn cannot_move() -> Self {
         SemanticError {
             kind: ErrorKind::CannotMove,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `AlreadyDefined`
-    pub fn already_defined() -> Self {
-        SemanticError {
-            kind: ErrorKind::AlreadyDefined,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -7,6 +7,9 @@ use fe_parser::node::Span;
 /// Error to be returned from APIs that should reject duplicate definitions
 #[derive(Debug)]
 pub struct AlreadyDefined;
+/// Error indicating that a value can not move between memory and storage
+#[derive(Debug)]
+pub struct CannotMove;
 
 #[derive(Debug)]
 pub struct AnalyzerError {
@@ -17,7 +20,6 @@ pub struct AnalyzerError {
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum ErrorKind {
-    CannotMove,
     NotCallable,
     NotSubscriptable,
     SignedExponentNotAllowed,
@@ -70,14 +72,6 @@ impl SemanticError {
     pub fn type_error() -> Self {
         SemanticError {
             kind: ErrorKind::TypeError,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `CannotMove`
-    pub fn cannot_move() -> Self {
-        SemanticError {
-            kind: ErrorKind::CannotMove,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -23,7 +23,6 @@ pub enum ErrorKind {
     NotSubscriptable,
     SignedExponentNotAllowed,
     TypeError,
-    UndefinedValue,
     Fatal,
 }
 
@@ -55,14 +54,6 @@ impl SemanticError {
     pub fn signed_exponent_not_allowed() -> Self {
         SemanticError {
             kind: ErrorKind::SignedExponentNotAllowed,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `UndefinedValue`
-    pub fn undefined_value() -> Self {
-        SemanticError {
-            kind: ErrorKind::UndefinedValue,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -20,7 +20,6 @@ pub struct AnalyzerError {
 /// Errors for things that may arise in a valid Fe AST.
 #[derive(Debug, PartialEq)]
 pub enum ErrorKind {
-    NotCallable,
     NotSubscriptable,
     SignedExponentNotAllowed,
     TypeError,
@@ -72,14 +71,6 @@ impl SemanticError {
     pub fn type_error() -> Self {
         SemanticError {
             kind: ErrorKind::TypeError,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `NotCallable`
-    pub fn not_callable() -> Self {
-        SemanticError {
-            kind: ErrorKind::NotCallable,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -15,7 +15,6 @@ pub struct AnalyzerError {
 pub enum ErrorKind {
     AlreadyDefined,
     CannotMove,
-    MoreThanThreeIndexedParams,
     NotCallable,
     NotSubscriptable,
     SignedExponentNotAllowed,
@@ -92,14 +91,6 @@ impl SemanticError {
     pub fn not_callable() -> Self {
         SemanticError {
             kind: ErrorKind::NotCallable,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `MoreThanThreeIndexedParams`
-    pub fn more_than_three_indexed_params() -> Self {
-        SemanticError {
-            kind: ErrorKind::MoreThanThreeIndexedParams,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -19,10 +19,7 @@ pub enum ErrorKind {
     MoreThanThreeIndexedParams,
     NotCallable,
     NotSubscriptable,
-    NumericCapacityMismatch,
-    NumericLiteralExpected,
     SignedExponentNotAllowed,
-    StringCapacityMismatch,
     TypeError,
     UndefinedValue,
     Fatal,
@@ -60,26 +57,10 @@ impl SemanticError {
         }
     }
 
-    /// Create a new error with kind `NumericCapacityMismatch`
-    pub fn numeric_capacity_mismatch() -> Self {
-        SemanticError {
-            kind: ErrorKind::NumericCapacityMismatch,
-            context: vec![],
-        }
-    }
-
     /// Create a new error with kind `SignedExponentNotAllowed`
     pub fn signed_exponent_not_allowed() -> Self {
         SemanticError {
             kind: ErrorKind::SignedExponentNotAllowed,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `NumericCapacityMismatch`
-    pub fn string_capacity_mismatch() -> Self {
-        SemanticError {
-            kind: ErrorKind::StringCapacityMismatch,
             context: vec![],
         }
     }
@@ -120,14 +101,6 @@ impl SemanticError {
     pub fn not_callable() -> Self {
         SemanticError {
             kind: ErrorKind::NotCallable,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `NumericLiteralExpected`
-    pub fn numeric_literal_expected() -> Self {
-        SemanticError {
-            kind: ErrorKind::NumericLiteralExpected,
             context: vec![],
         }
     }

--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -15,7 +15,6 @@ pub struct AnalyzerError {
 pub enum ErrorKind {
     AlreadyDefined,
     CannotMove,
-    CircularDependency,
     MoreThanThreeIndexedParams,
     NotCallable,
     NotSubscriptable,
@@ -37,14 +36,6 @@ impl SemanticError {
     pub fn fatal() -> Self {
         SemanticError {
             kind: ErrorKind::Fatal,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `CircularDependency`
-    pub fn circular_dependency() -> Self {
-        SemanticError {
-            kind: ErrorKind::CircularDependency,
             context: vec![],
         }
     }

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -5,6 +5,7 @@
 //! that can be used to query contextual information attributed to AST nodes.
 
 pub mod builtins;
+pub mod constants;
 pub mod context;
 pub mod errors;
 pub mod namespace;

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -1,4 +1,4 @@
-use crate::errors::SemanticError;
+use crate::errors::{AlreadyDefined, SemanticError};
 use crate::namespace::events::EventDef;
 use crate::namespace::types::{Array, FixedSize, Tuple, Type};
 use std::cell::RefCell;
@@ -94,9 +94,9 @@ impl ModuleScope {
     }
 
     /// Add a type definiton to the scope
-    pub fn add_type_def(&mut self, name: &str, typ: Type) -> Result<(), SemanticError> {
+    pub fn add_type_def(&mut self, name: &str, typ: Type) -> Result<(), AlreadyDefined> {
         match self.type_defs.entry(name.to_owned()) {
-            Entry::Occupied(_) => Err(SemanticError::already_defined()),
+            Entry::Occupied(_) => Err(AlreadyDefined),
             Entry::Vacant(entry) => Ok(entry.insert(typ)).map(|_| ()),
         }
     }
@@ -154,9 +154,9 @@ impl ContractScope {
     }
 
     /// Add a contract field definition to the scope.
-    pub fn add_field(&mut self, name: &str, typ: Type) -> Result<(), SemanticError> {
+    pub fn add_field(&mut self, name: &str, typ: Type) -> Result<(), AlreadyDefined> {
         match self.field_defs.entry(name.to_owned()) {
-            Entry::Occupied(_) => Err(SemanticError::already_defined()),
+            Entry::Occupied(_) => Err(AlreadyDefined),
             Entry::Vacant(e) => {
                 e.insert(ContractFieldDef {
                     nonce: self.num_fields,
@@ -176,9 +176,9 @@ impl ContractScope {
         params: Vec<(String, FixedSize)>,
         return_type: FixedSize,
         scope: Shared<BlockScope>,
-    ) -> Result<&ContractFunctionDef, SemanticError> {
+    ) -> Result<&ContractFunctionDef, AlreadyDefined> {
         match self.function_defs.entry(name.to_owned()) {
-            Entry::Occupied(_) => Err(SemanticError::already_defined()),
+            Entry::Occupied(_) => Err(AlreadyDefined),
             Entry::Vacant(entry) => Ok(entry.insert(ContractFunctionDef {
                 is_public,
                 name: name.to_string(),
@@ -190,9 +190,9 @@ impl ContractScope {
     }
 
     /// Add an event definition to the scope.
-    pub fn add_event(&mut self, name: &str, event: EventDef) -> Result<(), SemanticError> {
+    pub fn add_event(&mut self, name: &str, event: EventDef) -> Result<(), AlreadyDefined> {
         match self.event_defs.entry(name.to_owned()) {
-            Entry::Occupied(_) => Err(SemanticError::already_defined()),
+            Entry::Occupied(_) => Err(AlreadyDefined),
             Entry::Vacant(e) => {
                 e.insert(event);
                 Ok(())
@@ -312,12 +312,12 @@ impl BlockScope {
     }
 
     /// Add a variable to the block scope.
-    pub fn add_var(&mut self, name: &str, typ: FixedSize) -> Result<(), SemanticError> {
+    pub fn add_var(&mut self, name: &str, typ: FixedSize) -> Result<(), AlreadyDefined> {
         if self.get_variable_def(name).is_some() {
-            return Err(SemanticError::already_defined());
+            return Err(AlreadyDefined);
         }
         match self.variable_defs.entry(name.to_owned()) {
-            Entry::Occupied(_) => Err(SemanticError::already_defined()),
+            Entry::Occupied(_) => Err(AlreadyDefined),
             Entry::Vacant(e) => {
                 e.insert(typ);
                 Ok(())

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -1,4 +1,4 @@
-use crate::errors::SemanticError;
+use crate::errors::{AlreadyDefined, SemanticError};
 use std::convert::TryFrom;
 use std::fmt;
 
@@ -203,9 +203,9 @@ impl Struct {
     }
 
     /// Add a field to the struct
-    pub fn add_field(&mut self, name: &str, value: &FixedSize) -> Result<(), SemanticError> {
+    pub fn add_field(&mut self, name: &str, value: &FixedSize) -> Result<(), AlreadyDefined> {
         if self.fields.iter().any(|(fname, _)| fname == name) {
-            Err(SemanticError::already_defined())
+            Err(AlreadyDefined)
         } else {
             self.fields.push((name.to_string(), value.clone()));
             Ok(())

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -1185,7 +1185,18 @@ fn expr_call_type(
     let call_type = match &func.kind {
         fe::Expr::Name(name) => expr_name_call_type(scope, context, name, func.span, generic_args),
         fe::Expr::Attribute { .. } => expr_attribute_call_type(scope, context, func),
-        _ => Err(SemanticError::not_callable()),
+        _ => {
+            let expression = expr(scope, context, func, None)?;
+            context.fancy_error(
+                format!("the {} type is not callable", expression.typ),
+                vec![Label::primary(
+                    func.span,
+                    format!("this has type {}", expression.typ),
+                )],
+                vec![],
+            );
+            Err(SemanticError::fatal())
+        }
     }?;
 
     context.add_call(func, call_type.clone());

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -12,8 +12,8 @@ use builtins::{
     BlockField, ChainField, ContractTypeMethod, GlobalMethod, MsgField, Object, TxField,
     ValueMethod,
 };
-use fe_common::diagnostics::Label;
 use fe_common::numeric;
+use fe_common::{diagnostics::Label, utils::humanize::pluralize_conditionally};
 use fe_common::{Span, Spanned};
 use fe_parser::ast as fe;
 use fe_parser::ast::UnaryOperator;
@@ -631,12 +631,14 @@ pub fn validate_arg_count(
     args: &Node<Vec<impl Spanned>>,
     param_count: usize,
 ) {
-    let ess = |len| if len == 1 { "" } else { "s" };
-
     if args.kind.len() != param_count {
         let mut labels = vec![Label::primary(
             name_span,
-            format!("expects {} argument{}", param_count, ess(param_count)),
+            format!(
+                "expects {} {}",
+                param_count,
+                pluralize_conditionally("argument", param_count)
+            ),
         )];
         if args.kind.is_empty() {
             labels.push(Label::secondary(args.span, "supplied 0 arguments"));
@@ -645,20 +647,20 @@ pub fn validate_arg_count(
                 labels.push(Label::secondary(arg.span(), ""));
             }
             labels.last_mut().unwrap().message = format!(
-                "supplied {} argument{}",
+                "supplied {} {}",
                 args.kind.len(),
-                ess(args.kind.len()),
+                pluralize_conditionally("argument", args.kind.len())
             );
         }
 
         context.fancy_error(
             format!(
-                "`{}` expects {} argument{}, but {} {} provided",
+                "`{}` expects {} {}, but {} {} provided",
                 name,
                 param_count,
-                ess(param_count),
+                pluralize_conditionally("argument", param_count),
                 args.kind.len(),
-                if args.kind.len() == 1 { "was" } else { "were" },
+                pluralize_conditionally(("was", "were"), args.kind.len())
             ),
             labels,
             vec![],

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -1058,12 +1058,19 @@ fn expr_call_type_attribute(
     let arg_attributes = expr_call_args(Rc::clone(&scope), context, args)?;
     let contract_name = scope.borrow().contract_scope().borrow().name.clone();
 
+    let report_circular_dependency = |context: &mut Context, method: String| {
+        context.fancy_error(
+            format!("`{contract}.{}(...)` called within `{contract}` creates an illegal circular dependency", method, contract=contract_name),
+            vec![Label::primary(name_span, "Contract creation")],
+            vec![format!("Note: Consider using a dedicated factory contract to create instances of `{}`", contract_name)]);
+    };
+
     match (typ, ContractTypeMethod::from_str(func_name)) {
         (Type::Contract(contract), Ok(ContractTypeMethod::Create2)) => {
             validate_arg_count(context, func_name, name_span, args, 2);
 
             if contract_name == contract.name {
-                return Err(SemanticError::circular_dependency());
+                report_circular_dependency(context, ContractTypeMethod::Create2.to_string());
             }
 
             if matches!(
@@ -1088,7 +1095,7 @@ fn expr_call_type_attribute(
             validate_arg_count(context, func_name, name_span, args, 1);
 
             if contract_name == contract.name {
-                return Err(SemanticError::circular_dependency());
+                report_circular_dependency(context, ContractTypeMethod::Create.to_string());
             }
 
             if matches!(&arg_attributes[0].typ, Type::Base(Base::Numeric(_))) {

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -485,11 +485,11 @@ fn expr_attribute(
                     Ok(ExpressionAttributes::new(typ.to_owned().into(), location))
                 } else {
                     context.fancy_error(
-                        "Invalid attempt to access struct field",
-                        vec![Label::primary(
-                            attr.span,
-                            format!("Not a valid field on the {} struct", struct_.name),
-                        )],
+                        format!(
+                            "No field `{}` exists on struct `{}`",
+                            &attr.kind, struct_.name
+                        ),
+                        vec![Label::primary(attr.span, "undefined field")],
                         vec![],
                     );
                     fatal_err
@@ -504,11 +504,11 @@ fn expr_attribute(
                     Some(index) => index,
                     None => {
                         context.fancy_error(
-                            "Invalid attempt to access tuple field",
+                            format!("No field `{}` exists on this tuple", &attr.kind),
                             vec![
                                 Label::primary(
                                     attr.span,
-                                    "Invalid attempt",
+                                    "undefined field",
                                 )
                             ],
                             vec!["Note: Tuple values are accessed via `itemN` properties such as `item0` or `item1`".into()],
@@ -521,11 +521,8 @@ fn expr_attribute(
                     Ok(ExpressionAttributes::new(typ.to_owned().into(), location))
                 } else {
                     context.fancy_error(
-                        "Invalid attempt to access tuple field",
-                        vec![Label::primary(
-                            attr.span,
-                            format!("Invalid attempt at index {}", item_index),
-                        )],
+                        format!("No field `item{}` exists on this tuple", item_index),
+                        vec![Label::primary(attr.span, "unknown field")],
                         vec![format!(
                             "Note: The highest possible field for this tuple is `item{}`",
                             tuple.items.len() - 1
@@ -571,8 +568,8 @@ fn expr_attribute_self(
         )),
         None => {
             context.fancy_error(
-                "Invalid attempt to access contract field",
-                vec![Label::primary(attr.span, "Not a valid contract field")],
+                format!("No field `{}` exists on this contract", &attr.kind),
+                vec![Label::primary(attr.span, "undefined field")],
                 vec![],
             );
             Err(SemanticError::fatal())
@@ -989,8 +986,8 @@ fn expr_call_self_attribute(
         ))
     } else {
         context.fancy_error(
-            "Call to undefined function",
-            vec![Label::primary(name_span, "Called undefined function")],
+            format!("no function `{}` exists this contract", func_name),
+            vec![Label::primary(name_span, "undefined function")],
             vec![],
         );
         Err(SemanticError::fatal())
@@ -1038,7 +1035,10 @@ fn expr_call_value_attribute(
         return match ValueMethod::from_str(&attr.kind) {
             Err(_) => {
                 context.fancy_error(
-                    format!("Invalid call to `{}`", &attr.kind),
+                    format!(
+                        "No function `{}` exists on type `{}`",
+                        &attr.kind, &value_attributes.typ
+                    ),
                     vec![Label::primary(attr.span, "undefined function")],
                     vec![],
                 );
@@ -1388,8 +1388,8 @@ fn expr_attribute_call_type(
             match Object::from_str(&name) {
                 Ok(Object::Block) | Ok(Object::Chain) | Ok(Object::Msg) | Ok(Object::Tx) => {
                     context.fancy_error(
-                        "illegal call on builtin object",
-                        vec![Label::primary(exp.span, "illegal call")],
+                        format!("no function `{}` exists on builtin `{}`", &attr.kind, &name),
+                        vec![Label::primary(exp.span, "undefined function")],
                         vec![],
                     );
 

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -1,4 +1,4 @@
-use crate::errors::SemanticError;
+use crate::errors::{AlreadyDefined, SemanticError};
 use crate::namespace::scopes::{ModuleScope, Scope, Shared};
 use crate::traversal::{contracts, structs, types};
 use crate::Context;
@@ -18,8 +18,8 @@ pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), Semantic
         match &stmt.kind {
             fe::ModuleStmt::TypeDef { .. } => type_def(context, Rc::clone(&scope), stmt)?,
             fe::ModuleStmt::Pragma { .. } => pragma_stmt(context, stmt),
-            fe::ModuleStmt::StructDef { name, fields } => {
-                structs::struct_def(context, Rc::clone(&scope), &name.kind, fields)?
+            fe::ModuleStmt::StructDef { .. } => {
+                structs::struct_def(context, Rc::clone(&scope), stmt)?
             }
             fe::ModuleStmt::ContractDef { .. } => {
                 // Collect contract statements and the scope that we create for them. After we
@@ -55,7 +55,22 @@ fn type_def(
 ) -> Result<(), SemanticError> {
     if let fe::ModuleStmt::TypeDef { name, typ } = &stmt.kind {
         let typ = types::type_desc(&Scope::Module(Rc::clone(&scope)), context, &typ)?;
-        scope.borrow_mut().add_type_def(&name.kind, typ)?;
+
+        if let Err(AlreadyDefined) = scope.borrow_mut().add_type_def(&name.kind, typ) {
+            context.fancy_error(
+                "a type definition with the same name already exists",
+                // TODO: figure out how to include the previously defined definition
+                vec![Label::primary(
+                    stmt.span,
+                    format!("Conflicting definition of `{}`", name.kind),
+                )],
+                vec![format!(
+                    "Note: Give one of the `{}` definitions a different name",
+                    name.kind
+                )],
+            )
+        }
+
         return Ok(());
     }
 

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -1,6 +1,8 @@
+use fe_common::diagnostics::Label;
+use fe_parser::ast as fe;
 use fe_parser::{ast::Field, node::Node};
 
-use crate::errors::SemanticError;
+use crate::errors::{AlreadyDefined, SemanticError};
 use crate::namespace::scopes::{ModuleScope, Scope, Shared};
 use crate::namespace::types::{FixedSize, Struct, Type};
 use crate::traversal::types::type_desc;
@@ -10,21 +12,66 @@ use std::rc::Rc;
 pub fn struct_def(
     context: &mut Context,
     module_scope: Shared<ModuleScope>,
-    name: &str,
-    fields: &[Node<Field>],
+    stmt: &Node<fe::ModuleStmt>,
 ) -> Result<(), SemanticError> {
-    let mut val = Struct::new(name);
-    for field in fields {
-        let Field { name, typ, .. } = &field.kind;
-        let field_type = type_desc(&Scope::Module(Rc::clone(&module_scope)), context, typ)?;
-        if let Type::Base(base_typ) = field_type {
-            val.add_field(&name.kind, &FixedSize::Base(base_typ))?;
-        } else {
-            context.not_yet_implemented("non-base type struct fields", field.span)
+    if let fe::ModuleStmt::StructDef { name, fields } = &stmt.kind {
+        let mut val = Struct::new(&name.kind);
+        for field in fields {
+            let Field { name, typ, .. } = &field.kind;
+            let field_type = type_desc(&Scope::Module(Rc::clone(&module_scope)), context, typ)?;
+            if let Type::Base(base_typ) = field_type {
+                if let Err(AlreadyDefined) = val.add_field(&name.kind, &FixedSize::Base(base_typ)) {
+                    let first_definition = fields
+                        .iter()
+                        .find(|val| {
+                            let Field {
+                                name: inner_name, ..
+                            } = &val.kind;
+                            inner_name.kind == name.kind && val.span != field.span
+                        })
+                        .expect("Missing field");
+
+                    context.fancy_error(
+                        "a struct field with the same name already exists",
+                        vec![
+                            Label::primary(
+                                first_definition.span,
+                                format!("First definition of field `{}`", name.kind),
+                            ),
+                            Label::primary(
+                                field.span,
+                                format!("Conflicting definition of field `{}`", name.kind),
+                            ),
+                        ],
+                        vec![format!(
+                            "Note: Give one of the `{}` fields a different name",
+                            name.kind
+                        )],
+                    )
+                }
+            } else {
+                context.not_yet_implemented("non-base type struct fields", field.span)
+            }
         }
+        if let Err(AlreadyDefined) = module_scope
+            .borrow_mut()
+            .add_type_def(&name.kind, Type::Struct(val))
+        {
+            context.fancy_error(
+                "a struct with the same name already exists",
+                // TODO: figure out how to include the previously defined struct
+                vec![Label::primary(
+                    stmt.span,
+                    format!("Conflicting definition of struct `{}`", name.kind),
+                )],
+                vec![format!(
+                    "Note: Give one of the `{}` structs a different name",
+                    name.kind
+                )],
+            )
+        }
+
+        return Ok(());
     }
-    module_scope
-        .borrow_mut()
-        .add_type_def(name, Type::Struct(val))?;
-    Ok(())
+    unreachable!()
 }

--- a/common/src/utils/humanize.rs
+++ b/common/src/utils/humanize.rs
@@ -1,0 +1,44 @@
+/// A trait to derive plural or singular representations from
+pub trait Pluralizable {
+    fn to_plural(&self) -> String;
+
+    fn to_singular(&self) -> String;
+}
+
+impl Pluralizable for &str {
+    fn to_plural(&self) -> String {
+        if self.ends_with('s') {
+            self.to_string()
+        } else {
+            format!("{}s", self)
+        }
+    }
+
+    fn to_singular(&self) -> String {
+        if self.ends_with('s') {
+            self[0..self.len() - 1].to_string()
+        } else {
+            self.to_string()
+        }
+    }
+}
+
+// Impl Pluralizable for (singular, plural)
+impl Pluralizable for (&str, &str) {
+    fn to_plural(&self) -> String {
+        self.1.to_string()
+    }
+
+    fn to_singular(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+// Pluralize the given pluralizable if the `count` is greater than one.
+pub fn pluralize_conditionally(pluralizable: impl Pluralizable, count: usize) -> String {
+    if count == 1 {
+        pluralizable.to_singular()
+    } else {
+        pluralizable.to_plural()
+    }
+}

--- a/common/src/utils/mod.rs
+++ b/common/src/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod humanize;
 pub mod keccak;
 pub mod ron;

--- a/newsfragments/432.feature.md
+++ b/newsfragments/432.feature.md
@@ -1,0 +1,1 @@
+Converted more errors to use the new advanced error reporting system.

--- a/tests/fixtures/compile_errors/call_builtin_object.fe
+++ b/tests/fixtures/compile_errors/call_builtin_object.fe
@@ -1,0 +1,4 @@
+
+contract Bar:
+  pub def test():
+    block.foo()

--- a/tests/fixtures/compile_errors/cannot_move.fe
+++ b/tests/fixtures/compile_errors/cannot_move.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    data: u256[10]
+
+    pub def foo() -> u256[10]:
+        return self.data

--- a/tests/fixtures/compile_errors/cannot_move2.fe
+++ b/tests/fixtures/compile_errors/cannot_move2.fe
@@ -1,0 +1,6 @@
+contract Foo:
+
+  pub def foo():
+    x:u256[10]
+    y:u256[10]
+    c:u256[20] = x + y

--- a/tests/fixtures/compile_errors/duplicate_arg_in_contract_method.fe
+++ b/tests/fixtures/compile_errors/duplicate_arg_in_contract_method.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def bar(foo: u8, foo:u8):
+        pass

--- a/tests/fixtures/compile_errors/invalid_block_field.fe
+++ b/tests/fixtures/compile_errors/invalid_block_field.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+  pub def foo():
+    block.foo

--- a/tests/fixtures/compile_errors/invalid_chain_field.fe
+++ b/tests/fixtures/compile_errors/invalid_chain_field.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+  pub def foo():
+    chain.foo

--- a/tests/fixtures/compile_errors/invalid_contract_field.fe
+++ b/tests/fixtures/compile_errors/invalid_contract_field.fe
@@ -1,0 +1,5 @@
+contract Foo:
+  val: u256
+
+  pub def foo():
+    self.bar

--- a/tests/fixtures/compile_errors/invalid_msg_field.fe
+++ b/tests/fixtures/compile_errors/invalid_msg_field.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+  pub def foo():
+    msg.foo

--- a/tests/fixtures/compile_errors/invalid_struct_field.fe
+++ b/tests/fixtures/compile_errors/invalid_struct_field.fe
@@ -1,0 +1,8 @@
+struct Bar:
+  id: u256
+
+contract Foo:
+  val: Bar
+
+  pub def foo():
+    self.val.foo

--- a/tests/fixtures/compile_errors/invalid_tuple_field.fe
+++ b/tests/fixtures/compile_errors/invalid_tuple_field.fe
@@ -1,0 +1,5 @@
+contract Foo:
+  val: (u256, u8)
+
+  pub def foo():
+    self.val.item5

--- a/tests/fixtures/compile_errors/invalid_tx_field.fe
+++ b/tests/fixtures/compile_errors/invalid_tx_field.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+  pub def foo():
+    tx.foo

--- a/tests/fixtures/compile_errors/not_callable.fe
+++ b/tests/fixtures/compile_errors/not_callable.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+    pub def bar():
+        5()

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -178,6 +178,7 @@ test_file! { mismatch_return_type }
 test_file! { missing_return }
 test_file! { missing_return_in_else }
 test_file! { needs_mem_copy }
+test_file! { not_callable }
 test_file! { not_in_scope }
 test_file! { not_in_scope_2 }
 test_file! { return_addition_with_mixed_types }

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -156,6 +156,7 @@ test_file! { call_undefined_function_on_external_contract }
 test_file! { call_undefined_function_on_memory_struct }
 test_file! { call_undefined_function_on_storage_struct }
 test_file! { cannot_move }
+test_file! { cannot_move2 }
 test_file! { circular_dependency_create }
 test_file! { circular_dependency_create2 }
 test_file! { duplicate_arg_in_contract_method }

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -151,6 +151,7 @@ test_stmt! { unexpected_return, "return 1" }
 
 test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }
+test_file! { call_builtin_object }
 test_file! { call_event_with_wrong_types }
 test_file! { call_undefined_function_on_external_contract }
 test_file! { call_undefined_function_on_memory_struct }
@@ -174,6 +175,13 @@ test_file! { external_call_type_error }
 test_file! { external_call_wrong_number_of_params }
 test_file! { indexed_event }
 test_file! { invalid_compiler_version }
+test_file! { invalid_block_field }
+test_file! { invalid_chain_field }
+test_file! { invalid_contract_field }
+test_file! { invalid_msg_field }
+test_file! { invalid_struct_field }
+test_file! { invalid_tuple_field }
+test_file! { invalid_tx_field }
 test_file! { mismatch_return_type }
 test_file! { missing_return }
 test_file! { missing_return_in_else }

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -155,6 +155,7 @@ test_file! { call_event_with_wrong_types }
 test_file! { call_undefined_function_on_external_contract }
 test_file! { call_undefined_function_on_memory_struct }
 test_file! { call_undefined_function_on_storage_struct }
+test_file! { cannot_move }
 test_file! { circular_dependency_create }
 test_file! { circular_dependency_create2 }
 test_file! { duplicate_arg_in_contract_method }

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -157,6 +157,7 @@ test_file! { call_undefined_function_on_memory_struct }
 test_file! { call_undefined_function_on_storage_struct }
 test_file! { circular_dependency_create }
 test_file! { circular_dependency_create2 }
+test_file! { duplicate_arg_in_contract_method }
 test_file! { duplicate_contract_in_module }
 test_file! { duplicate_event_in_contract }
 test_file! { duplicate_field_in_contract }

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr1.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr1.snap
@@ -3,11 +3,11 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid attempt to access tuple field
+error: No field `iteo0` exists on this tuple
   ┌─ fixtures/compile_errors/bad_tuple_attr1.fe:6:27
   │
 6 │         self.my_sto_tuple.iteo0
-  │                           ^^^^^ Invalid attempt
+  │                           ^^^^^ undefined field
   │
   = Note: Tuple values are accessed via `itemN` properties such as `item0` or `item1`
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr1.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr1.snap
@@ -3,7 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: Invalid attempt to access tuple field
+  ┌─ fixtures/compile_errors/bad_tuple_attr1.fe:6:27
+  │
+6 │         self.my_sto_tuple.iteo0
+  │                           ^^^^^ Invalid attempt
+  │
+  = Note: Tuple values are accessed via `itemN` properties such as `item0` or `item1`
 
 
-UndefinedValue on line 6
-[31mself.my_sto_tuple.iteo0[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr2.snap
@@ -3,11 +3,11 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid attempt to access tuple field
+error: No field `m` exists on this tuple
   ┌─ fixtures/compile_errors/bad_tuple_attr2.fe:6:27
   │
 6 │         self.my_sto_tuple.m
-  │                           ^ Invalid attempt
+  │                           ^ undefined field
   │
   = Note: Tuple values are accessed via `itemN` properties such as `item0` or `item1`
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_tuple_attr2.snap
@@ -3,7 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: Invalid attempt to access tuple field
+  ┌─ fixtures/compile_errors/bad_tuple_attr2.fe:6:27
+  │
+6 │         self.my_sto_tuple.m
+  │                           ^ Invalid attempt
+  │
+  = Note: Tuple values are accessed via `itemN` properties such as `item0` or `item1`
 
 
-UndefinedValue on line 6
-[31mself.my_sto_tuple.m[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_builtin_object.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_builtin_object.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: illegal call on builtin object
+error: no function `foo` exists on builtin `block`
   ┌─ fixtures/compile_errors/call_builtin_object.fe:4:5
   │
 4 │     block.foo()
-  │     ^^^^^^^^^ illegal call
+  │     ^^^^^^^^^ undefined function
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_builtin_object.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_builtin_object.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: illegal call on builtin object
+  ┌─ fixtures/compile_errors/call_builtin_object.fe:4:5
+  │
+4 │     block.foo()
+  │     ^^^^^^^^^ illegal call
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_contract.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: Call to undefined function
+error: no function `doesnt_exist` exists this contract
   ┌─ [snippet]:3:3
   │
 3 │   self.doesnt_exist()
-  │   ^^^^^^^^^^^^^^^^^ Called undefined function
+  │   ^^^^^^^^^^^^^^^^^ undefined function
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_contract.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: Call to undefined function
+  ┌─ [snippet]:3:3
+  │
+3 │   self.doesnt_exist()
+  │   ^^^^^^^^^^^^^^^^^ Called undefined function
 
 
-UndefinedValue on line 3
-[31mself.doesnt_exist()[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_external_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_external_contract.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: No function `doesnt_exist` exists on contract `Foo`
+  ┌─ fixtures/compile_errors/call_undefined_function_on_external_contract.fe:7:21
+  │
+7 │     Foo(address(0)).doesnt_exist()
+  │                     ^^^^^^^^^^^^ undefined function
 
 
-UndefinedValue on line 7
-[31mFoo(address(0)).doesnt_exist()[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_memory_struct.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_memory_struct.snap
@@ -3,7 +3,7 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid call to `doesnt_exist`
+error: No function `doesnt_exist` exists on type `Something`
   ┌─ fixtures/compile_errors/call_undefined_function_on_memory_struct.fe:7:12
   │
 7 │     thingy.doesnt_exist()

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_memory_struct.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_memory_struct.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: Invalid call to `doesnt_exist`
+  ┌─ fixtures/compile_errors/call_undefined_function_on_memory_struct.fe:7:12
+  │
+7 │     thingy.doesnt_exist()
+  │            ^^^^^^^^^^^^ undefined function
 
 
-UndefinedValue on line 7
-[31mthingy.doesnt_exist()[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_storage_struct.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_storage_struct.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: Invalid call to `doesnt_exist`
+  ┌─ fixtures/compile_errors/call_undefined_function_on_storage_struct.fe:8:17
+  │
+8 │     self.thingy.doesnt_exist()
+  │                 ^^^^^^^^^^^^ undefined function
 
 
-UndefinedValue on line 8
-[31mself.thingy.doesnt_exist()[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_storage_struct.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_undefined_function_on_storage_struct.snap
@@ -3,7 +3,7 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid call to `doesnt_exist`
+error: No function `doesnt_exist` exists on type `Something`
   ┌─ fixtures/compile_errors/call_undefined_function_on_storage_struct.fe:8:17
   │
 8 │     self.thingy.doesnt_exist()

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__cannot_move.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__cannot_move.snap
@@ -1,0 +1,15 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: value must be copied to memory
+  ┌─ fixtures/compile_errors/cannot_move.fe:5:16
+  │
+5 │         return self.data
+  │                ^^^^^^^^^ this value is in storage
+  │
+  = Hint: values located in storage can be copied to memory using the `to_mem` function.
+  = Example: `self.my_array.to_mem()`
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__cannot_move2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__cannot_move2.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: can't move value onto stack
+  ┌─ fixtures/compile_errors/cannot_move2.fe:6:18
+  │
+6 │     c:u256[20] = x + y
+  │                  ^ Value to be moved
+  │
+  = Note: Can't move `u256[10]` types on the stack
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__circular_dependency_create.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__circular_dependency_create.snap
@@ -3,7 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: `Foo.create(...)` called within `Foo` creates an illegal circular dependency
+  ┌─ fixtures/compile_errors/circular_dependency_create.fe:3:20
+  │
+3 │         foo: Foo = Foo.create(0)
+  │                    ^^^^^^^^^^ Contract creation
+  │
+  = Note: Consider using a dedicated factory contract to create instances of `Foo`
 
 
-CircularDependency on line 3
-foo: Foo = [31mFoo.create(0)[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__circular_dependency_create2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__circular_dependency_create2.snap
@@ -3,7 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: `Foo.create2(...)` called within `Foo` creates an illegal circular dependency
+  ┌─ fixtures/compile_errors/circular_dependency_create2.fe:3:20
+  │
+3 │         foo: Foo = Foo.create2(2, 0)
+  │                    ^^^^^^^^^^^ Contract creation
+  │
+  = Note: Consider using a dedicated factory contract to create instances of `Foo`
 
 
-CircularDependency on line 3
-foo: Foo = [31mFoo.create2(2, 0)[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_arg_in_contract_method.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_arg_in_contract_method.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: a function argument with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_arg_in_contract_method.fe:2:26
+  │
+2 │     pub def bar(foo: u8, foo:u8):
+  │                          ^^^^^^ Conflicting definition of function argument `foo`
+  │
+  = Note: Give one of the `foo` function arguments a different name
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_contract_in_module.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_contract_in_module.snap
@@ -3,7 +3,15 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a contract with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_contract_in_module.fe:6:1
+  │  
+6 │ ╭ contract Foo:
+7 │ │ 
+8 │ │     pub def bar():
+9 │ │         pass
+  │ ╰────────────^ Conflicting definition of contract `Foo`
+  │  
+  = Note: Give one of the `Foo` contracts a different name
 
 
-AlreadyDefined on line 0
-no error context available

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_event_in_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_event_in_contract.snap
@@ -3,8 +3,13 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: an event with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_event_in_contract.fe:5:5
+  │  
+5 │ ╭     event MyEvent:
+6 │ │         idx addr1: address
+  │ ╰──────────────────────────^ Conflicting definition of event `MyEvent`
+  │  
+  = Note: Give one of the `MyEvent` events a different name
 
 
-AlreadyDefined on line 5
-event MyEvent:
-        idx addr1: address

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_field_in_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_field_in_contract.snap
@@ -3,7 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a contract field with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_field_in_contract.fe:3:5
+  │
+3 │     bar: u8
+  │     ^^^^^^^ Conflicting definition of field `bar`
+  │
+  = Note: Give one of the `bar` fields a different name
 
 
-AlreadyDefined on line 0
-no error context available

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_field_in_struct.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_field_in_struct.snap
@@ -3,7 +3,14 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a struct field with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_field_in_struct.fe:2:5
+  │
+2 │     foo: u8
+  │     ^^^^^^^ First definition of field `foo`
+3 │     foo: u8
+  │     ^^^^^^^ Conflicting definition of field `foo`
+  │
+  = Note: Give one of the `foo` fields a different name
 
 
-AlreadyDefined on line 0
-no error context available

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_method_in_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_method_in_contract.snap
@@ -3,8 +3,13 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a function with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_method_in_contract.fe:6:5
+  │  
+6 │ ╭     pub def bar():
+7 │ │         pass
+  │ ╰────────────^ Conflicting definition of contract `bar`
+  │  
+  = Note: Give one of the `bar` functions a different name
 
 
-AlreadyDefined on line 6
-pub def bar():
-        pass

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_struct_in_module.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_struct_in_module.snap
@@ -3,7 +3,13 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a struct with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_struct_in_module.fe:4:1
+  │  
+4 │ ╭ struct MyStruct:
+5 │ │     foo: u8
+  │ ╰───────────^ Conflicting definition of struct `MyStruct`
+  │  
+  = Note: Give one of the `MyStruct` structs a different name
 
 
-AlreadyDefined on line 0
-no error context available

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_typedef_in_module.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_typedef_in_module.snap
@@ -3,7 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a type definition with the same name already exists
+  ┌─ fixtures/compile_errors/duplicate_typedef_in_module.fe:4:1
+  │
+4 │ type bar = u8
+  │ ^^^^^^^^^^^^^ Conflicting definition of `bar`
+  │
+  = Note: Give one of the `bar` definitions a different name
 
 
-AlreadyDefined on line 0
-no error context available

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_var_in_child_scope.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_var_in_child_scope.snap
@@ -3,8 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a variable with the same name already exists in this scope
+  ┌─ fixtures/compile_errors/duplicate_var_in_child_scope.fe:6:13
+  │
+6 │             sum: u256 = 0
+  │             ^^^ Conflicting definition of `sum` variables
+  │
+  = Note: Give one of the `sum` variables a different name
 
 
-AlreadyDefined on line 6
-for i in my_array:
-            [31msum: u256 = 0[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_var_in_contract_method.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__duplicate_var_in_contract_method.snap
@@ -3,9 +3,12 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: a variable with the same name already exists in this scope
+  ┌─ fixtures/compile_errors/duplicate_var_in_contract_method.fe:4:9
+  │
+4 │         foo: u8
+  │         ^^^ Conflicting definition of `foo` variables
+  │
+  = Note: Give one of the `foo` variables a different name
 
 
-AlreadyDefined on line 4
-pub def bar():
-        foo: u8
-        [31mfoo: u8[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__indexed_event.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__indexed_event.snap
@@ -3,11 +3,18 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: More than three indexed fields.
+  ┌─ fixtures/compile_errors/indexed_event.fe:3:9
+  │
+3 │         idx addr1: address
+  │         ^^^^^^^^^^^^^^^^^^ Indexed field
+4 │         idx addr2: address
+  │         ^^^^^^^^^^^^^^^^^^ Indexed field
+5 │         idx addr3: address
+  │         ^^^^^^^^^^^^^^^^^^ Indexed field
+6 │         idx addr4: address
+  │         ^^^^^^^^^^^^^^^^^^ Indexed field
+  │
+  = Note: Remove the `idx` keyword from at least 1 field.
 
 
-MoreThanThreeIndexedParams on line 2
-event MyEvent:
-        idx addr1: address
-        idx addr2: address
-        idx addr3: address
-        idx addr4: address

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_block_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_block_field.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Not a block field
+  ┌─ fixtures/compile_errors/invalid_block_field.fe:4:11
+  │
+4 │     block.foo
+  │           ^^^
+  │
+  = Note: Only `coinbase`, `difficulty`, `number` and `timestamp` can be accessed on `block`.
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_chain_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_chain_field.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Not a chain field
+  ┌─ fixtures/compile_errors/invalid_chain_field.fe:4:11
+  │
+4 │     chain.foo
+  │           ^^^
+  │
+  = Note: Only `id` can be accessed on `chain`.
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_contract_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_contract_field.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid attempt to access contract field
+error: No field `bar` exists on this contract
   ┌─ fixtures/compile_errors/invalid_contract_field.fe:5:10
   │
 5 │     self.bar
-  │          ^^^ Not a valid contract field
+  │          ^^^ undefined field
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_contract_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_contract_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Invalid attempt to access contract field
+  ┌─ fixtures/compile_errors/invalid_contract_field.fe:5:10
+  │
+5 │     self.bar
+  │          ^^^ Not a valid contract field
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_msg_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_msg_field.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Not a `msg` field
+  ┌─ fixtures/compile_errors/invalid_msg_field.fe:4:9
+  │
+4 │     msg.foo
+  │         ^^^
+  │
+  = Note: Only `sender`, `sig` and `value` can be accessed on `msg`.
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_struct_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_struct_field.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid attempt to access struct field
+error: No field `foo` exists on struct `Bar`
   ┌─ fixtures/compile_errors/invalid_struct_field.fe:8:14
   │
 8 │     self.val.foo
-  │              ^^^ Not a valid field on the Bar struct
+  │              ^^^ undefined field
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_struct_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Invalid attempt to access struct field
+  ┌─ fixtures/compile_errors/invalid_struct_field.fe:8:14
+  │
+8 │     self.val.foo
+  │              ^^^ Not a valid field on the Bar struct
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_tuple_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_tuple_field.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Invalid attempt to access tuple field
+  ┌─ fixtures/compile_errors/invalid_tuple_field.fe:5:14
+  │
+5 │     self.val.item5
+  │              ^^^^^ Invalid attempt at index 5
+  │
+  = Note: The highest possible field for this tuple is `item1`
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_tuple_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_tuple_field.snap
@@ -3,11 +3,11 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Invalid attempt to access tuple field
+error: No field `item5` exists on this tuple
   ┌─ fixtures/compile_errors/invalid_tuple_field.fe:5:14
   │
 5 │     self.val.item5
-  │              ^^^^^ Invalid attempt at index 5
+  │              ^^^^^ unknown field
   │
   = Note: The highest possible field for this tuple is `item1`
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_tx_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_tx_field.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Not a `tx` field
+  ┌─ fixtures/compile_errors/invalid_tx_field.fe:4:8
+  │
+4 │     tx.foo
+  │        ^^^
+  │
+  = Note: Only `gas_price` and `origin` can be accessed on `tx`.
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__not_callable.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__not_callable.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: the u256 type is not callable
+  ┌─ fixtures/compile_errors/not_callable.fe:4:9
+  │
+4 │         5()
+  │         ^ this has type u256
+
+


### PR DESCRIPTION
### What was wrong?

As described in #432 we have a bunch of analyzer errors that still need to be migrated to the new system

### How was it fixed?

This doesn't migrate all errors but a substantial enough chunk of them to be wrapped up for now.

General path taken:

1. Added call to `context.fancy_error(...)`
2. Returned a `SemanticError::fatal()` if the error prevents us from returning meaningful information
3. Removed migrated semantic error type
4. If needed, created a standalone error to carry an error up the call stack in cases where we have to raise errors from a place that doesn't allow us to create a context rich error

The general direction of the migration is to eventually get rid of `SemanticError` entirely and just have a standalone `FatalError` struct that would be returned from the analyzer. 