### PR TITLE
Move ast::ModuleStmt and ContractStmt variants into separate structs

### DIFF
--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -343,7 +343,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_function(&mut self, node: &Node<fe::FuncDef>, attributes: FunctionAttributes) {
+    pub fn add_function(&mut self, node: &Node<fe::Function>, attributes: FunctionAttributes) {
         self.add_node(node);
         expect_none(
             self.functions.insert(node.id, attributes),
@@ -379,7 +379,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_contract(&mut self, node: &Node<fe::ContractDef>, attributes: ContractAttributes) {
+    pub fn add_contract(&mut self, node: &Node<fe::Contract>, attributes: ContractAttributes) {
         self.add_node(node);
         expect_none(
             self.contracts.insert(node.id, attributes),
@@ -415,7 +415,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_event(&mut self, node: &Node<fe::EventDef>, event: EventDef) {
+    pub fn add_event(&mut self, node: &Node<fe::Event>, event: EventDef) {
         self.add_node(node);
         expect_none(
             self.events.insert(node.id, event),

--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -343,7 +343,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_function(&mut self, node: &Node<fe::ContractStmt>, attributes: FunctionAttributes) {
+    pub fn add_function(&mut self, node: &Node<fe::FuncDef>, attributes: FunctionAttributes) {
         self.add_node(node);
         expect_none(
             self.functions.insert(node.id, attributes),
@@ -415,7 +415,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_event(&mut self, node: &Node<fe::ContractStmt>, event: EventDef) {
+    pub fn add_event(&mut self, node: &Node<fe::EventDef>, event: EventDef) {
         self.add_node(node);
         expect_none(
             self.events.insert(node.id, event),

--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -379,7 +379,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_contract(&mut self, node: &Node<fe::ModuleStmt>, attributes: ContractAttributes) {
+    pub fn add_contract(&mut self, node: &Node<fe::ContractDef>, attributes: ContractAttributes) {
         self.add_node(node);
         expect_none(
             self.contracts.insert(node.id, attributes),

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -425,53 +425,26 @@ mod tests {
         let module_scope = ModuleScope::new();
         let contract_scope = ContractScope::new("", module_scope);
         let block_scope_1 = BlockScope::from_contract_scope("", Rc::clone(&contract_scope));
-        assert_eq!(
-            true,
-            block_scope_1
-                .borrow()
-                .inherits_type(BlockScopeType::Function)
-        );
-        assert_eq!(
-            false,
-            block_scope_1.borrow().inherits_type(BlockScopeType::IfElse)
-        );
-        assert_eq!(
-            false,
-            block_scope_1.borrow().inherits_type(BlockScopeType::Loop)
-        );
+        assert!(block_scope_1
+            .borrow()
+            .inherits_type(BlockScopeType::Function));
+        assert!(!block_scope_1.borrow().inherits_type(BlockScopeType::IfElse));
+        assert!(!block_scope_1.borrow().inherits_type(BlockScopeType::Loop));
 
         let block_scope_2 =
             BlockScope::from_block_scope(BlockScopeType::IfElse, Rc::clone(&block_scope_1));
-        assert_eq!(
-            true,
-            block_scope_2
-                .borrow()
-                .inherits_type(BlockScopeType::Function)
-        );
-        assert_eq!(
-            true,
-            block_scope_2.borrow().inherits_type(BlockScopeType::IfElse)
-        );
-        assert_eq!(
-            false,
-            block_scope_2.borrow().inherits_type(BlockScopeType::Loop)
-        );
+        assert!(block_scope_2
+            .borrow()
+            .inherits_type(BlockScopeType::Function));
+        assert!(block_scope_2.borrow().inherits_type(BlockScopeType::IfElse));
+        assert!(!block_scope_2.borrow().inherits_type(BlockScopeType::Loop));
 
         let block_scope_3 =
             BlockScope::from_block_scope(BlockScopeType::Loop, Rc::clone(&block_scope_2));
-        assert_eq!(
-            true,
-            block_scope_3
-                .borrow()
-                .inherits_type(BlockScopeType::Function)
-        );
-        assert_eq!(
-            true,
-            block_scope_3.borrow().inherits_type(BlockScopeType::IfElse)
-        );
-        assert_eq!(
-            true,
-            block_scope_3.borrow().inherits_type(BlockScopeType::Loop)
-        );
+        assert!(block_scope_3
+            .borrow()
+            .inherits_type(BlockScopeType::Function));
+        assert!(block_scope_3.borrow().inherits_type(BlockScopeType::IfElse));
+        assert!(block_scope_3.borrow().inherits_type(BlockScopeType::Loop));
     }
 }

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -26,12 +26,10 @@ pub fn contract_def(
     // current contract.
 
     for stmt in body {
-        match &stmt.kind {
-            fe::ContractStmt::EventDef { .. } => {
-                event_def(Rc::clone(&contract_scope), context, stmt)
-            }
-            fe::ContractStmt::FuncDef { .. } => {
-                functions::func_def(Rc::clone(&contract_scope), context, stmt)
+        match &stmt {
+            fe::ContractStmt::Event(def) => event_def(Rc::clone(&contract_scope), context, def),
+            fe::ContractStmt::Function(def) => {
+                functions::func_def(Rc::clone(&contract_scope), context, def)
             }
         }?
     }
@@ -81,8 +79,8 @@ pub fn contract_body(
     }
 
     for stmt in body {
-        if let fe::ContractStmt::FuncDef { .. } = &stmt.kind {
-            functions::func_body(Rc::clone(&contract_scope), context, stmt)?
+        if let fe::ContractStmt::Function(def) = &stmt {
+            functions::func_body(Rc::clone(&contract_scope), context, def)?
         };
     }
 
@@ -121,84 +119,81 @@ fn contract_field(
 fn event_def(
     scope: Shared<ContractScope>,
     context: &mut Context,
-    stmt: &Node<fe::ContractStmt>,
+    stmt: &Node<fe::EventDef>,
 ) -> Result<(), FatalError> {
-    if let fe::ContractStmt::EventDef { name, fields } = &stmt.kind {
-        let name = &name.kind;
+    let fe::EventDef { name, fields } = &stmt.kind;
+    let name = &name.kind;
 
-        let (is_indexed_bools, all_fields): (Vec<bool>, Vec<(String, FixedSize)>) = fields
+    let (is_indexed_bools, all_fields): (Vec<bool>, Vec<(String, FixedSize)>) = fields
+        .iter()
+        .map(|field| event_field(Rc::clone(&scope), context, field))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .unzip();
+
+    let indexed_fields = is_indexed_bools
+        .into_iter()
+        .enumerate()
+        .filter(|(_, is_indexed)| *is_indexed)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+
+    if indexed_fields.len() > constants::MAX_INDEXED_EVENT_FIELDS {
+        let excess_count = indexed_fields.len() - constants::MAX_INDEXED_EVENT_FIELDS;
+
+        let labels = fields
             .iter()
-            .map(|field| event_field(Rc::clone(&scope), context, field))
-            .collect::<Result<Vec<_>, _>>()?
-            .into_iter()
-            .unzip();
-
-        let indexed_fields = is_indexed_bools
-            .into_iter()
             .enumerate()
-            .filter(|(_, is_indexed)| *is_indexed)
-            .map(|(index, _)| index)
-            .collect::<Vec<_>>();
+            .filter_map(|(idx, field)| {
+                if indexed_fields.contains(&idx) {
+                    Some(field)
+                } else {
+                    None
+                }
+            })
+            .map(|field| Label::primary(field.span, "Indexed field"))
+            .collect();
 
-        if indexed_fields.len() > constants::MAX_INDEXED_EVENT_FIELDS {
-            let excess_count = indexed_fields.len() - constants::MAX_INDEXED_EVENT_FIELDS;
-
-            let labels = fields
-                .iter()
-                .enumerate()
-                .filter_map(|(idx, field)| {
-                    if indexed_fields.contains(&idx) {
-                        Some(field)
-                    } else {
-                        None
-                    }
-                })
-                .map(|field| Label::primary(field.span, "Indexed field"))
-                .collect();
-
-            context.fancy_error(
-                "More than three indexed fields.",
-                labels,
-                vec![format!(
-                    "Note: Remove the `idx` keyword from at least {} {}.",
-                    excess_count,
-                    pluralize_conditionally("field", excess_count)
-                )],
-            );
-        }
-
-        // check if they are trying to index an array type
-        // todo clean all this up
-        for index in indexed_fields.clone() {
-            match all_fields[index].1.to_owned() {
-                FixedSize::Base(_) => {}
-                _ => context.not_yet_implemented("non-base type indexed event fields", stmt.span),
-            }
-        }
-
-        let event = EventDef::new(name, all_fields, indexed_fields);
-
-        context.add_event(stmt, event.clone());
-
-        if let Err(AlreadyDefined) = scope.borrow_mut().add_event(name, event) {
-            context.fancy_error(
-                "an event with the same name already exists",
-                // TODO: figure out how to include the previously defined event
-                vec![Label::primary(
-                    stmt.span,
-                    format!("Conflicting definition of event `{}`", name),
-                )],
-                vec![format!(
-                    "Note: Give one of the `{}` events a different name",
-                    name
-                )],
-            )
-        }
-
-        return Ok(());
+        context.fancy_error(
+            "More than three indexed fields.",
+            labels,
+            vec![format!(
+                "Note: Remove the `idx` keyword from at least {} {}.",
+                excess_count,
+                pluralize_conditionally("field", excess_count)
+            )],
+        );
     }
 
-    unreachable!()
+    // check if they are trying to index an array type
+    // todo clean all this up
+    for index in indexed_fields.clone() {
+        match all_fields[index].1.to_owned() {
+            FixedSize::Base(_) => {}
+            _ => context.not_yet_implemented("non-base type indexed event fields", stmt.span),
+        }
+    }
+
+    let event = EventDef::new(name, all_fields, indexed_fields);
+
+    context.add_event(stmt, event.clone());
+
+    if let Err(AlreadyDefined) = scope.borrow_mut().add_event(name, event) {
+        context.fancy_error(
+            "an event with the same name already exists",
+            // TODO: figure out how to include the previously defined event
+            vec![Label::primary(
+                stmt.span,
+                format!("Conflicting definition of event `{}`", name),
+            )],
+            vec![format!(
+                "Note: Give one of the `{}` events a different name",
+                name
+            )],
+        )
+    }
+
+    Ok(())
 }
 
 fn event_field(

--- a/analyzer/src/traversal/contracts.rs
+++ b/analyzer/src/traversal/contracts.rs
@@ -16,9 +16,9 @@ use std::rc::Rc;
 pub fn contract_def(
     module_scope: Shared<ModuleScope>,
     context: &mut Context,
-    stmt: &Node<fe::ContractDef>,
+    stmt: &Node<fe::Contract>,
 ) -> Result<Shared<ContractScope>, FatalError> {
-    let fe::ContractDef { name, body, .. } = &stmt.kind;
+    let fe::Contract { name, body, .. } = &stmt.kind;
     let contract_scope = ContractScope::new(&name.kind, Rc::clone(&module_scope));
 
     // Contract fields are evaluated in the next pass together with function bodies
@@ -71,9 +71,9 @@ pub fn contract_def(
 pub fn contract_body(
     contract_scope: Shared<ContractScope>,
     context: &mut Context,
-    stmt: &Node<fe::ContractDef>,
+    stmt: &Node<fe::Contract>,
 ) -> Result<(), FatalError> {
-    let fe::ContractDef { fields, body, .. } = &stmt.kind;
+    let fe::Contract { fields, body, .. } = &stmt.kind;
     for field in fields {
         contract_field(Rc::clone(&contract_scope), context, field)?;
     }
@@ -119,9 +119,9 @@ fn contract_field(
 fn event_def(
     scope: Shared<ContractScope>,
     context: &mut Context,
-    stmt: &Node<fe::EventDef>,
+    stmt: &Node<fe::Event>,
 ) -> Result<(), FatalError> {
-    let fe::EventDef { name, fields } = &stmt.kind;
+    let fe::Event { name, fields } = &stmt.kind;
     let name = &name.kind;
 
     let (is_indexed_bools, all_fields): (Vec<bool>, Vec<(String, FixedSize)>) = fields

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -13,154 +13,143 @@ use std::rc::Rc;
 pub fn func_def(
     contract_scope: Shared<ContractScope>,
     context: &mut Context,
-    def: &Node<fe::ContractStmt>,
+    def: &Node<fe::FuncDef>,
 ) -> Result<(), FatalError> {
-    if let fe::ContractStmt::FuncDef {
+    let fe::FuncDef {
         is_pub,
         name,
         args,
         return_type: return_type_node,
         ..
-    } = &def.kind
-    {
-        let name = &name.kind;
-        let function_scope = BlockScope::from_contract_scope(name, Rc::clone(&contract_scope));
+    } = &def.kind;
 
-        let mut is_pub = *is_pub;
-        let params = args
-            .iter()
-            .map(|arg| func_def_arg(Rc::clone(&function_scope), context, arg))
-            .collect::<Result<Vec<_>, _>>()?;
+    let name = &name.kind;
+    let function_scope = BlockScope::from_contract_scope(name, Rc::clone(&contract_scope));
 
-        let mut return_type = return_type_node
-            .as_ref()
-            .map(|typ| {
-                types::type_desc_fixed_size(
-                    &Scope::Block(Rc::clone(&function_scope)),
-                    context,
-                    &typ,
-                )
-            })
-            .transpose()?
-            .unwrap_or_else(FixedSize::unit);
+    let mut is_pub = *is_pub;
+    let params = args
+        .iter()
+        .map(|arg| func_def_arg(Rc::clone(&function_scope), context, arg))
+        .collect::<Result<Vec<_>, _>>()?;
 
-        if name == "__init__" {
-            // `__init__` must not return any type other than `()`.
-            if !return_type.is_unit() {
-                context.fancy_error(
-                    "`__init__` function has incorrect return type",
-                    vec![Label::primary(
-                        return_type_node.as_ref().unwrap().span,
-                        "return type should be `()`",
-                    )],
-                    vec![
-                        "Hint: Remove the return type specification.".to_string(),
-                        "Example: `pub def __init__():`".to_string(),
-                    ],
-                );
-                return_type = FixedSize::unit();
-            }
+    let mut return_type = return_type_node
+        .as_ref()
+        .map(|typ| {
+            types::type_desc_fixed_size(&Scope::Block(Rc::clone(&function_scope)), context, &typ)
+        })
+        .transpose()?
+        .unwrap_or_else(FixedSize::unit);
 
-            // `__init__` must be `pub`.
-            if !is_pub {
-                context.fancy_error(
-                    "`__init__` function is not public",
-                    vec![Label::primary(
-                        def.span,
-                        "`__init__` function must be public",
-                    )],
-                    vec![
-                        "Hint: Add the `pub` modifier.".to_string(),
-                        "Example: `pub def __init__():`".to_string(),
-                    ],
-                );
-                is_pub = true;
-            }
+    if name == "__init__" {
+        // `__init__` must not return any type other than `()`.
+        if !return_type.is_unit() {
+            context.fancy_error(
+                "`__init__` function has incorrect return type",
+                vec![Label::primary(
+                    return_type_node.as_ref().unwrap().span,
+                    "return type should be `()`",
+                )],
+                vec![
+                    "Hint: Remove the return type specification.".to_string(),
+                    "Example: `pub def __init__():`".to_string(),
+                ],
+            );
+            return_type = FixedSize::unit();
         }
 
-        match contract_scope.borrow_mut().add_function(
-            name,
-            is_pub,
-            params,
-            return_type,
-            Rc::clone(&function_scope),
-        ) {
-            Err(AlreadyDefined) => {
-                context.fancy_error(
-                    "a function with the same name already exists",
-                    // TODO: figure out how to include the previously defined function
-                    vec![Label::primary(
-                        def.span,
-                        format!("Conflicting definition of function `{}`", name),
-                    )],
-                    vec![format!(
-                        "Note: Give one of the `{}` functions a different name",
-                        name
-                    )],
-                );
-                return Err(FatalError);
-            }
-            Ok(val) => {
-                let attributes: FunctionAttributes = val.to_owned().into();
-                context.add_function(def, attributes);
-            }
+        // `__init__` must be `pub`.
+        if !is_pub {
+            context.fancy_error(
+                "`__init__` function is not public",
+                vec![Label::primary(
+                    def.span,
+                    "`__init__` function must be public",
+                )],
+                vec![
+                    "Hint: Add the `pub` modifier.".to_string(),
+                    "Example: `pub def __init__():`".to_string(),
+                ],
+            );
+            is_pub = true;
         }
-
-        Ok(())
-    } else {
-        unreachable!()
     }
+
+    match contract_scope.borrow_mut().add_function(
+        name,
+        is_pub,
+        params,
+        return_type,
+        Rc::clone(&function_scope),
+    ) {
+        Err(AlreadyDefined) => {
+            context.fancy_error(
+                "a function with the same name already exists",
+                // TODO: figure out how to include the previously defined function
+                vec![Label::primary(
+                    def.span,
+                    format!("Conflicting definition of function `{}`", name),
+                )],
+                vec![format!(
+                    "Note: Give one of the `{}` functions a different name",
+                    name
+                )],
+            );
+            return Err(FatalError);
+        }
+        Ok(val) => {
+            let attributes: FunctionAttributes = val.to_owned().into();
+            context.add_function(def, attributes);
+        }
+    }
+
+    Ok(())
 }
 
 /// Gather context information for a function body and check for type errors.
 pub fn func_body(
     contract_scope: Shared<ContractScope>,
     context: &mut Context,
-    def: &Node<fe::ContractStmt>,
+    def: &Node<fe::FuncDef>,
 ) -> Result<(), FatalError> {
-    if let fe::ContractStmt::FuncDef {
+    let fe::FuncDef {
         is_pub: _,
         name,
         body,
         return_type,
         args: _,
-    } = &def.kind
-    {
-        let host_func_def = contract_scope
-            .borrow()
-            .function_def(&name.kind)
-            .unwrap_or_else(|| panic!("Failed to lookup function definition for {}", &name.kind));
+    } = &def.kind;
+    let host_func_def = contract_scope
+        .borrow()
+        .function_def(&name.kind)
+        .unwrap_or_else(|| panic!("Failed to lookup function definition for {}", &name.kind));
 
-        // If the return type is unit we do not have to validate any further at this point because
-        // both returning (explicit) or not returning (implicit return) are valid syntax.
-        // If the return type is anything else, we do need to ensure that all code paths
-        // return or revert.
-        if !host_func_def.return_type.is_unit() && !all_paths_return_or_revert(&body) {
-            context.fancy_error(
-                "function body is missing a return or revert statement",
-                vec![
-                    Label::primary(
-                        name.span,
-                        "all paths of this function must `return` or `revert`",
+    // If the return type is unit we do not have to validate any further at this point because
+    // both returning (explicit) or not returning (implicit return) are valid syntax.
+    // If the return type is anything else, we do need to ensure that all code paths
+    // return or revert.
+    if !host_func_def.return_type.is_unit() && !all_paths_return_or_revert(&body) {
+        context.fancy_error(
+            "function body is missing a return or revert statement",
+            vec![
+                Label::primary(
+                    name.span,
+                    "all paths of this function must `return` or `revert`",
+                ),
+                Label::secondary(
+                    return_type.as_ref().unwrap().span,
+                    format!(
+                        "expected function to return `{}`",
+                        host_func_def.return_type
                     ),
-                    Label::secondary(
-                        return_type.as_ref().unwrap().span,
-                        format!(
-                            "expected function to return `{}`",
-                            host_func_def.return_type
-                        ),
-                    ),
-                ],
-                vec![],
-            );
-        }
-
-        traverse_statements(Rc::clone(&host_func_def.scope), context, body)?;
-
-        Ok(())
-    } else {
-        unreachable!()
+                ),
+            ],
+            vec![],
+        );
     }
+
+    traverse_statements(Rc::clone(&host_func_def.scope), context, body)?;
+
+    Ok(())
 }
 
 fn traverse_statements(

--- a/analyzer/src/traversal/functions.rs
+++ b/analyzer/src/traversal/functions.rs
@@ -13,9 +13,9 @@ use std::rc::Rc;
 pub fn func_def(
     contract_scope: Shared<ContractScope>,
     context: &mut Context,
-    def: &Node<fe::FuncDef>,
+    def: &Node<fe::Function>,
 ) -> Result<(), FatalError> {
-    let fe::FuncDef {
+    let fe::Function {
         is_pub,
         name,
         args,
@@ -109,9 +109,9 @@ pub fn func_def(
 pub fn func_body(
     contract_scope: Shared<ContractScope>,
     context: &mut Context,
-    def: &Node<fe::FuncDef>,
+    def: &Node<fe::Function>,
 ) -> Result<(), FatalError> {
-    let fe::FuncDef {
+    let fe::Function {
         is_pub: _,
         name,
         body,
@@ -189,9 +189,9 @@ fn all_paths_return_or_revert(block: &[Node<fe::FuncStmt>]) -> bool {
 fn func_def_arg(
     scope: Shared<BlockScope>,
     context: &mut Context,
-    arg: &Node<fe::FuncDefArg>,
+    arg: &Node<fe::FunctionArg>,
 ) -> Result<(String, FixedSize), FatalError> {
-    let fe::FuncDefArg { name, typ } = &arg.kind;
+    let fe::FunctionArg { name, typ } = &arg.kind;
     let typ = types::type_desc_fixed_size(&Scope::Block(Rc::clone(&scope)), context, &typ)?;
 
     if let Err(AlreadyDefined) = scope.borrow_mut().add_var(&name.kind, typ.clone()) {

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -15,32 +15,25 @@ pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), FatalErr
     let mut contracts = vec![];
 
     for stmt in module.body.iter() {
-        match &stmt.kind {
-            fe::ModuleStmt::TypeDef { .. } => type_def(context, Rc::clone(&scope), stmt)?,
-            fe::ModuleStmt::Pragma { .. } => pragma_stmt(context, stmt),
-            fe::ModuleStmt::StructDef { .. } => {
-                structs::struct_def(context, Rc::clone(&scope), stmt)?
+        match &stmt {
+            fe::ModuleStmt::TypeAlias(inner) => type_alias(context, Rc::clone(&scope), inner)?,
+            fe::ModuleStmt::Pragma(inner) => pragma_stmt(context, inner),
+            fe::ModuleStmt::StructDef(inner) => {
+                structs::struct_def(context, Rc::clone(&scope), inner)?
             }
-            fe::ModuleStmt::ContractDef { .. } => {
+            fe::ModuleStmt::ContractDef(inner) => {
                 // Collect contract statements and the scope that we create for them. After we
                 // have walked all contracts once, we walk over them again for a
                 // more detailed inspection.
-                let contract_scope = contracts::contract_def(Rc::clone(&scope), context, stmt)?;
-                contracts.push((stmt, contract_scope))
+                let contract_scope = contracts::contract_def(Rc::clone(&scope), context, inner)?;
+                contracts.push((inner, contract_scope))
             }
-            fe::ModuleStmt::FromImport { .. } => {
-                context.not_yet_implemented("from import", stmt.span)
-            }
-            fe::ModuleStmt::SimpleImport { .. } => {
-                context.not_yet_implemented("simple import", stmt.span)
-            }
+            fe::ModuleStmt::Import(inner) => context.not_yet_implemented("import", inner.span),
         }
     }
 
-    for (stmt, scope) in contracts.iter() {
-        if let fe::ModuleStmt::ContractDef { .. } = stmt.kind {
-            contracts::contract_body(Rc::clone(&scope), context, stmt)?
-        }
+    for (contract, scope) in contracts.iter() {
+        contracts::contract_body(Rc::clone(&scope), context, contract)?
     }
 
     context.set_module(scope.into());
@@ -48,63 +41,53 @@ pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), FatalErr
     Ok(())
 }
 
-fn type_def(
+fn type_alias(
     context: &mut Context,
     scope: Shared<ModuleScope>,
-    stmt: &Node<fe::ModuleStmt>,
+    type_alias: &Node<fe::TypeAlias>,
 ) -> Result<(), FatalError> {
-    if let fe::ModuleStmt::TypeDef { name, typ } = &stmt.kind {
-        let typ = types::type_desc(&Scope::Module(Rc::clone(&scope)), context, &typ)?;
+    let fe::TypeAlias { name, typ } = &type_alias.kind;
+    let typ = types::type_desc(&Scope::Module(Rc::clone(&scope)), context, &typ)?;
 
-        if let Err(AlreadyDefined) = scope.borrow_mut().add_type_def(&name.kind, typ) {
-            context.fancy_error(
-                "a type definition with the same name already exists",
-                // TODO: figure out how to include the previously defined definition
-                vec![Label::primary(
-                    stmt.span,
-                    format!("Conflicting definition of `{}`", name.kind),
-                )],
-                vec![format!(
-                    "Note: Give one of the `{}` definitions a different name",
-                    name.kind
-                )],
-            )
-        }
-
-        return Ok(());
+    if let Err(AlreadyDefined) = scope.borrow_mut().add_type_def(&name.kind, typ) {
+        context.fancy_error(
+            "a type definition with the same name already exists",
+            // TODO: figure out how to include the previously defined definition
+            vec![Label::primary(
+                type_alias.span,
+                format!("Conflicting definition of `{}`", name.kind),
+            )],
+            vec![format!(
+                "Note: Give one of the `{}` definitions a different name",
+                name.kind
+            )],
+        )
     }
-
-    unreachable!()
+    Ok(())
 }
 
-fn pragma_stmt(context: &mut Context, stmt: &Node<fe::ModuleStmt>) {
-    match &stmt.kind {
-        fe::ModuleStmt::Pragma {
-            version_requirement,
-        } => {
-            // This can't fail because the parser already validated it
-            let requirement =
-                VersionReq::parse(&version_requirement.kind).expect("Invalid version requirement");
-            let actual_version =
-                Version::parse(env!("CARGO_PKG_VERSION")).expect("Missing package version");
+fn pragma_stmt(context: &mut Context, stmt: &Node<fe::Pragma>) {
+    let version_requirement = &stmt.kind.version_requirement;
+    // This can't fail because the parser already validated it
+    let requirement =
+        VersionReq::parse(&version_requirement.kind).expect("Invalid version requirement");
+    let actual_version =
+        Version::parse(env!("CARGO_PKG_VERSION")).expect("Missing package version");
 
-            if !requirement.matches(&actual_version) {
-                context.fancy_error(
-                    format!(
-                        "The current compiler version {} doesn't match the specified requirement",
-                        actual_version
-                    ),
-                    vec![Label::primary(
-                        version_requirement.span,
-                        "The specified version requirement",
-                    )],
-                    vec![format!(
-                        "Note: Use `pragma {}` to make the code compile",
-                        actual_version
-                    )],
-                );
-            }
-        }
-        _ => unreachable!(),
+    if !requirement.matches(&actual_version) {
+        context.fancy_error(
+            format!(
+                "The current compiler version {} doesn't match the specified requirement",
+                actual_version
+            ),
+            vec![Label::primary(
+                version_requirement.span,
+                "The specified version requirement",
+            )],
+            vec![format!(
+                "Note: Use `pragma {}` to make the code compile",
+                actual_version
+            )],
+        );
     }
 }

--- a/analyzer/src/traversal/module.rs
+++ b/analyzer/src/traversal/module.rs
@@ -18,10 +18,10 @@ pub fn module(context: &mut Context, module: &fe::Module) -> Result<(), FatalErr
         match &stmt {
             fe::ModuleStmt::TypeAlias(inner) => type_alias(context, Rc::clone(&scope), inner)?,
             fe::ModuleStmt::Pragma(inner) => pragma_stmt(context, inner),
-            fe::ModuleStmt::StructDef(inner) => {
+            fe::ModuleStmt::Struct(inner) => {
                 structs::struct_def(context, Rc::clone(&scope), inner)?
             }
-            fe::ModuleStmt::ContractDef(inner) => {
+            fe::ModuleStmt::Contract(inner) => {
                 // Collect contract statements and the scope that we create for them. After we
                 // have walked all contracts once, we walk over them again for a
                 // more detailed inspection.

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -1,5 +1,5 @@
 use fe_common::diagnostics::Label;
-use fe_parser::ast::{Field, StructDef};
+use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 use crate::errors::{AlreadyDefined, FatalError};
@@ -12,19 +12,19 @@ use std::rc::Rc;
 pub fn struct_def(
     context: &mut Context,
     module_scope: Shared<ModuleScope>,
-    struct_def: &Node<StructDef>,
+    struct_def: &Node<fe::Struct>,
 ) -> Result<(), FatalError> {
-    let StructDef { name, fields } = &struct_def.kind;
+    let fe::Struct { name, fields } = &struct_def.kind;
     let mut val = Struct::new(&name.kind);
     for field in fields {
-        let Field { name, typ, .. } = &field.kind;
+        let fe::Field { name, typ, .. } = &field.kind;
         let field_type = type_desc(&Scope::Module(Rc::clone(&module_scope)), context, typ)?;
         if let Type::Base(base_typ) = field_type {
             if let Err(AlreadyDefined) = val.add_field(&name.kind, &FixedSize::Base(base_typ)) {
                 let first_definition = fields
                     .iter()
                     .find(|val| {
-                        let Field {
+                        let fe::Field {
                             name: inner_name, ..
                         } = &val.kind;
                         inner_name.kind == name.kind && val.span != field.span

--- a/analyzer/src/traversal/structs.rs
+++ b/analyzer/src/traversal/structs.rs
@@ -1,6 +1,6 @@
 use fe_common::diagnostics::Label;
-use fe_parser::ast as fe;
-use fe_parser::{ast::Field, node::Node};
+use fe_parser::ast::{Field, StructDef};
+use fe_parser::node::Node;
 
 use crate::errors::{AlreadyDefined, FatalError};
 use crate::namespace::scopes::{ModuleScope, Scope, Shared};
@@ -12,66 +12,64 @@ use std::rc::Rc;
 pub fn struct_def(
     context: &mut Context,
     module_scope: Shared<ModuleScope>,
-    stmt: &Node<fe::ModuleStmt>,
+    struct_def: &Node<StructDef>,
 ) -> Result<(), FatalError> {
-    if let fe::ModuleStmt::StructDef { name, fields } = &stmt.kind {
-        let mut val = Struct::new(&name.kind);
-        for field in fields {
-            let Field { name, typ, .. } = &field.kind;
-            let field_type = type_desc(&Scope::Module(Rc::clone(&module_scope)), context, typ)?;
-            if let Type::Base(base_typ) = field_type {
-                if let Err(AlreadyDefined) = val.add_field(&name.kind, &FixedSize::Base(base_typ)) {
-                    let first_definition = fields
-                        .iter()
-                        .find(|val| {
-                            let Field {
-                                name: inner_name, ..
-                            } = &val.kind;
-                            inner_name.kind == name.kind && val.span != field.span
-                        })
-                        .expect("Missing field");
+    let StructDef { name, fields } = &struct_def.kind;
+    let mut val = Struct::new(&name.kind);
+    for field in fields {
+        let Field { name, typ, .. } = &field.kind;
+        let field_type = type_desc(&Scope::Module(Rc::clone(&module_scope)), context, typ)?;
+        if let Type::Base(base_typ) = field_type {
+            if let Err(AlreadyDefined) = val.add_field(&name.kind, &FixedSize::Base(base_typ)) {
+                let first_definition = fields
+                    .iter()
+                    .find(|val| {
+                        let Field {
+                            name: inner_name, ..
+                        } = &val.kind;
+                        inner_name.kind == name.kind && val.span != field.span
+                    })
+                    .expect("Missing field");
 
-                    context.fancy_error(
-                        "a struct field with the same name already exists",
-                        vec![
-                            Label::primary(
-                                first_definition.span,
-                                format!("First definition of field `{}`", name.kind),
-                            ),
-                            Label::primary(
-                                field.span,
-                                format!("Conflicting definition of field `{}`", name.kind),
-                            ),
-                        ],
-                        vec![format!(
-                            "Note: Give one of the `{}` fields a different name",
-                            name.kind
-                        )],
-                    )
-                }
-            } else {
-                context.not_yet_implemented("non-base type struct fields", field.span)
+                context.fancy_error(
+                    "a struct field with the same name already exists",
+                    vec![
+                        Label::primary(
+                            first_definition.span,
+                            format!("First definition of field `{}`", name.kind),
+                        ),
+                        Label::primary(
+                            field.span,
+                            format!("Conflicting definition of field `{}`", name.kind),
+                        ),
+                    ],
+                    vec![format!(
+                        "Note: Give one of the `{}` fields a different name",
+                        name.kind
+                    )],
+                )
             }
+        } else {
+            context.not_yet_implemented("non-base type struct fields", field.span)
         }
-        if let Err(AlreadyDefined) = module_scope
-            .borrow_mut()
-            .add_type_def(&name.kind, Type::Struct(val))
-        {
-            context.fancy_error(
-                "a struct with the same name already exists",
-                // TODO: figure out how to include the previously defined struct
-                vec![Label::primary(
-                    stmt.span,
-                    format!("Conflicting definition of struct `{}`", name.kind),
-                )],
-                vec![format!(
-                    "Note: Give one of the `{}` structs a different name",
-                    name.kind
-                )],
-            )
-        }
-
-        return Ok(());
     }
-    unreachable!()
+    if let Err(AlreadyDefined) = module_scope
+        .borrow_mut()
+        .add_type_def(&name.kind, Type::Struct(val))
+    {
+        context.fancy_error(
+            "a struct with the same name already exists",
+            // TODO: figure out how to include the previously defined struct
+            vec![Label::primary(
+                struct_def.span,
+                format!("Conflicting definition of struct `{}`", name.kind),
+            )],
+            vec![format!(
+                "Note: Give one of the `{}` structs a different name",
+                name.kind
+            )],
+        )
+    }
+
+    Ok(())
 }

--- a/common/src/span.rs
+++ b/common/src/span.rs
@@ -77,6 +77,17 @@ where
     }
 }
 
+impl<'a, T> Add<&'a T> for Span
+where
+    T: Spanned,
+{
+    type Output = Self;
+
+    fn add(self, other: &'a T) -> Self {
+        self + other.span()
+    }
+}
+
 impl<T> AddAssign<T> for Span
 where
     Span: Add<T, Output = Self>,

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -11,9 +11,12 @@ pub fn module(context: &Context, module: &fe::Module) -> Result<ModuleAbis, Comp
         .body
         .iter()
         .try_fold(ModuleAbis::new(), |mut abis, stmt| {
-            if let fe::ModuleStmt::ContractDef { name, body, .. } = &stmt.kind {
+            if let fe::ModuleStmt::ContractDef(contract) = &stmt {
                 if abis
-                    .insert(name.kind.to_string(), contract_def(context, body)?)
+                    .insert(
+                        contract.kind.name.kind.to_string(),
+                        contract_def(context, &contract.kind.body)?,
+                    )
                     .is_some()
                 {
                     return Err(CompileError::static_str("duplicate contract definition"));

--- a/compiler/src/abi/builder.rs
+++ b/compiler/src/abi/builder.rs
@@ -10,7 +10,7 @@ pub fn module(context: &Context, module: &fe::Module) -> Result<ModuleAbis, Comp
         .body
         .iter()
         .try_fold(ModuleAbis::new(), |mut abis, stmt| {
-            if let fe::ModuleStmt::ContractDef(contract) = &stmt {
+            if let fe::ModuleStmt::Contract(contract) = &stmt {
                 if abis
                     .insert(
                         contract.kind.name.kind.to_string(),

--- a/compiler/src/lowering/mappers/contracts.rs
+++ b/compiler/src/lowering/mappers/contracts.rs
@@ -8,8 +8,8 @@ use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Lowers a contract definition.
-pub fn contract_def(context: &mut Context, stmt: Node<fe::ContractDef>) -> Node<fe::ContractDef> {
-    let fe::ContractDef { name, fields, body } = stmt.kind;
+pub fn contract_def(context: &mut Context, stmt: Node<fe::Contract>) -> Node<fe::Contract> {
+    let fe::Contract { name, fields, body } = stmt.kind;
     let lowered_body = body
         .into_iter()
         .map(|stmt| match stmt {
@@ -36,7 +36,7 @@ pub fn contract_def(context: &mut Context, stmt: Node<fe::ContractDef>) -> Node<
         .collect();
 
     Node::new(
-        fe::ContractDef {
+        fe::Contract {
             name,
             fields: lowered_fields,
             body: lowered_body,
@@ -58,8 +58,8 @@ fn contract_field(context: &mut Context, field: Node<fe::Field>) -> Node<fe::Fie
     )
 }
 
-fn event_def(context: &mut Context, stmt: Node<fe::EventDef>) -> Node<fe::EventDef> {
-    let fe::EventDef { name, fields } = stmt.kind;
+fn event_def(context: &mut Context, stmt: Node<fe::Event>) -> Node<fe::Event> {
+    let fe::Event { name, fields } = stmt.kind;
     let lowered_fields = fields
         .into_iter()
         .map(|field| {
@@ -75,7 +75,7 @@ fn event_def(context: &mut Context, stmt: Node<fe::EventDef>) -> Node<fe::EventD
         .collect();
 
     return Node::new(
-        fe::EventDef {
+        fe::Event {
             name,
             fields: lowered_fields,
         },
@@ -83,11 +83,11 @@ fn event_def(context: &mut Context, stmt: Node<fe::EventDef>) -> Node<fe::EventD
     );
 }
 
-fn list_expr_to_fn_def(array: &Array) -> fe::FuncDef {
+fn list_expr_to_fn_def(array: &Array) -> fe::Function {
     // Built the AST nodes for the function arguments
     let args = (0..array.size)
         .map(|index| {
-            fe::FuncDefArg {
+            fe::FunctionArg {
                 name: format!("val{}", index).into_node(),
                 typ: names::fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
             }
@@ -129,7 +129,7 @@ fn list_expr_to_fn_def(array: &Array) -> fe::FuncDef {
         Some(names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node());
 
     // Put it all together in one AST node that holds the entire function definition
-    fe::FuncDef {
+    fe::Function {
         is_pub: false,
         name: names::list_expr_generator_fn_name(array).into_node(),
         args,

--- a/compiler/src/lowering/mappers/contracts.rs
+++ b/compiler/src/lowering/mappers/contracts.rs
@@ -74,13 +74,13 @@ fn event_def(context: &mut Context, stmt: Node<fe::Event>) -> Node<fe::Event> {
         })
         .collect();
 
-    return Node::new(
+    Node::new(
         fe::Event {
             name,
             fields: lowered_fields,
         },
         stmt.span,
-    );
+    )
 }
 
 fn list_expr_to_fn_def(array: &Array) -> fe::Function {

--- a/compiler/src/lowering/mappers/functions.rs
+++ b/compiler/src/lowering/mappers/functions.rs
@@ -8,8 +8,8 @@ use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
 /// Lowers a function definition.
-pub fn func_def(context: &mut Context, def: Node<fe::FuncDef>) -> Node<fe::FuncDef> {
-    let fe::FuncDef {
+pub fn func_def(context: &mut Context, def: Node<fe::Function>) -> Node<fe::Function> {
+    let fe::Function {
         is_pub,
         name,
         args,
@@ -40,7 +40,7 @@ pub fn func_def(context: &mut Context, def: Node<fe::FuncDef>) -> Node<fe::FuncD
         .into_iter()
         .map(|arg| {
             Node::new(
-                fe::FuncDefArg {
+                fe::FunctionArg {
                     name: arg.kind.name,
                     typ: types::type_desc(context, arg.kind.typ),
                 },
@@ -49,7 +49,7 @@ pub fn func_def(context: &mut Context, def: Node<fe::FuncDef>) -> Node<fe::FuncD
         })
         .collect();
 
-    let lowered_function = fe::FuncDef {
+    let lowered_function = fe::Function {
         is_pub,
         name,
         args: lowered_args,

--- a/compiler/src/lowering/mappers/module.rs
+++ b/compiler/src/lowering/mappers/module.rs
@@ -11,13 +11,14 @@ pub fn module(context: &mut Context, module: fe::Module) -> fe::Module {
     let lowered_body = module
         .body
         .into_iter()
-        .map(|stmt| match &stmt.kind {
-            fe::ModuleStmt::Pragma { .. } => stmt,
-            fe::ModuleStmt::TypeDef { .. } => stmt,
-            fe::ModuleStmt::StructDef { .. } => stmt,
-            fe::ModuleStmt::FromImport { .. } => stmt,
-            fe::ModuleStmt::SimpleImport { .. } => stmt,
-            fe::ModuleStmt::ContractDef { .. } => contracts::contract_def(context, stmt),
+        .map(|stmt| match stmt {
+            fe::ModuleStmt::Pragma(_) => stmt,
+            fe::ModuleStmt::TypeAlias(_) => stmt,
+            fe::ModuleStmt::StructDef(_) => stmt,
+            fe::ModuleStmt::Import(_) => stmt,
+            fe::ModuleStmt::ContractDef(inner) => {
+                fe::ModuleStmt::ContractDef(contracts::contract_def(context, inner))
+            }
         })
         .collect::<Vec<_>>();
 
@@ -26,15 +27,15 @@ pub fn module(context: &mut Context, module: fe::Module) -> fe::Module {
     let struct_defs_from_tuples = attributes
         .tuples_used
         .iter()
-        .map(|tuple| Node::new(tuple_to_struct_def(tuple), Span::zero()))
-        .collect::<Vec<Node<fe::ModuleStmt>>>();
+        .map(|tuple| fe::ModuleStmt::StructDef(Node::new(tuple_to_struct_def(tuple), Span::zero())))
+        .collect::<Vec<fe::ModuleStmt>>();
 
     fe::Module {
         body: [struct_defs_from_tuples, lowered_body].concat(),
     }
 }
 
-fn tuple_to_struct_def(tuple: &Tuple) -> fe::ModuleStmt {
+fn tuple_to_struct_def(tuple: &Tuple) -> fe::StructDef {
     let fields = tuple
         .items
         .iter()
@@ -47,7 +48,7 @@ fn tuple_to_struct_def(tuple: &Tuple) -> fe::ModuleStmt {
         })
         .collect();
 
-    fe::ModuleStmt::StructDef {
+    fe::StructDef {
         name: Node::new(names::tuple_struct_string(tuple), Span::zero()),
         fields,
     }

--- a/compiler/src/lowering/mappers/module.rs
+++ b/compiler/src/lowering/mappers/module.rs
@@ -14,10 +14,10 @@ pub fn module(context: &mut Context, module: fe::Module) -> fe::Module {
         .map(|stmt| match stmt {
             fe::ModuleStmt::Pragma(_) => stmt,
             fe::ModuleStmt::TypeAlias(_) => stmt,
-            fe::ModuleStmt::StructDef(_) => stmt,
+            fe::ModuleStmt::Struct(_) => stmt,
             fe::ModuleStmt::Import(_) => stmt,
-            fe::ModuleStmt::ContractDef(inner) => {
-                fe::ModuleStmt::ContractDef(contracts::contract_def(context, inner))
+            fe::ModuleStmt::Contract(inner) => {
+                fe::ModuleStmt::Contract(contracts::contract_def(context, inner))
             }
         })
         .collect::<Vec<_>>();
@@ -27,7 +27,7 @@ pub fn module(context: &mut Context, module: fe::Module) -> fe::Module {
     let struct_defs_from_tuples = attributes
         .tuples_used
         .iter()
-        .map(|tuple| fe::ModuleStmt::StructDef(Node::new(tuple_to_struct_def(tuple), Span::zero())))
+        .map(|tuple| fe::ModuleStmt::Struct(Node::new(tuple_to_struct_def(tuple), Span::zero())))
         .collect::<Vec<fe::ModuleStmt>>();
 
     fe::Module {
@@ -35,7 +35,7 @@ pub fn module(context: &mut Context, module: fe::Module) -> fe::Module {
     }
 }
 
-fn tuple_to_struct_def(tuple: &Tuple) -> fe::StructDef {
+fn tuple_to_struct_def(tuple: &Tuple) -> fe::Struct {
     let fields = tuple
         .items
         .iter()
@@ -48,7 +48,7 @@ fn tuple_to_struct_def(tuple: &Tuple) -> fe::StructDef {
         })
         .collect();
 
-    fe::StructDef {
+    fe::Struct {
         name: Node::new(names::tuple_struct_string(tuple), Span::zero()),
         fields,
     }

--- a/compiler/src/lowering/names.rs
+++ b/compiler/src/lowering/names.rs
@@ -33,7 +33,7 @@ pub fn fixed_size_type_desc(typ: &FixedSize) -> fe::TypeDesc {
         },
         FixedSize::Array(array) => fe::TypeDesc::Array {
             dimension: array.size,
-            typ: fixed_size_type_desc(&array.inner.clone().into()).into_boxed_node(),
+            typ: fixed_size_type_desc(&array.inner.into()).into_boxed_node(),
         },
         FixedSize::Tuple(_) => todo!(),
         FixedSize::String(_) => todo!(),

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -20,14 +20,19 @@ pub fn contract_def(
 
     // map user defined functions
     for stmt in body.iter() {
-        if let (Some(attributes), fe::ContractStmt::FuncDef { name, .. }) =
-            (context.get_function(stmt), &stmt.kind)
-        {
-            if name.kind == "__init__" {
-                init_function = Some((functions::func_def(context, stmt), attributes.param_types()))
-            } else {
-                user_functions.push(functions::func_def(context, stmt))
+        match stmt {
+            fe::ContractStmt::Function(def) => {
+                let attributes = context
+                    .get_function(def)
+                    .expect("missing function attributes");
+                if def.kind.name.kind == "__init__" {
+                    init_function =
+                        Some((functions::func_def(context, def), attributes.param_types()))
+                } else {
+                    user_functions.push(functions::func_def(context, def))
+                }
             }
+            fe::ContractStmt::Event(_) => {}
         }
     }
 

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -10,73 +10,71 @@ use yultsur::*;
 /// Builds a Yul object from a Fe contract.
 pub fn contract_def(
     context: &Context,
-    stmt: &Node<fe::ModuleStmt>,
+    stmt: &Node<fe::ContractDef>,
     created_contracts: Vec<yul::Object>,
 ) -> yul::Object {
-    if let fe::ModuleStmt::ContractDef { name, body, .. } = &stmt.kind {
-        let contract_name = &name.kind;
-        let mut init_function = None;
-        let mut user_functions = vec![];
+    let fe::ContractDef { name, body, .. } = &stmt.kind;
+    let contract_name = &name.kind;
+    let mut init_function = None;
+    let mut user_functions = vec![];
 
-        // map user defined functions
-        for stmt in body.iter() {
-            if let (Some(attributes), fe::ContractStmt::FuncDef { name, .. }) =
-                (context.get_function(stmt), &stmt.kind)
-            {
-                if name.kind == "__init__" {
-                    init_function =
-                        Some((functions::func_def(context, stmt), attributes.param_types()))
-                } else {
-                    user_functions.push(functions::func_def(context, stmt))
-                }
+    // map user defined functions
+    for stmt in body.iter() {
+        if let (Some(attributes), fe::ContractStmt::FuncDef { name, .. }) =
+            (context.get_function(stmt), &stmt.kind)
+        {
+            if name.kind == "__init__" {
+                init_function = Some((functions::func_def(context, stmt), attributes.param_types()))
+            } else {
+                user_functions.push(functions::func_def(context, stmt))
             }
         }
+    }
 
-        // build the set of functions needed during runtime
-        let runtime_functions = runtime::build_with_abi_dispatcher(context, stmt);
+    // build the set of functions needed during runtime
+    let runtime_functions = runtime::build_with_abi_dispatcher(context, stmt);
 
-        // build data objects for static strings (also for constants in the future)
-        let data = if let Some(attributes) = context.get_contract(stmt) {
-            attributes
-                .string_literals
-                .clone()
-                .into_iter()
-                .map(|val| yul::Data {
-                    name: keccak::full(val.as_bytes()),
-                    value: val,
-                })
-                .collect::<Vec<_>>()
-        } else {
-            vec![]
-        };
+    // build data objects for static strings (also for constants in the future)
+    let data = if let Some(attributes) = context.get_contract(stmt) {
+        attributes
+            .string_literals
+            .clone()
+            .into_iter()
+            .map(|val| yul::Data {
+                name: keccak::full(val.as_bytes()),
+                value: val,
+            })
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
+    };
 
-        // create the runtime object
-        let runtime_object = yul::Object {
-            name: identifier! { runtime },
-            code: yul::Code {
-                block: yul::Block {
-                    statements: statements! {
-                        [user_functions...]
+    // create the runtime object
+    let runtime_object = yul::Object {
+        name: identifier! { runtime },
+        code: yul::Code {
+            block: yul::Block {
+                statements: statements! {
+                    [user_functions...]
                         [runtime_functions...]
-                        // we must return, otherwise we'll enter into other objects
+                    // we must return, otherwise we'll enter into other objects
                         (return(0, 0))
-                    },
                 },
             },
-            objects: created_contracts.clone(),
-            // We can't reach to data objects in the "contract" hierachy so in order to have
-            // the data objects available in both places we have to put them in both places.
-            data: data.clone(),
-        };
+        },
+        objects: created_contracts.clone(),
+        // We can't reach to data objects in the "contract" hierachy so in order to have
+        // the data objects available in both places we have to put them in both places.
+        data: data.clone(),
+    };
 
-        // Build the code and and objects fields for the constructor object.
-        //
-        // If there is an `__init__` function defined, we must include everything that
-        // is in the runtime object in the constructor object too. This is so
-        // user-defined functions can be called from `__init__`.
-        let (constructor_code, constructor_objects) = if let Some((init_func, init_params)) =
-            init_function
-        {
+    // Build the code and and objects fields for the constructor object.
+    //
+    // If there is an `__init__` function defined, we must include everything that
+    // is in the runtime object in the constructor object too. This is so
+    // user-defined functions can be called from `__init__`.
+    let (constructor_code, constructor_objects) =
+        if let Some((init_func, init_params)) = init_function {
             let init_runtime_functions = [runtime::build(context, stmt), user_functions].concat();
             let constructor_code = constructor::build_with_init(
                 contract_name,
@@ -95,14 +93,11 @@ pub fn contract_def(
             (constructor_code, vec![runtime_object])
         };
 
-        // We return the contract initialization object.
-        return yul::Object {
-            name: identifier! { (contract_name) },
-            code: constructor_code,
-            objects: constructor_objects,
-            data,
-        };
+    // We return the contract initialization object.
+    yul::Object {
+        name: identifier! { (contract_name) },
+        code: constructor_code,
+        objects: constructor_objects,
+        data,
     }
-
-    unreachable!()
 }

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -10,10 +10,10 @@ use yultsur::*;
 /// Builds a Yul object from a Fe contract.
 pub fn contract_def(
     context: &Context,
-    stmt: &Node<fe::ContractDef>,
+    stmt: &Node<fe::Contract>,
     created_contracts: Vec<yul::Object>,
 ) -> yul::Object {
-    let fe::ContractDef { name, body, .. } = &stmt.kind;
+    let fe::Contract { name, body, .. } = &stmt.kind;
     let contract_name = &name.kind;
     let mut init_function = None;
     let mut user_functions = vec![];

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -18,23 +18,19 @@ pub fn multiple_func_stmt(
 }
 
 /// Builds a Yul function definition from a Fe function definition.
-pub fn func_def(context: &Context, def: &Node<fe::ContractStmt>) -> yul::Statement {
-    if let fe::ContractStmt::FuncDef {
+pub fn func_def(context: &Context, def: &Node<fe::FuncDef>) -> yul::Statement {
+    let fe::FuncDef {
         name, args, body, ..
-    } = &def.kind
-    {
-        let function_name = names::func_name(&name.kind);
-        let param_names = args.iter().map(|arg| func_def_arg(arg)).collect::<Vec<_>>();
-        let function_statements = multiple_func_stmt(context, body);
+    } = &def.kind;
+    let function_name = names::func_name(&name.kind);
+    let param_names = args.iter().map(|arg| func_def_arg(arg)).collect::<Vec<_>>();
+    let function_statements = multiple_func_stmt(context, body);
 
-        // all user-defined functions are given a return value during lowering
-        function_definition! {
-            function [function_name]([param_names...]) -> return_val {
-                [function_statements...]
-            }
+    // all user-defined functions are given a return value during lowering
+    function_definition! {
+        function [function_name]([param_names...]) -> return_val {
+            [function_statements...]
         }
-    } else {
-        unreachable!()
     }
 }
 

--- a/compiler/src/yul/mappers/functions.rs
+++ b/compiler/src/yul/mappers/functions.rs
@@ -18,8 +18,8 @@ pub fn multiple_func_stmt(
 }
 
 /// Builds a Yul function definition from a Fe function definition.
-pub fn func_def(context: &Context, def: &Node<fe::FuncDef>) -> yul::Statement {
-    let fe::FuncDef {
+pub fn func_def(context: &Context, def: &Node<fe::Function>) -> yul::Statement {
+    let fe::Function {
         name, args, body, ..
     } = &def.kind;
     let function_name = names::func_name(&name.kind);
@@ -34,7 +34,7 @@ pub fn func_def(context: &Context, def: &Node<fe::FuncDef>) -> yul::Statement {
     }
 }
 
-fn func_def_arg(arg: &Node<fe::FuncDefArg>) -> yul::Identifier {
+fn func_def_arg(arg: &Node<fe::FunctionArg>) -> yul::Identifier {
     let name = &arg.kind.name.kind;
 
     names::var_name(name)

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -12,29 +12,31 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
         .body
         .iter()
         .fold(YulContracts::new(), |mut contracts, stmt| {
-            match &stmt.kind {
-                fe::ModuleStmt::Pragma { .. } => {}
-                fe::ModuleStmt::TypeDef { .. } => {}
-                fe::ModuleStmt::ContractDef { name, .. } => {
+            match &stmt {
+                fe::ModuleStmt::Pragma(_) => {}
+                fe::ModuleStmt::TypeAlias(_) => {}
+                fe::ModuleStmt::ContractDef(def) => {
                     // Map the set of created contract names to their Yul objects so they can be
                     // included in the Yul contract that deploys them.
                     let created_contracts = context
-                        .get_contract(stmt)
+                        .get_contract(def)
                         .expect("invalid attributes")
                         .created_contracts
                         .iter()
                         .map(|contract_name| contracts[contract_name].clone())
                         .collect::<Vec<_>>();
 
-                    let contract = contracts::contract_def(context, stmt, created_contracts);
+                    let contract = contracts::contract_def(context, def, created_contracts);
 
-                    if contracts.insert(name.kind.clone(), contract).is_some() {
+                    if contracts
+                        .insert(def.kind.name.kind.clone(), contract)
+                        .is_some()
+                    {
                         panic!("duplicate contract definition");
                     }
                 }
-                fe::ModuleStmt::StructDef { .. } => {}
-                fe::ModuleStmt::FromImport { .. } => unimplemented!(),
-                fe::ModuleStmt::SimpleImport { .. } => unimplemented!(),
+                fe::ModuleStmt::StructDef(_) => {}
+                fe::ModuleStmt::Import(_) => unimplemented!(),
             }
 
             contracts

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -15,7 +15,7 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
             match &stmt {
                 fe::ModuleStmt::Pragma(_) => {}
                 fe::ModuleStmt::TypeAlias(_) => {}
-                fe::ModuleStmt::ContractDef(def) => {
+                fe::ModuleStmt::Contract(def) => {
                     // Map the set of created contract names to their Yul objects so they can be
                     // included in the Yul contract that deploys them.
                     let created_contracts = context
@@ -35,7 +35,7 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
                         panic!("duplicate contract definition");
                     }
                 }
-                fe::ModuleStmt::StructDef(_) => {}
+                fe::ModuleStmt::Struct(_) => {}
                 fe::ModuleStmt::Import(_) => unimplemented!(),
             }
 

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -8,7 +8,7 @@ use fe_parser::node::Node;
 use yultsur::*;
 
 /// Builds the set of function statements that are needed during runtime.
-pub fn build(context: &Context, contract: &Node<fe::ModuleStmt>) -> Vec<yul::Statement> {
+pub fn build(context: &Context, contract: &Node<fe::ContractDef>) -> Vec<yul::Statement> {
     if let Some(attributes) = context.get_contract(contract) {
         let std = functions::std();
 
@@ -118,7 +118,7 @@ fn concat_contract_functions(contracts: Vec<Contract>) -> Vec<FunctionAttributes
 /// ABI dispatcher statement.
 pub fn build_with_abi_dispatcher(
     context: &Context,
-    contract: &Node<fe::ModuleStmt>,
+    contract: &Node<fe::ContractDef>,
 ) -> Vec<yul::Statement> {
     if let Some(attributes) = context.get_contract(contract) {
         let mut runtime = build(context, contract);

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -8,7 +8,7 @@ use fe_parser::node::Node;
 use yultsur::*;
 
 /// Builds the set of function statements that are needed during runtime.
-pub fn build(context: &Context, contract: &Node<fe::ContractDef>) -> Vec<yul::Statement> {
+pub fn build(context: &Context, contract: &Node<fe::Contract>) -> Vec<yul::Statement> {
     if let Some(attributes) = context.get_contract(contract) {
         let std = functions::std();
 
@@ -118,7 +118,7 @@ fn concat_contract_functions(contracts: Vec<Contract>) -> Vec<FunctionAttributes
 /// ABI dispatcher statement.
 pub fn build_with_abi_dispatcher(
     context: &Context,
-    contract: &Node<fe::ContractDef>,
+    contract: &Node<fe::Contract>,
 ) -> Vec<yul::Statement> {
     if let Some(attributes) = context.get_contract(contract) {
         let mut runtime = build(context, contract);

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -14,8 +14,8 @@ pub enum ModuleStmt {
     Pragma(Node<Pragma>),
     Import(Node<Import>),
     TypeAlias(Node<TypeAlias>),
-    ContractDef(Node<ContractDef>),
-    StructDef(Node<StructDef>),
+    Contract(Node<Contract>),
+    Struct(Node<Struct>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -41,14 +41,14 @@ pub struct TypeAlias {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct ContractDef {
+pub struct Contract {
     pub name: Node<String>,
     pub fields: Vec<Node<Field>>,
     pub body: Vec<ContractStmt>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct StructDef {
+pub struct Struct {
     pub name: Node<String>,
     pub fields: Vec<Node<Field>>,
 }
@@ -127,21 +127,21 @@ pub struct Field {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum ContractStmt {
-    Event(Node<EventDef>),
-    Function(Node<FuncDef>),
+    Event(Node<Event>),
+    Function(Node<Function>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct EventDef {
+pub struct Event {
     pub name: Node<String>,
     pub fields: Vec<Node<EventField>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct FuncDef {
+pub struct Function {
     pub is_pub: bool,
     pub name: Node<String>,
-    pub args: Vec<Node<FuncDefArg>>,
+    pub args: Vec<Node<FunctionArg>>,
     pub return_type: Option<Node<TypeDesc>>,
     pub body: Vec<Node<FuncStmt>>,
 }
@@ -154,7 +154,7 @@ pub struct EventField {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct FuncDefArg {
+pub struct FunctionArg {
     pub name: Node<String>,
     pub typ: Node<TypeDesc>,
 }
@@ -318,8 +318,8 @@ impl Spanned for ModuleStmt {
             ModuleStmt::Pragma(inner) => inner.span,
             ModuleStmt::Import(inner) => inner.span,
             ModuleStmt::TypeAlias(inner) => inner.span,
-            ModuleStmt::ContractDef(inner) => inner.span,
-            ModuleStmt::StructDef(inner) => inner.span,
+            ModuleStmt::Contract(inner) => inner.span,
+            ModuleStmt::Struct(inner) => inner.span,
         }
     }
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -6,34 +6,51 @@ use vec1::Vec1;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Module {
-    pub body: Vec<Node<ModuleStmt>>,
+    pub body: Vec<ModuleStmt>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum ModuleStmt {
-    Pragma {
-        version_requirement: Node<String>,
-    },
-    TypeDef {
-        name: Node<String>,
-        typ: Node<TypeDesc>,
-    },
-    SimpleImport {
+    Pragma(Node<Pragma>),
+    Import(Node<Import>),
+    TypeAlias(Node<TypeAlias>),
+    ContractDef(Node<ContractDef>),
+    StructDef(Node<StructDef>),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct Pragma {
+    pub version_requirement: Node<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum Import {
+    Simple {
         names: Vec<Node<SimpleImportName>>,
     },
-    FromImport {
+    From {
         path: Node<FromImportPath>,
         names: Node<FromImportNames>,
     },
-    ContractDef {
-        name: Node<String>,
-        fields: Vec<Node<Field>>,
-        body: Vec<Node<ContractStmt>>,
-    },
-    StructDef {
-        name: Node<String>,
-        fields: Vec<Node<Field>>,
-    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct TypeAlias {
+    pub name: Node<String>,
+    pub typ: Node<TypeDesc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct ContractDef {
+    pub name: Node<String>,
+    pub fields: Vec<Node<Field>>,
+    pub body: Vec<Node<ContractStmt>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct StructDef {
+    pub name: Node<String>,
+    pub fields: Vec<Node<Field>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -287,6 +304,18 @@ pub enum CompOperator {
     LtE,
     Gt,
     GtE,
+}
+
+impl Spanned for ModuleStmt {
+    fn span(&self) -> Span {
+        match self {
+            ModuleStmt::Pragma(inner) => inner.span,
+            ModuleStmt::Import(inner) => inner.span,
+            ModuleStmt::TypeAlias(inner) => inner.span,
+            ModuleStmt::ContractDef(inner) => inner.span,
+            ModuleStmt::StructDef(inner) => inner.span,
+        }
+    }
 }
 
 impl fmt::Display for BoolOperator {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -44,7 +44,7 @@ pub struct TypeAlias {
 pub struct ContractDef {
     pub name: Node<String>,
     pub fields: Vec<Node<Field>>,
-    pub body: Vec<Node<ContractStmt>>,
+    pub body: Vec<ContractStmt>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -127,17 +127,23 @@ pub struct Field {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub enum ContractStmt {
-    EventDef {
-        name: Node<String>,
-        fields: Vec<Node<EventField>>,
-    },
-    FuncDef {
-        is_pub: bool,
-        name: Node<String>,
-        args: Vec<Node<FuncDefArg>>,
-        return_type: Option<Node<TypeDesc>>,
-        body: Vec<Node<FuncStmt>>,
-    },
+    Event(Node<EventDef>),
+    Function(Node<FuncDef>),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct EventDef {
+    pub name: Node<String>,
+    pub fields: Vec<Node<EventField>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct FuncDef {
+    pub is_pub: bool,
+    pub name: Node<String>,
+    pub args: Vec<Node<FuncDefArg>>,
+    pub return_type: Option<Node<TypeDesc>>,
+    pub body: Vec<Node<FuncStmt>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -314,6 +320,15 @@ impl Spanned for ModuleStmt {
             ModuleStmt::TypeAlias(inner) => inner.span,
             ModuleStmt::ContractDef(inner) => inner.span,
             ModuleStmt::StructDef(inner) => inner.span,
+        }
+    }
+}
+
+impl Spanned for ContractStmt {
+    fn span(&self) -> Span {
+        match self {
+            ContractStmt::Event(inner) => inner.span,
+            ContractStmt::Function(inner) => inner.span,
         }
     }
 }

--- a/parser/src/grammar/contracts.rs
+++ b/parser/src/grammar/contracts.rs
@@ -1,7 +1,7 @@
 use super::functions::parse_fn_def;
 use super::types::{parse_event_def, parse_field, parse_opt_qualifier};
 
-use crate::ast::ModuleStmt;
+use crate::ast::ContractDef;
 use crate::grammar::functions::parse_single_word_stmt;
 use crate::node::Node;
 use crate::{ParseFailed, ParseResult, Parser, TokenKind};
@@ -15,7 +15,7 @@ use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 /// Parse a contract definition.
 /// # Panics
 /// Panics if the next token isn't `contract`.
-pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
+pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<ContractDef>> {
     use TokenKind::*;
     let contract_tok = par.assert(Contract);
 
@@ -106,7 +106,7 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
 
     let span = header_span + fields.last() + defs.last();
     Ok(Node::new(
-        ModuleStmt::ContractDef {
+        ContractDef {
             name: Node::new(contract_name.text.to_string(), contract_name.span),
             fields,
             body: defs,

--- a/parser/src/grammar/contracts.rs
+++ b/parser/src/grammar/contracts.rs
@@ -1,7 +1,7 @@
 use super::functions::parse_fn_def;
 use super::types::{parse_event_def, parse_field, parse_opt_qualifier};
 
-use crate::ast::ContractDef;
+use crate::ast::{ContractDef, ContractStmt};
 use crate::grammar::functions::parse_single_word_stmt;
 use crate::node::Node;
 use crate::{ParseFailed, ParseResult, Parser, TokenKind};
@@ -70,7 +70,7 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<ContractDef>> {
                         "`const` qualifier can't be used with function definitions",
                     );
                 }
-                defs.push(parse_fn_def(par, pub_qual)?);
+                defs.push(ContractStmt::Function(parse_fn_def(par, pub_qual)?));
             }
             Some(TokenKind::Event) => {
                 if let Some(span) = pub_qual {
@@ -82,7 +82,7 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<ContractDef>> {
                         "`const` qualifier can't be used with event definitions",
                     );
                 }
-                defs.push(parse_event_def(par)?);
+                defs.push(ContractStmt::Event(parse_event_def(par)?));
             }
             Some(Pass) => {
                 parse_single_word_stmt(par)?;

--- a/parser/src/grammar/functions.rs
+++ b/parser/src/grammar/functions.rs
@@ -1,7 +1,7 @@
 use super::expressions::{parse_call_args, parse_expr};
 use super::types::parse_type_desc;
 
-use crate::ast::{BinOperator, ContractStmt, Expr, FuncDefArg, FuncStmt, VarDeclTarget};
+use crate::ast::{BinOperator, Expr, FuncDef, FuncDefArg, FuncStmt, VarDeclTarget};
 use crate::lexer::TokenKind;
 use crate::node::{Node, Span};
 use crate::{Label, ParseFailed, ParseResult, Parser};
@@ -11,7 +11,7 @@ use crate::{Label, ParseFailed, ParseResult, Parser};
 ///
 /// # Panics
 /// Panics if the next token isn't `def`.
-pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<ContractStmt>> {
+pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<FuncDef>> {
     let def_tok = par.assert(TokenKind::Def);
     let name = par.expect(TokenKind::Name, "failed to parse function definition")?;
     let mut span = def_tok.span + pub_qual + name.span;
@@ -68,7 +68,7 @@ pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Nod
     let body = parse_block_stmts(par)?;
     span += body.last();
     Ok(Node::new(
-        ContractStmt::FuncDef {
+        FuncDef {
             is_pub: pub_qual.is_some(),
             name: name.into(),
             args,

--- a/parser/src/grammar/functions.rs
+++ b/parser/src/grammar/functions.rs
@@ -1,7 +1,7 @@
 use super::expressions::{parse_call_args, parse_expr};
 use super::types::parse_type_desc;
 
-use crate::ast::{BinOperator, Expr, FuncDef, FuncDefArg, FuncStmt, VarDeclTarget};
+use crate::ast::{BinOperator, Expr, FuncStmt, Function, FunctionArg, VarDeclTarget};
 use crate::lexer::TokenKind;
 use crate::node::{Node, Span};
 use crate::{Label, ParseFailed, ParseResult, Parser};
@@ -11,7 +11,7 @@ use crate::{Label, ParseFailed, ParseResult, Parser};
 ///
 /// # Panics
 /// Panics if the next token isn't `def`.
-pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<FuncDef>> {
+pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<Function>> {
     let def_tok = par.assert(TokenKind::Def);
     let name = par.expect(TokenKind::Name, "failed to parse function definition")?;
     let mut span = def_tok.span + pub_qual + name.span;
@@ -68,7 +68,7 @@ pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Nod
     let body = parse_block_stmts(par)?;
     span += body.last();
     Ok(Node::new(
-        FuncDef {
+        Function {
             is_pub: pub_qual.is_some(),
             name: name.into(),
             args,
@@ -79,7 +79,7 @@ pub fn parse_fn_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Nod
     ))
 }
 
-fn parse_fn_param_list(par: &mut Parser) -> ParseResult<Node<Vec<Node<FuncDefArg>>>> {
+fn parse_fn_param_list(par: &mut Parser) -> ParseResult<Node<Vec<Node<FunctionArg>>>> {
     let mut span = par.assert(TokenKind::ParenOpen).span;
     let mut params = vec![];
     loop {
@@ -105,7 +105,7 @@ fn parse_fn_param_list(par: &mut Parser) -> ParseResult<Node<Vec<Node<FuncDefArg
                 let typ = parse_type_desc(par)?;
                 let param_span = name.span + typ.span;
                 params.push(Node::new(
-                    FuncDefArg {
+                    FunctionArg {
                         name: Node::new(name.text.into(), name.span),
                         typ,
                     },

--- a/parser/src/grammar/module.rs
+++ b/parser/src/grammar/module.rs
@@ -32,8 +32,8 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
     let stmt = match par.peek_or_err()? {
         TokenKind::Pragma => ModuleStmt::Pragma(parse_pragma(par)?),
         TokenKind::Import => ModuleStmt::Import(parse_simple_import(par)?),
-        TokenKind::Contract => ModuleStmt::ContractDef(parse_contract_def(par)?),
-        TokenKind::Struct => ModuleStmt::StructDef(parse_struct_def(par)?),
+        TokenKind::Contract => ModuleStmt::Contract(parse_contract_def(par)?),
+        TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par)?),
         TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par)?),
 
         // Let these be parse errors for now:

--- a/parser/src/grammar/module.rs
+++ b/parser/src/grammar/module.rs
@@ -1,6 +1,6 @@
 use super::contracts::parse_contract_def;
-use super::types::{parse_struct_def, parse_type_def};
-use crate::ast::{Module, ModuleStmt, SimpleImportName};
+use super::types::{parse_struct_def, parse_type_alias};
+use crate::ast::{Import, Module, ModuleStmt, Pragma, SimpleImportName};
 use crate::node::{Node, Span};
 use crate::{Label, ParseFailed, ParseResult, Parser, TokenKind};
 
@@ -23,25 +23,22 @@ pub fn parse_module(par: &mut Parser) -> ParseResult<Node<Module>> {
             }
         }
     }
-    let span = if body.is_empty() {
-        Span::zero()
-    } else {
-        body.first().unwrap().span + body.last()
-    };
-
+    let span = Span::zero() + body.first() + body.last();
     Ok(Node::new(Module { body }, span))
 }
 
 /// Parse a [`ModuleStmt`].
-pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
-    match par.peek_or_err()? {
-        TokenKind::Pragma => parse_pragma(par),
-        TokenKind::Import => parse_simple_import(par),
-        TokenKind::Name if par.peeked_text() == "from" => parse_from_import(par),
-        TokenKind::Contract => parse_contract_def(par),
-        TokenKind::Struct => parse_struct_def(par),
-        TokenKind::Type => parse_type_def(par),
-        TokenKind::Event => todo!("module-level event def"),
+pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
+    let stmt = match par.peek_or_err()? {
+        TokenKind::Pragma => ModuleStmt::Pragma(parse_pragma(par)?),
+        TokenKind::Import => ModuleStmt::Import(parse_simple_import(par)?),
+        TokenKind::Contract => ModuleStmt::ContractDef(parse_contract_def(par)?),
+        TokenKind::Struct => ModuleStmt::StructDef(parse_struct_def(par)?),
+        TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par)?),
+
+        // Let these be parse errors for now:
+        // TokenKind::Event => todo!("module-level event def"),
+        // TokenKind::Name if par.peeked_text() == "from" => parse_from_import(par),
         _ => {
             let tok = par.next()?;
             par.unexpected_token_error(
@@ -49,9 +46,10 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
                 "failed to parse module",
                 vec!["Note: expected import, contract, struct, type, or event".into()],
             );
-            Err(ParseFailed)
+            return Err(ParseFailed);
         }
-    }
+    };
+    Ok(stmt)
 }
 
 /// Parse an `import` statement. This does not yet support paths, just module
@@ -59,7 +57,7 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
 /// [`parse_from_import`].
 /// # Panics
 /// Panics if the next token isn't `import`.
-pub fn parse_simple_import(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
+pub fn parse_simple_import(par: &mut Parser) -> ParseResult<Node<Import>> {
     let import_tok = par.assert(TokenKind::Import);
 
     // TODO: only handles `import foo, bar as baz`
@@ -106,20 +104,20 @@ pub fn parse_simple_import(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
     }
 
     let span = import_tok.span + names.last();
-    Ok(Node::new(ModuleStmt::SimpleImport { names }, span))
+    Ok(Node::new(Import::Simple { names }, span))
 }
 
 /// Parse a `from x import y` style import statement.
 /// # Panics
 /// Always panics. Unimplemented.
-pub fn parse_from_import(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
+pub fn parse_from_import(par: &mut Parser) -> ParseResult<Node<Import>> {
     let tok = par.assert(TokenKind::Name);
     assert_eq!(tok.text, "from");
     todo!("parse from .. import (not supported in rest of compiler yet)")
 }
 
 /// Parse a `pragma <version-requirement>` statement.
-pub fn parse_pragma(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
+pub fn parse_pragma(par: &mut Parser) -> ParseResult<Node<Pragma>> {
     let tok = par.assert(TokenKind::Pragma);
     assert_eq!(tok.text, "pragma");
 
@@ -150,7 +148,7 @@ pub fn parse_pragma(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
 
     match VersionReq::parse(&version_string) {
         Ok(_) => Ok(Node::new(
-            ModuleStmt::Pragma {
+            Pragma {
                 version_requirement: Node::new(version_string, version_requirement_span),
             },
             tok.span + version_requirement_span,

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -1,4 +1,4 @@
-use crate::ast::{ContractStmt, EventField, Field, GenericArg, ModuleStmt, TypeDesc};
+use crate::ast::{ContractStmt, EventField, Field, GenericArg, StructDef, TypeAlias, TypeDesc};
 use crate::grammar::expressions::parse_expr;
 use crate::grammar::functions::parse_single_word_stmt;
 use crate::node::{Node, Span};
@@ -8,7 +8,7 @@ use vec1::Vec1;
 /// Parse a [`ModuleStmt::StructDef`].
 /// # Panics
 /// Panics if the next token isn't `struct`.
-pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
+pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<StructDef>> {
     use TokenKind::*;
 
     let struct_tok = par.assert(Struct);
@@ -42,7 +42,7 @@ pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
     }
     let span = struct_tok.span + name.span + fields.last();
     Ok(Node::new(
-        ModuleStmt::StructDef {
+        StructDef {
             name: name.into(),
             fields,
         },
@@ -50,10 +50,10 @@ pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
     ))
 }
 
-/// Parse a type definition, e.g. `type MyMap = Map<u8, address>`.
+/// Parse a type alias definition, e.g. `type MyMap = Map<u8, address>`.
 /// # Panics
 /// Panics if the next token isn't `type`.
-pub fn parse_type_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
+pub fn parse_type_alias(par: &mut Parser) -> ParseResult<Node<TypeAlias>> {
     let type_tok = par.assert(TokenKind::Type);
     let name = par.expect(TokenKind::Name, "failed to parse type declaration")?;
     par.expect_with_notes(TokenKind::Eq, "failed to parse type declaration", || {
@@ -66,7 +66,7 @@ pub fn parse_type_def(par: &mut Parser) -> ParseResult<Node<ModuleStmt>> {
     let typ = parse_type_desc(par)?;
     let span = type_tok.span + typ.span;
     Ok(Node::new(
-        ModuleStmt::TypeDef {
+        TypeAlias {
             name: name.into(),
             typ,
         },

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -1,16 +1,15 @@
-use crate::ast::{EventDef, EventField, Field, GenericArg, StructDef, TypeAlias, TypeDesc};
+use crate::ast::{self, EventField, Field, GenericArg, TypeAlias, TypeDesc};
 use crate::grammar::expressions::parse_expr;
 use crate::grammar::functions::parse_single_word_stmt;
 use crate::node::{Node, Span};
 use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 use vec1::Vec1;
 
-/// Parse a [`ModuleStmt::StructDef`].
+/// Parse a [`ModuleStmt::Struct`].
 /// # Panics
 /// Panics if the next token isn't `struct`.
-pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<StructDef>> {
+pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ast::Struct>> {
     use TokenKind::*;
-
     let struct_tok = par.assert(Struct);
     let name = par.expect_with_notes(Name, "failed to parse struct definition", || {
         vec!["Note: a struct name must start with a letter or underscore, and contain letters, numbers, or underscores".into()]
@@ -21,8 +20,8 @@ pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<StructDef>> {
     loop {
         match par.peek() {
             Some(Name) | Some(Pub) | Some(Const) => {
-                let pub_qual = parse_opt_qualifier(par, TokenKind::Pub);
-                let const_qual = parse_opt_qualifier(par, TokenKind::Const);
+                let pub_qual = parse_opt_qualifier(par, Pub);
+                let const_qual = parse_opt_qualifier(par, Const);
                 fields.push(parse_field(par, pub_qual, const_qual)?);
             }
             Some(Dedent) => {
@@ -42,7 +41,7 @@ pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<StructDef>> {
     }
     let span = struct_tok.span + name.span + fields.last();
     Ok(Node::new(
-        StructDef {
+        ast::Struct {
             name: name.into(),
             fields,
         },
@@ -77,7 +76,7 @@ pub fn parse_type_alias(par: &mut Parser) -> ParseResult<Node<TypeAlias>> {
 /// Parse an event definition.
 /// # Panics
 /// Panics if the next token isn't `event`.
-pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<EventDef>> {
+pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<ast::Event>> {
     use TokenKind::*;
 
     let event_tok = par.assert(Event);
@@ -107,7 +106,7 @@ pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<EventDef>> {
     }
     let span = event_tok.span + name.span + fields.last();
     Ok(Node::new(
-        EventDef {
+        ast::Event {
             name: name.into(),
             fields,
         },

--- a/parser/src/grammar/types.rs
+++ b/parser/src/grammar/types.rs
@@ -1,4 +1,4 @@
-use crate::ast::{ContractStmt, EventField, Field, GenericArg, StructDef, TypeAlias, TypeDesc};
+use crate::ast::{EventDef, EventField, Field, GenericArg, StructDef, TypeAlias, TypeDesc};
 use crate::grammar::expressions::parse_expr;
 use crate::grammar::functions::parse_single_word_stmt;
 use crate::node::{Node, Span};
@@ -77,7 +77,7 @@ pub fn parse_type_alias(par: &mut Parser) -> ParseResult<Node<TypeAlias>> {
 /// Parse an event definition.
 /// # Panics
 /// Panics if the next token isn't `event`.
-pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<ContractStmt>> {
+pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<EventDef>> {
     use TokenKind::*;
 
     let event_tok = par.assert(Event);
@@ -107,7 +107,7 @@ pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<ContractStmt>> {
     }
     let span = event_tok.span + name.span + fields.last();
     Ok(Node::new(
-        ContractStmt::EventDef {
+        EventDef {
             name: name.into(),
             fields,
         },

--- a/parser/src/node.rs
+++ b/parser/src/node.rs
@@ -1,6 +1,5 @@
 pub use fe_common::{Span, Spanned};
 use serde::{Deserialize, Serialize};
-use std::ops::Add;
 use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Copy, Clone, Hash, Eq, Default, PartialOrd, Ord)]
@@ -9,14 +8,6 @@ pub struct NodeId(Uuid);
 impl NodeId {
     pub fn create() -> Self {
         Self(Uuid::new_v4())
-    }
-}
-
-impl<T> Add<&Node<T>> for Span {
-    type Output = Self;
-
-    fn add(self, other: &Node<T>) -> Self {
-        self + other.span
     }
 }
 

--- a/parser/tests/cases/parse_ast.rs
+++ b/parser/tests/cases/parse_ast.rs
@@ -130,7 +130,7 @@ test_parse! { stmt_var_decl_name, functions::parse_stmt, "foo: u256" }
 test_parse! { stmt_var_decl_tuple, functions::parse_stmt, "(foo, bar): (u256, u256) = (10, 10)" }
 test_parse! { stmt_var_decl_tuples, functions::parse_stmt, "(a, (b, (c, d))): x" }
 
-test_parse! { type_def, types::parse_type_def, "type X = Map<address, u256>" }
+test_parse! { type_def, types::parse_type_alias, "type X = Map<address, u256>" }
 test_parse! { type_name, types::parse_type_desc, "MyType" }
 test_parse! { type_array, types::parse_type_desc, "address[25]" }
 test_parse! { type_3d, types::parse_type_desc, "u256[4][4][4]" }

--- a/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -128,7 +128,7 @@ Node(
       ),
     ],
     body: [
-      Node(
+      Function(Node(
         kind: FuncDef(
           is_pub: true,
           name: Node(
@@ -170,8 +170,8 @@ Node(
           start: 73,
           end: 107,
         ),
-      ),
-      Node(
+      )),
+      Event(Node(
         kind: EventDef(
           name: Node(
             kind: "Bar",
@@ -212,7 +212,7 @@ Node(
           start: 110,
           end: 142,
         ),
-      ),
+      )),
     ],
   ),
   span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(contract_def), contracts::parse_contract_def,
 
 ---
 Node(
-  kind: ContractDef(
+  kind: Contract(
     name: Node(
       kind: "Foo",
       span: Span(
@@ -129,7 +129,7 @@ Node(
     ],
     body: [
       Function(Node(
-        kind: FuncDef(
+        kind: Function(
           is_pub: true,
           name: Node(
             kind: "foo",
@@ -172,7 +172,7 @@ Node(
         ),
       )),
       Event(Node(
-        kind: EventDef(
+        kind: Event(
           name: Node(
             kind: "Bar",
             span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__empty_contract_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__empty_contract_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(empty_contract_def), contracts::parse_contrac
 
 ---
 Node(
-  kind: ContractDef(
+  kind: Contract(
     name: Node(
       kind: "Foo",
       span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__empty_event_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__empty_event_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(empty_event_def), types::parse_event_def,\n  
 
 ---
 Node(
-  kind: EventDef(
+  kind: Event(
     name: Node(
       kind: "Foo",
       span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__empty_struct_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__empty_struct_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(empty_struct_def), types::parse_struct_def,\n
 
 ---
 Node(
-  kind: StructDef(
+  kind: Struct(
     name: Node(
       kind: "S",
       span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__event_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__event_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(event_def), types::parse_event_def,\n        
 
 ---
 Node(
-  kind: EventDef(
+  kind: Event(
     name: Node(
       kind: "Foo",
       span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__fn_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__fn_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(fn_def), |par| functions::parse_fn_def(par, N
 
 ---
 Node(
-  kind: FuncDef(
+  kind: Function(
     is_pub: false,
     name: Node(
       kind: "foo21",
@@ -15,7 +15,7 @@ Node(
     ),
     args: [
       Node(
-        kind: FuncDefArg(
+        kind: FunctionArg(
           name: Node(
             kind: "x",
             span: Span(
@@ -39,7 +39,7 @@ Node(
         ),
       ),
       Node(
-        kind: FuncDefArg(
+        kind: FunctionArg(
           name: Node(
             kind: "y",
             span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -110,7 +110,7 @@ Node(
             ),
           ],
           body: [
-            Node(
+            Event(Node(
               kind: EventDef(
                 name: Node(
                   kind: "Signed",
@@ -151,8 +151,8 @@ Node(
                 start: 95,
                 end: 138,
               ),
-            ),
-            Node(
+            )),
+            Function(Node(
               kind: FuncDef(
                 is_pub: true,
                 name: Node(
@@ -308,8 +308,8 @@ Node(
                 start: 144,
                 end: 263,
               ),
-            ),
-            Node(
+            )),
+            Function(Node(
               kind: FuncDef(
                 is_pub: true,
                 name: Node(
@@ -406,7 +406,7 @@ Node(
                 start: 269,
                 end: 348,
               ),
-            ),
+            )),
           ],
         ),
         span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -39,8 +39,8 @@ Node(
           end: 26,
         ),
       )),
-      ContractDef(Node(
-        kind: ContractDef(
+      Contract(Node(
+        kind: Contract(
           name: Node(
             kind: "GuestBook",
             span: Span(
@@ -111,7 +111,7 @@ Node(
           ],
           body: [
             Event(Node(
-              kind: EventDef(
+              kind: Event(
                 name: Node(
                   kind: "Signed",
                   span: Span(
@@ -153,7 +153,7 @@ Node(
               ),
             )),
             Function(Node(
-              kind: FuncDef(
+              kind: Function(
                 is_pub: true,
                 name: Node(
                   kind: "sign",
@@ -164,7 +164,7 @@ Node(
                 ),
                 args: [
                   Node(
-                    kind: FuncDefArg(
+                    kind: FunctionArg(
                       name: Node(
                         kind: "book_msg",
                         span: Span(
@@ -310,7 +310,7 @@ Node(
               ),
             )),
             Function(Node(
-              kind: FuncDef(
+              kind: Function(
                 is_pub: true,
                 name: Node(
                   kind: "get_msg",
@@ -321,7 +321,7 @@ Node(
                 ),
                 args: [
                   Node(
-                    kind: FuncDefArg(
+                    kind: FunctionArg(
                       name: Node(
                         kind: "addr",
                         span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -6,8 +6,8 @@ expression: "ast_string(stringify!(guest_book), module::parse_module,\n         
 Node(
   kind: Module(
     body: [
-      Node(
-        kind: TypeDef(
+      TypeAlias(Node(
+        kind: TypeAlias(
           name: Node(
             kind: "BookMsg",
             span: Span(
@@ -38,8 +38,8 @@ Node(
           start: 1,
           end: 26,
         ),
-      ),
-      Node(
+      )),
+      ContractDef(Node(
         kind: ContractDef(
           name: Node(
             kind: "GuestBook",
@@ -413,11 +413,11 @@ Node(
           start: 28,
           end: 348,
         ),
-      ),
+      )),
     ],
   ),
   span: Span(
-    start: 1,
+    start: 0,
     end: 348,
   ),
 )

--- a/parser/tests/cases/snapshots/cases__parse_ast__import_simple.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__import_simple.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(import_simple), module::parse_simple_import,\
 
 ---
 Node(
-  kind: SimpleImport(
+  kind: Simple(
     names: [
       Node(
         kind: SimpleImportName(

--- a/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -6,7 +6,7 @@ expression: "ast_string(stringify!(module_stmts), module::parse_module,\n       
 Node(
   kind: Module(
     body: [
-      Node(
+      Pragma(Node(
         kind: Pragma(
           version_requirement: Node(
             kind: "0.5.0",
@@ -20,9 +20,9 @@ Node(
           start: 1,
           end: 13,
         ),
-      ),
-      Node(
-        kind: SimpleImport(
+      )),
+      Import(Node(
+        kind: Simple(
           names: [
             Node(
               kind: SimpleImportName(
@@ -78,9 +78,9 @@ Node(
           start: 15,
           end: 44,
         ),
-      ),
-      Node(
-        kind: TypeDef(
+      )),
+      TypeAlias(Node(
+        kind: TypeAlias(
           name: Node(
             kind: "X",
             span: Span(
@@ -134,8 +134,8 @@ Node(
           start: 46,
           end: 67,
         ),
-      ),
-      Node(
+      )),
+      ContractDef(Node(
         kind: ContractDef(
           name: Node(
             kind: "A",
@@ -185,8 +185,8 @@ Node(
           start: 69,
           end: 102,
         ),
-      ),
-      Node(
+      )),
+      ContractDef(Node(
         kind: ContractDef(
           name: Node(
             kind: "B",
@@ -230,11 +230,11 @@ Node(
           start: 109,
           end: 133,
         ),
-      ),
+      )),
     ],
   ),
   span: Span(
-    start: 1,
+    start: 0,
     end: 133,
   ),
 )

--- a/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -135,8 +135,8 @@ Node(
           end: 67,
         ),
       )),
-      ContractDef(Node(
-        kind: ContractDef(
+      Contract(Node(
+        kind: Contract(
           name: Node(
             kind: "A",
             span: Span(
@@ -186,8 +186,8 @@ Node(
           end: 102,
         ),
       )),
-      ContractDef(Node(
-        kind: ContractDef(
+      Contract(Node(
+        kind: Contract(
           name: Node(
             kind: "B",
             span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(struct_def), types::parse_struct_def,\n      
 
 ---
 Node(
-  kind: StructDef(
+  kind: Struct(
     name: Node(
       kind: "S",
       span: Span(

--- a/parser/tests/cases/snapshots/cases__parse_ast__type_def.snap
+++ b/parser/tests/cases/snapshots/cases__parse_ast__type_def.snap
@@ -4,7 +4,7 @@ expression: "ast_string(stringify!(type_def), types::parse_type_def,\n          
 
 ---
 Node(
-  kind: TypeDef(
+  kind: TypeAlias(
     name: Node(
       kind: "X",
       span: Span(


### PR DESCRIPTION
Splitting my salsa refactorfest into some smaller PRs.

### What was wrong?

It's nice to refer to `StructDef`, `FuncDef`, etc directly instead of always matching on `ModuleStmt` or `ContractStmt` enums. This cleans up some of the ugly
```
if let ModuleStmt::StructDef { .. } = &stmt.kind {
  ... 
} else {
  unreachable!() 
}
```
blocks, and makes the salsa stuff cleaner.

I also renamed ast::FuncDef to Function, StructDef to Struct, etc, because it looks nicer to me.

### How was it fixed?
:raised_hands:
