### PR TITLE
Fix ICE when accessing an invalid attribute on a type

### DIFF
--- a/analyzer/src/namespace/types.rs
+++ b/analyzer/src/namespace/types.rs
@@ -876,7 +876,7 @@ impl fmt::Display for Tuple {
 
 impl fmt::Display for FeString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "string<{}>", self.max_size)
+        write!(f, "String<{}>", self.max_size)
     }
 }
 

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -521,7 +521,8 @@ fn expr_attribute(
 
         // We attempt to analyze the value as an expression. If this is successful, we
         // build a new set of attributes from the value attributes.
-        return match expr(scope, context, value, None)? {
+        let expression_attributes = expr(Rc::clone(&scope), context, value, None)?;
+        return match expression_attributes {
             // If the value is a struct, we return the type of the attribute. The location stays the
             // same and can be memory or storage.
             ExpressionAttributes {
@@ -579,7 +580,17 @@ fn expr_attribute(
                     fatal_err
                 }
             }
-            _ => fatal_err,
+            _ => {
+                context.fancy_error(
+                    format!(
+                        "No field `{}` exists on type {}",
+                        &attr.kind, expression_attributes.typ
+                    ),
+                    vec![Label::primary(attr.span, "unknown field")],
+                    vec![],
+                );
+                fatal_err
+            }
         };
     }
 

--- a/newsfragments/444.bugfix.md
+++ b/newsfragments/444.bugfix.md
@@ -1,0 +1,12 @@
+Fixed a crash when trying to access an invalid attribute on a string.
+
+Example:
+
+```
+contract Foo:
+
+  pub def foo():
+    "".does_not_exist
+```
+
+The above now yields a proper user error.

--- a/newsfragments/445.bugfix.md
+++ b/newsfragments/445.bugfix.md
@@ -1,0 +1,1 @@
+Ensure `String<N>` type is capitalized in error messages

--- a/tests/fixtures/compile_errors/invalid_string_field.fe
+++ b/tests/fixtures/compile_errors/invalid_string_field.fe
@@ -1,0 +1,4 @@
+contract Foo:
+
+  pub def foo():
+    "".does_not_exist

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -182,6 +182,7 @@ test_file! { invalid_chain_field }
 test_file! { invalid_contract_field }
 test_file! { invalid_generic_string }
 test_file! { invalid_msg_field }
+test_file! { invalid_string_field }
 test_file! { invalid_struct_field }
 test_file! { invalid_tuple_field }
 test_file! { invalid_tx_field }

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__array_mixed_types.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__array_mixed_types.snap
@@ -13,6 +13,6 @@ error: type mismatch
   ┌─ [snippet]:3:31
   │
 3 │   x: u16[3] = [1, address(0), "hi"]
-  │                               ^^^^ this has type `string<2>`; expected type `u16`
+  │                               ^^^^ this has type `String<2>`; expected type `u16`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__call_event_with_wrong_types.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__call_event_with_wrong_types.snap
@@ -23,7 +23,7 @@ error: incorrect type for `MyEvent` argument `val_1`
   ┌─ fixtures/compile_errors/call_event_with_wrong_types.fe:7:22
   │
 7 │         emit MyEvent("foo", 1000)
-  │                      ^^^^^ this has type `string<3>`; expected type `string<100>`
+  │                      ^^^^^ this has type `String<3>`; expected type `String<100>`
 
 error: literal out of range for `u8`
   ┌─ fixtures/compile_errors/call_event_with_wrong_types.fe:7:29

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__external_call_type_error.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__external_call_type_error.snap
@@ -7,6 +7,6 @@ error: incorrect type for `bar` argument `a`
   ┌─ fixtures/compile_errors/external_call_type_error.fe:7:29
   │
 7 │         Foo(address(0)).bar("hello world")
-  │                             ^^^^^^^^^^^^^ this has type `string<11>`; expected type `u256`
+  │                             ^^^^^^^^^^^^^ this has type `String<11>`; expected type `u256`
 
 

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_string_field.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__invalid_string_field.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: No field `does_not_exist` exists on type String<0>
+  ┌─ fixtures/compile_errors/invalid_string_field.fe:4:8
+  │
+4 │     "".does_not_exist
+  │        ^^^^^^^^^^^^^^ unknown field
+
+


### PR DESCRIPTION
### What was wrong?

As found by the fuzzer, the following code does currently result in a panic.

```
contract Foo:

  pub def foo():
    "".does_not_exist
````

### How was it fixed?

1. Return proper user error
2. Ensure `String<N>` type is capitalized when displayed to the user

