### PR TITLE
Upgrade some dependencies and re-enable test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
 name = "ascii"
@@ -109,7 +121,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
  "either",
- "radium",
+ "radium 0.3.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium 0.6.2",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -177,6 +201,12 @@ name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byte-tools"
@@ -516,42 +546,45 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "12.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+checksum = "c52991643379afc90bfe2df3c64d53983e59c35a82ba6e75c997cfc2880d8524"
 dependencies = [
+ "anyhow",
  "ethereum-types",
- "rustc-hex",
+ "hex",
  "serde",
  "serde_json",
- "tiny-keccak 1.5.0",
- "uint",
+ "sha3 0.9.1",
+ "thiserror",
+ "uint 0.9.0",
 ]
 
 [[package]]
 name = "ethbloom"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
 name = "ethereum"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ea35e1b0845310ade8eb048d401b0b899b8eff05c4d2a3454d29ef4eb1b8af"
+checksum = "567ce064a8232c16e2b2c2173a936b91fbe35c2f2c5278871f5a1a31688b42e9"
 dependencies = [
  "ethereum-types",
+ "funty",
  "hash-db",
  "hash256-std-hasher",
- "parity-scale-codec",
- "rlp 0.4.6",
+ "parity-scale-codec 2.1.3",
+ "rlp",
  "rlp-derive",
  "serde",
  "sha3 0.9.1",
@@ -560,32 +593,32 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
- "uint",
+ "primitive-types 0.9.0",
+ "uint 0.9.0",
 ]
 
 [[package]]
 name = "evm"
-version = "0.18.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286da2277b078e7033491d62e674eeccd01d913a87bb60ec0cabbcf80ec62e9"
+checksum = "1202e8dfa45bea73ee003c4be2f3549d60cb2e2ac5b0c1db563bd4653213efde"
 dependencies = [
  "ethereum",
- "evm-core",
+ "evm-core 0.26.1",
  "evm-gasometer",
- "evm-runtime",
+ "evm-runtime 0.26.0",
  "log",
- "parity-scale-codec",
- "primitive-types",
- "rlp 0.4.6",
+ "parity-scale-codec 2.1.3",
+ "primitive-types 0.9.0",
+ "rlp",
  "serde",
  "sha3 0.8.2",
 ]
@@ -596,20 +629,32 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c6c39300d7779427f461408d867426e202ea72ac7ece2455689ff0e4bddb6f"
 dependencies = [
- "parity-scale-codec",
- "primitive-types",
+ "parity-scale-codec 1.3.7",
+ "primitive-types 0.7.3",
+ "serde",
+]
+
+[[package]]
+name = "evm-core"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f235e93b84fccc1ebdffad226dc56caf833de2fb2f3395f933d95fbf66b254e"
+dependencies = [
+ "funty",
+ "parity-scale-codec 2.1.3",
+ "primitive-types 0.9.0",
  "serde",
 ]
 
 [[package]]
 name = "evm-gasometer"
-version = "0.18.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689c481648c3f45b64b1278077c04284ad535e068c9d6872153c7b74da7ccb03"
+checksum = "463412356790c5e34e8a13cd23ba06284d9afa999e82e8c64497aed2ee625375"
 dependencies = [
- "evm-core",
- "evm-runtime",
- "primitive-types",
+ "evm-core 0.26.1",
+ "evm-runtime 0.26.0",
+ "primitive-types 0.9.0",
 ]
 
 [[package]]
@@ -618,8 +663,19 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a148ad1b3e0af31aa03c6c3cc9df3a529e279dad8e29b4ef90dccad32601e4"
 dependencies = [
- "evm-core",
- "primitive-types",
+ "evm-core 0.18.3",
+ "primitive-types 0.7.3",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c08f510e5535cee2352adb9b93ff24dc80f8ca1bad445a9aa1292ce144b45a1"
+dependencies = [
+ "evm-core 0.26.1",
+ "primitive-types 0.9.0",
  "sha3 0.8.2",
 ]
 
@@ -662,7 +718,7 @@ dependencies = [
  "num-traits",
  "ron",
  "serde",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -671,7 +727,7 @@ version = "0.6.1-alpha"
 dependencies = [
  "ethabi",
  "evm",
- "evm-runtime",
+ "evm-runtime 0.18.3",
  "fe-analyzer",
  "fe-common",
  "fe-parser",
@@ -679,8 +735,8 @@ dependencies = [
  "maplit",
  "num-bigint",
  "once_cell",
- "primitive-types",
- "rand",
+ "primitive-types 0.9.0",
+ "rand 0.7.3",
  "regex",
  "rstest",
  "serde",
@@ -696,11 +752,11 @@ version = "0.6.1-alpha"
 dependencies = [
  "ethabi",
  "evm",
- "evm-runtime",
+ "evm-runtime 0.26.0",
  "fe-common",
  "fe-compiler",
  "hex",
- "primitive-types",
+ "primitive-types 0.9.0",
  "serde_json",
  "solc",
  "stringreader",
@@ -713,7 +769,7 @@ version = "0.6.1-alpha"
 dependencies = [
  "ethabi",
  "evm",
- "evm-runtime",
+ "evm-runtime 0.26.0",
  "fe-analyzer",
  "fe-common",
  "fe-compiler",
@@ -722,8 +778,8 @@ dependencies = [
  "hex",
  "insta",
  "pretty_assertions",
- "primitive-types",
- "rand",
+ "primitive-types 0.9.0",
+ "rand 0.7.3",
  "regex",
  "rstest",
  "stringreader",
@@ -756,7 +812,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.4",
  "rustc-hex",
  "static_assertions",
 ]
@@ -776,6 +844,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
@@ -952,16 +1026,25 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.7",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+dependencies = [
+ "parity-scale-codec 2.1.3",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp 0.4.6",
+ "rlp",
 ]
 
 [[package]]
@@ -1250,10 +1333,23 @@ version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
 dependencies = [
- "arrayvec",
- "bitvec",
- "byte-slice-cast",
- "parity-scale-codec-derive",
+ "arrayvec 0.5.2",
+ "bitvec 0.17.4",
+ "byte-slice-cast 0.3.5",
+ "parity-scale-codec-derive 1.2.3",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b310f220c335f9df1b3d2e9fbe3890bbfeef5030dad771620f48c5c229877cd3"
+dependencies = [
+ "arrayvec 0.7.1",
+ "bitvec 0.20.4",
+ "byte-slice-cast 1.0.0",
+ "parity-scale-codec-derive 2.1.3",
  "serde",
 ]
 
@@ -1263,7 +1359,19 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41512944b1faff334a5f1b9447611bf4ef40638ccb6328173dacefb338e878c"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81038e13ca2c32587201d544ea2e6b6c47120f1e4eae04478f9f60b6bcb89145"
+dependencies = [
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1320,11 +1428,22 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
- "fixed-hash",
- "impl-codec",
+ "fixed-hash 0.6.1",
+ "impl-codec 0.4.2",
+ "uint 0.8.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec 0.5.0",
  "impl-rlp",
  "impl-serde",
- "uint",
+ "uint 0.9.0",
 ]
 
 [[package]]
@@ -1333,6 +1452,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -1391,6 +1520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,9 +1533,20 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1410,7 +1556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1423,12 +1579,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.2",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1475,15 +1640,6 @@ name = "regex-syntax"
 version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00efb87459ba4f6fb2169d20f68565555688e1250ee6825cdf6254f8b48fafb2"
-
-[[package]]
-name = "rlp"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
-dependencies = [
- "rustc-hex",
-]
 
 [[package]]
 name = "rlp"
@@ -1793,6 +1949,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1983,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,15 +2019,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -1899,7 +2072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
 dependencies = [
  "hash-db",
- "rlp 0.5.0",
+ "rlp",
 ]
 
 [[package]]
@@ -1923,6 +2096,18 @@ dependencies = [
  "byteorder",
  "crunchy",
  "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
  "static_assertions",
 ]
 
@@ -2199,6 +2384,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -20,7 +20,7 @@ serde = "1.0"
 hex = "0.4"
 # This fork contains the shorthand macros and some other necessary updates.
 yultsur = { git = "https://github.com/g-r-a-n-t/yultsur"}
-ethabi = "12.0"
+ethabi = "14.0"
 # Optional
 # This fork supports concurrent compilation, which is required for Rust tests.
 solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true }
@@ -31,8 +31,8 @@ num-bigint = "0.3.1"
 
 [dev-dependencies]
 evm-runtime = "0.18"
-evm = "0.18"
-primitive-types = { version = "0.7", default-features = false, features = ["rlp"] }
+evm = "0.26.0"
+primitive-types = { version = "0.9", default-features = false, features = ["rlp"] }
 rand = "0.7.3"
 rstest = "0.6.4"
 regex="1.1.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 bincode = "1.3.3"
-ethabi = "12.0"
+ethabi = "14.0"
 fe-compiler-test-utils = {path = "../test-utils", version = "0.4.0-alpha"}
 libfuzzer-sys = "0.4"
 serde = {version = "1.0.125", features = ["derive"]}

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -7,13 +7,13 @@ version = "0.6.1-alpha"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethabi = "12.0"
-evm = "0.18"
-evm-runtime = "0.18"
+ethabi = "14.0"
+evm = "0.26.0"
+evm-runtime = "0.26.0"
 fe-common = {path = "../common", version = "^0.6.1-alpha"}
 fe-compiler = {path = "../compiler", version = "^0.6.1-alpha"}
 hex = "0.4"
-primitive-types = {version = "0.7", default-features = false, features = ["rlp"]}
+primitive-types = {version = "0.9", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"
 solc = {git = "https://github.com/g-r-a-n-t/solc-rust", optional = true}
 stringreader = "0.1"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,15 +10,15 @@ version = "0.6.1-alpha"
 [dependencies]
 fe-compiler = {path = "../compiler"}
 # This fork contains the shorthand macros and some other necessary updates.
-ethabi = "12.0"
-evm = "0.18"
-evm-runtime = "0.18"
+ethabi = "14.0"
+evm = "0.26.0"
+evm-runtime = "0.26.0"
 fe-analyzer = {path = "../analyzer", version = "^0.6.1-alpha"}
 fe-common = {path = "../common", version = "^0.6.1-alpha"}
 fe-compiler-test-utils = {path = "../test-utils" }
 fe-parser = {path = "../parser", version = "^0.6.1-alpha"}
 hex = "0.4"
-primitive-types = {version = "0.7", default-features = false, features = ["rlp"]}
+primitive-types = {version = "0.9", default-features = false, features = ["rlp"]}
 rand = "0.7.3"
 regex = "1.1.0"
 rstest = "0.6.4"

--- a/tests/src/demo_guestbook.rs
+++ b/tests/src/demo_guestbook.rs
@@ -22,7 +22,7 @@ fn guest_book() {
                 .as_str(),
         );
 
-        harness.caller = sender.clone().to_address().unwrap();
+        harness.caller = sender.clone().into_address().unwrap();
 
         harness.test_function(&mut executor, "sign", &[bytes.clone()], None);
 

--- a/tests/src/demo_uniswap.rs
+++ b/tests/src/demo_uniswap.rs
@@ -72,7 +72,7 @@ fn uniswap_contracts() {
 
         // Set the pair address for convenience.
         let pair_harness = load_contract(
-            pair_address.clone().to_address().expect("not an address"),
+            pair_address.clone().into_address().expect("not an address"),
             "fixtures/demos/uniswap.fe",
             "UniswapV2Pair",
         );
@@ -158,7 +158,7 @@ fn uniswap_contracts() {
         /* BOB PERFORMS A SWAP */
 
         // Set Bob as the token1 caller, this is so Bob can perform a swap.
-        token1_harness.set_caller(bob.clone().to_address().unwrap());
+        token1_harness.set_caller(bob.clone().into_address().unwrap());
 
         // Bob sends 1000 smallest units of token1 to the pair for swapping.
         // token1 is twice as valuable as token0, so we should expect to receive roughly

--- a/tests/src/features.rs
+++ b/tests/src/features.rs
@@ -962,12 +962,6 @@ fn checked_arithmetic() {
                 &[config.i_min.clone(), int_token(-2)],
             );
 
-            // signed: min_value * 1 works
-            if config.size == 256 {
-                // rust-evm has a bug with SDIV(256_min, 1). It returns 0 causing this test to
-                // fail. See: https://github.com/ethereum/fe/issues/285
-                continue;
-            }
             harness.test_function(
                 &mut executor,
                 &format!("mul_i{}", config.size),

--- a/tests/src/features.rs
+++ b/tests/src/features.rs
@@ -49,7 +49,7 @@ fn evm_sanity() {
         let address = H160::zero();
         let amount = U256::from(1000);
 
-        executor.deposit(address, amount);
+        executor.state_mut().deposit(address, amount);
         assert_eq!(executor.balance(address), amount);
     })
 }
@@ -366,56 +366,55 @@ fn return_builtin_attributes() {
 
     let vicinity = evm::backend::MemoryVicinity {
         gas_price: U256::from(gas_price),
-        origin: origin.clone().to_address().unwrap(),
+        origin: origin.clone().into_address().unwrap(),
         chain_id: U256::from(chain_id),
         block_hashes: Vec::new(),
         block_number: U256::from(block_number),
-        block_coinbase: block_coinbase.clone().to_address().unwrap(),
+        block_coinbase: block_coinbase.clone().into_address().unwrap(),
         block_timestamp: U256::from(block_timestamp),
         block_difficulty: U256::from(block_difficulty),
         block_gas_limit: primitive_types::U256::MAX,
     };
 
-    with_executor_backend(
-        evm::backend::MemoryBackend::new(&vicinity, BTreeMap::new()),
-        &|mut executor| {
-            let mut harness =
-                deploy_contract(&mut executor, "return_builtin_attributes.fe", "Foo", &[]);
-            let sender = address_token("1234000000000000000000000000000000005678");
-            harness.caller = sender.clone().to_address().unwrap();
-            let value = 55555;
-            harness.value = U256::from(value);
-            harness.test_function(&mut executor, "coinbase", &[], Some(&block_coinbase));
-            harness.test_function(
-                &mut executor,
-                "difficulty",
-                &[],
-                Some(&uint_token(block_difficulty)),
-            );
-            harness.test_function(
-                &mut executor,
-                "number",
-                &[],
-                Some(&uint_token(block_number)),
-            );
-            harness.test_function(
-                &mut executor,
-                "timestamp",
-                &[],
-                Some(&uint_token(block_timestamp)),
-            );
-            harness.test_function(&mut executor, "chainid", &[], Some(&uint_token(chain_id)));
-            harness.test_function(&mut executor, "sender", &[], Some(&sender));
-            harness.test_function(&mut executor, "value", &[], Some(&uint_token(value)));
-            harness.test_function(&mut executor, "origin", &[], Some(&origin));
-            harness.test_function(
-                &mut executor,
-                "gas_price",
-                &[],
-                Some(&uint_token(gas_price)),
-            );
-        },
-    )
+    let backend = evm::backend::MemoryBackend::new(&vicinity, BTreeMap::new());
+
+    with_executor_backend(backend, &|mut executor| {
+        let mut harness =
+            deploy_contract(&mut executor, "return_builtin_attributes.fe", "Foo", &[]);
+        let sender = address_token("1234000000000000000000000000000000005678");
+        harness.caller = sender.clone().into_address().unwrap();
+        let value = 55555;
+        harness.value = U256::from(value);
+        harness.test_function(&mut executor, "coinbase", &[], Some(&block_coinbase));
+        harness.test_function(
+            &mut executor,
+            "difficulty",
+            &[],
+            Some(&uint_token(block_difficulty)),
+        );
+        harness.test_function(
+            &mut executor,
+            "number",
+            &[],
+            Some(&uint_token(block_number)),
+        );
+        harness.test_function(
+            &mut executor,
+            "timestamp",
+            &[],
+            Some(&uint_token(block_timestamp)),
+        );
+        harness.test_function(&mut executor, "chainid", &[], Some(&uint_token(chain_id)));
+        harness.test_function(&mut executor, "sender", &[], Some(&sender));
+        harness.test_function(&mut executor, "value", &[], Some(&uint_token(value)));
+        harness.test_function(&mut executor, "origin", &[], Some(&origin));
+        harness.test_function(
+            &mut executor,
+            "gas_price",
+            &[],
+            Some(&uint_token(gas_price)),
+        );
+    })
 }
 
 #[test]
@@ -1144,7 +1143,7 @@ fn create2_contract() {
         let foo_address = factory_harness
             .call_function(&mut executor, "create2_foo", &[])
             .expect("factory did not return an address")
-            .to_address()
+            .into_address()
             .expect("not an address");
 
         let foo_harness = load_contract(foo_address, "create2_contract.fe", "Foo");
@@ -1162,7 +1161,7 @@ fn create_contract() {
         let foo_address = factory_harness
             .call_function(&mut executor, "create_foo", &[])
             .expect("factory did not return an address")
-            .to_address()
+            .into_address()
             .expect("not an address");
 
         let foo_harness = load_contract(foo_address, "create_contract.fe", "Foo");
@@ -1184,7 +1183,7 @@ fn create_contract_from_init() {
         let foo_address = factory_harness
             .call_function(&mut executor, "get_foo_addr", &[])
             .expect("factory did not return an address")
-            .to_address()
+            .into_address()
             .expect("not an address");
 
         let foo_harness = load_contract(foo_address, "create_contract_from_init.fe", "Foo");


### PR DESCRIPTION
### What was wrong?

Our `ethereum_types`, `primitive_types` and `evm_runtime` dependencies were out of date. We also had one test disabled that was waiting on these upgrades

### How was it fixed?

- Modifications on some testing helpers (done by Grant)
- Re-enabled arithmetic test that was failing with previous eth_runtime versions
