### PR TITLE
Fix broken CI build

### DIFF
--- a/.github/install_deps.sh
+++ b/.github/install_deps.sh
@@ -1,3 +1,4 @@
+sudo apt-get update
 sudo apt-get install -y libboost-all-dev
 sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 50
 sudo update-alternatives --set g++ "/usr/bin/g++-10"


### PR DESCRIPTION
### What was wrong?

CI is currently broken.

### How was it fixed?

Turns out our system dependencies install script was missing an `apt-get update` which started causing problems with the boost install not getting carried out as entirely causing the build to fail). Adding `apt-get update` was all it needed to fix it.