### PR TITLE
Fix issue with multi line strings in Fe code

### DIFF
--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -56,6 +56,16 @@ ModuleAttributes {
                             },
                         ),
                     },
+                    FunctionAttributes {
+                        is_public: true,
+                        name: "return_with_newline",
+                        params: [],
+                        return_type: String(
+                            FeString {
+                                max_size: 16,
+                            },
+                        ),
+                    },
                 ],
             },
         ),
@@ -246,6 +256,24 @@ note:
          typ: String(
              FeString {
                  max_size: 100,
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/strings.fe:24:16
+   │  
+24 │           return "foo
+   │ ╭────────────────^
+25 │ │         balu"
+   │ ╰─────────────^ attributes hash: 15759196394724794690
+   │  
+   = ExpressionAttributes {
+         typ: String(
+             FeString {
+                 max_size: 16,
              },
          ),
          location: Memory,
@@ -447,6 +475,25 @@ note:
      }
 
 note: 
+   ┌─ features/strings.fe:23:5
+   │  
+23 │ ╭     pub def return_with_newline() -> String<16>:
+24 │ │         return "foo
+25 │ │         balu"
+   │ ╰─────────────^ attributes hash: 14350780978254754932
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "return_with_newline",
+         params: [],
+         return_type: String(
+             FeString {
+                 max_size: 16,
+             },
+         ),
+     }
+
+note: 
    ┌─ features/strings.fe:1:1
    │  
  1 │ ╭ contract Foo:
@@ -454,9 +501,9 @@ note:
  3 │ │         s2: String<26>
  4 │ │         u: u256
    · │
-20 │ │     pub def return_casted_static_string() -> String<100>:
-21 │ │         return String<100>("foo")
-   │ ╰─────────────────────────────────^ attributes hash: 2821469132888555159
+24 │ │         return "foo
+25 │ │         balu"
+   │ ╰─────────────^ attributes hash: 8230381975525950566
    │  
    = ContractAttributes {
          public_functions: [
@@ -504,6 +551,16 @@ note:
                  return_type: String(
                      FeString {
                          max_size: 43,
+                     },
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "return_with_newline",
+                 params: [],
+                 return_type: String(
+                     FeString {
+                         max_size: 16,
                      },
                  ),
              },
@@ -923,6 +980,18 @@ note:
    = String(
          FeString {
              max_size: 100,
+         },
+     )
+
+note: 
+   ┌─ features/strings.fe:23:38
+   │
+23 │     pub def return_with_newline() -> String<16>:
+   │                                      ^^^^^^^^^^ attributes hash: 7943909822945469766
+   │
+   = String(
+         FeString {
+             max_size: 16,
          },
      )
 

--- a/crates/test-files/fixtures/features/strings.fe
+++ b/crates/test-files/fixtures/features/strings.fe
@@ -19,3 +19,7 @@ contract Foo:
 
     pub def return_casted_static_string() -> String<100>:
         return String<100>("foo")
+
+    pub def return_with_newline() -> String<16>:
+        return "foo
+        balu"

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -593,6 +593,16 @@ fn strings() {
             Some(&string_token("foo")),
         );
 
+        harness.test_function(
+            &mut executor,
+            "return_with_newline",
+            &[],
+            Some(&string_token(
+                "foo
+        balu",
+            )),
+        );
+
         harness.events_emitted(
             executor,
             &[(

--- a/crates/yulgen/src/lib.rs
+++ b/crates/yulgen/src/lib.rs
@@ -3,6 +3,7 @@
 use fe_analyzer::context::Context as AnalyzerContext;
 use fe_parser::ast;
 use std::collections::HashMap;
+use yultsur::yul;
 
 pub mod constants;
 pub mod constructor;
@@ -31,6 +32,31 @@ pub type NamedYulContracts = HashMap<ContractName, YulIr>;
 pub fn compile(analysis: &AnalyzerContext, module: &ast::Module) -> NamedYulContracts {
     mappers::module::module(analysis, module)
         .drain()
-        .map(|(name, object)| (name, object.to_string().replace("\"", "\\\"")))
+        .map(|(name, object)| (name, to_safe_json(object)))
         .collect::<NamedYulContracts>()
+}
+
+fn to_safe_json(obj: yul::Object) -> String {
+    normalize_object(obj).to_string().replace("\"", "\\\"")
+}
+
+fn normalize_object(obj: yul::Object) -> yul::Object {
+    let data = obj
+        .data
+        .into_iter()
+        .map(|data| yul::Data {
+            name: data.name,
+            value: data.value.replace('\n', "\\\\n"),
+        })
+        .collect::<Vec<_>>();
+    yul::Object {
+        name: obj.name,
+        code: obj.code,
+        objects: obj
+            .objects
+            .into_iter()
+            .map(normalize_object)
+            .collect::<Vec<_>>(),
+        data,
+    }
 }

--- a/newsfragments/448.bugfix.md
+++ b/newsfragments/448.bugfix.md
@@ -1,0 +1,12 @@
+Fixed ICE when using a static string that spans over multiple lines.
+
+Previous to this fix, the following code would lead to a compiler crash:
+
+```
+contract Foo:
+    pub def return_with_newline() -> String<16>:
+        return "foo
+        balu"
+```
+
+The above code now works as intended.


### PR DESCRIPTION
### What was wrong?

As found by the fuzzer in #448, static strings do not work yet if they contain line breaks.

### How was it fixed?

Added the proper escaping for data objects when converting from ` yul::Object` to the JSON string that is passed to `solc`.
