### PR TITLE
`__init__` must be `pub`

### DIFF
--- a/newsfragments/435.feature.md
+++ b/newsfragments/435.feature.md
@@ -1,0 +1,1 @@
+Analyzer throws an error if `__init__` is not public.

--- a/tests/fixtures/compile_errors/non_pub_init.fe
+++ b/tests/fixtures/compile_errors/non_pub_init.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    def __init__():
+        pass

--- a/tests/fixtures/features/ownable.fe
+++ b/tests/fixtures/features/ownable.fe
@@ -5,7 +5,7 @@ contract Ownable:
     idx previousOwner: address
     idx newOwner: address
 
-  def __init__():
+  pub def __init__():
     self._owner = msg.sender
 
   pub def owner() -> address:

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -185,3 +185,4 @@ test_file! { return_lt_mixed_types }
 test_file! { strict_boolean_if_else }
 test_file! { struct_call_bad_args }
 test_file! { struct_call_without_kw_args }
+test_file! { non_pub_init }

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
@@ -466,12 +466,12 @@ note:
 note: 
   ┌─ features/ownable.fe:8:3
   │  
-8 │ ╭   def __init__():
+8 │ ╭   pub def __init__():
 9 │ │     self._owner = msg.sender
-  │ ╰────────────────────────────^ attributes hash: 14570492547403311025
+  │ ╰────────────────────────────^ attributes hash: 3035129065019296448
   │  
   = FunctionAttributes {
-        is_public: false,
+        is_public: true,
         name: "__init__",
         params: [],
         return_type: Base(
@@ -549,7 +549,7 @@ note:
    · │
 22 │ │     self._owner = newOwner
 23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 17730541326400548227
+   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 17669221761082887319
    │  
    = ContractAttributes {
          public_functions: [
@@ -585,7 +585,16 @@ note:
                  ),
              },
          ],
-         init_function: None,
+         init_function: Some(
+             FunctionAttributes {
+                 is_public: true,
+                 name: "__init__",
+                 params: [],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+         ),
          events: [
              EventDef {
                  name: "OwnershipTransferred",

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__non_pub_init.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__non_pub_init.snap
@@ -1,0 +1,16 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `__init__` function is not public
+  ┌─ fixtures/compile_errors/non_pub_init.fe:2:5
+  │  
+2 │ ╭     def __init__():
+3 │ │         pass
+  │ ╰────────────^ `__init__` function must be public
+  │  
+  = Hint: Add the `pub` modifier.
+  = Example: `pub def __init__():`
+
+


### PR DESCRIPTION
### What was wrong?

closes #353

See https://github.com/ethereum/fe/issues/353#issuecomment-848205436

### How was it fixed?

Throw a compiler error if `__init__` is not public.

My thinking is that `__init__` should either always be *public* or *not public*. If there are good reasons to go with always not pub, then I can modify this PR to do the opposite.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
