### PR TITLE
Make duplicate function definitons a fatal error

### DIFF
--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -91,13 +91,14 @@ pub fn func_def(
                     // TODO: figure out how to include the previously defined function
                     vec![Label::primary(
                         def.span,
-                        format!("Conflicting definition of contract `{}`", name),
+                        format!("Conflicting definition of function `{}`", name),
                     )],
                     vec![format!(
                         "Note: Give one of the `{}` functions a different name",
                         name
                     )],
-                )
+                );
+                return Err(FatalError);
             }
             Ok(val) => {
                 let attributes: FunctionAttributes = val.to_owned().into();

--- a/tests/fixtures/compile_errors/issue_451.fe
+++ b/tests/fixtures/compile_errors/issue_451.fe
@@ -1,0 +1,5 @@
+contract o
+    pub def bar(x:u256,y:u256)->bool
+     return
+    pub def bar:
+     s

--- a/tests/src/compile_errors.rs
+++ b/tests/src/compile_errors.rs
@@ -172,6 +172,7 @@ test_file! { invalid_string_field }
 test_file! { invalid_struct_field }
 test_file! { invalid_tuple_field }
 test_file! { invalid_tx_field }
+test_file! { issue_451 }
 test_file! { mismatch_return_type }
 test_file! { missing_return }
 test_file! { missing_return_in_else }

--- a/tests/src/snapshots/fe_compiler_tests__compile_errors__issue_451.snap
+++ b/tests/src/snapshots/fe_compiler_tests__compile_errors__issue_451.snap
@@ -4,11 +4,11 @@ expression: "error_string(&path, &src)"
 
 ---
 error: a function with the same name already exists
-  ┌─ fixtures/compile_errors/duplicate_method_in_contract.fe:6:5
+  ┌─ fixtures/compile_errors/issue_451.fe:4:5
   │  
-6 │ ╭     pub def bar():
-7 │ │         pass
-  │ ╰────────────^ Conflicting definition of function `bar`
+4 │ ╭     pub def bar:
+5 │ │      s
+  │ ╰──────^ Conflicting definition of function `bar`
   │  
   = Note: Give one of the `bar` functions a different name
 


### PR DESCRIPTION

### What was wrong?

#451 demonstrates an interesting issue where we crash when trying to present a certain error. The reason for that is that the function is defined multiple times and when we retrieve the type information for another error we don't get the type for that function `bar` that we assume but for that other `function` bar that has a different type.

### How was it fixed?

An easy way to fix this is to say that duplicate definitions are treated as fatal errors with the reasoning that it becomes unsafe to retrieve type information for definitions of which we have multiple for the same name.
