### PR TITLE
Friendlier parser error for old `def` keyword

### DIFF
--- a/crates/parser/src/grammar/contracts.rs
+++ b/crates/parser/src/grammar/contracts.rs
@@ -34,7 +34,7 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<Contract>> {
     let contract_name = par.expect_with_notes(
         TokenKind::Name,
         "failed to parse contract definition",
-        || vec!["Note: `contract` must be followed by a name, which must start with a letter and contain only letters, numbers, or underscores".into()],
+        |_| vec!["Note: `contract` must be followed by a name, which must start with a letter and contain only letters, numbers, or underscores".into()],
     )?;
 
     let header_span = contract_tok.span + contract_name.span;

--- a/crates/parser/src/grammar/functions.rs
+++ b/crates/parser/src/grammar/functions.rs
@@ -94,7 +94,7 @@ fn parse_fn_param_list(par: &mut Parser) -> ParseResult<Node<Vec<Node<FunctionAr
                 par.expect_with_notes(
                     TokenKind::Colon,
                     "failed to parse function parameter",
-                    || {
+                    |_| {
                         vec![
                             "Note: parameter name must be followed by a colon and a type description"
                                 .into(),

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -65,7 +65,7 @@ pub fn parse_simple_import(par: &mut Parser) -> ParseResult<Node<Import>> {
     let mut names = vec![];
     loop {
         let name =
-            par.expect_with_notes(TokenKind::Name, "failed to parse import statement", || {
+            par.expect_with_notes(TokenKind::Name, "failed to parse import statement", |_| {
                 vec![
                     "Note: `import` must be followed by a module name or path".into(),
                     "Example: `import mymodule".into(),

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -208,7 +208,7 @@ impl<'a> Parser<'a> {
         expected: TokenKind,
         message: S,
     ) -> ParseResult<Token<'a>> {
-        self.expect_with_notes(expected, message, Vec::new)
+        self.expect_with_notes(expected, message, |_| Vec::new())
     }
 
     /// Like [`Parser::expect`], but with additional notes to be appended to the
@@ -223,7 +223,7 @@ impl<'a> Parser<'a> {
     ) -> ParseResult<Token<'a>>
     where
         Str: Into<String>,
-        NotesFn: FnOnce() -> Vec<String>,
+        NotesFn: FnOnce(&Token) -> Vec<String>,
     {
         let tok = self.next()?;
         if tok.kind == expected {
@@ -240,7 +240,7 @@ impl<'a> Parser<'a> {
             self.fancy_error(
                 message.into(),
                 vec![Label::primary(tok.span, label)],
-                notes_fn(),
+                notes_fn(&tok),
             );
             Err(ParseFailed)
         }

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -81,6 +81,7 @@ test_parse_err! { emit_bad_call, functions::parse_stmt, true, "emit MyEvent(1)()
 test_parse_err! { expr_bad_prefix, expressions::parse_expr, true, "*x + 1" }
 test_parse_err! { for_no_in, functions::parse_stmt, true, "for x:\n pass" }
 test_parse_err! { fn_no_args, |par| functions::parse_fn_def(par, None), false, "fn f:\n  return 5" }
+test_parse_err! { fn_def_kw, contracts::parse_contract_def, true, "contract C:\n pub def f(x: u8):\n  return x" }
 test_parse_err! { if_no_body, functions::parse_stmt, true, "if x:\nelse:\n x" }
 test_parse_err! { import_bad_name, module::parse_simple_import, true, "import x as 123" }
 test_parse_err! { module_bad_stmt, module::parse_module, true, "if x:\n y" }

--- a/crates/parser/tests/cases/snapshots/cases__errors__fn_def_kw.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__fn_def_kw.snap
@@ -1,0 +1,17 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(fn_def_kw), contracts::parse_contract_def, true,\n           \"contract C:\\n pub def f(x: u8):\\n  return x\")"
+
+---
+error: failed to parse field definition
+  ┌─ fn_def_kw:2:10
+  │
+2 │  pub def f(x: u8):
+  │          ^ Unexpected token. Expected `:`
+  │
+  = Hint: use `fn` to define a function
+  = Example: `pub fn f( ...`
+  = Note: field name must be followed by a colon and a type description
+  = Example: pub def: address
+
+


### PR DESCRIPTION
### What was wrong?

The error message for "def foo():" assumes that the user is trying to define a field called "def", so it's not as helpful as it could be.

### How was it fixed?

Added a note about the `fn` keyword.

```
error: failed to parse field definition
  ┌─ fn_def_kw:2:10
  │
2 │  pub def f(x: u8):
  │          ^ Unexpected token. Expected `:`
  │
  = Hint: use `fn` to define a function
  = Example: `pub fn f( ...`
  = Note: field name must be followed by a colon and a type description
  = Example: pub def: address
```

We could probably delete this someday, but it's nice for the compiler to alert people to a keyword change.