### PR TITLE
Support revert with custom errors (EIP 838)

### DIFF
--- a/crates/abi/src/utils.rs
+++ b/crates/abi/src/utils.rs
@@ -2,16 +2,16 @@ use fe_common::utils::keccak;
 
 /// Formats the name and fields and calculates the 32 byte keccak256 value of
 /// the signature.
-pub fn event_topic(name: &str, fields: Vec<String>) -> String {
+pub fn event_topic(name: &str, fields: &[String]) -> String {
     sign_event_or_func(name, fields, 32)
 }
 /// Formats the name and params and calculates the 4 byte keccak256 value of the
 /// signature.
-pub fn func_selector(name: &str, params: Vec<String>) -> String {
+pub fn func_selector(name: &str, params: &[String]) -> String {
     sign_event_or_func(name, params, 4)
 }
 
-fn sign_event_or_func(name: &str, params: Vec<String>, size: usize) -> String {
+fn sign_event_or_func(name: &str, params: &[String], size: usize) -> String {
     let signature = format!("{}({})", name, params.join(","));
     keccak::partial(signature.as_bytes(), size)
 }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -220,6 +220,11 @@ impl Struct {
             .map(|(_, typ)| typ)
     }
 
+    /// Return the types of all fields
+    pub fn get_field_types(&self) -> Vec<FixedSize> {
+        self.fields.iter().cloned().map(|(_, typ)| typ).collect()
+    }
+
     /// Return the index of the given field name
     pub fn get_field_index(&self, name: &str) -> Option<usize> {
         self.fields.iter().position(|(field, _)| field == name)

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -397,6 +397,12 @@ impl From<Base> for FixedSize {
     }
 }
 
+impl From<FeString> for FixedSize {
+    fn from(value: FeString) -> Self {
+        FixedSize::String(value)
+    }
+}
+
 impl TryFrom<Type> for FixedSize {
     type Error = TypeError;
 

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -233,7 +233,7 @@ fn func_stmt(
         Assert { .. } => assert(scope, context, stmt),
         Expr { .. } => expr(scope, context, stmt),
         Pass => Ok(()),
-        Revert => Ok(()),
+        Revert { .. } => Ok(()),
         Break | Continue => {
             loop_flow_statement(scope, context, stmt);
             Ok(())

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -233,7 +233,7 @@ fn func_stmt(
         Assert { .. } => assert(scope, context, stmt),
         Expr { .. } => expr(scope, context, stmt),
         Pass => Ok(()),
-        Revert { .. } => Ok(()),
+        Revert { .. } => revert(scope, context, stmt),
         Break | Continue => {
             loop_flow_statement(scope, context, stmt);
             Ok(())
@@ -429,6 +429,32 @@ fn assert(
                     "`assert` reason must be a string",
                     msg.span,
                     format!("this has type `{}`; expected a string", msg_attributes.typ),
+                );
+            }
+        }
+
+        return Ok(());
+    }
+
+    unreachable!()
+}
+
+fn revert(
+    scope: Shared<BlockScope>,
+    context: &mut Context,
+    stmt: &Node<fe::FuncStmt>,
+) -> Result<(), FatalError> {
+    if let fe::FuncStmt::Revert { error } = &stmt.kind {
+        if let Some(error_expr) = error {
+            let error_attributes = expressions::expr(Rc::clone(&scope), context, error_expr, None)?;
+            if !matches!(error_attributes.typ, Type::Struct(_)) {
+                context.error(
+                    "`revert` error must be a struct",
+                    error_expr.span,
+                    format!(
+                        "this has type `{}`; expected a struct",
+                        error_attributes.typ
+                    ),
                 );
             }
         }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -187,6 +187,8 @@ test_file! { return_call_to_fn_with_param_type_mismatch }
 test_file! { return_call_to_fn_without_return }
 test_file! { return_from_init }
 test_file! { return_lt_mixed_types }
+
+test_stmt! { revert_reason_not_stuct, "revert 1" }
 test_file! { strict_boolean_if_else }
 test_file! { struct_call_bad_args }
 test_file! { struct_call_without_kw_args }

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -5,6 +5,27 @@ expression: "build_snapshot(\"features/revert.fe\", &src, &context)"
 ---
 ModuleAttributes {
     type_defs: {
+        "Error": Struct(
+            Struct {
+                name: "Error",
+                fields: [
+                    (
+                        "msg",
+                        Base(
+                            Numeric(
+                                U256,
+                            ),
+                        ),
+                    ),
+                    (
+                        "val",
+                        Base(
+                            Bool,
+                        ),
+                    ),
+                ],
+            },
+        ),
         "Foo": Contract(
             Contract {
                 name: "Foo",
@@ -19,6 +40,43 @@ ModuleAttributes {
                             ),
                         ),
                     },
+                    FunctionAttributes {
+                        is_public: true,
+                        name: "revert_custom_error",
+                        params: [],
+                        return_type: Base(
+                            Unit,
+                        ),
+                    },
+                    FunctionAttributes {
+                        is_public: true,
+                        name: "revert_other_error",
+                        params: [],
+                        return_type: Base(
+                            Unit,
+                        ),
+                    },
+                ],
+            },
+        ),
+        "OtherError": Struct(
+            Struct {
+                name: "OtherError",
+                fields: [
+                    (
+                        "msg",
+                        Base(
+                            Numeric(
+                                U256,
+                            ),
+                        ),
+                    ),
+                    (
+                        "val",
+                        Base(
+                            Bool,
+                        ),
+                    ),
                 ],
             },
         ),
@@ -26,60 +84,379 @@ ModuleAttributes {
 }
 
 note: 
-  ┌─ features/revert.fe:2:5
-  │  
-2 │ ╭     pub def bar() -> u256:
-3 │ │         revert
-  │ ╰──────────────^ attributes hash: 2041944711719443549
-  │  
-  = FunctionAttributes {
-        is_public: true,
-        name: "bar",
-        params: [],
-        return_type: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-    }
+   ┌─ features/revert.fe:14:26
+   │
+14 │         revert Error(msg=1, val=true)
+   │                          ^ attributes hash: 16797824492585953824
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+         location: Value,
+         move_location: None,
+     }
 
 note: 
-  ┌─ features/revert.fe:1:1
-  │  
-1 │ ╭ contract Foo:
-2 │ │     pub def bar() -> u256:
-3 │ │         revert
-  │ ╰──────────────^ attributes hash: 16417315723405128961
-  │  
-  = ContractAttributes {
-        public_functions: [
-            FunctionAttributes {
-                is_public: true,
-                name: "bar",
-                params: [],
-                return_type: Base(
-                    Numeric(
-                        U256,
-                    ),
-                ),
-            },
-        ],
-        init_function: None,
-        events: [],
-        structs: [],
-        external_contracts: [],
-    }
+   ┌─ features/revert.fe:14:33
+   │
+14 │         revert Error(msg=1, val=true)
+   │                                 ^^^^ attributes hash: 10866140763116710699
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Value,
+         move_location: None,
+     }
 
 note: 
-  ┌─ features/revert.fe:2:22
+   ┌─ features/revert.fe:14:16
+   │
+14 │         revert Error(msg=1, val=true)
+   │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11364813338237787146
+   │
+   = ExpressionAttributes {
+         typ: Struct(
+             Struct {
+                 name: "Error",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:17:31
+   │
+17 │         revert OtherError(msg=1, val=true)
+   │                               ^ attributes hash: 16797824492585953824
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:17:38
+   │
+17 │         revert OtherError(msg=1, val=true)
+   │                                      ^^^^ attributes hash: 10866140763116710699
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:17:16
+   │
+17 │         revert OtherError(msg=1, val=true)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14209897660967917692
+   │
+   = ExpressionAttributes {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:10:5
+   │  
+10 │ ╭     pub def bar() -> u256:
+11 │ │         revert
+   │ ╰──────────────^ attributes hash: 2041944711719443549
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "bar",
+         params: [],
+         return_type: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:13:5
+   │  
+13 │ ╭     pub def revert_custom_error():
+14 │ │         revert Error(msg=1, val=true)
+   │ ╰─────────────────────────────────────^ attributes hash: 12416044718721723673
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "revert_custom_error",
+         params: [],
+         return_type: Base(
+             Unit,
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:16:5
+   │  
+16 │ ╭     pub def revert_other_error():
+17 │ │         revert OtherError(msg=1, val=true)
+   │ ╰──────────────────────────────────────────^ attributes hash: 2922949012455231953
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "revert_other_error",
+         params: [],
+         return_type: Base(
+             Unit,
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:9:1
+   │  
+ 9 │ ╭ contract Foo:
+10 │ │     pub def bar() -> u256:
+11 │ │         revert
+12 │ │ 
+   · │
+16 │ │     pub def revert_other_error():
+17 │ │         revert OtherError(msg=1, val=true)
+   │ ╰──────────────────────────────────────────^ attributes hash: 5555419990939220415
+   │  
+   = ContractAttributes {
+         public_functions: [
+             FunctionAttributes {
+                 is_public: true,
+                 name: "bar",
+                 params: [],
+                 return_type: Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "revert_custom_error",
+                 params: [],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "revert_other_error",
+                 params: [],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+         ],
+         init_function: None,
+         events: [],
+         structs: [
+             Struct {
+                 name: "Error",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ],
+         external_contracts: [],
+     }
+
+note: 
+   ┌─ features/revert.fe:14:16
+   │
+14 │         revert Error(msg=1, val=true)
+   │                ^^^^^ attributes hash: 15710463956589891586
+   │
+   = TypeConstructor {
+         typ: Struct(
+             Struct {
+                 name: "Error",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:17:16
+   │
+17 │         revert OtherError(msg=1, val=true)
+   │                ^^^^^^^^^^ attributes hash: 9383899454640897483
+   │
+   = TypeConstructor {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+     }
+
+note: 
+  ┌─ features/revert.fe:2:10
   │
-2 │     pub def bar() -> u256:
-  │                      ^^^^ attributes hash: 17942395924573474124
+2 │     msg: u256
+  │          ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
             U256,
         ),
     )
+
+note: 
+  ┌─ features/revert.fe:3:10
+  │
+3 │     val: bool
+  │          ^^^^ attributes hash: 8311861578736502650
+  │
+  = Base(
+        Bool,
+    )
+
+note: 
+  ┌─ features/revert.fe:6:10
+  │
+6 │     msg: u256
+  │          ^^^^ attributes hash: 17942395924573474124
+  │
+  = Base(
+        Numeric(
+            U256,
+        ),
+    )
+
+note: 
+  ┌─ features/revert.fe:7:10
+  │
+7 │     val: bool
+  │          ^^^^ attributes hash: 8311861578736502650
+  │
+  = Base(
+        Bool,
+    )
+
+note: 
+   ┌─ features/revert.fe:10:22
+   │
+10 │     pub def bar() -> u256:
+   │                      ^^^^ attributes hash: 17942395924573474124
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
 
 

--- a/crates/analyzer/tests/snapshots/errors__revert_reason_not_stuct.snap
+++ b/crates/analyzer/tests/snapshots/errors__revert_reason_not_stuct.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `revert` error must be a struct
+  ┌─ [snippet]:3:10
+  │
+3 │   revert 1
+  │          ^ this has type `u256`; expected a struct
+
+

--- a/crates/analyzer/tests/snapshots/fe_compiler_tests__compile_errors__revert_reason_not_struct.snap
+++ b/crates/analyzer/tests/snapshots/fe_compiler_tests__compile_errors__revert_reason_not_struct.snap
@@ -1,0 +1,14 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `<` operands must have the same type
+  ┌─ fixtures/compile_errors/return_lt_mixed_types.fe:3:16
+  │
+3 │         return x < y
+  │                ^   - this has incompatible type `u256`
+  │                │    
+  │                this has type `u128`
+
+

--- a/crates/analyzer/tests/snapshots/fe_compiler_tests__compile_errors__revert_reason_not_stuct.snap
+++ b/crates/analyzer/tests/snapshots/fe_compiler_tests__compile_errors__revert_reason_not_stuct.snap
@@ -1,0 +1,12 @@
+---
+source: tests/src/compile_errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `revert` error must be a struct
+  ┌─ [snippet]:3:10
+  │
+3 │   revert 1
+  │          ^ this has type `u256`; expected a struct
+
+

--- a/crates/analyzer/tests/snapshots/fe_compiler_tests__yulgen__revert_string_error.snap
+++ b/crates/analyzer/tests/snapshots/fe_compiler_tests__yulgen__revert_string_error.snap
@@ -1,0 +1,10 @@
+---
+source: tests/src/yulgen.rs
+expression: "revert::generate_revert_fn_for_assert(&[FixedSize::String(FeString{max_size:\n                                                                      3,})])"
+
+---
+function revert_with_0x08c379a0_string_3(data_ptr, size) {
+    let ptr := alloc_mstoren(0x08c379a0, 4)
+    pop(abi_encode_string_3(data_ptr))
+    revert(ptr, add(4, size))
+}

--- a/crates/lowering/src/mappers/functions.rs
+++ b/crates/lowering/src/mappers/functions.rs
@@ -111,7 +111,7 @@ fn func_stmt(context: &mut Context, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::Fu
         fe::FuncStmt::Pass => vec![stmt.kind],
         fe::FuncStmt::Break => vec![stmt.kind],
         fe::FuncStmt::Continue => vec![stmt.kind],
-        fe::FuncStmt::Revert => vec![stmt.kind],
+        fe::FuncStmt::Revert { .. } => vec![stmt.kind],
     };
     let span = stmt.span;
 

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -207,7 +207,9 @@ pub enum FuncStmt {
     Pass,
     Break,
     Continue,
-    Revert,
+    Revert {
+        error: Option<Node<Expr>>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -105,7 +105,10 @@ test_parse! { stmt_emit2, functions::parse_stmt, "emit Foo(1, 2, x=y)" }
 test_parse! { stmt_return1, functions::parse_stmt, "return" }
 test_parse! { stmt_return2, functions::parse_stmt, "return x" }
 test_parse! { stmt_return3, functions::parse_stmt, "return not x" }
-test_parse! { stmt_revert, functions::parse_stmt, "revert" }
+test_parse! { stmt_revert1, functions::parse_stmt, "revert" }
+
+test_parse! { stmt_revert2, functions::parse_stmt, "revert something" }
+
 test_parse! { stmt_if, functions::parse_stmt, "if a:\n b" }
 test_parse! { stmt_if2, functions::parse_stmt, "if a:\n b \nelif c:\n d \nelif e: \n f \nelse:\n g" }
 test_parse! { stmt_while, functions::parse_stmt, "while a > 5:\n a -= 1" }

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_revert1.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_revert1.snap
@@ -4,7 +4,9 @@ expression: "ast_string(stringify!(stmt_revert), functions::parse_stmt, \"revert
 
 ---
 Node(
-  kind: Revert,
+  kind: Revert(
+    error: None,
+  ),
   span: Span(
     start: 0,
     end: 6,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_revert2.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_revert2.snap
@@ -1,0 +1,20 @@
+---
+source: parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_revert2), functions::parse_stmt,\n           \"revert something\")"
+
+---
+Node(
+  kind: Revert(
+    error: Some(Node(
+      kind: Name("something"),
+      span: Span(
+        start: 7,
+        end: 16,
+      ),
+    )),
+  ),
+  span: Span(
+    start: 0,
+    end: 16,
+  ),
+)

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -1,3 +1,17 @@
+struct Error:
+    msg: u256
+    val: bool
+
+struct OtherError:
+    msg: u256
+    val: bool
+
 contract Foo:
     pub def bar() -> u256:
         revert
+
+    pub def revert_custom_error():
+        revert Error(msg=1, val=true)
+
+    pub def revert_other_error():
+        revert OtherError(msg=1, val=true)

--- a/crates/test-files/fixtures/solidity/revert_test.sol
+++ b/crates/test-files/fixtures/solidity/revert_test.sol
@@ -1,13 +1,53 @@
+error StringError(string reason);
+error U256Error(uint256 reason);
+error I256Error(int256 reason);
+error U8Error(uint8 reason);
+error TwoU256Error(uint256 reason, uint256 reason2);
+
+struct Bag {
+  uint256 val1;
+  int256 val2;
+  bool val3;
+}
+
+error StructError(Bag data);
+
 contract Foo {
-  function revert_me() public pure returns(uint){
+
+  function revert_me() public pure {
     revert("Not enough Ether provided.");
   }
 
-  function revert_with_long_string() public pure returns(uint){
+  function revert_with_long_string() public pure {
     revert("A muuuuuch longer reason string that consumes multiple words");
   }
 
-  function revert_with_empty_string() public pure returns(uint){
+  function revert_with_empty_string() public pure {
     revert("");
   }
+
+  function revert_with_string_error() public pure {
+    revert StringError("Not enough Ether provided.");
+  }
+
+  function revert_with_u256_error() public pure {
+    revert U256Error(100);
+  }
+
+  function revert_with_i256_error() public pure {
+    revert I256Error(-100);
+  }
+
+  function revert_with_u8_error() public pure {
+    revert U8Error(100);
+  }
+
+  function revert_with_two_u256_error() public pure {
+    revert TwoU256Error(100, 100);
+  }
+
+  function revert_with_struct_error() public pure {
+    revert StructError(Bag ({ val1: 100, val2: -100, val3: true }));
+  }
+
 }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -1,9 +1,9 @@
 use evm_runtime::{ExitReason, Handler};
 use fe_common::diagnostics::print_diagnostics;
 use fe_common::files::FileStore;
+use fe_common::utils::keccak;
 use fe_driver as driver;
 use fe_yulgen::runtime::functions;
-use fe_common::utils::keccak;
 use primitive_types::{H160, H256, U256};
 use std::collections::BTreeMap;
 use std::str::FromStr;

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -60,7 +60,24 @@ fn test_revert() {
         assert!(matches!(
             exit,
             evm::Capture::Exit((evm::ExitReason::Revert(_), _))
-        ))
+        ));
+
+        let exit2 = harness.capture_call(&mut executor, "revert_custom_error", &[]);
+
+        validate_revert(
+            exit2,
+            &encode_error("Error(uint256,bool)", &[uint_token(1), bool_token(true)]),
+        );
+
+        let exit3 = harness.capture_call(&mut executor, "revert_other_error", &[]);
+
+        validate_revert(
+            exit3,
+            &encode_error(
+                "OtherError(uint256,bool)",
+                &[uint_token(1), bool_token(true)],
+            ),
+        );
     })
 }
 

--- a/crates/tests/src/runtime.rs
+++ b/crates/tests/src/runtime.rs
@@ -2,11 +2,9 @@
 
 #![cfg(feature = "solc-backend")]
 use fe_yulgen::runtime::functions;
-use rstest::rstest;
 use yultsur::*;
 
 use fe_analyzer::namespace::types::{Base, FixedSize, Integer, Struct};
-use fe_common::utils::keccak;
 use fe_compiler_test_utils::*;
 
 macro_rules! assert_eq {
@@ -17,30 +15,6 @@ macro_rules! assert_eq {
             })
         }
     };
-}
-
-#[rstest(
-    reason,
-    case("foo"),
-    case("A very looooooooooooooong reason that consumes multiple words")
-)]
-fn test_revert_with_reason_string(reason: &str) {
-    let reason_id = format!(r#""{}""#, keccak::full(reason.as_bytes()));
-
-    with_executor(&|mut executor| {
-        Runtime::default()
-                .with_data(
-                    vec![yul::Data { name: keccak::full(reason.as_bytes()), value: reason.to_owned() }]
-                )
-                .with_test_statements(
-                statements! {
-                    (let reason := load_data_string((dataoffset([literal_expression! { (reason_id) }])), (datasize([literal_expression! { (reason_id) }]))))
-                    (revert_with_reason_string(reason))
-                })
-                .execute(&mut executor)
-                .expect_revert()
-                .expect_revert_reason(reason);
-    })
 }
 
 #[test]

--- a/crates/yulgen/src/context.rs
+++ b/crates/yulgen/src/context.rs
@@ -1,4 +1,5 @@
 use crate::AnalyzerContext;
+use fe_analyzer::namespace::types::{FeString, Struct};
 use indexmap::IndexSet;
 
 // This is contract context, but it's used all over so it has a short name.
@@ -10,6 +11,12 @@ pub struct Context<'a> {
 
     /// Names of contracts that have been created inside of this contract.
     pub created_contracts: IndexSet<String>,
+
+    /// Strings that can be used as revert error in assertions
+    pub assert_strings: IndexSet<FeString>,
+
+    // Structs that can be used as errors in revert statements
+    pub revert_errors: IndexSet<Struct>,
 }
 
 impl<'a> Context<'a> {
@@ -18,6 +25,8 @@ impl<'a> Context<'a> {
             analysis,
             string_literals: IndexSet::new(),
             created_contracts: IndexSet::new(),
+            assert_strings: IndexSet::new(),
+            revert_errors: IndexSet::new(),
         }
     }
 }

--- a/crates/yulgen/src/mappers/functions.rs
+++ b/crates/yulgen/src/mappers/functions.rs
@@ -56,7 +56,7 @@ fn func_stmt(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement
         fe::FuncStmt::Pass => statement! { pop(0) },
         fe::FuncStmt::Break => break_statement(context, stmt),
         fe::FuncStmt::Continue => continue_statement(context, stmt),
-        fe::FuncStmt::Revert => revert(stmt),
+        fe::FuncStmt::Revert { .. } => revert(stmt),
     }
 }
 
@@ -119,7 +119,7 @@ fn expr(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
 }
 
 fn revert(stmt: &Node<fe::FuncStmt>) -> yul::Statement {
-    if let fe::FuncStmt::Revert = &stmt.kind {
+    if let fe::FuncStmt::Revert { .. } = &stmt.kind {
         return statement! { revert(0, 0) };
     }
 

--- a/crates/yulgen/src/mappers/functions.rs
+++ b/crates/yulgen/src/mappers/functions.rs
@@ -1,9 +1,10 @@
 use crate::mappers::{assignments, declarations, expressions};
 use crate::names;
+use crate::operations::abi as abi_operations;
 use crate::operations::data as data_operations;
 use crate::Context;
 use fe_analyzer::context::ExpressionAttributes;
-use fe_analyzer::namespace::types::{FeSized, Type};
+use fe_analyzer::namespace::types::{FeSized, FixedSize, Type};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use yultsur::*;
@@ -56,7 +57,7 @@ fn func_stmt(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement
         fe::FuncStmt::Pass => statement! { pop(0) },
         fe::FuncStmt::Break => break_statement(context, stmt),
         fe::FuncStmt::Continue => continue_statement(context, stmt),
-        fe::FuncStmt::Revert { .. } => revert(stmt),
+        fe::FuncStmt::Revert { .. } => revert(context, stmt),
     }
 }
 
@@ -118,8 +119,28 @@ fn expr(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     }
 }
 
-fn revert(stmt: &Node<fe::FuncStmt>) -> yul::Statement {
-    if let fe::FuncStmt::Revert { .. } = &stmt.kind {
+fn revert(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
+    if let fe::FuncStmt::Revert { error } = &stmt.kind {
+        if let Some(error_expr) = error {
+            let error_attributes = context
+                .analysis
+                .get_expression(error_expr)
+                .expect("missing expression");
+
+            if let Type::Struct(val) = &error_attributes.typ {
+                context.revert_errors.insert(val.clone());
+
+                let revert_data = expressions::expr(context, error_expr);
+                let size =
+                    abi_operations::encode_size(vec![val.clone()], vec![revert_data.clone()]);
+                let revert_fn = names::revert_name(&val.name, &val.get_field_types());
+
+                return statement! {
+                    ([revert_fn]([revert_data], [size]))
+                };
+            }
+        }
+
         return statement! { revert(0, 0) };
     }
 
@@ -150,7 +171,24 @@ fn assert(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
         return match msg {
             Some(val) => {
                 let msg = expressions::expr(context, val);
-                statement! { if (iszero([test])) { (revert_with_reason_string([msg])) } }
+                let msg_attributes = context
+                    .analysis
+                    .get_expression(val)
+                    .expect("missing expression");
+
+                if let Type::String(str) = &msg_attributes.typ {
+                    let size = abi_operations::encode_size(vec![str.clone()], vec![msg.clone()]);
+                    let fixed_size = FixedSize::String(str.clone());
+                    context.assert_strings.insert(str.clone());
+                    let revert_fn = names::error_revert_name(&[fixed_size]);
+
+                    return statement! {
+                        if (iszero([test])) {
+                            ([revert_fn]([msg], [size]))
+                        }
+                    };
+                }
+                unreachable!()
             }
             None => statement! { if (iszero([test])) { (revert(0, 0)) } },
         };

--- a/crates/yulgen/src/names.rs
+++ b/crates/yulgen/src/names.rs
@@ -1,3 +1,4 @@
+use fe_abi::utils as abi_utils;
 use fe_analyzer::namespace::types::{AbiDecodeLocation, AbiEncoding, Integer};
 use yultsur::*;
 
@@ -57,6 +58,30 @@ pub fn func_name(name: &str) -> yul::Identifier {
 /// Generate a safe variable name for a user defined function
 pub fn var_name(name: &str) -> yul::Identifier {
     identifier! { (format!("${}", name)) }
+}
+
+/// Generate a revert function name for the name `Error` and a given set of types
+pub fn error_revert_name<T: AbiEncoding>(types: &[T]) -> yul::Identifier {
+    revert_name("Error", types)
+}
+
+/// Generates a revert function name for a given name and types
+pub fn revert_name<T: AbiEncoding>(name: &str, types: &[T]) -> yul::Identifier {
+    let type_names = types
+        .iter()
+        .map(|param| param.lower_snake())
+        .collect::<Vec<String>>();
+
+    let abi_names = types
+        .iter()
+        .map(|param| param.abi_selector_name())
+        .collect::<Vec<String>>();
+
+    let selector = abi_utils::func_selector(name, &abi_names);
+
+    let name = format!("revert_with_{}_{}", selector, &type_names.join("_"));
+
+    identifier! { (name) }
 }
 
 /// Generates an ABI encoding function name for a given set of types.

--- a/crates/yulgen/src/runtime/abi_dispatcher.rs
+++ b/crates/yulgen/src/runtime/abi_dispatcher.rs
@@ -58,7 +58,7 @@ fn selector(name: &str, params: &[FixedSize]) -> yul::Literal {
         .map(|param| param.abi_selector_name())
         .collect::<Vec<String>>();
 
-    literal! {(abi_utils::func_selector(name, params))}
+    literal! {(abi_utils::func_selector(name, &params))}
 }
 
 fn selection(name: &str, params: &[FixedSize]) -> yul::Expression {

--- a/crates/yulgen/src/runtime/functions/contracts.rs
+++ b/crates/yulgen/src/runtime/functions/contracts.rs
@@ -39,7 +39,7 @@ pub fn calls(contract: Contract) -> Vec<yul::Statement> {
                 .unzip();
             // the function selector must be added to the first 4 bytes of the calldata
             let selector = {
-                let selector = abi_utils::func_selector(&function.name, param_names);
+                let selector = abi_utils::func_selector(&function.name, &param_names);
                 literal_expression! { (selector) }
             };
             // the operations used to encode the parameters

--- a/crates/yulgen/src/runtime/functions/data.rs
+++ b/crates/yulgen/src/runtime/functions/data.rs
@@ -21,7 +21,6 @@ pub fn all() -> Vec<yul::Statement> {
         mcopys(),
         mloadn(),
         mstoren(),
-        revert_with_reason_string(),
         scopym(),
         scopys(),
         set_zero(),
@@ -378,31 +377,6 @@ pub fn load_data_string() -> yul::Statement {
             (mstore(mptr, size))
             (let content_ptr := alloc(size))
             (datacopy(content_ptr, code_ptr, size))
-        }
-    }
-}
-
-/// Revert with encoded reason string
-pub fn revert_with_reason_string() -> yul::Statement {
-    function_definition! {
-        function revert_with_reason_string(reason) {
-            // Function selector for Error(string)
-            (let ptr := alloc_mstoren(0x08C379A0, 4))
-
-            // Write the (fixed) data offset into the next 32 bytes of memory
-            (pop((alloc_mstoren(0x0000000000000000000000000000000000000000000000000000000000000020, 32))))
-
-            // Read the size of the string
-            (let reason_size := mloadn(reason, 32))
-
-            //Copy the whole reason string (length + data) to the current segment of memory
-            (pop((mcopym(reason , (add(reason_size, 32))))))
-
-            // Right pad the reason bytes to a multiple of 32 bytes
-            (let padding := sub((ceil32(reason_size)), reason_size))
-            (pop((alloc(padding))))
-
-            (revert(ptr, (add(68, (add(reason_size, padding))))))
         }
     }
 }

--- a/crates/yulgen/src/runtime/functions/mod.rs
+++ b/crates/yulgen/src/runtime/functions/mod.rs
@@ -4,6 +4,7 @@ pub mod abi;
 pub mod contracts;
 pub mod data;
 pub mod math;
+pub mod revert;
 pub mod structs;
 
 /// Returns all functions that should be available during runtime.

--- a/crates/yulgen/src/runtime/functions/revert.rs
+++ b/crates/yulgen/src/runtime/functions/revert.rs
@@ -1,0 +1,49 @@
+use crate::names;
+use fe_abi::utils as abi_utils;
+use fe_analyzer::namespace::types::Struct;
+use fe_analyzer::namespace::types::{AbiEncoding, FixedSize};
+use yultsur::*;
+
+fn selector(name: &str, params: &[FixedSize]) -> yul::Expression {
+    let params = params
+        .iter()
+        .map(|param| param.abi_selector_name())
+        .collect::<Vec<String>>();
+
+    literal_expression! {(abi_utils::func_selector(name, &params))}
+}
+
+/// Generate a YUL function to revert with the `Error` signature and the
+/// given set of params.
+/// NOTE: This is currently used for `assert False, "message"` statements which are
+/// encoded as `Error(msg="message")`. This will be removed in the future.
+pub fn generate_revert_fn_for_assert(params: &[FixedSize]) -> yul::Statement {
+    generate_revert_fn("Error", params, params)
+}
+
+/// Generate a YUL function to revert with a specific struct used as error data
+pub fn generate_struct_revert(val: &Struct) -> yul::Statement {
+    let struct_fields = val.get_field_types();
+    generate_revert_fn(&val.name, &[FixedSize::Struct(val.clone())], &struct_fields)
+}
+
+/// Generate a YUL function that can be used to revert with data
+pub fn generate_revert_fn(
+    name: &str,
+    encoding_params: &[FixedSize],
+    selector_params: &[FixedSize],
+) -> yul::Statement {
+    let abi_encode_fn = names::encode_name(encoding_params);
+
+    let function_name = names::revert_name(name, selector_params);
+
+    let selector = selector(name, &selector_params);
+
+    return function_definition! {
+        function [function_name](data_ptr, size) {
+            (let ptr := alloc_mstoren([selector], 4))
+            (pop(([abi_encode_fn](data_ptr))))
+            (revert(ptr, (add(4, size))))
+        }
+    };
+}

--- a/crates/yulgen/tests/snapshots/yulgen__revert_string_error.snap
+++ b/crates/yulgen/tests/snapshots/yulgen__revert_string_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/yulgen/tests/yulgen.rs
+expression: "revert::generate_revert_fn_for_assert(&[FeString{max_size: 3,}.into()])"
+
+---
+function revert_with_0x08c379a0_string_3(data_ptr, size) {
+    let ptr := alloc_mstoren(0x08c379a0, 4)
+    pop(abi_encode_string_3(data_ptr))
+    revert(ptr, add(4, size))
+}

--- a/crates/yulgen/tests/yulgen.rs
+++ b/crates/yulgen/tests/yulgen.rs
@@ -1,6 +1,6 @@
 use fe_analyzer::namespace::types::{AbiDecodeLocation, Base, FeString, FixedSize, Struct, U256};
 use fe_yulgen::constructor;
-use fe_yulgen::runtime::functions::{abi, structs};
+use fe_yulgen::runtime::functions::{abi, revert, structs};
 use insta::assert_display_snapshot;
 use wasm_bindgen_test::wasm_bindgen_test;
 
@@ -39,3 +39,5 @@ test_yulgen! { struct_empty, structs::generate_new_fn(&Struct::new("Foo")) }
 test_yulgen! { struct_new_gen, structs::generate_new_fn(&struct_bool_bool()) }
 test_yulgen! { struct_getter_gen_bar, structs::generate_get_fn(&struct_bool_bool(), &struct_bool_bool().fields[0].0) }
 test_yulgen! { struct_getter_gen_bar2, structs::generate_get_fn(&struct_bool_bool(), &struct_bool_bool().fields[1].0) }
+
+test_yulgen! { revert_string_error, revert::generate_revert_fn_for_assert(&[FeString { max_size: 3}.into()]) }

--- a/newsfragments/464.feature.md
+++ b/newsfragments/464.feature.md
@@ -1,0 +1,13 @@
+Revert with custom errors
+
+Example:
+
+```
+struct PlatformError:
+  code: u256
+
+pub def do_something():
+  revert PlatformError(code=4711)
+```
+
+Error encoding [follows Solidity](https://docs.soliditylang.org/en/v0.8.4/abi-spec.html#errors) which is based on [EIP-838](https://github.com/ethereum/EIPs/issues/838). This means that custom errors returned from Fe are fully compatible with Solidity.


### PR DESCRIPTION
### What was wrong?

We don't support custom errors as specified by [EIP-838](https://github.com/ethereum/EIPs/issues/838) ([solidity docs have more info](https://docs.soliditylang.org/en/v0.8.4/abi-spec.html#errors))


### How was it fixed?

1. Added support for `revert <expression>` where `<expression>` has to be a `struct`. We might change that in the future to allow more flexibility with reverts. For now structs are the only way to return an EIP-838 compatible error.

E.g.

```
struct Error:
    msg: u256
    val: bool
    
pub def revert_custom_error():
    revert Error(msg=100, val=true)
```

The revert data for the above would be:

```
  --sig--|-----------------------------100------------------------------|---------------------------------true----------------------------
0x3253e3c700000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000001
```

2. This PR doesn't change anything about `assert` statements but as a recap we currently encode `assert false, "foo"` as if it were `assert false, Error(msg="foo")`. We could use the lowering pass to do the conversion but since we do not yet support `String<N>` in structs this continues to be a special case. But again, this PR doesn't change the existing encoding of `assert` it only refactors the underlying code to be more flexible and shared across `revert` and `assert` statements.

3. I added a bunch of new solidity tests that prove that the error coding on their end works similar to ours
