### PR TITLE
Move static string and created-contracts collection from the analyzer the yulgen stage

### DIFF
--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -11,7 +11,7 @@ use fe_parser::ast as fe;
 use fe_parser::node::{Node, NodeId};
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::rc::Rc;
@@ -56,8 +56,6 @@ pub struct ContractAttributes {
     pub structs: Vec<Struct>,
     /// External contracts that may be called from within this contract.
     pub external_contracts: Vec<Contract>,
-    /// Names of contracts that have been created inside of this contract.
-    pub created_contracts: BTreeSet<String>,
 }
 
 impl From<Shared<ContractScope>> for ContractAttributes {
@@ -119,7 +117,6 @@ impl From<Shared<ContractScope>> for ContractAttributes {
                 .collect::<Vec<EventDef>>(),
             structs,
             external_contracts,
-            created_contracts: scope.borrow().created_contracts.to_owned(),
         }
     }
 }

--- a/analyzer/src/context.rs
+++ b/analyzer/src/context.rs
@@ -52,8 +52,6 @@ pub struct ContractAttributes {
     pub init_function: Option<FunctionAttributes>,
     /// Events that have been defined by the user.
     pub events: Vec<EventDef>,
-    /// Static strings that the contract defines
-    pub string_literals: BTreeSet<String>,
     /// Structs that have been defined by the user
     pub structs: Vec<Struct>,
     /// External contracts that may be called from within this contract.
@@ -119,7 +117,6 @@ impl From<Shared<ContractScope>> for ContractAttributes {
                 .values()
                 .map(|event| event.to_owned())
                 .collect::<Vec<EventDef>>(),
-            string_literals: scope.borrow().string_defs.clone(),
             structs,
             external_contracts,
             created_contracts: scope.borrow().created_contracts.to_owned(),

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -37,7 +37,6 @@ pub struct ContractScope {
     pub event_defs: BTreeMap<String, EventDef>,
     pub field_defs: BTreeMap<String, ContractFieldDef>,
     pub function_defs: BTreeMap<String, ContractFunctionDef>,
-    pub string_defs: BTreeSet<String>,
     pub created_contracts: BTreeSet<String>,
     num_fields: usize,
 }
@@ -114,7 +113,6 @@ impl ContractScope {
             function_defs: BTreeMap::new(),
             event_defs: BTreeMap::new(),
             field_defs: BTreeMap::new(),
-            string_defs: BTreeSet::new(),
             interface: vec![],
             created_contracts: BTreeSet::new(),
             num_fields: 0,
@@ -191,11 +189,6 @@ impl ContractScope {
                 Ok(())
             }
         }
-    }
-
-    /// Add a static string definition to the scope.
-    pub fn add_string(&mut self, value: &str) {
-        self.string_defs.insert(value.to_owned());
     }
 
     /// Add the name of another contract that has been created within this

--- a/analyzer/src/namespace/scopes.rs
+++ b/analyzer/src/namespace/scopes.rs
@@ -3,7 +3,7 @@ use crate::namespace::events::EventDef;
 use crate::namespace::types::{FixedSize, Type};
 use std::cell::RefCell;
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 pub type Shared<T> = Rc<RefCell<T>>;
@@ -37,7 +37,6 @@ pub struct ContractScope {
     pub event_defs: BTreeMap<String, EventDef>,
     pub field_defs: BTreeMap<String, ContractFieldDef>,
     pub function_defs: BTreeMap<String, ContractFunctionDef>,
-    pub created_contracts: BTreeSet<String>,
     num_fields: usize,
 }
 
@@ -114,7 +113,6 @@ impl ContractScope {
             event_defs: BTreeMap::new(),
             field_defs: BTreeMap::new(),
             interface: vec![],
-            created_contracts: BTreeSet::new(),
             num_fields: 0,
         }))
     }
@@ -189,12 +187,6 @@ impl ContractScope {
                 Ok(())
             }
         }
-    }
-
-    /// Add the name of another contract that has been created within this
-    /// contract.
-    pub fn add_created_contract(&mut self, name: &str) {
-        self.created_contracts.insert(name.to_owned());
     }
 }
 

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -1252,16 +1252,10 @@ fn expr_call_type_attribute(
                 report_circular_dependency(context, ContractTypeMethod::Create2.to_string());
             }
 
-            if matches!(
+            if !matches!(
                 (&arg_attributes[0].typ, &arg_attributes[1].typ),
                 (Type::Base(Base::Numeric(_)), Type::Base(Base::Numeric(_)))
             ) {
-                scope
-                    .borrow()
-                    .contract_scope()
-                    .borrow_mut()
-                    .add_created_contract(&contract.name);
-            } else {
                 context.fancy_error(
                     "function `create2` expects numeric parameters",
                     vec![Label::primary(args.span, "invalid argument")],
@@ -1280,13 +1274,7 @@ fn expr_call_type_attribute(
                 report_circular_dependency(context, ContractTypeMethod::Create.to_string());
             }
 
-            if matches!(&arg_attributes[0].typ, Type::Base(Base::Numeric(_))) {
-                scope
-                    .borrow()
-                    .contract_scope()
-                    .borrow_mut()
-                    .add_created_contract(&contract.name);
-            } else {
+            if !matches!(&arg_attributes[0].typ, Type::Base(Base::Numeric(_))) {
                 context.fancy_error(
                     "function `create` expects numeric parameter",
                     vec![Label::primary(args.span, "invalid argument")],

--- a/analyzer/src/traversal/expressions.rs
+++ b/analyzer/src/traversal/expressions.rs
@@ -46,7 +46,7 @@ pub fn expr(
         fe::Expr::Call { .. } => expr_call(scope, context, exp),
         fe::Expr::List { elts } => expr_list(scope, context, elts, expected_type.as_array()),
         fe::Expr::Tuple { .. } => expr_tuple(scope, context, exp, expected_type.as_tuple()),
-        fe::Expr::Str(_) => expr_str(scope, exp),
+        fe::Expr::Str(_) => expr_str(exp),
         fe::Expr::Unit => Ok(ExpressionAttributes::new(Type::unit(), Location::Value)),
     }?;
 
@@ -312,17 +312,8 @@ fn expr_name(
     unreachable!()
 }
 
-fn expr_str(
-    scope: Shared<BlockScope>,
-    exp: &Node<fe::Expr>,
-) -> Result<ExpressionAttributes, FatalError> {
+fn expr_str(exp: &Node<fe::Expr>) -> Result<ExpressionAttributes, FatalError> {
     if let fe::Expr::Str(string) = &exp.kind {
-        scope
-            .borrow()
-            .contract_scope()
-            .borrow_mut()
-            .add_string(&string);
-
         return Ok(ExpressionAttributes::new(
             Type::String(FeString {
                 max_size: string.len(),

--- a/compiler/src/yul/context.rs
+++ b/compiler/src/yul/context.rs
@@ -1,4 +1,4 @@
-use fe_analyzer::context::Context as AnalyzerContext;
+use crate::yul::AnalyzerContext;
 use indexmap::IndexSet;
 
 // This is contract context, but it's used all over so it has a short name.

--- a/compiler/src/yul/context.rs
+++ b/compiler/src/yul/context.rs
@@ -1,0 +1,19 @@
+use fe_analyzer::context::Context as AnalyzerContext;
+use indexmap::IndexSet;
+
+// This is contract context, but it's used all over so it has a short name.
+pub struct Context<'a> {
+    pub analysis: &'a AnalyzerContext,
+
+    /// String literals used in the contrat
+    pub string_literals: IndexSet<String>,
+}
+
+impl<'a> Context<'a> {
+    pub fn new(analysis: &'a AnalyzerContext) -> Self {
+        Self {
+            analysis,
+            string_literals: IndexSet::new(),
+        }
+    }
+}

--- a/compiler/src/yul/context.rs
+++ b/compiler/src/yul/context.rs
@@ -5,8 +5,11 @@ use indexmap::IndexSet;
 pub struct Context<'a> {
     pub analysis: &'a AnalyzerContext,
 
-    /// String literals used in the contrat
+    /// String literals used in the contract
     pub string_literals: IndexSet<String>,
+
+    /// Names of contracts that have been created inside of this contract.
+    pub created_contracts: IndexSet<String>,
 }
 
 impl<'a> Context<'a> {
@@ -14,6 +17,7 @@ impl<'a> Context<'a> {
         Self {
             analysis,
             string_literals: IndexSet::new(),
+            created_contracts: IndexSet::new(),
         }
     }
 }

--- a/compiler/src/yul/mappers/assignments.rs
+++ b/compiler/src/yul/mappers/assignments.rs
@@ -1,6 +1,7 @@
 use crate::yul::mappers::expressions;
 use crate::yul::operations::data as data_operations;
-use fe_analyzer::context::{Context, Location};
+use crate::yul::Context;
+use fe_analyzer::context::Location;
 use fe_analyzer::namespace::types::FixedSize;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -8,14 +9,14 @@ use std::convert::TryFrom;
 use yultsur::*;
 
 /// Builds a Yul statement from a Fe assignment.
-pub fn assign(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
+pub fn assign(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::Assign { target, value } = &stmt.kind {
         if let (Some(target_attributes), Some(value_attributes)) = (
-            context.get_expression(target),
-            context.get_expression(value),
+            context.analysis.get_expression(target),
+            context.analysis.get_expression(value),
         ) {
-            let target = expressions::expr(&context, target);
-            let value = expressions::expr(&context, value);
+            let target = expressions::expr(context, target);
+            let value = expressions::expr(context, value);
 
             let typ =
                 FixedSize::try_from(target_attributes.typ.to_owned()).expect("invalid attributes");

--- a/compiler/src/yul/mappers/contracts.rs
+++ b/compiler/src/yul/mappers/contracts.rs
@@ -1,7 +1,8 @@
 use crate::yul::constructor;
 use crate::yul::mappers::functions;
 use crate::yul::runtime;
-use fe_analyzer::context::Context;
+use crate::yul::Context;
+use fe_analyzer::context::Context as AnalyzerContext;
 use fe_common::utils::keccak;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -9,7 +10,7 @@ use yultsur::*;
 
 /// Builds a Yul object from a Fe contract.
 pub fn contract_def(
-    context: &Context,
+    analysis: &AnalyzerContext,
     stmt: &Node<fe::Contract>,
     created_contracts: Vec<yul::Object>,
 ) -> yul::Object {
@@ -18,18 +19,21 @@ pub fn contract_def(
     let mut init_function = None;
     let mut user_functions = vec![];
 
+    let mut context = Context::new(analysis);
+
     // map user defined functions
     for stmt in body.iter() {
         match stmt {
             fe::ContractStmt::Function(def) => {
-                let attributes = context
-                    .get_function(def)
-                    .expect("missing function attributes");
+                let yulfn = functions::func_def(&mut context, def);
+
                 if def.kind.name.kind == "__init__" {
-                    init_function =
-                        Some((functions::func_def(context, def), attributes.param_types()))
+                    let attributes = analysis
+                        .get_function(def)
+                        .expect("missing function attributes");
+                    init_function = Some((yulfn, attributes.param_types()))
                 } else {
-                    user_functions.push(functions::func_def(context, def))
+                    user_functions.push(yulfn)
                 }
             }
             fe::ContractStmt::Event(_) => {}
@@ -37,22 +41,17 @@ pub fn contract_def(
     }
 
     // build the set of functions needed during runtime
-    let runtime_functions = runtime::build_with_abi_dispatcher(context, stmt);
+    let runtime_functions = runtime::build_with_abi_dispatcher(analysis, stmt);
 
     // build data objects for static strings (also for constants in the future)
-    let data = if let Some(attributes) = context.get_contract(stmt) {
-        attributes
-            .string_literals
-            .clone()
-            .into_iter()
-            .map(|val| yul::Data {
-                name: keccak::full(val.as_bytes()),
-                value: val,
-            })
-            .collect::<Vec<_>>()
-    } else {
-        vec![]
-    };
+    let data = context
+        .string_literals
+        .into_iter()
+        .map(|val| yul::Data {
+            name: keccak::full(val.as_bytes()),
+            value: val,
+        })
+        .collect::<Vec<_>>();
 
     // create the runtime object
     let runtime_object = yul::Object {
@@ -80,7 +79,7 @@ pub fn contract_def(
     // user-defined functions can be called from `__init__`.
     let (constructor_code, constructor_objects) =
         if let Some((init_func, init_params)) = init_function {
-            let init_runtime_functions = [runtime::build(context, stmt), user_functions].concat();
+            let init_runtime_functions = [runtime::build(analysis, stmt), user_functions].concat();
             let constructor_code = constructor::build_with_init(
                 contract_name,
                 init_func,

--- a/compiler/src/yul/mappers/declarations.rs
+++ b/compiler/src/yul/mappers/declarations.rs
@@ -1,14 +1,16 @@
 use crate::yul::mappers::expressions;
-use crate::yul::names;
-use fe_analyzer::context::Context;
+use crate::yul::{names, Context};
 use fe_analyzer::namespace::types::{FeSized, FixedSize};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use yultsur::*;
 
 /// Builds a Yul statement from a Fe variable declaration
-pub fn var_decl(context: &Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
-    let decl_type = context.get_declaration(stmt).expect("missing attributes");
+pub fn var_decl(context: &mut Context, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
+    let decl_type = context
+        .analysis
+        .get_declaration(stmt)
+        .expect("missing attributes");
 
     if let fe::FuncStmt::VarDecl { target, value, .. } = &stmt.kind {
         let target = names::var_name(var_decl_name(&target.kind));

--- a/compiler/src/yul/mappers/expressions.rs
+++ b/compiler/src/yul/mappers/expressions.rs
@@ -153,6 +153,7 @@ fn expr_call(context: &mut Context, exp: &Node<fe::Expr>) -> yul::Expression {
                             .expect("invalid attributes"),
                     ) {
                         (Type::Contract(contract), ContractTypeMethod::Create2) => {
+                            context.created_contracts.insert(contract.name.clone());
                             contract_operations::create2(
                                 &contract,
                                 yul_args[0].to_owned(),
@@ -160,6 +161,7 @@ fn expr_call(context: &mut Context, exp: &Node<fe::Expr>) -> yul::Expression {
                             )
                         }
                         (Type::Contract(contract), ContractTypeMethod::Create) => {
+                            context.created_contracts.insert(contract.name.clone());
                             contract_operations::create(&contract, yul_args[0].to_owned())
                         }
                         _ => panic!("invalid attributes"),

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -16,17 +16,7 @@ pub fn module(analysis: &AnalyzerContext, module: &fe::Module) -> YulContracts {
                 fe::ModuleStmt::Pragma(_) => {}
                 fe::ModuleStmt::TypeAlias(_) => {}
                 fe::ModuleStmt::Contract(def) => {
-                    // Map the set of created contract names to their Yul objects so they can be
-                    // included in the Yul contract that deploys them.
-                    let created_contracts = analysis
-                        .get_contract(def)
-                        .expect("invalid attributes")
-                        .created_contracts
-                        .iter()
-                        .map(|contract_name| contracts[contract_name].clone())
-                        .collect::<Vec<_>>();
-
-                    let contract = contracts::contract_def(analysis, def, created_contracts);
+                    let contract = contracts::contract_def(analysis, def, &contracts);
 
                     if contracts
                         .insert(def.kind.name.kind.clone(), contract)

--- a/compiler/src/yul/mappers/module.rs
+++ b/compiler/src/yul/mappers/module.rs
@@ -1,5 +1,5 @@
 use crate::yul::mappers::contracts;
-use fe_analyzer::context::Context;
+use crate::yul::AnalyzerContext;
 use fe_parser::ast as fe;
 use std::collections::HashMap;
 use yultsur::yul;
@@ -7,7 +7,7 @@ use yultsur::yul;
 pub type YulContracts = HashMap<String, yul::Object>;
 
 /// Builds a vector of Yul contracts from a Fe module.
-pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
+pub fn module(analysis: &AnalyzerContext, module: &fe::Module) -> YulContracts {
     module
         .body
         .iter()
@@ -18,7 +18,7 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
                 fe::ModuleStmt::Contract(def) => {
                     // Map the set of created contract names to their Yul objects so they can be
                     // included in the Yul contract that deploys them.
-                    let created_contracts = context
+                    let created_contracts = analysis
                         .get_contract(def)
                         .expect("invalid attributes")
                         .created_contracts
@@ -26,7 +26,7 @@ pub fn module(context: &Context, module: &fe::Module) -> YulContracts {
                         .map(|contract_name| contracts[contract_name].clone())
                         .collect::<Vec<_>>();
 
-                    let contract = contracts::contract_def(context, def, created_contracts);
+                    let contract = contracts::contract_def(analysis, def, created_contracts);
 
                     if contracts
                         .insert(def.kind.name.kind.clone(), contract)

--- a/compiler/src/yul/mod.rs
+++ b/compiler/src/yul/mod.rs
@@ -1,15 +1,18 @@
 //! Fe to Yul compiler.
 
 use crate::types::{FeModuleAst, NamedYulContracts};
-use fe_analyzer::context::Context;
+pub use fe_analyzer::context::Context as AnalyzerContext;
 
 pub mod constants;
 pub mod constructor;
+mod context;
 mod mappers;
 mod names;
 mod operations;
 pub mod runtime;
 mod utils;
+
+pub(crate) use context::Context;
 
 /// Compiles Fe source code to Yul.
 ///
@@ -17,8 +20,8 @@ mod utils;
 ///
 /// Any failure to compile an AST to Yul is considered a bug, and thus panics.
 /// Invalid ASTs should be caught by an analysis step prior to Yul generation.
-pub fn compile(context: &Context, module: &FeModuleAst) -> NamedYulContracts {
-    mappers::module::module(context, module)
+pub fn compile(analysis: &AnalyzerContext, module: &FeModuleAst) -> NamedYulContracts {
+    mappers::module::module(analysis, module)
         .drain()
         .map(|(name, object)| (name, object.to_string().replace("\"", "\\\"")))
         .collect::<NamedYulContracts>()

--- a/compiler/src/yul/runtime/mod.rs
+++ b/compiler/src/yul/runtime/mod.rs
@@ -1,7 +1,7 @@
 mod abi_dispatcher;
 pub mod functions;
-
-use fe_analyzer::context::{Context, FunctionAttributes};
+use crate::yul::Context;
+use fe_analyzer::context::FunctionAttributes;
 use fe_analyzer::namespace::types::{AbiDecodeLocation, Contract, FixedSize};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -9,7 +9,7 @@ use yultsur::*;
 
 /// Builds the set of function statements that are needed during runtime.
 pub fn build(context: &Context, contract: &Node<fe::Contract>) -> Vec<yul::Statement> {
-    if let Some(attributes) = context.get_contract(contract) {
+    if let Some(attributes) = context.analysis.get_contract(contract) {
         let std = functions::std();
 
         let external_functions =
@@ -120,7 +120,7 @@ pub fn build_with_abi_dispatcher(
     context: &Context,
     contract: &Node<fe::Contract>,
 ) -> Vec<yul::Statement> {
-    if let Some(attributes) = context.get_contract(contract) {
+    if let Some(attributes) = context.analysis.get_contract(contract) {
         let mut runtime = build(context, contract);
         runtime.push(abi_dispatcher::dispatcher(
             attributes.public_functions.to_owned(),

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
@@ -4228,7 +4228,6 @@ note:
                   ],
               },
           ],
-          string_literals: {},
           structs: [],
           external_contracts: [],
           created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_001_erc20_token.snap
@@ -4230,7 +4230,6 @@ note:
           ],
           structs: [],
           external_contracts: [],
-          created_contracts: {},
       }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
@@ -379,7 +379,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_002_guest_book.snap
@@ -377,7 +377,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
@@ -16290,7 +16290,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {
@@ -16656,7 +16655,7 @@ note:
     · │
 282 │ │     def min(x: u256, y: u256) -> u256:
 283 │ │         return x if x < y else y
-    │ ╰────────────────────────────────^ attributes hash: 1073470112117261301
+    │ ╰────────────────────────────────^ attributes hash: 16662072184245108604
     │  
     = ContractAttributes {
           public_functions: [
@@ -17141,16 +17140,6 @@ note:
                   ],
               },
           ],
-          string_literals: {
-              "UniswapV2: FORBIDDEN",
-              "UniswapV2: INSUFFICIENT_INPUT_AMOUNT",
-              "UniswapV2: INSUFFICIENT_LIQUIDITY",
-              "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED",
-              "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED",
-              "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT",
-              "UniswapV2: INVALID_TO",
-              "UniswapV2: K",
-          },
           structs: [],
           external_contracts: [
               Contract {
@@ -17294,7 +17283,7 @@ note:
     · │
 337 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
 338 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 6112704229203799669
+    │ ╰──────────────────────────────────────────^ attributes hash: 16613142782390074906
     │  
     = ContractAttributes {
           public_functions: [
@@ -17431,12 +17420,6 @@ note:
                   ],
               },
           ],
-          string_literals: {
-              "UniswapV2: FORBIDDEN",
-              "UniswapV2: IDENTICAL_ADDRESSES",
-              "UniswapV2: PAIR_EXISTS",
-              "UniswapV2: ZERO_ADDRESS",
-          },
           structs: [],
           external_contracts: [
               Contract {

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_003_uniswap.snap
@@ -16642,7 +16642,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {},
     }
 
 note: 
@@ -17270,7 +17269,6 @@ note:
                   ],
               },
           ],
-          created_contracts: {},
       }
 
 note: 
@@ -17283,7 +17281,7 @@ note:
     · │
 337 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
 338 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 16613142782390074906
+    │ ╰──────────────────────────────────────────^ attributes hash: 13298094751066559288
     │  
     = ContractAttributes {
           public_functions: [
@@ -17735,9 +17733,6 @@ note:
                   ],
               },
           ],
-          created_contracts: {
-              "UniswapV2Pair",
-          },
       }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
@@ -330,7 +330,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_004_address_bytes10_map.snap
@@ -332,7 +332,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_005_assert.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_005_assert.snap
@@ -337,7 +337,7 @@ note:
   · │
 8 │ │     pub def revert_with(baz: u256, reason: String<1000>):
 9 │ │         assert baz > 5, reason
-  │ ╰──────────────────────────────^ attributes hash: 3230845884331180109
+  │ ╰──────────────────────────────^ attributes hash: 7910349604985706298
   │  
   = ContractAttributes {
         public_functions: [
@@ -403,9 +403,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {
-            "Must be greater than five",
-        },
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_005_assert.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_005_assert.snap
@@ -405,7 +405,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_006_aug_assign.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_006_aug_assign.snap
@@ -2029,7 +2029,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_006_aug_assign.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_006_aug_assign.snap
@@ -2031,7 +2031,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_007_base_tuple.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_007_base_tuple.snap
@@ -193,7 +193,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_007_base_tuple.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_007_base_tuple.snap
@@ -195,7 +195,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
@@ -266,7 +266,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_008_call_statement_with_args.snap
@@ -268,7 +268,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_009_call_statement_with_args_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_009_call_statement_with_args_2.snap
@@ -287,7 +287,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_009_call_statement_with_args_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_009_call_statement_with_args_2.snap
@@ -289,7 +289,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
@@ -243,7 +243,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_010_call_statement_without_args.snap
@@ -241,7 +241,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_011_checked_arithmetic.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_011_checked_arithmetic.snap
@@ -9896,7 +9896,6 @@ note:
           ],
           init_function: None,
           events: [],
-          string_literals: {},
           structs: [],
           external_contracts: [],
           created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_011_checked_arithmetic.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_011_checked_arithmetic.snap
@@ -9898,7 +9898,6 @@ note:
           events: [],
           structs: [],
           external_contracts: [],
-          created_contracts: {},
       }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
@@ -303,7 +303,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_012_constructor.snap
@@ -301,7 +301,6 @@ note:
             },
         ),
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_013_create2_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_013_create2_contract.snap
@@ -257,7 +257,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {},
     }
 
 note: 
@@ -268,7 +267,7 @@ note:
 7 │ │         # value and salt
 8 │ │         foo: Foo = Foo.create2(0, 52)
 9 │ │         return address(foo)
-  │ ╰───────────────────────────^ attributes hash: 6058629679001745727
+  │ ╰───────────────────────────^ attributes hash: 11718874792159837218
   │  
   = ContractAttributes {
         public_functions: [
@@ -301,9 +300,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {
-            "Foo",
-        },
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_013_create2_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_013_create2_contract.snap
@@ -241,7 +241,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {
@@ -284,7 +283,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_014_create_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_014_create_contract.snap
@@ -224,7 +224,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {
@@ -266,7 +265,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_014_create_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_014_create_contract.snap
@@ -240,7 +240,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {},
     }
 
 note: 
@@ -250,7 +249,7 @@ note:
 6 │ │     pub def create_foo() -> address:
 7 │ │         foo: Foo = Foo.create(0)
 8 │ │         return address(foo)
-  │ ╰───────────────────────────^ attributes hash: 16172122424065765611
+  │ ╰───────────────────────────^ attributes hash: 1619027558401104719
   │  
   = ContractAttributes {
         public_functions: [
@@ -283,9 +282,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {
-            "Foo",
-        },
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_015_create_contract_from_init.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_015_create_contract_from_init.snap
@@ -241,7 +241,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {},
     }
 
 note: 
@@ -254,7 +253,7 @@ note:
    · │
 11 │ │     pub def get_foo_addr() -> address:
 12 │ │         return self.foo_addr
-   │ ╰────────────────────────────^ attributes hash: 17693993461359681760
+   │ ╰────────────────────────────^ attributes hash: 11258106293181764517
    │  
    = ContractAttributes {
          public_functions: [
@@ -296,9 +295,6 @@ note:
                  ],
              },
          ],
-         created_contracts: {
-             "Foo",
-         },
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_015_create_contract_from_init.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_015_create_contract_from_init.snap
@@ -225,7 +225,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {
@@ -279,7 +278,6 @@ note:
              },
          ),
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [
              Contract {

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_016_empty.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_016_empty.snap
@@ -25,7 +25,6 @@ note:
         public_functions: [],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_016_empty.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_016_empty.snap
@@ -27,7 +27,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_017_events.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_017_events.snap
@@ -783,7 +783,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_017_events.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_017_events.snap
@@ -781,7 +781,6 @@ note:
                  ],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_018_external_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_018_external_contract.snap
@@ -1527,7 +1527,6 @@ note:
                  ],
              },
          ],
-         created_contracts: {},
      }
 
 note: 
@@ -1695,7 +1694,6 @@ note:
                  ],
              },
          ],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_018_external_contract.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_018_external_contract.snap
@@ -1443,7 +1443,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [
              Contract {
@@ -1624,7 +1623,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [
              Contract {

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_019_for_loop_with_break.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_019_for_loop_with_break.snap
@@ -466,7 +466,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_019_for_loop_with_break.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_019_for_loop_with_break.snap
@@ -464,7 +464,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_020_for_loop_with_continue.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_020_for_loop_with_continue.snap
@@ -630,7 +630,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_020_for_loop_with_continue.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_020_for_loop_with_continue.snap
@@ -632,7 +632,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_021_for_loop_with_static_array.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_021_for_loop_with_static_array.snap
@@ -418,7 +418,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_021_for_loop_with_static_array.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_021_for_loop_with_static_array.snap
@@ -420,7 +420,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_022_if_statement.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_022_if_statement.snap
@@ -180,7 +180,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_022_if_statement.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_022_if_statement.snap
@@ -178,7 +178,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_023_if_statement_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_023_if_statement_2.snap
@@ -196,7 +196,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_023_if_statement_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_023_if_statement_2.snap
@@ -194,7 +194,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_024_if_statement_with_block_declaration.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_024_if_statement_with_block_declaration.snap
@@ -177,7 +177,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_024_if_statement_with_block_declaration.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_024_if_statement_with_block_declaration.snap
@@ -179,7 +179,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_025_keccak.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_025_keccak.snap
@@ -335,7 +335,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_025_keccak.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_025_keccak.snap
@@ -337,7 +337,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_026_math.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_026_math.snap
@@ -767,7 +767,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_026_math.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_026_math.snap
@@ -769,7 +769,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_027_multi_param.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_027_multi_param.snap
@@ -393,7 +393,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_027_multi_param.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_027_multi_param.snap
@@ -395,7 +395,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
@@ -808,7 +808,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_028_nested_map.snap
@@ -806,7 +806,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_029_numeric_sizes.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_029_numeric_sizes.snap
@@ -1810,7 +1810,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_029_numeric_sizes.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_029_numeric_sizes.snap
@@ -1808,7 +1808,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
@@ -618,7 +618,6 @@ note:
                  ],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_030_ownable.snap
@@ -620,7 +620,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_031_return_addition_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_031_return_addition_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_031_return_addition_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_031_return_addition_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_032_return_addition_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_032_return_addition_u128.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_032_return_addition_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_032_return_addition_u128.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_033_return_addition_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_033_return_addition_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_033_return_addition_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_033_return_addition_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_034_return_array.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_034_return_array.snap
@@ -209,7 +209,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_034_return_array.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_034_return_array.snap
@@ -207,7 +207,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_035_return_bitwiseand_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_035_return_bitwiseand_u128.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_035_return_bitwiseand_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_035_return_bitwiseand_u128.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_036_return_bitwiseand_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_036_return_bitwiseand_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_036_return_bitwiseand_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_036_return_bitwiseand_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_037_return_bitwiseor_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_037_return_bitwiseor_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_037_return_bitwiseor_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_037_return_bitwiseor_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_038_return_bitwiseshl_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_038_return_bitwiseshl_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_038_return_bitwiseshl_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_038_return_bitwiseshl_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_039_return_bitwiseshr_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_039_return_bitwiseshr_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_039_return_bitwiseshr_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_039_return_bitwiseshr_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_040_return_bitwiseshr_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_040_return_bitwiseshr_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_040_return_bitwiseshr_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_040_return_bitwiseshr_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_041_return_bitwisexor_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_041_return_bitwisexor_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_041_return_bitwisexor_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_041_return_bitwisexor_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_042_return_bool_false.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_042_return_bool_false.snap
@@ -76,7 +76,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_042_return_bool_false.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_042_return_bool_false.snap
@@ -74,7 +74,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_043_return_bool_inverted.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_043_return_bool_inverted.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_043_return_bool_inverted.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_043_return_bool_inverted.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_044_return_bool_op_and.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_044_return_bool_op_and.snap
@@ -143,7 +143,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_044_return_bool_op_and.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_044_return_bool_op_and.snap
@@ -141,7 +141,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_045_return_bool_op_or.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_045_return_bool_op_or.snap
@@ -143,7 +143,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_045_return_bool_op_or.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_045_return_bool_op_or.snap
@@ -141,7 +141,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_046_return_bool_true.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_046_return_bool_true.snap
@@ -76,7 +76,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_046_return_bool_true.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_046_return_bool_true.snap
@@ -74,7 +74,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_047_return_builtin_attributes.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_047_return_builtin_attributes.snap
@@ -496,7 +496,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_047_return_builtin_attributes.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_047_return_builtin_attributes.snap
@@ -494,7 +494,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_048_return_division_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_048_return_division_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_048_return_division_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_048_return_division_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_049_return_division_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_049_return_division_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_049_return_division_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_049_return_division_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_050_return_empty_tuple.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_050_return_empty_tuple.snap
@@ -252,7 +252,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_050_return_empty_tuple.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_050_return_empty_tuple.snap
@@ -254,7 +254,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_051_return_eq_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_051_return_eq_u256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_051_return_eq_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_051_return_eq_u256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_052_return_gt_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_052_return_gt_i256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_052_return_gt_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_052_return_gt_i256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_053_return_gt_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_053_return_gt_u256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_053_return_gt_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_053_return_gt_u256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_054_return_gte_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_054_return_gte_i256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_054_return_gte_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_054_return_gte_i256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_055_return_gte_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_055_return_gte_u256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_055_return_gte_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_055_return_gte_u256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_056_return_i128_cast.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_056_return_i128_cast.snap
@@ -114,7 +114,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_056_return_i128_cast.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_056_return_i128_cast.snap
@@ -116,7 +116,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_057_return_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_057_return_i256.snap
@@ -100,7 +100,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_057_return_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_057_return_i256.snap
@@ -98,7 +98,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_058_return_identity_u8.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_058_return_identity_u8.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_058_return_identity_u8.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_058_return_identity_u8.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_059_return_identity_u16.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_059_return_identity_u16.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_059_return_identity_u16.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_059_return_identity_u16.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_060_return_identity_u32.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_060_return_identity_u32.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_060_return_identity_u32.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_060_return_identity_u32.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_061_return_identity_u64.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_061_return_identity_u64.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_061_return_identity_u64.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_061_return_identity_u64.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_062_return_identity_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_062_return_identity_u128.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_062_return_identity_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_062_return_identity_u128.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_063_return_identity_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_063_return_identity_u256.snap
@@ -109,7 +109,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_063_return_identity_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_063_return_identity_u256.snap
@@ -111,7 +111,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_064_return_lt_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_064_return_lt_i256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_064_return_lt_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_064_return_lt_i256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_065_return_lt_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_065_return_lt_u128.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_065_return_lt_u128.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_065_return_lt_u128.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_066_return_lt_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_066_return_lt_u256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_066_return_lt_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_066_return_lt_u256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_067_return_lte_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_067_return_lte_i256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_067_return_lte_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_067_return_lte_i256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_068_return_lte_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_068_return_lte_u256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_068_return_lte_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_068_return_lte_u256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_069_return_mod_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_069_return_mod_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_069_return_mod_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_069_return_mod_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_070_return_mod_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_070_return_mod_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_070_return_mod_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_070_return_mod_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_071_return_msg_sig.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_071_return_msg_sig.snap
@@ -139,7 +139,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_071_return_msg_sig.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_071_return_msg_sig.snap
@@ -137,7 +137,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_072_return_multiplication_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_072_return_multiplication_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_072_return_multiplication_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_072_return_multiplication_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_073_return_multiplication_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_073_return_multiplication_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_073_return_multiplication_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_073_return_multiplication_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_074_return_noteq_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_074_return_noteq_u256.snap
@@ -157,7 +157,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_074_return_noteq_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_074_return_noteq_u256.snap
@@ -159,7 +159,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_075_return_pow_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_075_return_pow_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_075_return_pow_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_075_return_pow_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_076_return_pow_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_076_return_pow_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_076_return_pow_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_076_return_pow_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_077_return_subtraction_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_077_return_subtraction_i256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_077_return_subtraction_i256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_077_return_subtraction_i256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_078_return_subtraction_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_078_return_subtraction_u256.snap
@@ -165,7 +165,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_078_return_subtraction_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_078_return_subtraction_u256.snap
@@ -167,7 +167,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_079_return_u128_cast.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_079_return_u128_cast.snap
@@ -100,7 +100,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_079_return_u128_cast.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_079_return_u128_cast.snap
@@ -98,7 +98,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_080_return_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_080_return_u256.snap
@@ -82,7 +82,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_080_return_u256.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_080_return_u256.snap
@@ -84,7 +84,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_081_return_u256_from_called_fn.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_081_return_u256_from_called_fn.snap
@@ -142,7 +142,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_081_return_u256_from_called_fn.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_081_return_u256_from_called_fn.snap
@@ -140,7 +140,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_082_return_u256_from_called_fn_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_082_return_u256_from_called_fn_with_args.snap
@@ -682,7 +682,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_082_return_u256_from_called_fn_with_args.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_082_return_u256_from_called_fn_with_args.snap
@@ -684,7 +684,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_083_revert.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_083_revert.snap
@@ -68,7 +68,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_083_revert.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_083_revert.snap
@@ -66,7 +66,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_084_self_address.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_084_self_address.snap
@@ -76,7 +76,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_084_self_address.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_084_self_address.snap
@@ -74,7 +74,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_085_sized_vals_in_sto.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_085_sized_vals_in_sto.snap
@@ -797,7 +797,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_085_sized_vals_in_sto.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_085_sized_vals_in_sto.snap
@@ -795,7 +795,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_086_strings.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_086_strings.snap
@@ -456,7 +456,7 @@ note:
    · │
 20 │ │     pub def return_casted_static_string() -> String<100>:
 21 │ │         return String<100>("foo")
-   │ ╰─────────────────────────────────^ attributes hash: 16268845723743637357
+   │ ╰─────────────────────────────────^ attributes hash: 4345389285039061508
    │  
    = ContractAttributes {
          public_functions: [
@@ -620,11 +620,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {
-             "The quick brown fox jumps over the lazy dog",
-             "foo",
-             "static string",
-         },
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_086_strings.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_086_strings.snap
@@ -622,7 +622,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
@@ -4715,7 +4715,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [
              Struct {
                  name: "House",

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_087_structs.snap
@@ -4753,7 +4753,6 @@ note:
              },
          ],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_088_ternary_expression.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_088_ternary_expression.snap
@@ -190,7 +190,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_088_ternary_expression.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_088_ternary_expression.snap
@@ -188,7 +188,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_089_two_contracts.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_089_two_contracts.snap
@@ -371,7 +371,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [
             Contract {
@@ -440,7 +439,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [
              Contract {

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_089_two_contracts.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_089_two_contracts.snap
@@ -399,7 +399,6 @@ note:
                 ],
             },
         ],
-        created_contracts: {},
     }
 
 note: 
@@ -467,7 +466,6 @@ note:
                  ],
              },
          ],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
@@ -320,7 +320,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_090_u8_u8_map.snap
@@ -322,7 +322,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
@@ -320,7 +320,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_091_u16_u16_map.snap
@@ -322,7 +322,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
@@ -320,7 +320,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_092_u32_u32_map.snap
@@ -322,7 +322,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
@@ -320,7 +320,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_093_u64_u64_map.snap
@@ -322,7 +322,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
@@ -320,7 +320,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_094_u128_u128_map.snap
@@ -322,7 +322,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
@@ -320,7 +320,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_095_u256_u256_map.snap
@@ -322,7 +322,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_096_while_loop.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_096_while_loop.snap
@@ -307,7 +307,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_096_while_loop.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_096_while_loop.snap
@@ -309,7 +309,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_097_while_loop_with_break.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_097_while_loop_with_break.snap
@@ -230,7 +230,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_097_while_loop_with_break.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_097_while_loop_with_break.snap
@@ -228,7 +228,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_098_while_loop_with_break_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_098_while_loop_with_break_2.snap
@@ -275,7 +275,6 @@ note:
         ],
         init_function: None,
         events: [],
-        string_literals: {},
         structs: [],
         external_contracts: [],
         created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_098_while_loop_with_break_2.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_098_while_loop_with_break_2.snap
@@ -277,7 +277,6 @@ note:
         events: [],
         structs: [],
         external_contracts: [],
-        created_contracts: {},
     }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_099_while_loop_with_continue.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_099_while_loop_with_continue.snap
@@ -369,7 +369,6 @@ note:
          events: [],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_099_while_loop_with_continue.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_099_while_loop_with_continue.snap
@@ -367,7 +367,6 @@ note:
          ],
          init_function: None,
          events: [],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
@@ -2404,7 +2404,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {},
          structs: [
              Struct {
                  name: "MyStruct",

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_100_abi_encoding_stress.snap
@@ -2440,7 +2440,6 @@ note:
              },
          ],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_101_data_copying_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_101_data_copying_stress.snap
@@ -2725,7 +2725,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_101_data_copying_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_101_data_copying_stress.snap
@@ -2727,7 +2727,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
@@ -1857,7 +1857,6 @@ note:
          ],
          structs: [],
          external_contracts: [],
-         created_contracts: {},
      }
 
 note: 

--- a/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
+++ b/tests/src/snapshots/fe_compiler_tests__analysis__case_102_tuple_stress.snap
@@ -1855,7 +1855,6 @@ note:
                  indexed_fields: [],
              },
          ],
-         string_literals: {},
          structs: [],
          external_contracts: [],
          created_contracts: {},


### PR DESCRIPTION
### What was wrong?

Nothing, really.

### How was it fixed?

I created a `yul::Context` struct, and used it to collect the static strings and created contracts during the yul mapper traversal, and removed the similar code from the analyzer pass.

This doesn't (intentionally) change any behavior or fix any bugs or limitations. (Specifically, contracts can still only create contracts that are defined above them in the file. I think we should address that with a future salsa refactor.)