### PR TITLE
Remove some fatal errors

### DIFF
--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -786,7 +786,6 @@ fn expr_call_builtin_function(
                     vec![Label::primary(args.span, "wrong type")],
                     vec!["Note: keccak(..) expects a byte array as parameter".into()],
                 );
-                return Err(FatalError);
             }
             Ok(ExpressionAttributes::new(Type::Base(U256), Location::Value))
         }
@@ -1016,7 +1015,6 @@ fn expr_call_type_constructor(
                             vec![Label::primary(arg.span, "wrong type")],
                             vec!["Note: address(..) expects a parameter of a contract type, numeric or address".into()],
                         );
-                        return Err(FatalError);
                     }
                 }
             };
@@ -1287,19 +1285,17 @@ fn expr_call_type_attribute(
                     .contract_scope()
                     .borrow_mut()
                     .add_created_contract(&contract.name);
-
-                Ok(ExpressionAttributes::new(
-                    Type::Contract(contract),
-                    Location::Value,
-                ))
             } else {
                 context.fancy_error(
                     "function `create2` expects numeric parameters",
                     vec![Label::primary(args.span, "invalid argument")],
                     vec![],
                 );
-                Err(FatalError)
             }
+            Ok(ExpressionAttributes::new(
+                Type::Contract(contract),
+                Location::Value,
+            ))
         }
         (Type::Contract(contract), Ok(ContractTypeMethod::Create)) => {
             validate_arg_count(context, func_name, name_span, args, 1);
@@ -1314,19 +1310,18 @@ fn expr_call_type_attribute(
                     .contract_scope()
                     .borrow_mut()
                     .add_created_contract(&contract.name);
-
-                Ok(ExpressionAttributes::new(
-                    Type::Contract(contract),
-                    Location::Value,
-                ))
             } else {
                 context.fancy_error(
                     "function `create` expects numeric parameter",
                     vec![Label::primary(args.span, "invalid argument")],
                     vec![],
                 );
-                Err(FatalError)
             }
+
+            Ok(ExpressionAttributes::new(
+                Type::Contract(contract),
+                Location::Value,
+            ))
         }
         _ => {
             context.fancy_error(


### PR DESCRIPTION
### What was wrong?

There were a few places where we returned a `FatalError` even though the return type was known. Doing so prevents us from collecting more errors without the need to do so.

### How was it fixed?

Removed the `FatalError`s
