### PR TITLE
Update readme hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ contract GuestBook:
         return self.guest_book[addr].to_mem()
 ```
 
-A lot more working examples can be found in our [test fixtures directory](https://github.com/ethereum/fe/tree/master/compiler/tests/fixtures).
+A lot more working examples can be found in our [test fixtures directory](https://github.com/ethereum/fe/tree/master/crates/test-files/fixtures/demos).
 
 The most advanced example that we can provide at this point is an implementation of the [Uniswap-V2 core contracts](https://github.com/ethereum/fe/blob/ec2ee41d16ec31ea0388d8fd7eb6266916d0e1f7/compiler/tests/fixtures/demos/uniswap.fe).
 


### PR DESCRIPTION
### What was wrong?
The hyperlink in [README.md](https://github.com/ethereum/fe/blob/master/README.md) that directs the user to the fe contract examples is not updated.



### How was it fixed?
I replaced the old hyperlink with the updated hyperlink.
