### PR TITLE
Fix path issue with cargp pkgid command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-website:
 	cp -r website/ target/
 
 	# Fill version marker with current version
-	sed -i "s/{{FE_VERSION}}/$$(cargo pkgid | cut -d# -f2 | cut -d: -f2)/g" target/website/index.html
+	sed -i "s/{{FE_VERSION}}/$$(cd crates/fe && cargo pkgid | cut -d# -f2 | cut -d: -f2)/g" target/website/index.html
 
 	# Generate the compiler API docs
 	cargo doc --no-deps --workspace


### PR DESCRIPTION
### What was wrong?

A tiny breakage that came out of the big repository reorganization. The website needs to read the current Fe version but the `cargo pkgid` command was confused now that the layout has changed.

### How was it fixed?

Added a `cd crates/fe` to the command. I tried specifying the command via `cargo pkgid -p crates/fe` but it seems that command only takes absolute file paths so I went for the `cd` instead.