### PR TITLE
Using `value_expr` and `assignable_expr` analysis functions where appropriate.

### DIFF
--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -197,3 +197,6 @@ test_file! { struct_call_without_kw_args }
 test_file! { non_pub_init }
 test_file! { abi_encode_u256 }
 test_file! { abi_encode_from_storage }
+test_file! { assert_sto_msg_no_copy }
+test_file! { for_loop_sto_iter_no_copy }
+test_file! { revert_sto_error_no_copy }

--- a/crates/analyzer/tests/snapshots/analysis__assert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__assert.snap
@@ -11,6 +11,22 @@ ModuleAttributes {
                 functions: [
                     FunctionAttributes {
                         is_public: true,
+                        name: "assert_sto_bool",
+                        params: [],
+                        return_type: Base(
+                            Unit,
+                        ),
+                    },
+                    FunctionAttributes {
+                        is_public: true,
+                        name: "assert_sto_string_msg",
+                        params: [],
+                        return_type: Base(
+                            Unit,
+                        ),
+                    },
+                    FunctionAttributes {
+                        is_public: true,
                         name: "bar",
                         params: [
                             (
@@ -75,55 +91,9 @@ ModuleAttributes {
 }
 
 note: 
-  ┌─ features/assert.fe:3:16
-  │
-3 │         assert baz > 5
-  │                ^^^ attributes hash: 1230752710897721197
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:3:22
-  │
-3 │         assert baz > 5
-  │                      ^ attributes hash: 1230752710897721197
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/assert.fe:3:16
-  │
-3 │         assert baz > 5
-  │                ^^^^^^^ attributes hash: 519621297275845584
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Bool,
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/assert.fe:6:16
   │
-6 │         assert baz > 5, "Must be greater than five"
+6 │         assert baz > 5
   │                ^^^ attributes hash: 1230752710897721197
   │
   = ExpressionAttributes {
@@ -139,7 +109,7 @@ note:
 note: 
   ┌─ features/assert.fe:6:22
   │
-6 │         assert baz > 5, "Must be greater than five"
+6 │         assert baz > 5
   │                      ^ attributes hash: 1230752710897721197
   │
   = ExpressionAttributes {
@@ -155,7 +125,7 @@ note:
 note: 
   ┌─ features/assert.fe:6:16
   │
-6 │         assert baz > 5, "Must be greater than five"
+6 │         assert baz > 5
   │                ^^^^^^^ attributes hash: 519621297275845584
   │
   = ExpressionAttributes {
@@ -167,25 +137,9 @@ note:
     }
 
 note: 
-  ┌─ features/assert.fe:6:25
-  │
-6 │         assert baz > 5, "Must be greater than five"
-  │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16264676341784907870
-  │
-  = ExpressionAttributes {
-        typ: String(
-            FeString {
-                max_size: 25,
-            },
-        ),
-        location: Memory,
-        move_location: None,
-    }
-
-note: 
   ┌─ features/assert.fe:9:16
   │
-9 │         assert baz > 5, reason
+9 │         assert baz > 5, "Must be greater than five"
   │                ^^^ attributes hash: 1230752710897721197
   │
   = ExpressionAttributes {
@@ -201,7 +155,7 @@ note:
 note: 
   ┌─ features/assert.fe:9:22
   │
-9 │         assert baz > 5, reason
+9 │         assert baz > 5, "Must be greater than five"
   │                      ^ attributes hash: 1230752710897721197
   │
   = ExpressionAttributes {
@@ -217,7 +171,7 @@ note:
 note: 
   ┌─ features/assert.fe:9:16
   │
-9 │         assert baz > 5, reason
+9 │         assert baz > 5, "Must be greater than five"
   │                ^^^^^^^ attributes hash: 519621297275845584
   │
   = ExpressionAttributes {
@@ -231,13 +185,13 @@ note:
 note: 
   ┌─ features/assert.fe:9:25
   │
-9 │         assert baz > 5, reason
-  │                         ^^^^^^ attributes hash: 3599122874764053339
+9 │         assert baz > 5, "Must be greater than five"
+  │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16264676341784907870
   │
   = ExpressionAttributes {
         typ: String(
             FeString {
-                max_size: 1000,
+                max_size: 25,
             },
         ),
         location: Memory,
@@ -245,10 +199,216 @@ note:
     }
 
 note: 
-  ┌─ features/assert.fe:2:5
+   ┌─ features/assert.fe:12:16
+   │
+12 │         assert baz > 5, reason
+   │                ^^^ attributes hash: 1230752710897721197
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:12:22
+   │
+12 │         assert baz > 5, reason
+   │                      ^ attributes hash: 1230752710897721197
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:12:16
+   │
+12 │         assert baz > 5, reason
+   │                ^^^^^^^ attributes hash: 519621297275845584
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:12:25
+   │
+12 │         assert baz > 5, reason
+   │                         ^^^^^^ attributes hash: 3599122874764053339
+   │
+   = ExpressionAttributes {
+         typ: String(
+             FeString {
+                 max_size: 1000,
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:15:9
+   │
+15 │         self.my_bool = false
+   │         ^^^^^^^^^^^^ attributes hash: 12273323640399429874
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Storage {
+             nonce: Some(
+                 0,
+             ),
+         },
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:15:24
+   │
+15 │         self.my_bool = false
+   │                        ^^^^^ attributes hash: 519621297275845584
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:16:16
+   │
+16 │         assert self.my_bool
+   │                ^^^^^^^^^^^^ attributes hash: 13730979586018155653
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Storage {
+             nonce: Some(
+                 0,
+             ),
+         },
+         move_location: Some(
+             Value,
+         ),
+     }
+
+note: 
+   ┌─ features/assert.fe:19:9
+   │
+19 │         self.my_string = "hello"
+   │         ^^^^^^^^^^^^^^ attributes hash: 9933875619792709288
+   │
+   = ExpressionAttributes {
+         typ: String(
+             FeString {
+                 max_size: 5,
+             },
+         ),
+         location: Storage {
+             nonce: Some(
+                 1,
+             ),
+         },
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:19:26
+   │
+19 │         self.my_string = "hello"
+   │                          ^^^^^^^ attributes hash: 4232494716478429185
+   │
+   = ExpressionAttributes {
+         typ: String(
+             FeString {
+                 max_size: 5,
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:20:16
+   │
+20 │         assert false, self.my_string.to_mem()
+   │                ^^^^^ attributes hash: 519621297275845584
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:20:23
+   │
+20 │         assert false, self.my_string.to_mem()
+   │                       ^^^^^^^^^^^^^^ attributes hash: 9933875619792709288
+   │
+   = ExpressionAttributes {
+         typ: String(
+             FeString {
+                 max_size: 5,
+             },
+         ),
+         location: Storage {
+             nonce: Some(
+                 1,
+             ),
+         },
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/assert.fe:20:23
+   │
+20 │         assert false, self.my_string.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1560482948859588432
+   │
+   = ExpressionAttributes {
+         typ: String(
+             FeString {
+                 max_size: 5,
+             },
+         ),
+         location: Storage {
+             nonce: Some(
+                 1,
+             ),
+         },
+         move_location: Some(
+             Memory,
+         ),
+     }
+
+note: 
+  ┌─ features/assert.fe:5:5
   │  
-2 │ ╭     pub def bar(baz: u256):
-3 │ │         assert baz > 5
+5 │ ╭     pub def bar(baz: u256):
+6 │ │         assert baz > 5
   │ ╰──────────────────────^ attributes hash: 14705602729846184909
   │  
   = FunctionAttributes {
@@ -270,10 +430,10 @@ note:
     }
 
 note: 
-  ┌─ features/assert.fe:5:5
+  ┌─ features/assert.fe:8:5
   │  
-5 │ ╭     pub def revert_with_static_string(baz: u256):
-6 │ │         assert baz > 5, "Must be greater than five"
+8 │ ╭     pub def revert_with_static_string(baz: u256):
+9 │ │         assert baz > 5, "Must be greater than five"
   │ ╰───────────────────────────────────────────────────^ attributes hash: 12915933724383760692
   │  
   = FunctionAttributes {
@@ -295,147 +455,181 @@ note:
     }
 
 note: 
-  ┌─ features/assert.fe:8:5
-  │  
-8 │ ╭     pub def revert_with(baz: u256, reason: String<1000>):
-9 │ │         assert baz > 5, reason
-  │ ╰──────────────────────────────^ attributes hash: 5206967184411358358
-  │  
-  = FunctionAttributes {
-        is_public: true,
-        name: "revert_with",
-        params: [
-            (
-                "baz",
-                Base(
-                    Numeric(
-                        U256,
-                    ),
-                ),
-            ),
-            (
-                "reason",
-                String(
-                    FeString {
-                        max_size: 1000,
-                    },
-                ),
-            ),
-        ],
-        return_type: Base(
-            Unit,
-        ),
-    }
+   ┌─ features/assert.fe:11:5
+   │  
+11 │ ╭     pub def revert_with(baz: u256, reason: String<1000>):
+12 │ │         assert baz > 5, reason
+   │ ╰──────────────────────────────^ attributes hash: 5206967184411358358
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "revert_with",
+         params: [
+             (
+                 "baz",
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+             ),
+             (
+                 "reason",
+                 String(
+                     FeString {
+                         max_size: 1000,
+                     },
+                 ),
+             ),
+         ],
+         return_type: Base(
+             Unit,
+         ),
+     }
 
 note: 
-  ┌─ features/assert.fe:1:1
-  │  
-1 │ ╭ contract Foo:
-2 │ │     pub def bar(baz: u256):
-3 │ │         assert baz > 5
-4 │ │ 
-  · │
-8 │ │     pub def revert_with(baz: u256, reason: String<1000>):
-9 │ │         assert baz > 5, reason
-  │ ╰──────────────────────────────^ attributes hash: 2501283307939429907
-  │  
-  = ContractAttributes {
-        public_functions: [
-            FunctionAttributes {
-                is_public: true,
-                name: "bar",
-                params: [
-                    (
-                        "baz",
-                        Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    ),
-                ],
-                return_type: Base(
-                    Unit,
-                ),
-            },
-            FunctionAttributes {
-                is_public: true,
-                name: "revert_with",
-                params: [
-                    (
-                        "baz",
-                        Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    ),
-                    (
-                        "reason",
-                        String(
-                            FeString {
-                                max_size: 1000,
-                            },
-                        ),
-                    ),
-                ],
-                return_type: Base(
-                    Unit,
-                ),
-            },
-            FunctionAttributes {
-                is_public: true,
-                name: "revert_with_static_string",
-                params: [
-                    (
-                        "baz",
-                        Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                    ),
-                ],
-                return_type: Base(
-                    Unit,
-                ),
-            },
-        ],
-        init_function: None,
-        events: [],
-        structs: [],
-        external_contracts: [],
-    }
+   ┌─ features/assert.fe:14:5
+   │  
+14 │ ╭     pub def assert_sto_bool():
+15 │ │         self.my_bool = false
+16 │ │         assert self.my_bool
+   │ ╰───────────────────────────^ attributes hash: 386062522787178436
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "assert_sto_bool",
+         params: [],
+         return_type: Base(
+             Unit,
+         ),
+     }
 
 note: 
-  ┌─ features/assert.fe:2:22
+   ┌─ features/assert.fe:18:5
+   │  
+18 │ ╭     pub def assert_sto_string_msg():
+19 │ │         self.my_string = "hello"
+20 │ │         assert false, self.my_string.to_mem()
+   │ ╰─────────────────────────────────────────────^ attributes hash: 1836150226267414980
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "assert_sto_string_msg",
+         params: [],
+         return_type: Base(
+             Unit,
+         ),
+     }
+
+note: 
+   ┌─ features/assert.fe:1:1
+   │  
+ 1 │ ╭ contract Foo:
+ 2 │ │     my_bool: bool
+ 3 │ │     my_string: String<5>
+ 4 │ │ 
+   · │
+19 │ │         self.my_string = "hello"
+20 │ │         assert false, self.my_string.to_mem()
+   │ ╰─────────────────────────────────────────────^ attributes hash: 1872320294411724862
+   │  
+   = ContractAttributes {
+         public_functions: [
+             FunctionAttributes {
+                 is_public: true,
+                 name: "assert_sto_bool",
+                 params: [],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "assert_sto_string_msg",
+                 params: [],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "bar",
+                 params: [
+                     (
+                         "baz",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                 ],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "revert_with",
+                 params: [
+                     (
+                         "baz",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "reason",
+                         String(
+                             FeString {
+                                 max_size: 1000,
+                             },
+                         ),
+                     ),
+                 ],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "revert_with_static_string",
+                 params: [
+                     (
+                         "baz",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                 ],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+         ],
+         init_function: None,
+         events: [],
+         structs: [],
+         external_contracts: [],
+     }
+
+note: 
+   ┌─ features/assert.fe:20:23
+   │
+20 │         assert false, self.my_string.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
+  ┌─ features/assert.fe:5:22
   │
-2 │     pub def bar(baz: u256):
+5 │     pub def bar(baz: u256):
   │                      ^^^^ attributes hash: 4293763436908729629
-  │
-  = Base(
-        Numeric(
-            U256,
-        ),
-    )
-
-note: 
-  ┌─ features/assert.fe:5:44
-  │
-5 │     pub def revert_with_static_string(baz: u256):
-  │                                            ^^^^ attributes hash: 4293763436908729629
-  │
-  = Base(
-        Numeric(
-            U256,
-        ),
-    )
-
-note: 
-  ┌─ features/assert.fe:8:30
-  │
-8 │     pub def revert_with(baz: u256, reason: String<1000>):
-  │                              ^^^^ attributes hash: 4293763436908729629
   │
   = Base(
         Numeric(
@@ -446,12 +640,58 @@ note:
 note: 
   ┌─ features/assert.fe:8:44
   │
-8 │     pub def revert_with(baz: u256, reason: String<1000>):
-  │                                            ^^^^^^^^^^^^ attributes hash: 7691650642384229431
+8 │     pub def revert_with_static_string(baz: u256):
+  │                                            ^^^^ attributes hash: 4293763436908729629
+  │
+  = Base(
+        Numeric(
+            U256,
+        ),
+    )
+
+note: 
+   ┌─ features/assert.fe:11:30
+   │
+11 │     pub def revert_with(baz: u256, reason: String<1000>):
+   │                              ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ features/assert.fe:11:44
+   │
+11 │     pub def revert_with(baz: u256, reason: String<1000>):
+   │                                            ^^^^^^^^^^^^ attributes hash: 7691650642384229431
+   │
+   = String(
+         FeString {
+             max_size: 1000,
+         },
+     )
+
+note: 
+  ┌─ features/assert.fe:2:14
+  │
+2 │     my_bool: bool
+  │              ^^^^ attributes hash: 5425972608982369985
+  │
+  = Base(
+        Bool,
+    )
+
+note: 
+  ┌─ features/assert.fe:3:16
+  │
+3 │     my_string: String<5>
+  │                ^^^^^^^^^ attributes hash: 4442886494745637937
   │
   = String(
         FeString {
-            max_size: 1000,
+            max_size: 5,
         },
     )
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -56,6 +56,14 @@ ModuleAttributes {
                             Unit,
                         ),
                     },
+                    FunctionAttributes {
+                        is_public: true,
+                        name: "revert_other_error_from_sto",
+                        params: [],
+                        return_type: Base(
+                            Unit,
+                        ),
+                    },
                 ],
             },
         ),
@@ -84,9 +92,9 @@ ModuleAttributes {
 }
 
 note: 
-   ┌─ features/revert.fe:14:26
+   ┌─ features/revert.fe:16:26
    │
-14 │         revert Error(msg=1, val=true)
+16 │         revert Error(msg=1, val=true)
    │                          ^ attributes hash: 1230752710897721197
    │
    = ExpressionAttributes {
@@ -100,9 +108,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:14:33
+   ┌─ features/revert.fe:16:33
    │
-14 │         revert Error(msg=1, val=true)
+16 │         revert Error(msg=1, val=true)
    │                                 ^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -114,9 +122,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:14:16
+   ┌─ features/revert.fe:16:16
    │
-14 │         revert Error(msg=1, val=true)
+16 │         revert Error(msg=1, val=true)
    │                ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11694781548607974207
    │
    = ExpressionAttributes {
@@ -146,9 +154,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:17:31
+   ┌─ features/revert.fe:19:31
    │
-17 │         revert OtherError(msg=1, val=true)
+19 │         revert OtherError(msg=1, val=true)
    │                               ^ attributes hash: 1230752710897721197
    │
    = ExpressionAttributes {
@@ -162,9 +170,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:17:38
+   ┌─ features/revert.fe:19:38
    │
-17 │         revert OtherError(msg=1, val=true)
+19 │         revert OtherError(msg=1, val=true)
    │                                      ^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -176,9 +184,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:17:16
+   ┌─ features/revert.fe:19:16
    │
-17 │         revert OtherError(msg=1, val=true)
+19 │         revert OtherError(msg=1, val=true)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6207322651044042545
    │
    = ExpressionAttributes {
@@ -208,10 +216,182 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:10:5
+   ┌─ features/revert.fe:22:9
+   │
+22 │         self.my_other_error = OtherError(msg=1, val=true)
+   │         ^^^^^^^^^^^^^^^^^^^ attributes hash: 1455945768619151908
+   │
+   = ExpressionAttributes {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+         location: Storage {
+             nonce: Some(
+                 0,
+             ),
+         },
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:22:46
+   │
+22 │         self.my_other_error = OtherError(msg=1, val=true)
+   │                                              ^ attributes hash: 1230752710897721197
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:22:53
+   │
+22 │         self.my_other_error = OtherError(msg=1, val=true)
+   │                                                     ^^^^ attributes hash: 519621297275845584
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Bool,
+         ),
+         location: Value,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:22:31
+   │
+22 │         self.my_other_error = OtherError(msg=1, val=true)
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6207322651044042545
+   │
+   = ExpressionAttributes {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:23:16
+   │
+23 │         revert self.my_other_error.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 1455945768619151908
+   │
+   = ExpressionAttributes {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+         location: Storage {
+             nonce: Some(
+                 0,
+             ),
+         },
+         move_location: None,
+     }
+
+note: 
+   ┌─ features/revert.fe:23:16
+   │
+23 │         revert self.my_other_error.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4295708869972799250
+   │
+   = ExpressionAttributes {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+         location: Storage {
+             nonce: Some(
+                 0,
+             ),
+         },
+         move_location: Some(
+             Memory,
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:12:5
    │  
-10 │ ╭     pub def bar() -> u256:
-11 │ │         revert
+12 │ ╭     pub def bar() -> u256:
+13 │ │         revert
    │ ╰──────────────^ attributes hash: 5931278080780939395
    │  
    = FunctionAttributes {
@@ -226,10 +406,10 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:13:5
+   ┌─ features/revert.fe:15:5
    │  
-13 │ ╭     pub def revert_custom_error():
-14 │ │         revert Error(msg=1, val=true)
+15 │ ╭     pub def revert_custom_error():
+16 │ │         revert Error(msg=1, val=true)
    │ ╰─────────────────────────────────────^ attributes hash: 8604546375909025578
    │  
    = FunctionAttributes {
@@ -242,10 +422,10 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:16:5
+   ┌─ features/revert.fe:18:5
    │  
-16 │ ╭     pub def revert_other_error():
-17 │ │         revert OtherError(msg=1, val=true)
+18 │ ╭     pub def revert_other_error():
+19 │ │         revert OtherError(msg=1, val=true)
    │ ╰──────────────────────────────────────────^ attributes hash: 13536596200836451553
    │  
    = FunctionAttributes {
@@ -258,16 +438,33 @@ note:
      }
 
 note: 
+   ┌─ features/revert.fe:21:5
+   │  
+21 │ ╭     pub def revert_other_error_from_sto():
+22 │ │         self.my_other_error = OtherError(msg=1, val=true)
+23 │ │         revert self.my_other_error.to_mem()
+   │ ╰───────────────────────────────────────────^ attributes hash: 10600311300800311694
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "revert_other_error_from_sto",
+         params: [],
+         return_type: Base(
+             Unit,
+         ),
+     }
+
+note: 
    ┌─ features/revert.fe:9:1
    │  
  9 │ ╭ contract Foo:
-10 │ │     pub def bar() -> u256:
-11 │ │         revert
-12 │ │ 
+10 │ │     my_other_error: OtherError
+11 │ │ 
+12 │ │     pub def bar() -> u256:
    · │
-16 │ │     pub def revert_other_error():
-17 │ │         revert OtherError(msg=1, val=true)
-   │ ╰──────────────────────────────────────────^ attributes hash: 1654722370251683476
+22 │ │         self.my_other_error = OtherError(msg=1, val=true)
+23 │ │         revert self.my_other_error.to_mem()
+   │ ╰───────────────────────────────────────────^ attributes hash: 15459304479214598396
    │  
    = ContractAttributes {
          public_functions: [
@@ -292,6 +489,14 @@ note:
              FunctionAttributes {
                  is_public: true,
                  name: "revert_other_error",
+                 params: [],
+                 return_type: Base(
+                     Unit,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
+                 name: "revert_other_error_from_sto",
                  params: [],
                  return_type: Base(
                      Unit,
@@ -344,9 +549,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:14:16
+   ┌─ features/revert.fe:16:16
    │
-14 │         revert Error(msg=1, val=true)
+16 │         revert Error(msg=1, val=true)
    │                ^^^^^ attributes hash: 563910565138212793
    │
    = TypeConstructor {
@@ -374,9 +579,9 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:17:16
+   ┌─ features/revert.fe:19:16
    │
-17 │         revert OtherError(msg=1, val=true)
+19 │         revert OtherError(msg=1, val=true)
    │                ^^^^^^^^^^ attributes hash: 371870897900126483
    │
    = TypeConstructor {
@@ -402,6 +607,44 @@ note:
              },
          ),
      }
+
+note: 
+   ┌─ features/revert.fe:22:31
+   │
+22 │         self.my_other_error = OtherError(msg=1, val=true)
+   │                               ^^^^^^^^^^ attributes hash: 371870897900126483
+   │
+   = TypeConstructor {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 fields: [
+                     (
+                         "msg",
+                         Base(
+                             Numeric(
+                                 U256,
+                             ),
+                         ),
+                     ),
+                     (
+                         "val",
+                         Base(
+                             Bool,
+                         ),
+                     ),
+                 ],
+             },
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:23:16
+   │
+23 │         revert self.my_other_error.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
   ┌─ features/revert.fe:2:10
@@ -448,15 +691,43 @@ note:
     )
 
 note: 
-   ┌─ features/revert.fe:10:22
+   ┌─ features/revert.fe:12:22
    │
-10 │     pub def bar() -> u256:
+12 │     pub def bar() -> u256:
    │                      ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
          Numeric(
              U256,
          ),
+     )
+
+note: 
+   ┌─ features/revert.fe:10:21
+   │
+10 │     my_other_error: OtherError
+   │                     ^^^^^^^^^^ attributes hash: 11110528865914593659
+   │
+   = Struct(
+         Struct {
+             name: "OtherError",
+             fields: [
+                 (
+                     "msg",
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 (
+                     "val",
+                     Base(
+                         Bool,
+                     ),
+                 ),
+             ],
+         },
      )
 
 

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -2205,7 +2205,7 @@ note:
    ┌─ features/structs.fe:37:16
    │
 37 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 12273323640399429874
+   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 13730979586018155653
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2216,7 +2216,9 @@ note:
                  0,
              ),
          },
-         move_location: None,
+         move_location: Some(
+             Value,
+         ),
      }
 
 note: 
@@ -2707,7 +2709,7 @@ note:
    ┌─ features/structs.fe:42:16
    │
 42 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 12273323640399429874
+   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 13730979586018155653
    │
    = ExpressionAttributes {
          typ: Base(
@@ -2718,7 +2720,9 @@ note:
                  0,
              ),
          },
-         move_location: None,
+         move_location: Some(
+             Value,
+         ),
      }
 
 note: 
@@ -3209,14 +3213,16 @@ note:
    ┌─ features/structs.fe:54:16
    │
 54 │         assert building.vacant
-   │                ^^^^^^^^^^^^^^^ attributes hash: 9492448225675818972
+   │                ^^^^^^^^^^^^^^^ attributes hash: 793140603415107164
    │
    = ExpressionAttributes {
          typ: Base(
              Bool,
          ),
          location: Memory,
-         move_location: None,
+         move_location: Some(
+             Value,
+         ),
      }
 
 note: 

--- a/crates/analyzer/tests/snapshots/errors__assert_sto_msg_no_copy.snap
+++ b/crates/analyzer/tests/snapshots/errors__assert_sto_msg_no_copy.snap
@@ -1,0 +1,15 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: value must be copied to memory
+  ┌─ compile_errors/assert_sto_msg_no_copy.fe:5:23
+  │
+5 │         assert false, self.my_string
+  │                       ^^^^^^^^^^^^^^ this value is in storage
+  │
+  = Hint: values located in storage can be copied to memory using the `to_mem` function.
+  = Example: `self.my_array.to_mem()`
+
+

--- a/crates/analyzer/tests/snapshots/errors__for_loop_sto_iter_no_copy.snap
+++ b/crates/analyzer/tests/snapshots/errors__for_loop_sto_iter_no_copy.snap
@@ -1,0 +1,15 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: value must be copied to memory
+  ┌─ compile_errors/for_loop_sto_iter_no_copy.fe:5:18
+  │
+5 │         for i in self.my_array:
+  │                  ^^^^^^^^^^^^^ this value is in storage
+  │
+  = Hint: values located in storage can be copied to memory using the `to_mem` function.
+  = Example: `self.my_array.to_mem()`
+
+

--- a/crates/analyzer/tests/snapshots/errors__revert_sto_error_no_copy.snap
+++ b/crates/analyzer/tests/snapshots/errors__revert_sto_error_no_copy.snap
@@ -1,0 +1,15 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: value must be copied to memory
+  ┌─ compile_errors/revert_sto_error_no_copy.fe:8:16
+  │
+8 │         revert self.my_error
+  │                ^^^^^^^^^^^^^ this value is in storage
+  │
+  = Hint: values located in storage can be copied to memory using the `to_mem` function.
+  = Example: `self.my_array.to_mem()`
+
+

--- a/crates/test-files/fixtures/compile_errors/assert_sto_msg_no_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/assert_sto_msg_no_copy.fe
@@ -1,0 +1,5 @@
+contract Foo:
+    my_string: String<42>
+
+    pub def bar():
+        assert false, self.my_string

--- a/crates/test-files/fixtures/compile_errors/for_loop_sto_iter_no_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/for_loop_sto_iter_no_copy.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    my_array: u256[3]
+
+    pub def bar():
+        for i in self.my_array:
+            pass

--- a/crates/test-files/fixtures/compile_errors/revert_sto_error_no_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/revert_sto_error_no_copy.fe
@@ -1,0 +1,8 @@
+struct MyError:
+    pass
+
+contract Foo:
+    my_error: MyError
+
+    pub def bar():
+        revert self.my_error

--- a/crates/test-files/fixtures/features/assert.fe
+++ b/crates/test-files/fixtures/features/assert.fe
@@ -1,4 +1,7 @@
 contract Foo:
+    my_bool: bool
+    my_string: String<5>
+
     pub def bar(baz: u256):
         assert baz > 5
 
@@ -7,3 +10,11 @@ contract Foo:
 
     pub def revert_with(baz: u256, reason: String<1000>):
         assert baz > 5, reason
+
+    pub def assert_sto_bool():
+        self.my_bool = false
+        assert self.my_bool
+
+    pub def assert_sto_string_msg():
+        self.my_string = "hello"
+        assert false, self.my_string.to_mem()

--- a/crates/test-files/fixtures/features/for_loop_with_static_array_from_sto.fe
+++ b/crates/test-files/fixtures/features/for_loop_with_static_array_from_sto.fe
@@ -1,0 +1,10 @@
+contract Foo:
+    my_array: u256[3]
+
+    pub def bar() -> u256:
+        self.my_array = [1,2,3]
+        sum: u256 = 0
+        for i in self.my_array.to_mem():
+            sum = sum + i
+
+        return sum

--- a/crates/test-files/fixtures/features/if_statement_test_from_sto.fe
+++ b/crates/test-files/fixtures/features/if_statement_test_from_sto.fe
@@ -1,0 +1,20 @@
+contract Foo:
+    my_bool1: bool
+    my_bool2: bool
+    my_bool3: bool
+
+    pub def bar() -> u256:
+        self.my_bool1 = false
+        self.my_bool2 = false
+        self.my_bool3 = true
+
+        if self.my_bool1:
+            return 26
+
+        if self.my_bool2:
+            return 26
+
+        if self.my_bool3:
+            return 42
+
+        return 26

--- a/crates/test-files/fixtures/features/return_sum_list_expression_1.fe
+++ b/crates/test-files/fixtures/features/return_sum_list_expression_1.fe
@@ -1,7 +1,9 @@
 contract Foo:
+    num_two: u256
 
     pub def bar() -> u256:
-        my_array: u256[20] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        self.num_two = 2
+        my_array: u256[20] = [1, self.num_two, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         sum: u256 = 0
         for i in my_array:
             sum = sum + i

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -7,6 +7,8 @@ struct OtherError:
     val: bool
 
 contract Foo:
+    my_other_error: OtherError
+
     pub def bar() -> u256:
         revert
 
@@ -15,3 +17,7 @@ contract Foo:
 
     pub def revert_other_error():
         revert OtherError(msg=1, val=true)
+
+    pub def revert_other_error_from_sto():
+        self.my_other_error = OtherError(msg=1, val=true)
+        revert self.my_other_error.to_mem()

--- a/crates/test-files/fixtures/features/while_loop_test_from_sto.fe
+++ b/crates/test-files/fixtures/features/while_loop_test_from_sto.fe
@@ -1,0 +1,10 @@
+contract Foo:
+    my_bool: bool
+
+    pub def bar() -> u256:
+        self.my_bool = false
+
+        while self.my_bool:
+            pass
+
+        return 42

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -68,6 +68,14 @@ fn test_revert() {
                 &[uint_token(1), bool_token(true)],
             ),
         );
+
+        validate_revert(
+            harness.capture_call(&mut executor, "revert_other_error_from_sto", &[]),
+            &encode_revert(
+                "OtherError(uint256,bool)",
+                &[uint_token(1), bool_token(true)],
+            ),
+        );
     })
 }
 
@@ -75,6 +83,16 @@ fn test_revert() {
 fn test_assert() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "assert.fe", "Foo", &[]);
+
+        validate_revert(
+            harness.capture_call(&mut executor, "assert_sto_bool", &[]),
+            &encoded_panic_assert(),
+        );
+
+        validate_revert(
+            harness.capture_call(&mut executor, "assert_sto_string_msg", &[]),
+            &encode_error_reason("hello"),
+        );
 
         validate_revert(
             harness.capture_call(&mut executor, "bar", &[uint_token(4)]),
@@ -106,14 +124,17 @@ fn test_assert() {
 
 #[rstest(fixture_file, input, expected,
     case("for_loop_with_static_array.fe", &[], uint_token(30)),
+    case("for_loop_with_static_array_from_sto.fe", &[], uint_token(6)),
     case("for_loop_with_break.fe", &[], uint_token(15)),
     case("for_loop_with_continue.fe", &[], uint_token(17)),
     case("while_loop_with_continue.fe", &[], uint_token(1)),
     case("while_loop.fe", &[], uint_token(3)),
+    case("while_loop_test_from_sto.fe", &[], uint_token(42)),
     case("while_loop_with_break.fe", &[], uint_token(1)),
     case("while_loop_with_break_2.fe", &[], uint_token(1)),
     case("if_statement.fe", &[uint_token(6)], uint_token(1)),
     case("if_statement.fe", &[uint_token(4)], uint_token(0)),
+    case("if_statement_test_from_sto.fe", &[], uint_token(42)),
     case("if_statement_2.fe", &[uint_token(6)], uint_token(1)),
     case("if_statement_with_block_declaration.fe", &[], uint_token(1)),
     case("ternary_expression.fe", &[uint_token(6)], uint_token(1)),

--- a/newsfragments/493.bugfix.md
+++ b/newsfragments/493.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue where certain expressions were not being moved to the correct location.


### PR DESCRIPTION
### What was wrong?

closes #491 

### How was it fixed?

Searched usages of `expression::expr` and fixed places where `value_expr` or `assignable_expr` needed to be used.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
