### PR TITLE
Migrate all remaining errors

### DIFF
--- a/analyzer/src/errors.rs
+++ b/analyzer/src/errors.rs
@@ -1,101 +1,39 @@
 //! Semantic errors.
 
-use ansi_term::Color::Red;
 use fe_common::diagnostics::Diagnostic;
-use fe_parser::node::Span;
 
 /// Error to be returned from APIs that should reject duplicate definitions
 #[derive(Debug)]
 pub struct AlreadyDefined;
+
+/// Error to be returned when otherwise no meaningful information can be returned
+#[derive(Debug)]
+pub struct FatalError;
+
 /// Error indicating that a value can not move between memory and storage
 #[derive(Debug)]
 pub struct CannotMove;
 
+/// Error indicating that a value has the wrong type
 #[derive(Debug)]
-pub struct AnalyzerError {
-    pub diagnostics: Vec<Diagnostic>,
-    pub classic: Option<SemanticError>,
-}
+pub struct TypeError;
 
-/// Errors for things that may arise in a valid Fe AST.
+/// Errors that can result from indexing
 #[derive(Debug, PartialEq)]
-pub enum ErrorKind {
+pub enum IndexingError {
+    WrongIndexType,
     NotSubscriptable,
-    SignedExponentNotAllowed,
-    TypeError,
-    Fatal,
 }
 
+/// Errors that can result from a binary operation
 #[derive(Debug, PartialEq)]
-pub struct SemanticError {
-    pub kind: ErrorKind,
-    /// A sequence of nested spans containing the error's origin in the source
-    /// code.
-    pub context: Vec<Span>,
+pub enum BinaryOperationError {
+    TypesNotEqual,
+    TypesNotNumeric,
+    RightTooLarge,
+    RightIsSigned,
+    NotEqualAndUnsigned,
 }
 
-impl SemanticError {
-    pub fn fatal() -> Self {
-        SemanticError {
-            kind: ErrorKind::Fatal,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `NotSubscriptable`
-    pub fn not_subscriptable() -> Self {
-        SemanticError {
-            kind: ErrorKind::NotSubscriptable,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `SignedExponentNotAllowed`
-    pub fn signed_exponent_not_allowed() -> Self {
-        SemanticError {
-            kind: ErrorKind::SignedExponentNotAllowed,
-            context: vec![],
-        }
-    }
-
-    /// Create a new error with kind `TypeError`
-    pub fn type_error() -> Self {
-        SemanticError {
-            kind: ErrorKind::TypeError,
-            context: vec![],
-        }
-    }
-
-    /// Maps the error to a new error that contains the given span in its
-    /// context.
-    pub fn with_context(mut self, span: Span) -> Self {
-        self.context.push(span);
-        self
-    }
-
-    /// Formats the error using the source code.
-    ///
-    /// The string will contain the error kind, line number, and surrounding
-    /// code.
-    pub fn format_user(&self, src: &str) -> String {
-        let line = if let Some(span) = self.context.first() {
-            src[..span.start].lines().count()
-        } else {
-            0
-        };
-
-        let context = match (self.context.get(0), self.context.get(1)) {
-            (Some(inner), Some(outer)) => {
-                let first_part = src[outer.start..inner.start].to_string();
-                let middle_part = Red.paint(&src[inner.start..inner.end]).to_string();
-                let last_part = src[inner.end..outer.end].to_string();
-
-                format!("{}{}{}", first_part, middle_part, last_part)
-            }
-            (Some(span), None) => src[span.start..span.end].to_string(),
-            (_, _) => "no error context available".to_string(),
-        };
-
-        format!("{:?} on line {}\n{}", self.kind, line, context)
-    }
-}
+#[derive(Debug)]
+pub struct AnalyzerError(pub Vec<Diagnostic>);

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -12,7 +12,7 @@ pub mod namespace;
 mod operations;
 mod traversal;
 
-use crate::errors::{AnalyzerError, ErrorKind};
+use crate::errors::{AnalyzerError, FatalError};
 use context::Context;
 use fe_common::files::SourceFileId;
 use fe_parser::ast as fe;
@@ -28,20 +28,15 @@ pub fn analyze(module: &fe::Module, file_id: SourceFileId) -> Result<Context, An
             if context.diagnostics.is_empty() {
                 Ok(context)
             } else {
-                Err(AnalyzerError {
-                    diagnostics: context.diagnostics,
-                    classic: None,
-                })
+                Err(AnalyzerError(context.diagnostics))
             }
         }
-        Err(err) => Err(AnalyzerError {
-            diagnostics: context.diagnostics,
-            classic: if err.kind == ErrorKind::Fatal {
-                None
-            } else {
-                Some(err)
-            },
-        }),
+        Err(FatalError) => {
+            if context.diagnostics.is_empty() {
+                panic!("Expected at least one error")
+            }
+            Err(AnalyzerError(context.diagnostics))
+        }
     }
 }
 

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -1,4 +1,4 @@
-use crate::errors::{AlreadyDefined, SemanticError};
+use crate::errors::AlreadyDefined;
 use crate::namespace::events::EventDef;
 use crate::namespace::types::{Array, FixedSize, Tuple, Type};
 use std::cell::RefCell;
@@ -201,9 +201,8 @@ impl ContractScope {
     }
 
     /// Add a static string definition to the scope.
-    pub fn add_string(&mut self, value: &str) -> Result<(), SemanticError> {
+    pub fn add_string(&mut self, value: &str) {
         self.string_defs.insert(value.to_owned());
-        Ok(())
     }
 
     /// Add the name of another contract that has been created within this

--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -1,4 +1,4 @@
-use crate::errors::{AlreadyDefined, SemanticError};
+use crate::errors::{AlreadyDefined, TypeError};
 use std::convert::TryFrom;
 use std::fmt;
 
@@ -380,16 +380,16 @@ impl From<Base> for FixedSize {
 }
 
 impl TryFrom<Type> for FixedSize {
-    type Error = SemanticError;
+    type Error = TypeError;
 
-    fn try_from(value: Type) -> Result<Self, SemanticError> {
+    fn try_from(value: Type) -> Result<Self, TypeError> {
         match value {
             Type::Array(array) => Ok(FixedSize::Array(array)),
             Type::Base(base) => Ok(FixedSize::Base(base)),
             Type::Tuple(tuple) => Ok(FixedSize::Tuple(tuple)),
             Type::String(string) => Ok(FixedSize::String(string)),
             Type::Struct(val) => Ok(FixedSize::Struct(val)),
-            Type::Map(_) => Err(SemanticError::type_error()),
+            Type::Map(_) => Err(TypeError),
             Type::Contract(contract) => Ok(FixedSize::Contract(contract)),
         }
     }

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -1,4 +1,4 @@
-use crate::errors::{AlreadyDefined, SemanticError};
+use crate::errors::{AlreadyDefined, FatalError};
 use crate::namespace::scopes::{ModuleScope, Scope, Shared};
 use crate::traversal::{contracts, structs, types};
 use crate::Context;
@@ -9,7 +9,7 @@ use semver::{Version, VersionReq};
 use std::rc::Rc;
 
 /// Gather context information for a module and check for type errors.
-pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), SemanticError> {
+pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), FatalError> {
     let scope = ModuleScope::new();
 
     let mut contracts = vec![];
@@ -52,7 +52,7 @@ fn type_def(
     context: &mut Context,
     scope: Shared<ModuleScope>,
     stmt: &Node<fe::ModuleStmt>,
-) -> Result<(), SemanticError> {
+) -> Result<(), FatalError> {
     if let fe::ModuleStmt::TypeDef { name, typ } = &stmt.kind {
         let typ = types::type_desc(&Scope::Module(Rc::clone(&scope)), context, &typ)?;
 

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -2,7 +2,7 @@ use fe_common::diagnostics::Label;
 use fe_parser::ast as fe;
 use fe_parser::{ast::Field, node::Node};
 
-use crate::errors::{AlreadyDefined, SemanticError};
+use crate::errors::{AlreadyDefined, FatalError};
 use crate::namespace::scopes::{ModuleScope, Scope, Shared};
 use crate::namespace::types::{FixedSize, Struct, Type};
 use crate::traversal::types::type_desc;
@@ -13,7 +13,7 @@ pub fn struct_def(
     context: &mut Context,
     module_scope: Shared<ModuleScope>,
     stmt: &Node<fe::ModuleStmt>,
-) -> Result<(), SemanticError> {
+) -> Result<(), FatalError> {
     if let fe::ModuleStmt::StructDef { name, fields } = &stmt.kind {
         let mut val = Struct::new(&name.kind);
         for field in fields {

--- a/analyzer/src/traversal/utils.rs
+++ b/analyzer/src/traversal/utils.rs
@@ -1,7 +1,56 @@
-use crate::errors::SemanticError;
+use fe_common::diagnostics::Label;
+use fe_parser::ast as fe;
+use fe_parser::node::Node;
+
+use crate::context::Context;
+use crate::errors::{BinaryOperationError, TypeError};
 use crate::namespace::types::{FixedSize, Type};
 use std::convert::TryInto;
 
-pub fn types_to_fixed_sizes(sizes: &[Type]) -> Result<Vec<FixedSize>, SemanticError> {
+pub fn types_to_fixed_sizes(sizes: &[Type]) -> Result<Vec<FixedSize>, TypeError> {
     sizes.iter().map(|param| param.clone().try_into()).collect()
+}
+
+pub fn add_bin_operations_errors(
+    context: &mut Context,
+    left: &Node<fe::Expr>,
+    right: &Node<fe::Expr>,
+    error: BinaryOperationError,
+) {
+    match error {
+        BinaryOperationError::NotEqualAndUnsigned => context.fancy_error(
+            "The types for this operation must be equal and unsigned",
+            vec![
+                Label::primary(left.span, ""),
+                Label::primary(right.span, ""),
+            ],
+            vec![],
+        ),
+        BinaryOperationError::RightIsSigned => context.fancy_error(
+            "The right hand side of this operation must be unsigned",
+            vec![Label::primary(right.span, "incompatible signed numeric")],
+            vec![],
+        ),
+        BinaryOperationError::RightTooLarge => context.fancy_error(
+            "The right hand side of this operation must fit into the left",
+            vec![Label::primary(right.span, "size too large")],
+            vec![],
+        ),
+        BinaryOperationError::TypesNotEqual => context.fancy_error(
+            "The types for this operation must be equal",
+            vec![
+                Label::primary(left.span, ""),
+                Label::primary(right.span, ""),
+            ],
+            vec![],
+        ),
+        BinaryOperationError::TypesNotNumeric => context.fancy_error(
+            "The types for this operation must be numeric",
+            vec![
+                Label::primary(left.span, ""),
+                Label::primary(right.span, ""),
+            ],
+            vec![],
+        ),
+    }
 }

--- a/newsfragments/432.feature.md
+++ b/newsfragments/432.feature.md
@@ -1,1 +1,1 @@
-Converted more errors to use the new advanced error reporting system.
+Convert all remaining errors to use the new advanced error reporting system

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,14 +183,8 @@ pub fn main() {
             for err in error.errors {
                 match err {
                     ErrorKind::Str(err) => eprintln!("Compiler error: {}", err),
-                    ErrorKind::Analyzer(AnalyzerError {
-                        diagnostics,
-                        classic,
-                    }) => {
+                    ErrorKind::Analyzer(AnalyzerError(diagnostics)) => {
                         print_diagnostics(&diagnostics, &files);
-                        if let Some(err) = classic {
-                            eprintln!("Analyzer error: {}", err.format_user(&content));
-                        }
                     }
                     ErrorKind::Parser(diags) => print_diagnostics(&diags, &files),
                 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -192,18 +192,12 @@ pub fn read_fixture(path: &str) -> (String, SourceFileId) {
         .unwrap_or_else(|_| panic!("unable to read fixture file: {}", path))
 }
 
-fn print_compiler_errors(error: CompileError, src: &str, files: &FileStore) {
+fn print_compiler_errors(error: CompileError, files: &FileStore) {
     for err in error.errors {
         match err {
             ErrorKind::Str(err) => eprintln!("Compiler error: {}", err),
-            ErrorKind::Analyzer(AnalyzerError {
-                diagnostics,
-                classic,
-            }) => {
+            ErrorKind::Analyzer(AnalyzerError(diagnostics)) => {
                 print_diagnostics(&diagnostics, &files);
-                if let Some(err) = classic {
-                    eprintln!("Analyzer error: {}", err.format_user(&src))
-                }
             }
             ErrorKind::Parser(diags) => print_diagnostics(&diags, &files),
         }
@@ -225,7 +219,7 @@ pub fn deploy_contract(
     let compiled_module = match compiler::compile(&src, id, true, true) {
         Ok(module) => module,
         Err(error) => {
-            print_compiler_errors(error, &src, &files);
+            print_compiler_errors(error, &files);
             panic!("failed to compile module: {}", fixture)
         }
     };

--- a/tests/fixtures/compile_errors/call_address_with_wrong_type.fe
+++ b/tests/fixtures/compile_errors/call_address_with_wrong_type.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub def foo():
+        address(true)

--- a/tests/fixtures/compile_errors/call_create2_with_wrong_type.fe
+++ b/tests/fixtures/compile_errors/call_create2_with_wrong_type.fe
@@ -1,0 +1,7 @@
+contract Bar:
+    pass
+
+contract Foo:
+
+    pub def foo():
+        Bar.create2(true, 1)

--- a/tests/fixtures/compile_errors/call_create_with_wrong_type.fe
+++ b/tests/fixtures/compile_errors/call_create_with_wrong_type.fe
@@ -1,0 +1,7 @@
+contract Bar:
+    pass
+
+contract Foo:
+
+    pub def foo():
+        Bar.create(true)

--- a/tests/fixtures/compile_errors/call_keccak_with_wrong_type.fe
+++ b/tests/fixtures/compile_errors/call_keccak_with_wrong_type.fe
@@ -1,0 +1,7 @@
+contract Bar:
+    pass
+
+contract Foo:
+
+    pub def foo():
+       keccak256(true)

--- a/tests/fixtures/compile_errors/call_keccak_without_parameter.fe
+++ b/tests/fixtures/compile_errors/call_keccak_without_parameter.fe
@@ -1,0 +1,7 @@
+contract Bar:
+    pass
+
+contract Foo:
+
+    pub def foo():
+       keccak256()

--- a/tests/fixtures/compile_errors/invalid_generic_string.fe
+++ b/tests/fixtures/compile_errors/invalid_generic_string.fe
@@ -1,0 +1,2 @@
+contract Foo:
+  val: String<foo>

--- a/tests/src/analysis.rs
+++ b/tests/src/analysis.rs
@@ -126,14 +126,8 @@ fn analysis(fixture: &str) {
     };
     match fe_analyzer::analyze(&fe_module, id) {
         Ok(context) => assert_snapshot!(build_snapshot(fixture, &src, &context)),
-        Err(AnalyzerError {
-            diagnostics,
-            classic,
-        }) => {
+        Err(AnalyzerError(diagnostics)) => {
             print_diagnostics(&diagnostics, &files);
-            if let Some(err) = classic {
-                eprintln!("Analyzer error: {}", err.format_user(&src));
-            }
             panic!("analysis failed");
         }
     }

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -1,5 +1,6 @@
 //! Tests for contracts that should cause compile errors
 
+use fe_analyzer::errors::AnalyzerError;
 use fe_common::diagnostics::{diagnostics_string, print_diagnostics};
 use fe_common::files::FileStore;
 use insta::assert_snapshot;
@@ -16,13 +17,9 @@ fn error_string(path: &str, src: &str) -> String {
             panic!("parsing failed");
         }
     };
-    let err = fe_analyzer::analyze(&fe_module, id).unwrap_err();
+    let AnalyzerError(diagnostics) = fe_analyzer::analyze(&fe_module, id).unwrap_err();
 
-    let mut errstr = diagnostics_string(&err.diagnostics, &files);
-    if let Some(classic) = err.classic {
-        errstr.push_str(&format!("\n\n{}", classic.format_user(&src)));
-    }
-    errstr
+    diagnostics_string(&diagnostics, &files)
 }
 
 macro_rules! assert_snapshot_wasm {
@@ -152,7 +149,12 @@ test_stmt! { unexpected_return, "return 1" }
 test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }
 test_file! { call_builtin_object }
+test_file! { call_address_with_wrong_type }
+test_file! { call_create_with_wrong_type }
+test_file! { call_create2_with_wrong_type }
 test_file! { call_event_with_wrong_types }
+test_file! { call_keccak_without_parameter }
+test_file! { call_keccak_with_wrong_type }
 test_file! { call_undefined_function_on_external_contract }
 test_file! { call_undefined_function_on_memory_struct }
 test_file! { call_undefined_function_on_storage_struct }
@@ -178,6 +180,7 @@ test_file! { invalid_compiler_version }
 test_file! { invalid_block_field }
 test_file! { invalid_chain_field }
 test_file! { invalid_contract_field }
+test_file! { invalid_generic_string }
 test_file! { invalid_msg_field }
 test_file! { invalid_struct_field }
 test_file! { invalid_tuple_field }

--- a/tests/src/lowering/mod.rs
+++ b/tests/src/lowering/mod.rs
@@ -21,7 +21,6 @@ fn analyze(module: &fe::Module, id: SourceFileId, files: &FileStore) -> Context 
     match fe_analyzer::analyze(&module, id) {
         Ok(context) => context,
         Err(AnalyzerError {
-            classic,
             diagnostics,
         }) => {
             print_diagnostics(&diagnostics, &files);

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__aug_assign_non_numeric.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__aug_assign_non_numeric.snap
@@ -3,10 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The types for this operation must be numeric
+  ┌─ [snippet]:5:3
+  │
+5 │   a += b
+  │   ^    ^
 
 
-TypeError on line 5
-pub def f():
-  a: u256 = 1
-  b: bool = true
-  [31ma += b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__bad_map.snap
@@ -11,8 +11,10 @@ error: `Map` expects 2 arguments, but 3 were provided
   │      │            
   │      expects 2 arguments
 
+error: Expected a value with a fixed size
+  ┌─ [snippet]:3:6
+  │
+3 │   x: Map<u8, u8, u8>
+  │      ^^^^^^^^^^^^^^^
 
 
-TypeError on line 3
-pub def f():
-  [31mx: Map<u8, u8, u8>[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_add_uints.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_add_uints.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The types for this operation must be equal
+  ┌─ [snippet]:5:3
+  │
+5 │   a + b
+  │   ^   ^
 
 
-TypeError on line 5
-[31ma + b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_lshift_bool.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_lshift_bool.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The types for this operation must be numeric
+  ┌─ [snippet]:5:3
+  │
+5 │   a << b
+  │   ^    ^
 
 
-TypeError on line 5
-[31ma << b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_lshift_with_int.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_lshift_with_int.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The right hand side of this operation must be unsigned
+  ┌─ [snippet]:5:8
+  │
+5 │   a << b
+  │        ^ incompatible signed numeric
 
 
-TypeError on line 5
-[31ma << b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_pow_int.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__binary_op_pow_int.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The right hand side of this operation must be unsigned
+  ┌─ [snippet]:5:8
+  │
+5 │   a ** b
+  │        ^ incompatible signed numeric
 
 
-SignedExponentNotAllowed on line 5
-[31ma ** b[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_address_with_wrong_type.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_address_with_wrong_type.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `bool` can not be used as a parameter to `address(..)`
+  ┌─ fixtures/compile_errors/call_address_with_wrong_type.fe:3:17
+  │
+3 │         address(true)
+  │                 ^^^^ wrong type
+  │
+  = Note: address(..) expects a parameter of a contract type, numeric or address
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_create2_with_wrong_type.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_create2_with_wrong_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: function `create2` expects numeric parameters
+  ┌─ fixtures/compile_errors/call_create2_with_wrong_type.fe:7:20
+  │
+7 │         Bar.create2(true, 1)
+  │                    ^^^^^^^^^ invalid argument
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_create_with_wrong_type.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_create_with_wrong_type.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: function `create` expects numeric parameter
+  ┌─ fixtures/compile_errors/call_create_with_wrong_type.fe:7:19
+  │
+7 │         Bar.create(true)
+  │                   ^^^^^^ invalid argument
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_keccak_with_wrong_type.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_keccak_with_wrong_type.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `bool` can not be used as a parameter to `keccak(..)`
+  ┌─ fixtures/compile_errors/call_keccak_with_wrong_type.fe:7:17
+  │
+7 │        keccak256(true)
+  │                 ^^^^^^ wrong type
+  │
+  = Note: keccak(..) expects a byte array as parameter
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_keccak_without_parameter.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_keccak_without_parameter.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `keccak256` expects 1 argument, but 0 were provided
+  ┌─ fixtures/compile_errors/call_keccak_without_parameter.fe:7:8
+  │
+7 │        keccak256()
+  │        ^^^^^^^^^-- supplied 0 arguments
+  │        │         
+  │        expects 1 argument
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_generic_string.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_generic_string.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Numeric generic type parameter expected
+  ┌─ fixtures/compile_errors/invalid_generic_string.fe:2:14
+  │
+2 │   val: String<foo>
+  │              ^^^^^ invalid type parameter
+  │
+  = Example: String<100>
+
+

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__keccak_called_with_wrong_type.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__keccak_called_with_wrong_type.snap
@@ -17,7 +17,12 @@ error: argument should not be labeled
 4 │   keccak256(foo=x, 10)
   │             ^^^ remove this label
 
+error: `u256[1]` can not be used as a parameter to `keccak(..)`
+  ┌─ [snippet]:4:12
+  │
+4 │   keccak256(foo=x, 10)
+  │            ^^^^^^^^^^^ wrong type
+  │
+  = Note: keccak(..) expects a byte array as parameter
 
 
-TypeError on line 4
-[31mkeccak256(foo=x, 10)[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__mismatch_return_type.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__mismatch_return_type.snap
@@ -3,8 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: expected function to return `address` but was `u256`
+  ┌─ fixtures/compile_errors/mismatch_return_type.fe:4:9
+  │
+4 │         return 1
+  │         ^^^^^^^^
 
 
-TypeError on line 4
-pub def bar() -> address:
-        [31mreturn 1[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__pow_with_signed_exponent.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__pow_with_signed_exponent.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The right hand side of this operation must be unsigned
+  ┌─ [snippet]:5:11
+  │
+5 │   base ** exp
+  │           ^^^ incompatible signed numeric
 
 
-SignedExponentNotAllowed on line 5
-[31mbase ** exp[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__pow_with_wrong_capacity.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__pow_with_wrong_capacity.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: The right hand side of this operation must fit into the left
+  ┌─ [snippet]:5:11
+  │
+5 │   base ** exp
+  │           ^^^ size too large
 
 
-TypeError on line 5
-[31mbase ** exp[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__return_addition_with_mixed_types.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__return_addition_with_mixed_types.snap
@@ -3,7 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: The types for this operation must be equal
+  ┌─ fixtures/compile_errors/return_addition_with_mixed_types.fe:3:16
+  │
+3 │         return x + y
+  │                ^   ^
 
 
-TypeError on line 3
-return [31mx + y[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__return_call_to_fn_without_return.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__return_call_to_fn_without_return.snap
@@ -3,8 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(&path, &src)"
 
 ---
+error: expected function to return `u256` but was `()`
+  ┌─ fixtures/compile_errors/return_call_to_fn_without_return.fe:7:9
+  │
+7 │         return self.foo()
+  │         ^^^^^^^^^^^^^^^^^
 
 
-TypeError on line 7
-pub def bar() -> u256:
-        [31mreturn self.foo()[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__return_from_init.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__return_from_init.snap
@@ -12,8 +12,10 @@ error: `__init__` function has incorrect return type
   = Hint: Remove the return type specification.
   = Example: `pub def __init__():`
 
+error: expected function to return `()` but was `u256`
+  ┌─ fixtures/compile_errors/return_from_init.fe:3:9
+  │
+3 │         return 0
+  │         ^^^^^^^^
 
 
-TypeError on line 3
-pub def __init__() -> i32:
-        [31mreturn 0[0m

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__unexpected_return.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__unexpected_return.snap
@@ -3,8 +3,10 @@ source: tests/src/compile_errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
+error: expected function to return `()` but was `u256`
+  ┌─ [snippet]:3:3
+  │
+3 │   return 1
+  │   ^^^^^^^^
 
 
-TypeError on line 3
-pub def f():
-  [31mreturn 1[0m


### PR DESCRIPTION
### What was wrong?

Finalization of #432 (Migrating errors)

### How was it fixed?

The general approach taken was as follows:

1. If we have to return errors (because not enough access to report them directly) we create very narrow function specific errors
2. The only error that can be returned from the analyzer is `FatalError` which is an empty struct
3. There's a safety check in place that would panic in case the analyzer returns a `FatalError` but has not logged any errors
4. `SemanticError` and everything around it is gone :fire: 
5. The `AnaylzerError` was turned into a `pub struct AnalyzerError(pub Vec<Diagnostic>)` (since the `classic` property is gone)
6. Lots of new errors and test cases

### To-Do

There's still a lot to improve about the errors but at least this cleans up the migration work