### PR TITLE
Feat/let var decl

### DIFF
--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -62,37 +62,37 @@ macro_rules! test_stmt {
     };
 }
 
-test_stmt! { array_non_primitive, "x: (u8, u8)[10]" }
-test_stmt! { array_mixed_types, "x: u16[3] = [1, address(0), \"hi\"]" }
-test_stmt! { array_size_mismatch, "x: u8[3] = []\ny: u8[3] = [1, 2]" }
+test_stmt! { array_non_primitive, "let x: (u8, u8)[10]" }
+test_stmt! { array_mixed_types, "let x: u16[3] = [1, address(0), \"hi\"]" }
+test_stmt! { array_size_mismatch, "let x: u8[3] = []\nlet y: u8[3] = [1, 2]" }
 test_stmt! { assert_reason_not_string, "assert true, 1" }
 test_stmt! { assign_int, "5 = 6" }
 test_stmt! { assign_call, "self.f() = 10" }
-test_stmt! { assign_type_mismatch, "x: u256 = 10\nx = address(0)" }
-test_stmt! { aug_assign_non_numeric, "a: u256 = 1\nb: bool = true\na += b" }
-test_stmt! { bad_map, "x: Map<u8, u8, u8>" }
-test_stmt! { bad_map2, "x: Map<address, 100>" }
-test_stmt! { bad_map3, "x: Map<>" }
-test_stmt! { bad_map4, "x: Map<y>" }
-test_stmt! { bad_map5, "x: Map<Map<u8, u8>, address>" }
-test_stmt! { bad_map6, "x: Map<10, 20>" }
-test_stmt! { binary_op_add_uints, "a: u256 = 1\nb: u8 = 2\na + b" }
-test_stmt! { binary_op_lshift_bool, "a: bool = true\nb: i256\na << b" }
-test_stmt! { binary_op_lshift_with_int, "a: u256 = 1\nb: i256 = 2\na << b" }
-test_stmt! { binary_op_pow_int, "a: u256 = 1\nb: i256 = 2\na ** b" }
+test_stmt! { assign_type_mismatch, "let x: u256 = 10\nx = address(0)" }
+test_stmt! { aug_assign_non_numeric, "let a: u256 = 1\nlet b: bool = true\na += b" }
+test_stmt! { bad_map, "let x: Map<u8, u8, u8>" }
+test_stmt! { bad_map2, "let x: Map<address, 100>" }
+test_stmt! { bad_map3, "let x: Map<>" }
+test_stmt! { bad_map4, "let x: Map<y>" }
+test_stmt! { bad_map5, "let x: Map<Map<u8, u8>, address>" }
+test_stmt! { bad_map6, "let x: Map<10, 20>" }
+test_stmt! { binary_op_add_uints, "let a: u256 = 1\nlet b: u8 = 2\na + b" }
+test_stmt! { binary_op_lshift_bool, "let a: bool = true\nlet b: i256\na << b" }
+test_stmt! { binary_op_lshift_with_int, "let a: u256 = 1\nlet b: i256 = 2\na << b" }
+test_stmt! { binary_op_pow_int, "let a: u256 = 1\nlet b: i256 = 2\na ** b" }
 test_stmt! { binary_op_boolean_mismatch1, "10 and true" }
 test_stmt! { binary_op_boolean_mismatch2, "false or 1" }
 test_stmt! { binary_op_boolean_mismatch3, "1 or 2" }
 test_stmt! { break_without_loop, "break" }
 test_stmt! { break_without_loop_2, "if true:\n  break" }
 test_stmt! { call_undefined_function_on_contract, "self.doesnt_exist()" }
-test_stmt! { clone_arg_count, "x: u256[2] = [5, 6]\ny: u256[2] = x.clone(y)" }
+test_stmt! { clone_arg_count, "let x: u256[2] = [5, 6]\nlet y: u256[2] = x.clone(y)" }
 test_stmt! { continue_without_loop, "continue" }
 test_stmt! { continue_without_loop_2, "if true:\n  continue" }
 test_stmt! { emit_undefined_event, "emit MyEvent()" }
-test_stmt! { keccak_called_with_wrong_type, "x: u256[1]\nkeccak256(foo=x, 10)" }
-test_stmt! { non_bool_and, "x: bool = true\ny: u256 = 1\nx = x and y" }
-test_stmt! { non_bool_or, "x: bool = true\ny: u256 = 1\nx = x or y" }
+test_stmt! { keccak_called_with_wrong_type, "let x: u256[1]\nkeccak256(foo=x, 10)" }
+test_stmt! { non_bool_and, "let x: bool = true\nlet y: u256 = 1\nx = x and y" }
+test_stmt! { non_bool_or, "let x: bool = true\nlet y: u256 = 1\nx = x or y" }
 test_stmt! { overflow_i128_neg, "i128(-170141183460469231731687303715884105729)" }
 test_stmt! { overflow_i128_pos, "i128(170141183460469231731687303715884105728)" }
 test_stmt! { overflow_i16_neg, "i16(-32769)" }
@@ -103,11 +103,11 @@ test_stmt! { overflow_i32_neg, "i32(-2147483649)" }
 test_stmt! { overflow_i32_pos, "i32(2147483648)" }
 test_stmt! { overflow_i64_neg, "i64(-9223372036854775809)" }
 test_stmt! { overflow_i64_pos, "i64(9223372036854775808)" }
-test_stmt! { overflow_i8_neg, "x: i8 = -129" }
-test_stmt! { overflow_i8_pos, "x: i8 = 128" }
+test_stmt! { overflow_i8_neg, "let x: i8 = -129" }
+test_stmt! { overflow_i8_pos, "let x: i8 = 128" }
 test_stmt! { overflow_literal_too_big, "115792089237316195423570985008687907853269984665640564039457584007913129639936" }
 test_stmt! { overflow_literal_too_small, "-115792089237316195423570985008687907853269984665640564039457584007913129639936" }
-test_stmt! { overflow_u128_neg, "x: u128 = -1" }
+test_stmt! { overflow_u128_neg, "let x: u128 = -1" }
 test_stmt! { overflow_u128_pos, "u128(340282366920938463463374607431768211456)" }
 test_stmt! { overflow_u16_neg, "u16(-1)" }
 test_stmt! { overflow_u16_pos, "u16(65536)" }
@@ -119,19 +119,19 @@ test_stmt! { overflow_u64_neg, "u64(-1)" }
 test_stmt! { overflow_u64_pos, "u64(18446744073709551616)" }
 test_stmt! { overflow_u8_neg, "u8(-1)" }
 test_stmt! { overflow_u8_pos, "u8(256)" }
-test_stmt! { overflow_u8_assignment, "x: u8 = 260" }
-test_stmt! { pow_with_signed_exponent, "base: i128\nexp: i128\nbase ** exp" }
+test_stmt! { overflow_u8_assignment, "let x: u8 = 260" }
+test_stmt! { pow_with_signed_exponent, "let base: i128\nlet xp: i128\nbase ** exp" }
 // Exponent can be unsigned but needs to be same size or smaller
-test_stmt! { pow_with_wrong_capacity, "base: i128\nexp: u256\nbase ** exp" }
+test_stmt! { pow_with_wrong_capacity, "let base: i128\nlet exp: u256\nbase ** exp" }
 test_stmt! { string_capacity_mismatch, "String<3>(\"too long\")" }
 test_stmt! { ternary_type_mismatch, "10 if 100 else true" }
-test_stmt! { type_constructor_from_variable, "x: u8\ny: u16 = u16(x)" }
-test_stmt! { type_constructor_arg_count, "x: u8 = u8(1, 10)" }
-test_stmt! { unary_minus_on_bool, "x: bool = true\n-x" }
-test_stmt! { unary_not_on_int, "x: u256 = 10\nnot x" }
-test_stmt! { undefined_generic_type, "x: foobar<u256> = 10" }
-test_stmt! { undefined_name, "x: u16 = y\nz: u16 = y" }
-test_stmt! { undefined_type, "x: foobar = 10" }
+test_stmt! { type_constructor_from_variable, "let x: u8\nlet y: u16 = u16(x)" }
+test_stmt! { type_constructor_arg_count, "let x: u8 = u8(1, 10)" }
+test_stmt! { unary_minus_on_bool, "let x: bool = true\n-x" }
+test_stmt! { unary_not_on_int, "let x: u256 = 10\nnot x" }
+test_stmt! { undefined_generic_type, "let x: foobar<u256> = 10" }
+test_stmt! { undefined_name, "let x: u16 = y\nlet z: u16 = y" }
+test_stmt! { undefined_type, "let x: foobar = 10" }
 test_stmt! { unexpected_return, "return 1" }
 
 test_file! { bad_tuple_attr1 }

--- a/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
+++ b/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
@@ -1612,7 +1612,7 @@ note:
    ┌─ features/aug_assign.fe:53:5
    │  
 53 │ ╭     pub def add_from_mem(a: u256, b: u256) -> u256:
-54 │ │         my_array: u256[10]
+54 │ │         let my_array: u256[10]
 55 │ │         my_array[7] = a
 56 │ │         my_array[7] += b
 57 │ │         return my_array[7]
@@ -1649,8 +1649,8 @@ note:
 note: 
    ┌─ features/aug_assign.fe:54:9
    │
-54 │         my_array: u256[10]
-   │         ^^^^^^^^^^^^^^^^^^ attributes hash: 17323625354857110317
+54 │         let my_array: u256[10]
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17323625354857110317
    │
    = Array(
          Array {
@@ -2514,10 +2514,10 @@ note:
     )
 
 note: 
-   ┌─ features/aug_assign.fe:54:19
+   ┌─ features/aug_assign.fe:54:23
    │
-54 │         my_array: u256[10]
-   │                   ^^^^ attributes hash: 17942395924573474124
+54 │         let my_array: u256[10]
+   │                       ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -2526,10 +2526,10 @@ note:
      )
 
 note: 
-   ┌─ features/aug_assign.fe:54:19
+   ┌─ features/aug_assign.fe:54:23
    │
-54 │         my_array: u256[10]
-   │                   ^^^^^^^^ attributes hash: 17323625354857110317
+54 │         let my_array: u256[10]
+   │                       ^^^^^^^^ attributes hash: 17323625354857110317
    │
    = Array(
          Array {

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -57,26 +57,10 @@ note:
     }
 
 note: 
-  ┌─ features/create2_contract.fe:8:32
+  ┌─ features/create2_contract.fe:8:36
   │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                                ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/create2_contract.fe:8:35
-  │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                                   ^^ attributes hash: 16797824492585953824
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │                                    ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -89,10 +73,26 @@ note:
     }
 
 note: 
-  ┌─ features/create2_contract.fe:8:20
+  ┌─ features/create2_contract.fe:8:39
   │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                    ^^^^^^^^^^^^^^^^^^ attributes hash: 8552961459538575979
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │                                       ^^ attributes hash: 16797824492585953824
+  │
+  = ExpressionAttributes {
+        typ: Base(
+            Numeric(
+                U256,
+            ),
+        ),
+        location: Value,
+        move_location: None,
+    }
+
+note: 
+  ┌─ features/create2_contract.fe:8:24
+  │
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │                        ^^^^^^^^^^^^^^^^^^ attributes hash: 8552961459538575979
   │
   = ExpressionAttributes {
         typ: Contract(
@@ -181,7 +181,7 @@ note:
   │  
 6 │ ╭     pub def create2_foo() -> address:
 7 │ │         # value and salt
-8 │ │         foo: Foo = Foo.create2(0, 52)
+8 │ │         let foo: Foo = Foo.create2(0, 52)
 9 │ │         return address(foo)
   │ ╰───────────────────────────^ attributes hash: 15788904857074118116
   │  
@@ -197,8 +197,8 @@ note:
 note: 
   ┌─ features/create2_contract.fe:8:9
   │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11013990582171916248
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11013990582171916248
   │
   = Contract(
         Contract {
@@ -265,7 +265,7 @@ note:
 5 │ ╭ contract FooFactory:
 6 │ │     pub def create2_foo() -> address:
 7 │ │         # value and salt
-8 │ │         foo: Foo = Foo.create2(0, 52)
+8 │ │         let foo: Foo = Foo.create2(0, 52)
 9 │ │         return address(foo)
   │ ╰───────────────────────────^ attributes hash: 9489720864976305437
   │  
@@ -303,10 +303,10 @@ note:
     }
 
 note: 
-  ┌─ features/create2_contract.fe:8:20
+  ┌─ features/create2_contract.fe:8:24
   │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │                    ^^^^^^^^^^^ attributes hash: 7190587645396562862
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │                        ^^^^^^^^^^^ attributes hash: 7190587645396562862
   │
   = TypeAttribute {
         typ: Contract(
@@ -364,10 +364,10 @@ note:
     )
 
 note: 
-  ┌─ features/create2_contract.fe:8:14
+  ┌─ features/create2_contract.fe:8:18
   │
-8 │         foo: Foo = Foo.create2(0, 52)
-  │              ^^^ attributes hash: 2324270301873557290
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │                  ^^^ attributes hash: 2324270301873557290
   │
   = Contract(
         Contract {

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -57,10 +57,10 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract.fe:7:31
+  ┌─ features/create_contract.fe:7:35
   │
-7 │         foo: Foo = Foo.create(0)
-  │                               ^ attributes hash: 16797824492585953824
+7 │         let foo: Foo = Foo.create(0)
+  │                                   ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -73,10 +73,10 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract.fe:7:20
+  ┌─ features/create_contract.fe:7:24
   │
-7 │         foo: Foo = Foo.create(0)
-  │                    ^^^^^^^^^^^^^ attributes hash: 8552961459538575979
+7 │         let foo: Foo = Foo.create(0)
+  │                        ^^^^^^^^^^^^^ attributes hash: 8552961459538575979
   │
   = ExpressionAttributes {
         typ: Contract(
@@ -164,7 +164,7 @@ note:
   ┌─ features/create_contract.fe:6:5
   │  
 6 │ ╭     pub def create_foo() -> address:
-7 │ │         foo: Foo = Foo.create(0)
+7 │ │         let foo: Foo = Foo.create(0)
 8 │ │         return address(foo)
   │ ╰───────────────────────────^ attributes hash: 11307555315188767880
   │  
@@ -180,8 +180,8 @@ note:
 note: 
   ┌─ features/create_contract.fe:7:9
   │
-7 │         foo: Foo = Foo.create(0)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11013990582171916248
+7 │         let foo: Foo = Foo.create(0)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11013990582171916248
   │
   = Contract(
         Contract {
@@ -247,7 +247,7 @@ note:
   │  
 5 │ ╭ contract FooFactory:
 6 │ │     pub def create_foo() -> address:
-7 │ │         foo: Foo = Foo.create(0)
+7 │ │         let foo: Foo = Foo.create(0)
 8 │ │         return address(foo)
   │ ╰───────────────────────────^ attributes hash: 15817588436725138336
   │  
@@ -285,10 +285,10 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract.fe:7:20
+  ┌─ features/create_contract.fe:7:24
   │
-7 │         foo: Foo = Foo.create(0)
-  │                    ^^^^^^^^^^ attributes hash: 4712101790258272829
+7 │         let foo: Foo = Foo.create(0)
+  │                        ^^^^^^^^^^ attributes hash: 4712101790258272829
   │
   = TypeAttribute {
         typ: Contract(
@@ -346,10 +346,10 @@ note:
     )
 
 note: 
-  ┌─ features/create_contract.fe:7:14
+  ┌─ features/create_contract.fe:7:18
   │
-7 │         foo: Foo = Foo.create(0)
-  │              ^^^ attributes hash: 2324270301873557290
+7 │         let foo: Foo = Foo.create(0)
+  │                  ^^^ attributes hash: 2324270301873557290
   │
   = Contract(
         Contract {

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -431,10 +431,10 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:32:34
+   ┌─ stress/data_copying_stress.fe:32:38
    │
-32 │         my_2nd_array: u256[10] = my_array
-   │                                  ^^^^^^^^ attributes hash: 12880944358712268851
+32 │         let my_2nd_array: u256[10] = my_array
+   │                                      ^^^^^^^^ attributes hash: 12880944358712268851
    │
    = ExpressionAttributes {
          typ: Array(
@@ -450,10 +450,10 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:33:34
+   ┌─ stress/data_copying_stress.fe:33:38
    │
-33 │         my_3rd_array: u256[10] = my_2nd_array
-   │                                  ^^^^^^^^^^^^ attributes hash: 12880944358712268851
+33 │         let my_3rd_array: u256[10] = my_2nd_array
+   │                                      ^^^^^^^^^^^^ attributes hash: 12880944358712268851
    │
    = ExpressionAttributes {
          typ: Array(
@@ -2198,8 +2198,8 @@ note:
    ┌─ stress/data_copying_stress.fe:31:5
    │  
 31 │ ╭     pub def multiple_references_shared_memory(my_array: u256[10]):
-32 │ │         my_2nd_array: u256[10] = my_array
-33 │ │         my_3rd_array: u256[10] = my_2nd_array
+32 │ │         let my_2nd_array: u256[10] = my_array
+33 │ │         let my_3rd_array: u256[10] = my_2nd_array
 34 │ │ 
    · │
 43 │ │         assert my_2nd_array[3] == 50
@@ -2332,7 +2332,7 @@ note:
    ┌─ stress/data_copying_stress.fe:57:5
    │  
 57 │ ╭     pub def assign_my_nums_and_return() -> u256[5]:
-58 │ │         my_nums_mem: u256[5]
+58 │ │         let my_nums_mem: u256[5]
 59 │ │         self.my_nums[0] = 42
 60 │ │         self.my_nums[1] = 26
    · │
@@ -2451,8 +2451,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:32:9
    │
-32 │         my_2nd_array: u256[10] = my_array
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17323625354857110317
+32 │         let my_2nd_array: u256[10] = my_array
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17323625354857110317
    │
    = Array(
          Array {
@@ -2466,8 +2466,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:33:9
    │
-33 │         my_3rd_array: u256[10] = my_2nd_array
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17323625354857110317
+33 │         let my_3rd_array: u256[10] = my_2nd_array
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17323625354857110317
    │
    = Array(
          Array {
@@ -2481,8 +2481,8 @@ note:
 note: 
    ┌─ stress/data_copying_stress.fe:58:9
    │
-58 │         my_nums_mem: u256[5]
-   │         ^^^^^^^^^^^^^^^^^^^^ attributes hash: 12285037458725956106
+58 │         let my_nums_mem: u256[5]
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12285037458725956106
    │
    = Array(
          Array {
@@ -3255,10 +3255,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:32:23
+   ┌─ stress/data_copying_stress.fe:32:27
    │
-32 │         my_2nd_array: u256[10] = my_array
-   │                       ^^^^ attributes hash: 17942395924573474124
+32 │         let my_2nd_array: u256[10] = my_array
+   │                           ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -3267,10 +3267,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:32:23
+   ┌─ stress/data_copying_stress.fe:32:27
    │
-32 │         my_2nd_array: u256[10] = my_array
-   │                       ^^^^^^^^ attributes hash: 17323625354857110317
+32 │         let my_2nd_array: u256[10] = my_array
+   │                           ^^^^^^^^ attributes hash: 17323625354857110317
    │
    = Array(
          Array {
@@ -3282,10 +3282,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:33:23
+   ┌─ stress/data_copying_stress.fe:33:27
    │
-33 │         my_3rd_array: u256[10] = my_2nd_array
-   │                       ^^^^ attributes hash: 17942395924573474124
+33 │         let my_3rd_array: u256[10] = my_2nd_array
+   │                           ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -3294,10 +3294,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:33:23
+   ┌─ stress/data_copying_stress.fe:33:27
    │
-33 │         my_3rd_array: u256[10] = my_2nd_array
-   │                       ^^^^^^^^ attributes hash: 17323625354857110317
+33 │         let my_3rd_array: u256[10] = my_2nd_array
+   │                           ^^^^^^^^ attributes hash: 17323625354857110317
    │
    = Array(
          Array {
@@ -3309,10 +3309,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:58:22
+   ┌─ stress/data_copying_stress.fe:58:26
    │
-58 │         my_nums_mem: u256[5]
-   │                      ^^^^ attributes hash: 17942395924573474124
+58 │         let my_nums_mem: u256[5]
+   │                          ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -3321,10 +3321,10 @@ note:
      )
 
 note: 
-   ┌─ stress/data_copying_stress.fe:58:22
+   ┌─ stress/data_copying_stress.fe:58:26
    │
-58 │         my_nums_mem: u256[5]
-   │                      ^^^^^^^ attributes hash: 12285037458725956106
+58 │         let my_nums_mem: u256[5]
+   │                          ^^^^^^^ attributes hash: 12285037458725956106
    │
    = Array(
          Array {

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -560,7 +560,7 @@ note:
    ┌─ features/events.fe:28:5
    │  
 28 │ ╭     pub def emit_addresses(addr1: address, addr2: address):
-29 │ │         addrs: address[2]
+29 │ │         let addrs: address[2]
 30 │ │         addrs[0] = addr1
 31 │ │         addrs[1] = addr2
 32 │ │         emit Addresses(addrs)
@@ -591,8 +591,8 @@ note:
 note: 
    ┌─ features/events.fe:29:9
    │
-29 │         addrs: address[2]
-   │         ^^^^^^^^^^^^^^^^^ attributes hash: 16566349279731954343
+29 │         let addrs: address[2]
+   │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16566349279731954343
    │
    = Array(
          Array {
@@ -1136,20 +1136,20 @@ note:
      )
 
 note: 
-   ┌─ features/events.fe:29:16
+   ┌─ features/events.fe:29:20
    │
-29 │         addrs: address[2]
-   │                ^^^^^^^ attributes hash: 16931239362436195516
+29 │         let addrs: address[2]
+   │                    ^^^^^^^ attributes hash: 16931239362436195516
    │
    = Base(
          Address,
      )
 
 note: 
-   ┌─ features/events.fe:29:16
+   ┌─ features/events.fe:29:20
    │
-29 │         addrs: address[2]
-   │                ^^^^^^^^^^ attributes hash: 16566349279731954343
+29 │         let addrs: address[2]
+   │                    ^^^^^^^^^^ attributes hash: 16566349279731954343
    │
    = Array(
          Array {

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -464,10 +464,10 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:24:24
+   ┌─ features/external_contract.fe:24:28
    │
-24 │         foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^ attributes hash: 16366719240912622931
+24 │         let foo: Foo = Foo(foo_address)
+   │                            ^^^^^^^^^^^ attributes hash: 16366719240912622931
    │
    = ExpressionAttributes {
          typ: Base(
@@ -478,10 +478,10 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:24:20
+   ┌─ features/external_contract.fe:24:24
    │
-24 │         foo: Foo = Foo(foo_address)
-   │                    ^^^^^^^^^^^^^^^^ attributes hash: 7045153914799271565
+24 │         let foo: Foo = Foo(foo_address)
+   │                        ^^^^^^^^^^^^^^^^ attributes hash: 7045153914799271565
    │
    = ExpressionAttributes {
          typ: Contract(
@@ -705,10 +705,10 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:32:24
+   ┌─ features/external_contract.fe:32:28
    │
-32 │         foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^ attributes hash: 16366719240912622931
+32 │         let foo: Foo = Foo(foo_address)
+   │                            ^^^^^^^^^^^ attributes hash: 16366719240912622931
    │
    = ExpressionAttributes {
          typ: Base(
@@ -719,10 +719,10 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:32:20
+   ┌─ features/external_contract.fe:32:24
    │
-32 │         foo: Foo = Foo(foo_address)
-   │                    ^^^^^^^^^^^^^^^^ attributes hash: 7045153914799271565
+32 │         let foo: Foo = Foo(foo_address)
+   │                        ^^^^^^^^^^^^^^^^ attributes hash: 7045153914799271565
    │
    = ExpressionAttributes {
          typ: Contract(
@@ -1018,7 +1018,7 @@ note:
    ┌─ features/external_contract.fe:10:5
    │  
 10 │ ╭     pub def build_array(a: u256, b: u256) -> u256[3]:
-11 │ │         my_array: u256[3]
+11 │ │         let my_array: u256[3]
 12 │ │         my_array[0] = a
 13 │ │         my_array[1] = a * b
 14 │ │         my_array[2] = b
@@ -1064,7 +1064,7 @@ note:
 20 │ │         my_num: u256,
 21 │ │         my_addrs: address[5],
    · │
-24 │ │         foo: Foo = Foo(foo_address)
+24 │ │         let foo: Foo = Foo(foo_address)
 25 │ │         foo.emit_event(my_num, my_addrs, my_string)
    │ ╰───────────────────────────────────────────────────^ attributes hash: 15540531040497604947
    │  
@@ -1117,7 +1117,7 @@ note:
 29 │ │          a: u256,
 30 │ │          b: u256,
 31 │ │     ) -> u256[3]:
-32 │ │         foo: Foo = Foo(foo_address)
+32 │ │         let foo: Foo = Foo(foo_address)
 33 │ │         return foo.build_array(a, b)
    │ ╰────────────────────────────────────^ attributes hash: 17961685809848126830
    │  
@@ -1161,8 +1161,8 @@ note:
 note: 
    ┌─ features/external_contract.fe:11:9
    │
-11 │         my_array: u256[3]
-   │         ^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
+11 │         let my_array: u256[3]
+   │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
    │
    = Array(
          Array {
@@ -1176,8 +1176,8 @@ note:
 note: 
    ┌─ features/external_contract.fe:24:9
    │
-24 │         foo: Foo = Foo(foo_address)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 649988358200888429
+24 │         let foo: Foo = Foo(foo_address)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 649988358200888429
    │
    = Contract(
          Contract {
@@ -1254,8 +1254,8 @@ note:
 note: 
    ┌─ features/external_contract.fe:32:9
    │
-32 │         foo: Foo = Foo(foo_address)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 649988358200888429
+32 │         let foo: Foo = Foo(foo_address)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 649988358200888429
    │
    = Contract(
          Contract {
@@ -1537,7 +1537,7 @@ note:
 19 │ │         foo_address: address,
 20 │ │         my_num: u256,
    · │
-32 │ │         foo: Foo = Foo(foo_address)
+32 │ │         let foo: Foo = Foo(foo_address)
 33 │ │         return foo.build_array(a, b)
    │ ╰────────────────────────────────────^ attributes hash: 13297917713247410406
    │  
@@ -1697,10 +1697,10 @@ note:
      }
 
 note: 
-   ┌─ features/external_contract.fe:24:20
+   ┌─ features/external_contract.fe:24:24
    │
-24 │         foo: Foo = Foo(foo_address)
-   │                    ^^^ attributes hash: 11173587274812739149
+24 │         let foo: Foo = Foo(foo_address)
+   │                        ^^^ attributes hash: 11173587274812739149
    │
    = TypeConstructor {
          typ: Contract(
@@ -1785,10 +1785,10 @@ note:
    = ValueAttribute
 
 note: 
-   ┌─ features/external_contract.fe:32:20
+   ┌─ features/external_contract.fe:32:24
    │
-32 │         foo: Foo = Foo(foo_address)
-   │                    ^^^ attributes hash: 11173587274812739149
+32 │         let foo: Foo = Foo(foo_address)
+   │                        ^^^ attributes hash: 11173587274812739149
    │
    = TypeConstructor {
          typ: Contract(
@@ -2178,10 +2178,10 @@ note:
      )
 
 note: 
-   ┌─ features/external_contract.fe:11:19
+   ┌─ features/external_contract.fe:11:23
    │
-11 │         my_array: u256[3]
-   │                   ^^^^ attributes hash: 17942395924573474124
+11 │         let my_array: u256[3]
+   │                       ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -2190,10 +2190,10 @@ note:
      )
 
 note: 
-   ┌─ features/external_contract.fe:11:19
+   ┌─ features/external_contract.fe:11:23
    │
-11 │         my_array: u256[3]
-   │                   ^^^^^^^ attributes hash: 5963828201795370982
+11 │         let my_array: u256[3]
+   │                       ^^^^^^^ attributes hash: 5963828201795370982
    │
    = Array(
          Array {
@@ -2205,10 +2205,10 @@ note:
      )
 
 note: 
-   ┌─ features/external_contract.fe:24:14
+   ┌─ features/external_contract.fe:24:18
    │
-24 │         foo: Foo = Foo(foo_address)
-   │              ^^^ attributes hash: 18327896826829233347
+24 │         let foo: Foo = Foo(foo_address)
+   │                  ^^^ attributes hash: 18327896826829233347
    │
    = Contract(
          Contract {
@@ -2283,10 +2283,10 @@ note:
      )
 
 note: 
-   ┌─ features/external_contract.fe:32:14
+   ┌─ features/external_contract.fe:32:18
    │
-32 │         foo: Foo = Foo(foo_address)
-   │              ^^^ attributes hash: 18327896826829233347
+32 │         let foo: Foo = Foo(foo_address)
+   │                  ^^^ attributes hash: 18327896826829233347
    │
    = Contract(
          Contract {

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
@@ -227,10 +227,10 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_break.fe:8:21
+  ┌─ features/for_loop_with_break.fe:8:25
   │
-8 │         sum: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
+8 │         let sum: u256 = 0
+  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -391,7 +391,7 @@ note:
    ┌─ features/for_loop_with_break.fe:3:5
    │  
  3 │ ╭     pub def bar() -> u256:
- 4 │ │         my_array: u256[3]
+ 4 │ │         let my_array: u256[3]
  5 │ │         my_array[0] = 5
  6 │ │         my_array[1] = 10
    · │
@@ -413,8 +413,8 @@ note:
 note: 
   ┌─ features/for_loop_with_break.fe:4:9
   │
-4 │         my_array: u256[3]
-  │         ^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
+4 │         let my_array: u256[3]
+  │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
   │
   = Array(
         Array {
@@ -428,8 +428,8 @@ note:
 note: 
   ┌─ features/for_loop_with_break.fe:8:9
   │
-8 │         sum: u256 = 0
-  │         ^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+8 │         let sum: u256 = 0
+  │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -443,7 +443,7 @@ note:
  1 │ ╭ contract Foo:
  2 │ │ 
  3 │ │     pub def bar() -> u256:
- 4 │ │         my_array: u256[3]
+ 4 │ │         let my_array: u256[3]
    · │
 12 │ │                 break
 13 │ │         return sum
@@ -481,10 +481,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_break.fe:4:19
+  ┌─ features/for_loop_with_break.fe:4:23
   │
-4 │         my_array: u256[3]
-  │                   ^^^^ attributes hash: 17942395924573474124
+4 │         let my_array: u256[3]
+  │                       ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -493,10 +493,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_break.fe:4:19
+  ┌─ features/for_loop_with_break.fe:4:23
   │
-4 │         my_array: u256[3]
-  │                   ^^^^^^^ attributes hash: 5963828201795370982
+4 │         let my_array: u256[3]
+  │                       ^^^^^^^ attributes hash: 5963828201795370982
   │
   = Array(
         Array {
@@ -508,10 +508,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_break.fe:8:14
+  ┌─ features/for_loop_with_break.fe:8:18
   │
-8 │         sum: u256 = 0
-  │              ^^^^ attributes hash: 17942395924573474124
+8 │         let sum: u256 = 0
+  │                  ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
@@ -361,10 +361,10 @@ note:
     }
 
 note: 
-   ┌─ features/for_loop_with_continue.fe:10:21
+   ┌─ features/for_loop_with_continue.fe:10:25
    │
-10 │         sum: u256 = 0
-   │                     ^ attributes hash: 16797824492585953824
+10 │         let sum: u256 = 0
+   │                         ^ attributes hash: 16797824492585953824
    │
    = ExpressionAttributes {
          typ: Base(
@@ -557,7 +557,7 @@ note:
    ┌─ features/for_loop_with_continue.fe:3:5
    │  
  3 │ ╭     pub def bar() -> u256:
- 4 │ │         my_array: u256[5]
+ 4 │ │         let my_array: u256[5]
  5 │ │         my_array[0] = 2
  6 │ │         my_array[1] = 3
    · │
@@ -579,8 +579,8 @@ note:
 note: 
   ┌─ features/for_loop_with_continue.fe:4:9
   │
-4 │         my_array: u256[5]
-  │         ^^^^^^^^^^^^^^^^^ attributes hash: 12285037458725956106
+4 │         let my_array: u256[5]
+  │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12285037458725956106
   │
   = Array(
         Array {
@@ -594,8 +594,8 @@ note:
 note: 
    ┌─ features/for_loop_with_continue.fe:10:9
    │
-10 │         sum: u256 = 0
-   │         ^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+10 │         let sum: u256 = 0
+   │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -609,7 +609,7 @@ note:
  1 │ ╭ contract Foo:
  2 │ │ 
  3 │ │     pub def bar() -> u256:
- 4 │ │         my_array: u256[5]
+ 4 │ │         let my_array: u256[5]
    · │
 14 │ │             sum = sum + i
 15 │ │         return sum
@@ -647,10 +647,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_continue.fe:4:19
+  ┌─ features/for_loop_with_continue.fe:4:23
   │
-4 │         my_array: u256[5]
-  │                   ^^^^ attributes hash: 17942395924573474124
+4 │         let my_array: u256[5]
+  │                       ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -659,10 +659,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_continue.fe:4:19
+  ┌─ features/for_loop_with_continue.fe:4:23
   │
-4 │         my_array: u256[5]
-  │                   ^^^^^^^ attributes hash: 12285037458725956106
+4 │         let my_array: u256[5]
+  │                       ^^^^^^^ attributes hash: 12285037458725956106
   │
   = Array(
         Array {
@@ -674,10 +674,10 @@ note:
     )
 
 note: 
-   ┌─ features/for_loop_with_continue.fe:10:14
+   ┌─ features/for_loop_with_continue.fe:10:18
    │
-10 │         sum: u256 = 0
-   │              ^^^^ attributes hash: 17942395924573474124
+10 │         let sum: u256 = 0
+   │                  ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
@@ -227,10 +227,10 @@ note:
     }
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:8:21
+  ┌─ features/for_loop_with_static_array.fe:8:25
   │
-8 │         sum: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
+8 │         let sum: u256 = 0
+  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -345,7 +345,7 @@ note:
    ┌─ features/for_loop_with_static_array.fe:3:5
    │  
  3 │ ╭     pub def bar() -> u256:
- 4 │ │         my_array: u256[3]
+ 4 │ │         let my_array: u256[3]
  5 │ │         my_array[0] = 5
  6 │ │         my_array[1] = 10
    · │
@@ -367,8 +367,8 @@ note:
 note: 
   ┌─ features/for_loop_with_static_array.fe:4:9
   │
-4 │         my_array: u256[3]
-  │         ^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
+4 │         let my_array: u256[3]
+  │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
   │
   = Array(
         Array {
@@ -382,8 +382,8 @@ note:
 note: 
   ┌─ features/for_loop_with_static_array.fe:8:9
   │
-8 │         sum: u256 = 0
-  │         ^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+8 │         let sum: u256 = 0
+  │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -397,7 +397,7 @@ note:
  1 │ ╭ contract Foo:
  2 │ │ 
  3 │ │     pub def bar() -> u256:
- 4 │ │         my_array: u256[3]
+ 4 │ │         let my_array: u256[3]
    · │
 10 │ │             sum = sum + i
 11 │ │         return sum
@@ -435,10 +435,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:4:19
+  ┌─ features/for_loop_with_static_array.fe:4:23
   │
-4 │         my_array: u256[3]
-  │                   ^^^^ attributes hash: 17942395924573474124
+4 │         let my_array: u256[3]
+  │                       ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -447,10 +447,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:4:19
+  ┌─ features/for_loop_with_static_array.fe:4:23
   │
-4 │         my_array: u256[3]
-  │                   ^^^^^^^ attributes hash: 5963828201795370982
+4 │         let my_array: u256[3]
+  │                       ^^^^^^^ attributes hash: 5963828201795370982
   │
   = Array(
         Array {
@@ -462,10 +462,10 @@ note:
     )
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:8:14
+  ┌─ features/for_loop_with_static_array.fe:8:18
   │
-8 │         sum: u256 = 0
-  │              ^^^^ attributes hash: 17942395924573474124
+8 │         let sum: u256 = 0
+  │                  ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
@@ -40,10 +40,10 @@ note:
     }
 
 note: 
-  ┌─ features/if_statement_with_block_declaration.fe:5:23
+  ┌─ features/if_statement_with_block_declaration.fe:5:27
   │
-5 │             y: u256 = 1
-  │                       ^ attributes hash: 16797824492585953824
+5 │             let y: u256 = 1
+  │                           ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -72,10 +72,10 @@ note:
     }
 
 note: 
-  ┌─ features/if_statement_with_block_declaration.fe:8:23
+  ┌─ features/if_statement_with_block_declaration.fe:8:27
   │
-8 │             y: u256 = 1
-  │                       ^ attributes hash: 16797824492585953824
+8 │             let y: u256 = 1
+  │                           ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -108,10 +108,10 @@ note:
   │  
 3 │ ╭     pub def bar() -> u256:
 4 │ │         if true:
-5 │ │             y: u256 = 1
+5 │ │             let y: u256 = 1
 6 │ │             return y
 7 │ │         else:
-8 │ │             y: u256 = 1
+8 │ │             let y: u256 = 1
 9 │ │             return y
   │ ╰────────────────────^ attributes hash: 2041944711719443549
   │  
@@ -129,8 +129,8 @@ note:
 note: 
   ┌─ features/if_statement_with_block_declaration.fe:5:13
   │
-5 │             y: u256 = 1
-  │             ^^^^^^^^^^^ attributes hash: 17942395924573474124
+5 │             let y: u256 = 1
+  │             ^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -141,8 +141,8 @@ note:
 note: 
   ┌─ features/if_statement_with_block_declaration.fe:8:13
   │
-8 │             y: u256 = 1
-  │             ^^^^^^^^^^^ attributes hash: 17942395924573474124
+8 │             let y: u256 = 1
+  │             ^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -158,7 +158,7 @@ note:
 3 │ │     pub def bar() -> u256:
 4 │ │         if true:
   · │
-8 │ │             y: u256 = 1
+8 │ │             let y: u256 = 1
 9 │ │             return y
   │ ╰────────────────────^ attributes hash: 16417315723405128961
   │  
@@ -194,10 +194,10 @@ note:
     )
 
 note: 
-  ┌─ features/if_statement_with_block_declaration.fe:5:16
+  ┌─ features/if_statement_with_block_declaration.fe:5:20
   │
-5 │             y: u256 = 1
-  │                ^^^^ attributes hash: 17942395924573474124
+5 │             let y: u256 = 1
+  │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -206,10 +206,10 @@ note:
     )
 
 note: 
-  ┌─ features/if_statement_with_block_declaration.fe:8:16
+  ┌─ features/if_statement_with_block_declaration.fe:8:20
   │
-8 │             y: u256 = 1
-  │                ^^^^ attributes hash: 17942395924573474124
+8 │             let y: u256 = 1
+  │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__math.snap
+++ b/crates/analyzer/tests/snapshots/analysis__math.snap
@@ -140,42 +140,10 @@ note:
     }
 
 note: 
-  ┌─ features/math.fe:8:23
+  ┌─ features/math.fe:8:27
   │
-8 │             x: u256 = val / 2 + 1
-  │                       ^^^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:8:29
-  │
-8 │             x: u256 = val / 2 + 1
-  │                             ^ attributes hash: 16797824492585953824
-  │
-  = ExpressionAttributes {
-        typ: Base(
-            Numeric(
-                U256,
-            ),
-        ),
-        location: Value,
-        move_location: None,
-    }
-
-note: 
-  ┌─ features/math.fe:8:23
-  │
-8 │             x: u256 = val / 2 + 1
-  │                       ^^^^^^^ attributes hash: 16797824492585953824
+8 │             let x: u256 = val / 2 + 1
+  │                           ^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -190,7 +158,7 @@ note:
 note: 
   ┌─ features/math.fe:8:33
   │
-8 │             x: u256 = val / 2 + 1
+8 │             let x: u256 = val / 2 + 1
   │                                 ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
@@ -204,10 +172,42 @@ note:
     }
 
 note: 
-  ┌─ features/math.fe:8:23
+  ┌─ features/math.fe:8:27
   │
-8 │             x: u256 = val / 2 + 1
-  │                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
+8 │             let x: u256 = val / 2 + 1
+  │                           ^^^^^^^ attributes hash: 16797824492585953824
+  │
+  = ExpressionAttributes {
+        typ: Base(
+            Numeric(
+                U256,
+            ),
+        ),
+        location: Value,
+        move_location: None,
+    }
+
+note: 
+  ┌─ features/math.fe:8:37
+  │
+8 │             let x: u256 = val / 2 + 1
+  │                                     ^ attributes hash: 16797824492585953824
+  │
+  = ExpressionAttributes {
+        typ: Base(
+            Numeric(
+                U256,
+            ),
+        ),
+        location: Value,
+        move_location: None,
+    }
+
+note: 
+  ┌─ features/math.fe:8:27
+  │
+8 │             let x: u256 = val / 2 + 1
+  │                           ^^^^^^^^^^^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -617,7 +617,7 @@ note:
    ┌─ features/math.fe:4:5
    │  
  4 │ ╭     pub def sqrt(val: u256) -> u256:
- 5 │ │         z: u256
+ 5 │ │         let z: u256
  6 │ │         if (val > 3):
  7 │ │             z = val
    · │
@@ -683,8 +683,8 @@ note:
 note: 
   ┌─ features/math.fe:5:9
   │
-5 │         z: u256
-  │         ^^^^^^^ attributes hash: 17942395924573474124
+5 │         let z: u256
+  │         ^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -695,8 +695,8 @@ note:
 note: 
   ┌─ features/math.fe:8:13
   │
-8 │             x: u256 = val / 2 + 1
-  │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+8 │             let x: u256 = val / 2 + 1
+  │             ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -832,10 +832,10 @@ note:
      )
 
 note: 
-  ┌─ features/math.fe:5:12
+  ┌─ features/math.fe:5:16
   │
-5 │         z: u256
-  │            ^^^^ attributes hash: 17942395924573474124
+5 │         let z: u256
+  │                ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -844,10 +844,10 @@ note:
     )
 
 note: 
-  ┌─ features/math.fe:8:16
+  ┌─ features/math.fe:8:20
   │
-8 │             x: u256 = val / 2 + 1
-  │                ^^^^ attributes hash: 17942395924573474124
+8 │             let x: u256 = val / 2 + 1
+  │                    ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -277,7 +277,7 @@ note:
   ┌─ features/multi_param.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u256, y: u256, z: u256) -> u256[3]:
-3 │ │         my_array: u256[3]
+3 │ │         let my_array: u256[3]
 4 │ │         my_array[0] = x
 5 │ │         my_array[1] = y
 6 │ │         my_array[2] = z
@@ -326,8 +326,8 @@ note:
 note: 
   ┌─ features/multi_param.fe:3:9
   │
-3 │         my_array: u256[3]
-  │         ^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
+3 │         let my_array: u256[3]
+  │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5963828201795370982
   │
   = Array(
         Array {
@@ -343,7 +343,7 @@ note:
   │  
 1 │ ╭ contract Foo:
 2 │ │     pub def bar(x: u256, y: u256, z: u256) -> u256[3]:
-3 │ │         my_array: u256[3]
+3 │ │         let my_array: u256[3]
 4 │ │         my_array[0] = x
 5 │ │         my_array[1] = y
 6 │ │         my_array[2] = z
@@ -461,10 +461,10 @@ note:
     )
 
 note: 
-  ┌─ features/multi_param.fe:3:19
+  ┌─ features/multi_param.fe:3:23
   │
-3 │         my_array: u256[3]
-  │                   ^^^^ attributes hash: 17942395924573474124
+3 │         let my_array: u256[3]
+  │                       ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -473,10 +473,10 @@ note:
     )
 
 note: 
-  ┌─ features/multi_param.fe:3:19
+  ┌─ features/multi_param.fe:3:23
   │
-3 │         my_array: u256[3]
-  │                   ^^^^^^^ attributes hash: 5963828201795370982
+3 │         let my_array: u256[3]
+  │                       ^^^^^^^ attributes hash: 5963828201795370982
   │
   = Array(
         Array {

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -127,7 +127,7 @@ note:
   ┌─ features/return_array.fe:2:5
   │  
 2 │ ╭     pub def bar(x: u256) -> u256[5]:
-3 │ │         my_array: u256[5]
+3 │ │         let my_array: u256[5]
 4 │ │         my_array[3] = x
 5 │ │         return my_array
   │ ╰───────────────────────^ attributes hash: 3941419229809522806
@@ -158,8 +158,8 @@ note:
 note: 
   ┌─ features/return_array.fe:3:9
   │
-3 │         my_array: u256[5]
-  │         ^^^^^^^^^^^^^^^^^ attributes hash: 12285037458725956106
+3 │         let my_array: u256[5]
+  │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12285037458725956106
   │
   = Array(
         Array {
@@ -175,7 +175,7 @@ note:
   │  
 1 │ ╭ contract Foo:
 2 │ │     pub def bar(x: u256) -> u256[5]:
-3 │ │         my_array: u256[5]
+3 │ │         let my_array: u256[5]
 4 │ │         my_array[3] = x
 5 │ │         return my_array
   │ ╰───────────────────────^ attributes hash: 17525689165764501083
@@ -251,10 +251,10 @@ note:
     )
 
 note: 
-  ┌─ features/return_array.fe:3:19
+  ┌─ features/return_array.fe:3:23
   │
-3 │         my_array: u256[5]
-  │                   ^^^^ attributes hash: 17942395924573474124
+3 │         let my_array: u256[5]
+  │                       ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -263,10 +263,10 @@ note:
     )
 
 note: 
-  ┌─ features/return_array.fe:3:19
+  ┌─ features/return_array.fe:3:23
   │
-3 │         my_array: u256[5]
-  │                   ^^^^^^^ attributes hash: 12285037458725956106
+3 │         let my_array: u256[5]
+  │                       ^^^^^^^ attributes hash: 12285037458725956106
   │
   = Array(
         Array {

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -2800,10 +2800,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:45:27
+   ┌─ features/structs.fe:45:31
    │  
-45 │           building: House = House(
-   │ ╭───────────────────────────^
+45 │           let building: House = House(
+   │ ╭───────────────────────────────^
 46 │ │             price=300,
 47 │ │             size=500,
 48 │ │             rooms=u8(20),
@@ -4092,10 +4092,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:68:24
+   ┌─ features/structs.fe:68:28
    │  
-68 │           house: House = House(
-   │ ╭────────────────────────^
+68 │           let house: House = House(
+   │ ╭────────────────────────────^
 69 │ │             price=300,
 70 │ │             size=500,
 71 │ │             rooms=u8(20),
@@ -4291,10 +4291,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:77:24
+   ┌─ features/structs.fe:77:28
    │  
-77 │           house: House = House(
-   │ ╭────────────────────────^
+77 │           let house: House = House(
+   │ ╭────────────────────────────^
 78 │ │             price=300,
 79 │ │             size=500,
 80 │ │             rooms=u8(20),
@@ -4452,7 +4452,7 @@ note:
    ┌─ features/structs.fe:44:5
    │  
 44 │ ╭     pub def bar() -> u256:
-45 │ │         building: House = House(
+45 │ │         let building: House = House(
 46 │ │             price=300,
 47 │ │             size=500,
    · │
@@ -4475,7 +4475,7 @@ note:
    ┌─ features/structs.fe:67:5
    │  
 67 │ ╭     pub def encode_house() -> u8[128]:
-68 │ │         house: House = House(
+68 │ │         let house: House = House(
 69 │ │             price=300,
 70 │ │             size=500,
    · │
@@ -4501,7 +4501,7 @@ note:
    ┌─ features/structs.fe:76:5
    │  
 76 │ ╭     pub def hashed_house() -> u256:
-77 │ │         house: House = House(
+77 │ │         let house: House = House(
 78 │ │             price=300,
 79 │ │             size=500,
    · │
@@ -4523,7 +4523,7 @@ note:
 note: 
    ┌─ features/structs.fe:45:9
    │  
-45 │ ╭         building: House = House(
+45 │ ╭         let building: House = House(
 46 │ │             price=300,
 47 │ │             size=500,
 48 │ │             rooms=u8(20),
@@ -4572,7 +4572,7 @@ note:
 note: 
    ┌─ features/structs.fe:68:9
    │  
-68 │ ╭         house: House = House(
+68 │ ╭         let house: House = House(
 69 │ │             price=300,
 70 │ │             size=500,
 71 │ │             rooms=u8(20),
@@ -4621,7 +4621,7 @@ note:
 note: 
    ┌─ features/structs.fe:77:9
    │  
-77 │ ╭         house: House = House(
+77 │ ╭         let house: House = House(
 78 │ │             price=300,
 79 │ │             size=500,
 80 │ │             rooms=u8(20),
@@ -4910,10 +4910,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:45:27
+   ┌─ features/structs.fe:45:31
    │
-45 │         building: House = House(
-   │                           ^^^^^ attributes hash: 3351743285761427611
+45 │         let building: House = House(
+   │                               ^^^^^ attributes hash: 3351743285761427611
    │
    = TypeConstructor {
          typ: Struct(
@@ -5012,10 +5012,10 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:68:24
+   ┌─ features/structs.fe:68:28
    │
-68 │         house: House = House(
-   │                        ^^^^^ attributes hash: 3351743285761427611
+68 │         let house: House = House(
+   │                            ^^^^^ attributes hash: 3351743285761427611
    │
    = TypeConstructor {
          typ: Struct(
@@ -5080,10 +5080,10 @@ note:
    = ValueAttribute
 
 note: 
-   ┌─ features/structs.fe:77:24
+   ┌─ features/structs.fe:77:28
    │
-77 │         house: House = House(
-   │                        ^^^^^ attributes hash: 3351743285761427611
+77 │         let house: House = House(
+   │                            ^^^^^ attributes hash: 3351743285761427611
    │
    = TypeConstructor {
          typ: Struct(
@@ -5299,54 +5299,10 @@ note:
     )
 
 note: 
-   ┌─ features/structs.fe:45:19
+   ┌─ features/structs.fe:45:23
    │
-45 │         building: House = House(
-   │                   ^^^^^ attributes hash: 17457972932280273688
-   │
-   = Struct(
-         Struct {
-             name: "House",
-             fields: [
-                 (
-                     "price",
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 (
-                     "size",
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 (
-                     "rooms",
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-                 (
-                     "vacant",
-                     Base(
-                         Bool,
-                     ),
-                 ),
-             ],
-         },
-     )
-
-note: 
-   ┌─ features/structs.fe:68:16
-   │
-68 │         house: House = House(
-   │                ^^^^^ attributes hash: 17457972932280273688
+45 │         let building: House = House(
+   │                       ^^^^^ attributes hash: 17457972932280273688
    │
    = Struct(
          Struct {
@@ -5387,10 +5343,54 @@ note:
      )
 
 note: 
-   ┌─ features/structs.fe:77:16
+   ┌─ features/structs.fe:68:20
    │
-77 │         house: House = House(
-   │                ^^^^^ attributes hash: 17457972932280273688
+68 │         let house: House = House(
+   │                    ^^^^^ attributes hash: 17457972932280273688
+   │
+   = Struct(
+         Struct {
+             name: "House",
+             fields: [
+                 (
+                     "price",
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 (
+                     "size",
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 (
+                     "rooms",
+                     Base(
+                         Numeric(
+                             U8,
+                         ),
+                     ),
+                 ),
+                 (
+                     "vacant",
+                     Base(
+                         Bool,
+                     ),
+                 ),
+             ],
+         },
+     )
+
+note: 
+   ┌─ features/structs.fe:77:20
+   │
+77 │         let house: House = House(
+   │                    ^^^^^ attributes hash: 17457972932280273688
    │
    = Struct(
          Struct {

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -865,10 +865,10 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:24
+   ┌─ stress/tuple_stress.fe:34:28
    │
-34 │         my_num: u256 = self.my_sto_tuple.item0
-   │                        ^^^^^^^^^^^^^^^^^ attributes hash: 5427295442955120331
+34 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                            ^^^^^^^^^^^^^^^^^ attributes hash: 5427295442955120331
    │
    = ExpressionAttributes {
          typ: Tuple(
@@ -896,10 +896,10 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:24
+   ┌─ stress/tuple_stress.fe:34:28
    │
-34 │         my_num: u256 = self.my_sto_tuple.item0
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
+34 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                            ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4679040613115932727
    │
    = ExpressionAttributes {
          typ: Base(
@@ -1043,10 +1043,10 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:43
+   ┌─ stress/tuple_stress.fe:35:47
    │  
-35 │           my_tuple: (u256, bool, address) = (
-   │ ╭───────────────────────────────────────────^
+35 │           let my_tuple: (u256, bool, address) = (
+   │ ╭───────────────────────────────────────────────^
 36 │ │             self.my_sto_tuple.item0,
 37 │ │             true and false,
 38 │ │             address(26)
@@ -1470,8 +1470,8 @@ note:
    ┌─ stress/tuple_stress.fe:33:5
    │  
 33 │ ╭     pub def build_tuple_and_emit():
-34 │ │         my_num: u256 = self.my_sto_tuple.item0
-35 │ │         my_tuple: (u256, bool, address) = (
+34 │ │         let my_num: u256 = self.my_sto_tuple.item0
+35 │ │         let my_tuple: (u256, bool, address) = (
 36 │ │             self.my_sto_tuple.item0,
    · │
 39 │ │         )
@@ -1532,8 +1532,8 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:34:9
    │
-34 │         my_num: u256 = self.my_sto_tuple.item0
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+34 │         let my_num: u256 = self.my_sto_tuple.item0
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -1544,7 +1544,7 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:35:9
    │  
-35 │ ╭         my_tuple: (u256, bool, address) = (
+35 │ ╭         let my_tuple: (u256, bool, address) = (
 36 │ │             self.my_sto_tuple.item0,
 37 │ │             true and false,
 38 │ │             address(26)
@@ -2570,22 +2570,10 @@ note:
     )
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:17
+   ┌─ stress/tuple_stress.fe:34:21
    │
-34 │         my_num: u256 = self.my_sto_tuple.item0
-   │                 ^^^^ attributes hash: 17942395924573474124
-   │
-   = Base(
-         Numeric(
-             U256,
-         ),
-     )
-
-note: 
-   ┌─ stress/tuple_stress.fe:35:20
-   │
-35 │         my_tuple: (u256, bool, address) = (
-   │                    ^^^^ attributes hash: 17942395924573474124
+34 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                     ^^^^ attributes hash: 17942395924573474124
    │
    = Base(
          Numeric(
@@ -2594,30 +2582,42 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:26
+   ┌─ stress/tuple_stress.fe:35:24
    │
-35 │         my_tuple: (u256, bool, address) = (
-   │                          ^^^^ attributes hash: 8311861578736502650
+35 │         let my_tuple: (u256, bool, address) = (
+   │                        ^^^^ attributes hash: 17942395924573474124
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:35:30
+   │
+35 │         let my_tuple: (u256, bool, address) = (
+   │                              ^^^^ attributes hash: 8311861578736502650
    │
    = Base(
          Bool,
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:32
+   ┌─ stress/tuple_stress.fe:35:36
    │
-35 │         my_tuple: (u256, bool, address) = (
-   │                                ^^^^^^^ attributes hash: 16931239362436195516
+35 │         let my_tuple: (u256, bool, address) = (
+   │                                    ^^^^^^^ attributes hash: 16931239362436195516
    │
    = Base(
          Address,
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:19
+   ┌─ stress/tuple_stress.fe:35:23
    │
-35 │         my_tuple: (u256, bool, address) = (
-   │                   ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13223894189960686356
+35 │         let my_tuple: (u256, bool, address) = (
+   │                       ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13223894189960686356
    │
    = Tuple(
          Tuple {

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -2458,26 +2458,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:125:33
+    ┌─ demos/uniswap.fe:125:37
     │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                 ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:125:51
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                                   ^ attributes hash: 16797824492585953824
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                     ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -2490,26 +2474,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:125:54
+    ┌─ demos/uniswap.fe:125:55
     │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                                      ^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:125:51
-    │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                                   ^^^^^ attributes hash: 16797824492585953824
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                                       ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -2522,26 +2490,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:125:33
+    ┌─ demos/uniswap.fe:125:58
     │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                                 ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:127:30
-    │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                              ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                                          ^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -2554,10 +2506,58 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:127:48
+    ┌─ demos/uniswap.fe:125:55
     │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                                ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6371053836336388098
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                                       ^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:125:37
+    │
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                     ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:127:34
+    │
+127 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                                  ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:127:52
+    │
+127 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6371053836336388098
     │
     = ExpressionAttributes {
           typ: Base(
@@ -2576,10 +2576,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:127:30
+    ┌─ demos/uniswap.fe:127:34
     │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+127 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3186,10 +3186,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:140:44
+    ┌─ demos/uniswap.fe:140:48
     │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                                            ^^^^^^^^^^^^ attributes hash: 10795788383055974872
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                                                ^^^^^^^^^^^^ attributes hash: 10795788383055974872
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3206,10 +3206,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:140:27
+    ┌─ demos/uniswap.fe:140:31
     │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 2682470432657360711
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 2682470432657360711
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -3301,24 +3301,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:140:27
+    ┌─ demos/uniswap.fe:140:31
     │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:141:24
-    │
-141 │         fee_on: bool = fee_to != address(0)
-    │                        ^^^^^^ attributes hash: 16366719240912622931
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3329,10 +3315,24 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:141:42
+    ┌─ demos/uniswap.fe:141:28
     │
-141 │         fee_on: bool = fee_to != address(0)
-    │                                          ^ attributes hash: 16797824492585953824
+141 │         let fee_on: bool = fee_to != address(0)
+    │                            ^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:141:46
+    │
+141 │         let fee_on: bool = fee_to != address(0)
+    │                                              ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3345,10 +3345,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:141:34
+    ┌─ demos/uniswap.fe:141:38
     │
-141 │         fee_on: bool = fee_to != address(0)
-    │                                  ^^^^^^^^^^ attributes hash: 16366719240912622931
+141 │         let fee_on: bool = fee_to != address(0)
+    │                                      ^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3359,10 +3359,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:141:24
+    ┌─ demos/uniswap.fe:141:28
     │
-141 │         fee_on: bool = fee_to != address(0)
-    │                        ^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+141 │         let fee_on: bool = fee_to != address(0)
+    │                            ^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3373,10 +3373,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:142:24
+    ┌─ demos/uniswap.fe:142:28
     │
-142 │         k_last: u256 = self.k_last # gas savings
-    │                        ^^^^^^^^^^^ attributes hash: 12467918549696538113
+142 │         let k_last: u256 = self.k_last # gas savings
+    │                            ^^^^^^^^^^^ attributes hash: 12467918549696538113
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3455,26 +3455,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:145:42
+    ┌─ demos/uniswap.fe:145:46
     │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:145:53
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                                     ^^^^^^^^ attributes hash: 16797824492585953824
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                                              ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3487,26 +3471,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:145:42
+    ┌─ demos/uniswap.fe:145:57
     │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                          ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:145:32
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                                                         ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3519,10 +3487,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:146:47
+    ┌─ demos/uniswap.fe:145:46
     │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
-    │                                               ^^^^^^ attributes hash: 16797824492585953824
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                                              ^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3535,10 +3503,42 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:146:37
+    ┌─ demos/uniswap.fe:145:36
     │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
-    │                                     ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:146:51
+    │
+146 │                 let root_k_last: u256 = self.sqrt(k_last)
+    │                                                   ^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:146:41
+    │
+146 │                 let root_k_last: u256 = self.sqrt(k_last)
+    │                                         ^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3597,10 +3597,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:148:39
+    ┌─ demos/uniswap.fe:148:43
     │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                       ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                           ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3619,26 +3619,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:148:59
+    ┌─ demos/uniswap.fe:148:63
     │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                                           ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:148:39
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                                               ^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3651,26 +3635,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:148:68
+    ┌─ demos/uniswap.fe:148:43
     │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                                                    ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:148:39
-    │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3683,26 +3651,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:149:41
+    ┌─ demos/uniswap.fe:148:72
     │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                         ^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:149:50
-    │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                                  ^ attributes hash: 16797824492585953824
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                                                        ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3715,10 +3667,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:149:41
+    ┌─ demos/uniswap.fe:148:43
     │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                         ^^^^^^^^^^ attributes hash: 16797824492585953824
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:149:45
+    │
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                             ^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3733,8 +3701,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:149:54
     │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                                      ^^^^^^^^^^^ attributes hash: 16797824492585953824
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                                      ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3747,26 +3715,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:149:41
+    ┌─ demos/uniswap.fe:149:45
     │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:150:39
-    │
-150 │                     liquidity: u256 = numerator / denominator
-    │                                       ^^^^^^^^^ attributes hash: 16797824492585953824
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                             ^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3779,10 +3731,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:150:51
+    ┌─ demos/uniswap.fe:149:58
     │
-150 │                     liquidity: u256 = numerator / denominator
-    │                                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                                          ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3795,10 +3747,58 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:150:39
+    ┌─ demos/uniswap.fe:149:45
     │
-150 │                     liquidity: u256 = numerator / denominator
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:150:43
+    │
+150 │                     let liquidity: u256 = numerator / denominator
+    │                                           ^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:150:55
+    │
+150 │                     let liquidity: u256 = numerator / denominator
+    │                                                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:150:43
+    │
+150 │                     let liquidity: u256 = numerator / denominator
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -3997,10 +3997,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:160:35
+    ┌─ demos/uniswap.fe:160:39
     │
-160 │         MINIMUM_LIQUIDITY: u256 = 1000
-    │                                   ^^^^ attributes hash: 16797824492585953824
+160 │         let MINIMUM_LIQUIDITY: u256 = 1000
+    │                                       ^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4013,10 +4013,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:161:26
+    ┌─ demos/uniswap.fe:161:30
     │
-161 │         reserve0: u256 = self.reserve0
-    │                          ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
+161 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4035,10 +4035,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:162:26
+    ┌─ demos/uniswap.fe:162:30
     │
-162 │         reserve1: u256 = self.reserve1
-    │                          ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
+162 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4057,10 +4057,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:163:32
+    ┌─ demos/uniswap.fe:163:36
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                ^^^^^^^^^^^ attributes hash: 14552118647532869459
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                                    ^^^^^^^^^^^ attributes hash: 14552118647532869459
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4077,10 +4077,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:163:26
+    ┌─ demos/uniswap.fe:163:30
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -4135,10 +4135,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:163:55
+    ┌─ demos/uniswap.fe:163:59
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                                       ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                                                           ^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4149,10 +4149,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:163:26
+    ┌─ demos/uniswap.fe:163:30
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4165,10 +4165,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:164:32
+    ┌─ demos/uniswap.fe:164:36
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                ^^^^^^^^^^^ attributes hash: 6763598575633575517
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                                    ^^^^^^^^^^^ attributes hash: 6763598575633575517
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4185,10 +4185,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:164:26
+    ┌─ demos/uniswap.fe:164:30
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -4243,10 +4243,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:164:55
+    ┌─ demos/uniswap.fe:164:59
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                                       ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                                                           ^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4257,26 +4257,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:164:26
+    ┌─ demos/uniswap.fe:164:30
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:165:25
-    │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                         ^^^^^^^^ attributes hash: 16797824492585953824
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4289,10 +4273,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:165:36
+    ┌─ demos/uniswap.fe:165:29
     │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                                    ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
+165 │         let amount0: u256 = balance0 - self.reserve0
+    │                             ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:165:40
+    │
+165 │         let amount0: u256 = balance0 - self.reserve0
+    │                                        ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4311,26 +4311,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:165:25
+    ┌─ demos/uniswap.fe:165:29
     │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:166:25
-    │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                         ^^^^^^^^ attributes hash: 16797824492585953824
+165 │         let amount0: u256 = balance0 - self.reserve0
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4343,10 +4327,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:166:36
+    ┌─ demos/uniswap.fe:166:29
     │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                                    ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
+166 │         let amount1: u256 = balance1 - self.reserve1
+    │                             ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:166:40
+    │
+166 │         let amount1: u256 = balance1 - self.reserve1
+    │                                        ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4365,26 +4365,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:166:25
+    ┌─ demos/uniswap.fe:166:29
     │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:168:39
-    │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                       ^^^^^^^^ attributes hash: 16797824492585953824
+166 │         let amount1: u256 = balance1 - self.reserve1
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4397,10 +4381,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:168:49
+    ┌─ demos/uniswap.fe:168:43
     │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                                 ^^^^^^^^ attributes hash: 16797824492585953824
+168 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                                           ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4413,10 +4397,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:168:24
+    ┌─ demos/uniswap.fe:168:53
     │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+168 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                                                     ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:168:28
+    │
+168 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4427,10 +4427,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:169:30
+    ┌─ demos/uniswap.fe:169:34
     │
-169 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │                              ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
+169 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+    │                                  ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
     │
     = ExpressionAttributes {
           typ: Base(
@@ -4449,10 +4449,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:170:27
+    ┌─ demos/uniswap.fe:170:31
     │
-170 │         liquidity: u256 = 0
-    │                           ^ attributes hash: 16797824492585953824
+170 │         let liquidity: u256 = 0
+    │                               ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5203,10 +5203,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:190:26
+    ┌─ demos/uniswap.fe:190:30
     │
-190 │         reserve0: u256 = self.reserve0
-    │                          ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
+190 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5225,10 +5225,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:191:26
+    ┌─ demos/uniswap.fe:191:30
     │
-191 │         reserve1: u256 = self.reserve1
-    │                          ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
+191 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5247,10 +5247,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:192:31
+    ┌─ demos/uniswap.fe:192:35
     │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │                               ^^^^^^^^^^^ attributes hash: 14552118647532869459
+192 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ attributes hash: 14552118647532869459
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5267,10 +5267,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:192:25
+    ┌─ demos/uniswap.fe:192:29
     │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+192 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -5325,10 +5325,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:193:31
+    ┌─ demos/uniswap.fe:193:35
     │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │                               ^^^^^^^^^^^ attributes hash: 6763598575633575517
+193 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ attributes hash: 6763598575633575517
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5345,68 +5345,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:193:25
+    ┌─ demos/uniswap.fe:193:29
     │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:194:26
-    │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^ attributes hash: 16734680361006464993
+193 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -5461,10 +5403,68 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:194:43
+    ┌─ demos/uniswap.fe:194:30
     │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+194 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^ attributes hash: 16734680361006464993
+    │
+    = ExpressionAttributes {
+          typ: Contract(
+              Contract {
+                  name: "ERC20",
+                  functions: [
+                      FunctionAttributes {
+                          is_public: true,
+                          name: "balanceOf",
+                          params: [
+                              (
+                                  "account",
+                                  Base(
+                                      Address,
+                                  ),
+                              ),
+                          ],
+                          return_type: Base(
+                              Numeric(
+                                  U256,
+                              ),
+                          ),
+                      },
+                      FunctionAttributes {
+                          is_public: true,
+                          name: "transfer",
+                          params: [
+                              (
+                                  "recipient",
+                                  Base(
+                                      Address,
+                                  ),
+                              ),
+                              (
+                                  "amount",
+                                  Base(
+                                      Numeric(
+                                          U256,
+                                      ),
+                                  ),
+                              ),
+                          ],
+                          return_type: Base(
+                              Bool,
+                          ),
+                      },
+                  ],
+              },
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:194:47
+    │
+194 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5475,10 +5475,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:194:26
+    ┌─ demos/uniswap.fe:194:30
     │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+194 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5491,10 +5491,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:195:26
+    ┌─ demos/uniswap.fe:195:30
     │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^ attributes hash: 16734680361006464993
+195 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -5549,10 +5549,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:195:43
+    ┌─ demos/uniswap.fe:195:47
     │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+195 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5563,10 +5563,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:195:26
+    ┌─ demos/uniswap.fe:195:30
     │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+195 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5579,10 +5579,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:196:27
+    ┌─ demos/uniswap.fe:196:31
     │
-196 │         liquidity: u256 = self.balances[self.address]
-    │                           ^^^^^^^^^^^^^ attributes hash: 16295847970515239570
+196 │         let liquidity: u256 = self.balances[self.address]
+    │                               ^^^^^^^^^^^^^ attributes hash: 16295847970515239570
     │
     = ExpressionAttributes {
           typ: Map(
@@ -5604,10 +5604,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:196:41
+    ┌─ demos/uniswap.fe:196:45
     │
-196 │         liquidity: u256 = self.balances[self.address]
-    │                                         ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+196 │         let liquidity: u256 = self.balances[self.address]
+    │                                             ^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5618,10 +5618,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:196:27
+    ┌─ demos/uniswap.fe:196:31
     │
-196 │         liquidity: u256 = self.balances[self.address]
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
+196 │         let liquidity: u256 = self.balances[self.address]
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9781479072077703403
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5638,26 +5638,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:198:39
+    ┌─ demos/uniswap.fe:198:43
     │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                       ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:198:49
-    │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                                 ^^^^^^^^ attributes hash: 16797824492585953824
+198 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                                           ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5670,10 +5654,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:198:24
+    ┌─ demos/uniswap.fe:198:53
     │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+198 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                                                     ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:198:28
+    │
+198 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5684,10 +5684,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:199:30
+    ┌─ demos/uniswap.fe:199:34
     │
-199 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │                              ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
+199 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+    │                                  ^^^^^^^^^^^^^^^^^ attributes hash: 5126058488677760853
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5706,26 +5706,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:200:26
+    ┌─ demos/uniswap.fe:200:30
     │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                          ^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:200:38
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                                      ^^^^^^^^ attributes hash: 16797824492585953824
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                              ^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5738,26 +5722,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:200:25
+    ┌─ demos/uniswap.fe:200:42
     │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:200:50
-    │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                                                  ^^^^^^^^^^^^ attributes hash: 16797824492585953824
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5770,26 +5738,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:200:25
+    ┌─ demos/uniswap.fe:200:29
     │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:201:26
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                          ^^^^^^^^^ attributes hash: 16797824492585953824
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5802,26 +5754,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:201:38
+    ┌─ demos/uniswap.fe:200:54
     │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                                      ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:201:25
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                                                      ^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5834,10 +5770,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:201:50
+    ┌─ demos/uniswap.fe:200:29
     │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                                                  ^^^^^^^^^^^^ attributes hash: 16797824492585953824
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -5850,10 +5786,74 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:201:25
+    ┌─ demos/uniswap.fe:201:30
     │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                              ^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:201:42
+    │
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                                          ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:201:29
+    │
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:201:54
+    │
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                                                      ^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:201:29
+    │
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6845,10 +6845,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:222:26
+    ┌─ demos/uniswap.fe:222:30
     │
-222 │         reserve0: u256 = self.reserve0
-    │                          ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
+222 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ attributes hash: 16880951683415213473
     │
     = ExpressionAttributes {
           typ: Base(
@@ -6867,10 +6867,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:223:26
+    ┌─ demos/uniswap.fe:223:30
     │
-223 │         reserve1: u256 = self.reserve1
-    │                          ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
+223 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ attributes hash: 12418118303529001266
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7011,10 +7011,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:226:31
+    ┌─ demos/uniswap.fe:226:35
     │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │                               ^^^^^^^^^^^ attributes hash: 14552118647532869459
+226 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ attributes hash: 14552118647532869459
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7031,10 +7031,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:226:25
+    ┌─ demos/uniswap.fe:226:29
     │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+226 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -7089,10 +7089,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:227:31
+    ┌─ demos/uniswap.fe:227:35
     │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │                               ^^^^^^^^^^^ attributes hash: 6763598575633575517
+227 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ attributes hash: 6763598575633575517
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7109,10 +7109,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:227:25
+    ┌─ demos/uniswap.fe:227:29
     │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+227 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -7693,98 +7693,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:240:26
+    ┌─ demos/uniswap.fe:240:30
     │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^ attributes hash: 16734680361006464993
-    │
-    = ExpressionAttributes {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:240:43
-    │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:240:26
-    │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:241:26
-    │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^ attributes hash: 16734680361006464993
+240 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -7839,10 +7751,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:241:43
+    ┌─ demos/uniswap.fe:240:47
     │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                                           ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+240 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7853,26 +7765,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:241:26
+    ┌─ demos/uniswap.fe:240:30
     │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:67
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                   ^^^^^^^^ attributes hash: 16797824492585953824
+240 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7885,10 +7781,82 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:78
+    ┌─ demos/uniswap.fe:241:30
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                              ^^^^^^^^ attributes hash: 16797824492585953824
+241 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^ attributes hash: 16734680361006464993
+    │
+    = ExpressionAttributes {
+          typ: Contract(
+              Contract {
+                  name: "ERC20",
+                  functions: [
+                      FunctionAttributes {
+                          is_public: true,
+                          name: "balanceOf",
+                          params: [
+                              (
+                                  "account",
+                                  Base(
+                                      Address,
+                                  ),
+                              ),
+                          ],
+                          return_type: Base(
+                              Numeric(
+                                  U256,
+                              ),
+                          ),
+                      },
+                      FunctionAttributes {
+                          is_public: true,
+                          name: "transfer",
+                          params: [
+                              (
+                                  "recipient",
+                                  Base(
+                                      Address,
+                                  ),
+                              ),
+                              (
+                                  "amount",
+                                  Base(
+                                      Numeric(
+                                          U256,
+                                      ),
+                                  ),
+                              ),
+                          ],
+                          return_type: Base(
+                              Bool,
+                          ),
+                      },
+                  ],
+              },
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:241:47
+    │
+241 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:241:30
+    │
+241 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7901,26 +7869,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:89
+    ┌─ demos/uniswap.fe:243:71
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                         ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:78
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                              ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                       ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7933,10 +7885,58 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:67
+    ┌─ demos/uniswap.fe:243:82
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                                  ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:243:93
+    │
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                                             ^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:243:82
+    │
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:243:71
+    │
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7947,26 +7947,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:28
+    ┌─ demos/uniswap.fe:243:32
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                            ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:40
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                        ^^^^^^^^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -7979,26 +7963,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:51
+    ┌─ demos/uniswap.fe:243:44
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:39
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                            ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8011,26 +7979,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:28
+    ┌─ demos/uniswap.fe:243:55
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:243:106
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                                          ^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8043,26 +7995,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:243:28
+    ┌─ demos/uniswap.fe:243:43
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:67
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                   ^^^^^^^^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8075,26 +8011,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:78
+    ┌─ demos/uniswap.fe:243:32
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                              ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:89
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                         ^^^^^^^^^^^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8107,10 +8027,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:78
+    ┌─ demos/uniswap.fe:243:110
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                              ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                                                              ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8123,10 +8043,90 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:67
+    ┌─ demos/uniswap.fe:243:32
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:71
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                       ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:82
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                                  ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:93
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                                             ^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:82
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:71
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8137,26 +8137,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:28
+    ┌─ demos/uniswap.fe:244:32
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                            ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:40
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                        ^^^^^^^^ attributes hash: 16797824492585953824
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8169,26 +8153,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:51
+    ┌─ demos/uniswap.fe:244:44
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                   ^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:39
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                            ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8201,26 +8169,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:28
+    ┌─ demos/uniswap.fe:244:55
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:244:106
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                                          ^ attributes hash: 16797824492585953824
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8233,10 +8185,58 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:244:28
+    ┌─ demos/uniswap.fe:244:43
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:32
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:110
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                                                              ^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:244:32
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8371,26 +8371,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:248:35
+    ┌─ demos/uniswap.fe:248:39
     │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                   ^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:46
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                              ^^^^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                       ^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8403,26 +8387,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:248:35
+    ┌─ demos/uniswap.fe:248:50
     │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                   ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:53
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                     ^^^^^^^^^^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                                  ^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8435,26 +8403,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:248:66
+    ┌─ demos/uniswap.fe:248:39
     │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                                  ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:248:53
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                     ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                       ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8467,26 +8419,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:248:35
+    ┌─ demos/uniswap.fe:248:57
     │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:35
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                   ^^^^^^^^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                                         ^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8499,26 +8435,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:46
+    ┌─ demos/uniswap.fe:248:70
     │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                              ^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:35
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                   ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                                                      ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8531,26 +8451,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:53
+    ┌─ demos/uniswap.fe:248:57
     │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                     ^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:249:66
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                                  ^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                                         ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8563,10 +8467,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:53
+    ┌─ demos/uniswap.fe:248:39
     │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                     ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8579,10 +8483,106 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:249:35
+    ┌─ demos/uniswap.fe:249:39
     │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                       ^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:249:50
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                                  ^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:249:39
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                       ^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:249:57
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                                         ^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:249:70
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                                                      ^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:249:57
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                                         ^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:249:39
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8923,10 +8923,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:258:31
+    ┌─ demos/uniswap.fe:258:35
     │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │                               ^^^^^^^^^^^ attributes hash: 14552118647532869459
+258 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                                   ^^^^^^^^^^^ attributes hash: 14552118647532869459
     │
     = ExpressionAttributes {
           typ: Base(
@@ -8943,10 +8943,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:258:25
+    ┌─ demos/uniswap.fe:258:29
     │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+258 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -9001,10 +9001,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:259:31
+    ┌─ demos/uniswap.fe:259:35
     │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │                               ^^^^^^^^^^^ attributes hash: 6763598575633575517
+259 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                                   ^^^^^^^^^^^ attributes hash: 6763598575633575517
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9021,10 +9021,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:259:25
+    ┌─ demos/uniswap.fe:259:29
     │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+259 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -9503,10 +9503,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:266:31
+    ┌─ demos/uniswap.fe:266:35
     │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │                               ^^^^^^^^^^^ attributes hash: 14552118647532869459
+266 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ attributes hash: 14552118647532869459
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9523,10 +9523,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:266:25
+    ┌─ demos/uniswap.fe:266:29
     │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+266 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -9581,10 +9581,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:267:31
+    ┌─ demos/uniswap.fe:267:35
     │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │                               ^^^^^^^^^^^ attributes hash: 6763598575633575517
+267 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ attributes hash: 6763598575633575517
     │
     = ExpressionAttributes {
           typ: Base(
@@ -9601,10 +9601,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:267:25
+    ┌─ demos/uniswap.fe:267:29
     │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
+267 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^^^^^^^^^^^^^^ attributes hash: 16734680361006464993
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -9971,42 +9971,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:274:23
+    ┌─ demos/uniswap.fe:274:27
     │
-274 │             x: u256 = val / 2 + 1
-    │                       ^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:274:29
-    │
-274 │             x: u256 = val / 2 + 1
-    │                             ^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:274:23
-    │
-274 │             x: u256 = val / 2 + 1
-    │                       ^^^^^^^ attributes hash: 16797824492585953824
+274 │             let x: u256 = val / 2 + 1
+    │                           ^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10021,7 +9989,7 @@ note:
 note: 
     ┌─ demos/uniswap.fe:274:33
     │
-274 │             x: u256 = val / 2 + 1
+274 │             let x: u256 = val / 2 + 1
     │                                 ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
@@ -10035,10 +10003,42 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:274:23
+    ┌─ demos/uniswap.fe:274:27
     │
-274 │             x: u256 = val / 2 + 1
-    │                       ^^^^^^^^^^^ attributes hash: 16797824492585953824
+274 │             let x: u256 = val / 2 + 1
+    │                           ^^^^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:274:37
+    │
+274 │             let x: u256 = val / 2 + 1
+    │                                     ^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:274:27
+    │
+274 │             let x: u256 = val / 2 + 1
+    │                           ^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10597,24 +10597,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:38
+    ┌─ demos/uniswap.fe:315:42
     │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                      ^^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:315:48
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                                ^^^^^^^ attributes hash: 16366719240912622931
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                                          ^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10625,10 +10611,24 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:38
+    ┌─ demos/uniswap.fe:315:52
     │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                      ^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                                                    ^^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:315:42
+    │
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                                          ^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10639,24 +10639,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:27
+    ┌─ demos/uniswap.fe:315:31
     │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                           ^^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:315:61
-    │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                                                             ^^^^^^^ attributes hash: 16366719240912622931
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                               ^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10667,24 +10653,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:315:27
+    ┌─ demos/uniswap.fe:315:65
     │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:316:38
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                      ^^^^^^^ attributes hash: 16366719240912622931
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                                                                 ^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10695,10 +10667,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:316:48
+    ┌─ demos/uniswap.fe:315:31
     │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                                ^^^^^^^ attributes hash: 16366719240912622931
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10709,10 +10681,38 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:316:38
+    ┌─ demos/uniswap.fe:316:42
     │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                      ^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                                          ^^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:316:52
+    │
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                                                    ^^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:316:42
+    │
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                                          ^^^^^^^^^^^^^^^^^ attributes hash: 10866140763116710699
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10723,24 +10723,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:316:27
+    ┌─ demos/uniswap.fe:316:31
     │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                           ^^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:316:61
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                                                             ^^^^^^^ attributes hash: 16366719240912622931
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                               ^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10751,10 +10737,24 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:316:27
+    ┌─ demos/uniswap.fe:316:65
     │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16366719240912622931
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                                                                 ^^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:316:31
+    │
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -10994,24 +10994,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:33
+    ┌─ demos/uniswap.fe:320:37
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                 ^^^^^^ attributes hash: 16366719240912622931
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Address,
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:320:41
-    │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                         ^^^^^^ attributes hash: 16366719240912622931
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                     ^^^^^^ attributes hash: 16366719240912622931
     │
     = ExpressionAttributes {
           typ: Base(
@@ -11022,10 +11008,24 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:32
+    ┌─ demos/uniswap.fe:320:45
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                ^^^^^^^^^^^^^^^^ attributes hash: 9028867466715729072
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                             ^^^^^^ attributes hash: 16366719240912622931
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Address,
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:320:36
+    │
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                    ^^^^^^^^^^^^^^^^ attributes hash: 9028867466715729072
     │
     = ExpressionAttributes {
           typ: Tuple(
@@ -11045,10 +11045,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:32
+    ┌─ demos/uniswap.fe:320:36
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14154226366475970246
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14154226366475970246
     │
     = ExpressionAttributes {
           typ: Array(
@@ -11064,26 +11064,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:22
+    ┌─ demos/uniswap.fe:320:26
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
-    │
-    = ExpressionAttributes {
-          typ: Base(
-              Numeric(
-                  U256,
-              ),
-          ),
-          location: Value,
-          move_location: None,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:321:53
-    │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                     ^ attributes hash: 16797824492585953824
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -11096,10 +11080,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:321:56
+    ┌─ demos/uniswap.fe:321:57
     │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                        ^^^^ attributes hash: 16797824492585953824
+321 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                                                         ^ attributes hash: 16797824492585953824
     │
     = ExpressionAttributes {
           typ: Base(
@@ -11112,10 +11096,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:321:31
+    ┌─ demos/uniswap.fe:321:60
     │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14208569303922594645
+321 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                                                            ^^^^ attributes hash: 16797824492585953824
+    │
+    = ExpressionAttributes {
+          typ: Base(
+              Numeric(
+                  U256,
+              ),
+          ),
+          location: Value,
+          move_location: None,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:321:35
+    │
+321 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14208569303922594645
     │
     = ExpressionAttributes {
           typ: Contract(
@@ -14567,7 +14567,7 @@ note:
     │  
 123 │ ╭     def _update(balance0: u256, balance1: u256, reserve0: u256, reserve1: u256):
 124 │ │         # changed from u32s
-125 │ │         block_timestamp: u256 = block.timestamp % 2**32
+125 │ │         let block_timestamp: u256 = block.timestamp % 2**32
 126 │ │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
     · │
 135 │ │         self.block_timestamp_last = block_timestamp
@@ -14620,9 +14620,9 @@ note:
     ┌─ demos/uniswap.fe:139:5
     │  
 139 │ ╭     def _mint_fee(reserve0: u256, reserve1: u256) -> bool:
-140 │ │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-141 │ │         fee_on: bool = fee_to != address(0)
-142 │ │         k_last: u256 = self.k_last # gas savings
+140 │ │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+141 │ │         let fee_on: bool = fee_to != address(0)
+142 │ │         let k_last: u256 = self.k_last # gas savings
     · │
 155 │ │ 
 156 │ │         return fee_on
@@ -14658,9 +14658,9 @@ note:
     ┌─ demos/uniswap.fe:159:5
     │  
 159 │ ╭     pub def mint(to: address) -> u256:
-160 │ │         MINIMUM_LIQUIDITY: u256 = 1000
-161 │ │         reserve0: u256 = self.reserve0
-162 │ │         reserve1: u256 = self.reserve1
+160 │ │         let MINIMUM_LIQUIDITY: u256 = 1000
+161 │ │         let reserve0: u256 = self.reserve0
+162 │ │         let reserve1: u256 = self.reserve1
     · │
 185 │ │         emit Mint(sender=msg.sender, amount0, amount1)
 186 │ │         return liquidity
@@ -14688,9 +14688,9 @@ note:
     ┌─ demos/uniswap.fe:189:5
     │  
 189 │ ╭     pub def burn(to: address) -> (u256, u256):
-190 │ │         reserve0: u256 = self.reserve0
-191 │ │         reserve1: u256 = self.reserve1
-192 │ │         token0: ERC20 = ERC20(self.token0)
+190 │ │         let reserve0: u256 = self.reserve0
+191 │ │         let reserve1: u256 = self.reserve1
+192 │ │         let token0: ERC20 = ERC20(self.token0)
     · │
 214 │ │         emit Burn(sender=msg.sender, amount0, amount1, to)
 215 │ │         return (amount0, amount1)
@@ -14730,8 +14730,8 @@ note:
     │  
 220 │ ╭     pub def swap(amount0_out: u256, amount1_out: u256, to: address):
 221 │ │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-222 │ │         reserve0: u256 = self.reserve0
-223 │ │         reserve1: u256 = self.reserve1
+222 │ │         let reserve0: u256 = self.reserve0
+223 │ │         let reserve1: u256 = self.reserve1
     · │
 253 │ │         self._update(balance0, balance1, reserve0, reserve1)
 254 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
@@ -14773,8 +14773,8 @@ note:
     ┌─ demos/uniswap.fe:257:5
     │  
 257 │ ╭     pub def skim(to: address):
-258 │ │         token0: ERC20 = ERC20(self.token0) # gas savings
-259 │ │         token1: ERC20 = ERC20(self.token1) # gas savings
+258 │ │         let token0: ERC20 = ERC20(self.token0) # gas savings
+259 │ │         let token1: ERC20 = ERC20(self.token1) # gas savings
 260 │ │ 
 261 │ │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
 262 │ │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
@@ -14800,8 +14800,8 @@ note:
     ┌─ demos/uniswap.fe:265:5
     │  
 265 │ ╭     pub def sync():
-266 │ │         token0: ERC20 = ERC20(self.token0)
-267 │ │         token1: ERC20 = ERC20(self.token1)
+266 │ │         let token0: ERC20 = ERC20(self.token0)
+267 │ │         let token1: ERC20 = ERC20(self.token1)
 268 │ │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
     │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 3209711833240093660
     │  
@@ -14818,7 +14818,7 @@ note:
     ┌─ demos/uniswap.fe:270:5
     │  
 270 │ ╭     def sqrt(val: u256) -> u256:
-271 │ │         z: u256
+271 │ │         let z: u256
 272 │ │         if (val > 3):
 273 │ │             z = val
     · │
@@ -14960,7 +14960,7 @@ note:
 312 │ ╭     pub def create_pair(token_a: address, token_b: address) -> address:
 313 │ │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
 314 │ │ 
-315 │ │         token0: address = token_a if token_a < token_b else token_b
+315 │ │         let token0: address = token_a if token_a < token_b else token_b
     · │
 329 │ │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
 330 │ │         return address(pair)
@@ -15039,8 +15039,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:125:9
     │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15051,8 +15051,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:127:9
     │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+127 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15063,8 +15063,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:140:9
     │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16931239362436195516
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16931239362436195516
     │
     = Base(
           Address,
@@ -15073,8 +15073,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:141:9
     │
-141 │         fee_on: bool = fee_to != address(0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8311861578736502650
+141 │         let fee_on: bool = fee_to != address(0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8311861578736502650
     │
     = Base(
           Bool,
@@ -15083,8 +15083,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:142:9
     │
-142 │         k_last: u256 = self.k_last # gas savings
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+142 │         let k_last: u256 = self.k_last # gas savings
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15095,8 +15095,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:145:17
     │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15107,8 +15107,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:146:17
     │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
-    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+146 │                 let root_k_last: u256 = self.sqrt(k_last)
+    │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15119,8 +15119,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:148:21
     │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15131,8 +15131,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:149:21
     │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
-    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15143,8 +15143,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:150:21
     │
-150 │                     liquidity: u256 = numerator / denominator
-    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+150 │                     let liquidity: u256 = numerator / denominator
+    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15155,8 +15155,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:160:9
     │
-160 │         MINIMUM_LIQUIDITY: u256 = 1000
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+160 │         let MINIMUM_LIQUIDITY: u256 = 1000
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15167,8 +15167,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:161:9
     │
-161 │         reserve0: u256 = self.reserve0
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+161 │         let reserve0: u256 = self.reserve0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15179,8 +15179,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:162:9
     │
-162 │         reserve1: u256 = self.reserve1
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+162 │         let reserve1: u256 = self.reserve1
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15191,8 +15191,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:163:9
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15203,8 +15203,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:164:9
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15215,8 +15215,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:165:9
     │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+165 │         let amount0: u256 = balance0 - self.reserve0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15227,8 +15227,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:166:9
     │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+166 │         let amount1: u256 = balance1 - self.reserve1
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15239,8 +15239,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:168:9
     │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8311861578736502650
+168 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8311861578736502650
     │
     = Base(
           Bool,
@@ -15249,8 +15249,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:169:9
     │
-169 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+169 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15261,8 +15261,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:170:9
     │
-170 │         liquidity: u256 = 0
-    │         ^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+170 │         let liquidity: u256 = 0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15273,8 +15273,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:190:9
     │
-190 │         reserve0: u256 = self.reserve0
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+190 │         let reserve0: u256 = self.reserve0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15285,8 +15285,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:191:9
     │
-191 │         reserve1: u256 = self.reserve1
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+191 │         let reserve1: u256 = self.reserve1
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15297,8 +15297,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:192:9
     │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+192 │         let token0: ERC20 = ERC20(self.token0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15351,8 +15351,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:193:9
     │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+193 │         let token1: ERC20 = ERC20(self.token1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15405,8 +15405,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:194:9
     │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+194 │         let balance0: u256 = token0.balanceOf(self.address)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15417,8 +15417,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:195:9
     │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+195 │         let balance1: u256 = token1.balanceOf(self.address)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15429,8 +15429,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:196:9
     │
-196 │         liquidity: u256 = self.balances[self.address]
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+196 │         let liquidity: u256 = self.balances[self.address]
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15441,8 +15441,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:198:9
     │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8311861578736502650
+198 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8311861578736502650
     │
     = Base(
           Bool,
@@ -15451,8 +15451,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:199:9
     │
-199 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+199 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15463,8 +15463,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:200:9
     │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15475,8 +15475,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:201:9
     │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15487,8 +15487,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:222:9
     │
-222 │         reserve0: u256 = self.reserve0
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+222 │         let reserve0: u256 = self.reserve0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15499,8 +15499,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:223:9
     │
-223 │         reserve1: u256 = self.reserve1
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+223 │         let reserve1: u256 = self.reserve1
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15511,8 +15511,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:226:9
     │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+226 │         let token0: ERC20 = ERC20(self.token0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15565,8 +15565,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:227:9
     │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+227 │         let token1: ERC20 = ERC20(self.token1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15619,8 +15619,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:240:9
     │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+240 │         let balance0: u256 = token0.balanceOf(self.address)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15631,8 +15631,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:241:9
     │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+241 │         let balance1: u256 = token1.balanceOf(self.address)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15643,8 +15643,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:243:9
     │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15655,8 +15655,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:244:9
     │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15667,8 +15667,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:248:9
     │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15679,8 +15679,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:249:9
     │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15691,8 +15691,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:258:9
     │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+258 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15745,8 +15745,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:259:9
     │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+259 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15799,8 +15799,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:266:9
     │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+266 │         let token0: ERC20 = ERC20(self.token0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15853,8 +15853,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:267:9
     │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
+267 │         let token1: ERC20 = ERC20(self.token1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16090334921223932666
     │
     = Contract(
           Contract {
@@ -15907,8 +15907,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:271:9
     │
-271 │         z: u256
-    │         ^^^^^^^ attributes hash: 17942395924573474124
+271 │         let z: u256
+    │         ^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15919,8 +15919,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:274:13
     │
-274 │             x: u256 = val / 2 + 1
-    │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+274 │             let x: u256 = val / 2 + 1
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15931,8 +15931,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:315:9
     │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16931239362436195516
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16931239362436195516
     │
     = Base(
           Address,
@@ -15941,8 +15941,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:316:9
     │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16931239362436195516
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16931239362436195516
     │
     = Base(
           Address,
@@ -15951,8 +15951,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:320:9
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -15963,8 +15963,8 @@ note:
 note: 
     ┌─ demos/uniswap.fe:321:9
     │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13101972698481963745
+321 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13101972698481963745
     │
     = Contract(
           Contract {
@@ -17792,18 +17792,18 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:140:27
+    ┌─ demos/uniswap.fe:140:31
     │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:140:27
+    ┌─ demos/uniswap.fe:140:31
     │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                           ^^^^^^^^^^^^^^^^ attributes hash: 16400890784664137154
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                               ^^^^^^^^^^^^^^^^ attributes hash: 16400890784664137154
     │
     = TypeConstructor {
           typ: Contract(
@@ -17893,10 +17893,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:141:34
+    ┌─ demos/uniswap.fe:141:38
     │
-141 │         fee_on: bool = fee_to != address(0)
-    │                                  ^^^^^^^ attributes hash: 12543456546113081273
+141 │         let fee_on: bool = fee_to != address(0)
+    │                                      ^^^^^^^ attributes hash: 12543456546113081273
     │
     = TypeConstructor {
           typ: Base(
@@ -17905,20 +17905,20 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:145:32
+    ┌─ demos/uniswap.fe:145:36
     │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                ^^^^^^^^^ attributes hash: 10928421685292136472
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                                    ^^^^^^^^^ attributes hash: 10928421685292136472
     │
     = SelfAttribute {
           func_name: "sqrt",
       }
 
 note: 
-    ┌─ demos/uniswap.fe:146:37
+    ┌─ demos/uniswap.fe:146:41
     │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
-    │                                     ^^^^^^^^^ attributes hash: 10928421685292136472
+146 │                 let root_k_last: u256 = self.sqrt(k_last)
+    │                                         ^^^^^^^^^ attributes hash: 10928421685292136472
     │
     = SelfAttribute {
           func_name: "sqrt",
@@ -17935,18 +17935,18 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:163:26
+    ┌─ demos/uniswap.fe:163:30
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:163:26
+    ┌─ demos/uniswap.fe:163:30
     │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                          ^^^^^ attributes hash: 17643750814894473408
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                              ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -17999,18 +17999,18 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:164:26
+    ┌─ demos/uniswap.fe:164:30
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:164:26
+    ┌─ demos/uniswap.fe:164:30
     │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                          ^^^^^ attributes hash: 17643750814894473408
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18063,10 +18063,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:168:24
+    ┌─ demos/uniswap.fe:168:28
     │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                        ^^^^^^^^^^^^^^ attributes hash: 13246624443285848464
+168 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                            ^^^^^^^^^^^^^^ attributes hash: 13246624443285848464
     │
     = SelfAttribute {
           func_name: "_mint_fee",
@@ -18135,66 +18135,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:192:25
+    ┌─ demos/uniswap.fe:192:29
     │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^ attributes hash: 17643750814894473408
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  functions: [
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "balanceOf",
-                          params: [
-                              (
-                                  "account",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      },
-                      FunctionAttributes {
-                          is_public: true,
-                          name: "transfer",
-                          params: [
-                              (
-                                  "recipient",
-                                  Base(
-                                      Address,
-                                  ),
-                              ),
-                              (
-                                  "amount",
-                                  Base(
-                                      Numeric(
-                                          U256,
-                                      ),
-                                  ),
-                              ),
-                          ],
-                          return_type: Base(
-                              Bool,
-                          ),
-                      },
-                  ],
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:193:25
-    │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^ attributes hash: 17643750814894473408
+192 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18247,26 +18191,82 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:194:26
+    ┌─ demos/uniswap.fe:193:29
     │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+193 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^ attributes hash: 17643750814894473408
+    │
+    = TypeConstructor {
+          typ: Contract(
+              Contract {
+                  name: "ERC20",
+                  functions: [
+                      FunctionAttributes {
+                          is_public: true,
+                          name: "balanceOf",
+                          params: [
+                              (
+                                  "account",
+                                  Base(
+                                      Address,
+                                  ),
+                              ),
+                          ],
+                          return_type: Base(
+                              Numeric(
+                                  U256,
+                              ),
+                          ),
+                      },
+                      FunctionAttributes {
+                          is_public: true,
+                          name: "transfer",
+                          params: [
+                              (
+                                  "recipient",
+                                  Base(
+                                      Address,
+                                  ),
+                              ),
+                              (
+                                  "amount",
+                                  Base(
+                                      Numeric(
+                                          U256,
+                                      ),
+                                  ),
+                              ),
+                          ],
+                          return_type: Base(
+                              Bool,
+                          ),
+                      },
+                  ],
+              },
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:194:30
+    │
+194 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:195:26
+    ┌─ demos/uniswap.fe:195:30
     │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+195 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:198:24
+    ┌─ demos/uniswap.fe:198:28
     │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                        ^^^^^^^^^^^^^^ attributes hash: 13246624443285848464
+198 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                            ^^^^^^^^^^^^^^ attributes hash: 13246624443285848464
     │
     = SelfAttribute {
           func_name: "_mint_fee",
@@ -18325,10 +18325,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:226:25
+    ┌─ demos/uniswap.fe:226:29
     │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^ attributes hash: 17643750814894473408
+226 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18381,10 +18381,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:227:25
+    ┌─ demos/uniswap.fe:227:29
     │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^ attributes hash: 17643750814894473408
+227 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18477,18 +18477,18 @@ note:
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:240:26
+    ┌─ demos/uniswap.fe:240:30
     │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+240 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:241:26
+    ┌─ demos/uniswap.fe:241:30
     │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                          ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+241 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
@@ -18503,10 +18503,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:258:25
+    ┌─ demos/uniswap.fe:258:29
     │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │                         ^^^^^ attributes hash: 17643750814894473408
+258 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18559,10 +18559,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:259:25
+    ┌─ demos/uniswap.fe:259:29
     │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │                         ^^^^^ attributes hash: 17643750814894473408
+259 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18647,10 +18647,10 @@ note:
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:266:25
+    ┌─ demos/uniswap.fe:266:29
     │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │                         ^^^^^ attributes hash: 17643750814894473408
+266 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18703,10 +18703,10 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:267:25
+    ┌─ demos/uniswap.fe:267:29
     │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │                         ^^^^^ attributes hash: 17643750814894473408
+267 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^ attributes hash: 17643750814894473408
     │
     = TypeConstructor {
           typ: Contract(
@@ -18809,28 +18809,28 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:22
+    ┌─ demos/uniswap.fe:320:26
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                      ^^^^^^^^^ attributes hash: 13646096770106105413
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                          ^^^^^^^^^ attributes hash: 13646096770106105413
     │
     = BuiltinFunction {
           func: Keccak256,
       }
 
 note: 
-    ┌─ demos/uniswap.fe:320:32
+    ┌─ demos/uniswap.fe:320:36
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 18270091135093349626
     │
     = ValueAttribute
 
 note: 
-    ┌─ demos/uniswap.fe:321:31
+    ┌─ demos/uniswap.fe:321:35
     │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                               ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6121931892408705938
+321 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                                   ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6121931892408705938
     │
     = TypeAttribute {
           typ: Contract(
@@ -20790,77 +20790,9 @@ note:
      )
 
 note: 
-    ┌─ demos/uniswap.fe:125:26
+    ┌─ demos/uniswap.fe:125:30
     │
-125 │         block_timestamp: u256 = block.timestamp % 2**32
-    │                          ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:127:23
-    │
-127 │         time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                       ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:140:17
-    │
-140 │         fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                 ^^^^^^^ attributes hash: 16931239362436195516
-    │
-    = Base(
-          Address,
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:141:17
-    │
-141 │         fee_on: bool = fee_to != address(0)
-    │                 ^^^^ attributes hash: 8311861578736502650
-    │
-    = Base(
-          Bool,
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:142:17
-    │
-142 │         k_last: u256 = self.k_last # gas savings
-    │                 ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:145:25
-    │
-145 │                 root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                         ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:146:30
-    │
-146 │                 root_k_last: u256 = self.sqrt(k_last)
+125 │         let block_timestamp: u256 = block.timestamp % 2**32
     │                              ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
@@ -20870,10 +20802,10 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:148:32
+    ┌─ demos/uniswap.fe:127:27
     │
-148 │                     numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                ^^^^ attributes hash: 17942395924573474124
+127 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                           ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -20882,9 +20814,53 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:149:34
+    ┌─ demos/uniswap.fe:140:21
     │
-149 │                     denominator: u256 = root_k * 5 + root_k_last
+140 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                     ^^^^^^^ attributes hash: 16931239362436195516
+    │
+    = Base(
+          Address,
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:141:21
+    │
+141 │         let fee_on: bool = fee_to != address(0)
+    │                     ^^^^ attributes hash: 8311861578736502650
+    │
+    = Base(
+          Bool,
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:142:21
+    │
+142 │         let k_last: u256 = self.k_last # gas savings
+    │                     ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:145:29
+    │
+145 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+    │                             ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:146:34
+    │
+146 │                 let root_k_last: u256 = self.sqrt(k_last)
     │                                  ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
@@ -20894,9 +20870,45 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:150:32
+    ┌─ demos/uniswap.fe:148:36
     │
-150 │                     liquidity: u256 = numerator / denominator
+148 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                    ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:149:38
+    │
+149 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                      ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:150:36
+    │
+150 │                     let liquidity: u256 = numerator / denominator
+    │                                    ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:160:32
+    │
+160 │         let MINIMUM_LIQUIDITY: u256 = 1000
     │                                ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
@@ -20906,103 +20918,9 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:160:28
+    ┌─ demos/uniswap.fe:161:23
     │
-160 │         MINIMUM_LIQUIDITY: u256 = 1000
-    │                            ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:161:19
-    │
-161 │         reserve0: u256 = self.reserve0
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:162:19
-    │
-162 │         reserve1: u256 = self.reserve1
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:163:19
-    │
-163 │         balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:164:19
-    │
-164 │         balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:165:18
-    │
-165 │         amount0: u256 = balance0 - self.reserve0
-    │                  ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:166:18
-    │
-166 │         amount1: u256 = balance1 - self.reserve1
-    │                  ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:168:17
-    │
-168 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                 ^^^^ attributes hash: 8311861578736502650
-    │
-    = Base(
-          Bool,
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:169:23
-    │
-169 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+161 │         let reserve0: u256 = self.reserve0
     │                       ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
@@ -21012,199 +20930,9 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:170:20
+    ┌─ demos/uniswap.fe:162:23
     │
-170 │         liquidity: u256 = 0
-    │                    ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:190:19
-    │
-190 │         reserve0: u256 = self.reserve0
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:191:19
-    │
-191 │         reserve1: u256 = self.reserve1
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:192:17
-    │
-192 │         token0: ERC20 = ERC20(self.token0)
-    │                 ^^^^^ attributes hash: 3621211662183276994
-    │
-    = Contract(
-          Contract {
-              name: "ERC20",
-              functions: [
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "balanceOf",
-                      params: [
-                          (
-                              "account",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  },
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "transfer",
-                      params: [
-                          (
-                              "recipient",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                          (
-                              "amount",
-                              Base(
-                                  Numeric(
-                                      U256,
-                                  ),
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Bool,
-                      ),
-                  },
-              ],
-          },
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:193:17
-    │
-193 │         token1: ERC20 = ERC20(self.token1)
-    │                 ^^^^^ attributes hash: 3621211662183276994
-    │
-    = Contract(
-          Contract {
-              name: "ERC20",
-              functions: [
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "balanceOf",
-                      params: [
-                          (
-                              "account",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  },
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "transfer",
-                      params: [
-                          (
-                              "recipient",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                          (
-                              "amount",
-                              Base(
-                                  Numeric(
-                                      U256,
-                                  ),
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Bool,
-                      ),
-                  },
-              ],
-          },
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:194:19
-    │
-194 │         balance0: u256 = token0.balanceOf(self.address)
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:195:19
-    │
-195 │         balance1: u256 = token1.balanceOf(self.address)
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:196:20
-    │
-196 │         liquidity: u256 = self.balances[self.address]
-    │                    ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:198:17
-    │
-198 │         fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                 ^^^^ attributes hash: 8311861578736502650
-    │
-    = Base(
-          Bool,
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:199:23
-    │
-199 │         total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+162 │         let reserve1: u256 = self.reserve1
     │                       ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
@@ -21214,22 +20942,10 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:200:18
+    ┌─ demos/uniswap.fe:163:23
     │
-200 │         amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                  ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:201:18
-    │
-201 │         amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                  ^^^^ attributes hash: 17942395924573474124
+163 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                       ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -21238,22 +20954,10 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:222:19
+    ┌─ demos/uniswap.fe:164:23
     │
-222 │         reserve0: u256 = self.reserve0
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:223:19
-    │
-223 │         reserve1: u256 = self.reserve1
-    │                   ^^^^ attributes hash: 17942395924573474124
+164 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                       ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -21262,10 +20966,92 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:226:17
+    ┌─ demos/uniswap.fe:165:22
     │
-226 │         token0: ERC20 = ERC20(self.token0)
-    │                 ^^^^^ attributes hash: 3621211662183276994
+165 │         let amount0: u256 = balance0 - self.reserve0
+    │                      ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:166:22
+    │
+166 │         let amount1: u256 = balance1 - self.reserve1
+    │                      ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:168:21
+    │
+168 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                     ^^^^ attributes hash: 8311861578736502650
+    │
+    = Base(
+          Bool,
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:169:27
+    │
+169 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+    │                           ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:170:24
+    │
+170 │         let liquidity: u256 = 0
+    │                        ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:190:23
+    │
+190 │         let reserve0: u256 = self.reserve0
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:191:23
+    │
+191 │         let reserve1: u256 = self.reserve1
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:192:21
+    │
+192 │         let token0: ERC20 = ERC20(self.token0)
+    │                     ^^^^^ attributes hash: 3621211662183276994
     │
     = Contract(
           Contract {
@@ -21316,136 +21102,10 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:227:17
+    ┌─ demos/uniswap.fe:193:21
     │
-227 │         token1: ERC20 = ERC20(self.token1)
-    │                 ^^^^^ attributes hash: 3621211662183276994
-    │
-    = Contract(
-          Contract {
-              name: "ERC20",
-              functions: [
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "balanceOf",
-                      params: [
-                          (
-                              "account",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  },
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "transfer",
-                      params: [
-                          (
-                              "recipient",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                          (
-                              "amount",
-                              Base(
-                                  Numeric(
-                                      U256,
-                                  ),
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Bool,
-                      ),
-                  },
-              ],
-          },
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:240:19
-    │
-240 │         balance0: u256 = token0.balanceOf(self.address)
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:241:19
-    │
-241 │         balance1: u256 = token1.balanceOf(self.address)
-    │                   ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:243:21
-    │
-243 │         amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                     ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:244:21
-    │
-244 │         amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                     ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:248:28
-    │
-248 │         balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                            ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:249:28
-    │
-249 │         balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                            ^^^^ attributes hash: 17942395924573474124
-    │
-    = Base(
-          Numeric(
-              U256,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:258:17
-    │
-258 │         token0: ERC20 = ERC20(self.token0) # gas savings
-    │                 ^^^^^ attributes hash: 3621211662183276994
+193 │         let token1: ERC20 = ERC20(self.token1)
+    │                     ^^^^^ attributes hash: 3621211662183276994
     │
     = Contract(
           Contract {
@@ -21496,172 +21156,10 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:259:17
+    ┌─ demos/uniswap.fe:194:23
     │
-259 │         token1: ERC20 = ERC20(self.token1) # gas savings
-    │                 ^^^^^ attributes hash: 3621211662183276994
-    │
-    = Contract(
-          Contract {
-              name: "ERC20",
-              functions: [
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "balanceOf",
-                      params: [
-                          (
-                              "account",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  },
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "transfer",
-                      params: [
-                          (
-                              "recipient",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                          (
-                              "amount",
-                              Base(
-                                  Numeric(
-                                      U256,
-                                  ),
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Bool,
-                      ),
-                  },
-              ],
-          },
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:266:17
-    │
-266 │         token0: ERC20 = ERC20(self.token0)
-    │                 ^^^^^ attributes hash: 3621211662183276994
-    │
-    = Contract(
-          Contract {
-              name: "ERC20",
-              functions: [
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "balanceOf",
-                      params: [
-                          (
-                              "account",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  },
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "transfer",
-                      params: [
-                          (
-                              "recipient",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                          (
-                              "amount",
-                              Base(
-                                  Numeric(
-                                      U256,
-                                  ),
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Bool,
-                      ),
-                  },
-              ],
-          },
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:267:17
-    │
-267 │         token1: ERC20 = ERC20(self.token1)
-    │                 ^^^^^ attributes hash: 3621211662183276994
-    │
-    = Contract(
-          Contract {
-              name: "ERC20",
-              functions: [
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "balanceOf",
-                      params: [
-                          (
-                              "account",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  },
-                  FunctionAttributes {
-                      is_public: true,
-                      name: "transfer",
-                      params: [
-                          (
-                              "recipient",
-                              Base(
-                                  Address,
-                              ),
-                          ),
-                          (
-                              "amount",
-                              Base(
-                                  Numeric(
-                                      U256,
-                                  ),
-                              ),
-                          ),
-                      ],
-                      return_type: Base(
-                          Bool,
-                      ),
-                  },
-              ],
-          },
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:271:12
-    │
-271 │         z: u256
-    │            ^^^^ attributes hash: 17942395924573474124
+194 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                       ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -21670,10 +21168,512 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:274:16
+    ┌─ demos/uniswap.fe:195:23
     │
-274 │             x: u256 = val / 2 + 1
+195 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:196:24
+    │
+196 │         let liquidity: u256 = self.balances[self.address]
+    │                        ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:198:21
+    │
+198 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                     ^^^^ attributes hash: 8311861578736502650
+    │
+    = Base(
+          Bool,
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:199:27
+    │
+199 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+    │                           ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:200:22
+    │
+200 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                      ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:201:22
+    │
+201 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                      ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:222:23
+    │
+222 │         let reserve0: u256 = self.reserve0
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:223:23
+    │
+223 │         let reserve1: u256 = self.reserve1
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:226:21
+    │
+226 │         let token0: ERC20 = ERC20(self.token0)
+    │                     ^^^^^ attributes hash: 3621211662183276994
+    │
+    = Contract(
+          Contract {
+              name: "ERC20",
+              functions: [
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "balanceOf",
+                      params: [
+                          (
+                              "account",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  },
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "transfer",
+                      params: [
+                          (
+                              "recipient",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                          (
+                              "amount",
+                              Base(
+                                  Numeric(
+                                      U256,
+                                  ),
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Bool,
+                      ),
+                  },
+              ],
+          },
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:227:21
+    │
+227 │         let token1: ERC20 = ERC20(self.token1)
+    │                     ^^^^^ attributes hash: 3621211662183276994
+    │
+    = Contract(
+          Contract {
+              name: "ERC20",
+              functions: [
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "balanceOf",
+                      params: [
+                          (
+                              "account",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  },
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "transfer",
+                      params: [
+                          (
+                              "recipient",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                          (
+                              "amount",
+                              Base(
+                                  Numeric(
+                                      U256,
+                                  ),
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Bool,
+                      ),
+                  },
+              ],
+          },
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:240:23
+    │
+240 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:241:23
+    │
+241 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                       ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:243:25
+    │
+243 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                         ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:244:25
+    │
+244 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                         ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:248:32
+    │
+248 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:249:32
+    │
+249 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:258:21
+    │
+258 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                     ^^^^^ attributes hash: 3621211662183276994
+    │
+    = Contract(
+          Contract {
+              name: "ERC20",
+              functions: [
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "balanceOf",
+                      params: [
+                          (
+                              "account",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  },
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "transfer",
+                      params: [
+                          (
+                              "recipient",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                          (
+                              "amount",
+                              Base(
+                                  Numeric(
+                                      U256,
+                                  ),
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Bool,
+                      ),
+                  },
+              ],
+          },
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:259:21
+    │
+259 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                     ^^^^^ attributes hash: 3621211662183276994
+    │
+    = Contract(
+          Contract {
+              name: "ERC20",
+              functions: [
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "balanceOf",
+                      params: [
+                          (
+                              "account",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  },
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "transfer",
+                      params: [
+                          (
+                              "recipient",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                          (
+                              "amount",
+                              Base(
+                                  Numeric(
+                                      U256,
+                                  ),
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Bool,
+                      ),
+                  },
+              ],
+          },
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:266:21
+    │
+266 │         let token0: ERC20 = ERC20(self.token0)
+    │                     ^^^^^ attributes hash: 3621211662183276994
+    │
+    = Contract(
+          Contract {
+              name: "ERC20",
+              functions: [
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "balanceOf",
+                      params: [
+                          (
+                              "account",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  },
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "transfer",
+                      params: [
+                          (
+                              "recipient",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                          (
+                              "amount",
+                              Base(
+                                  Numeric(
+                                      U256,
+                                  ),
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Bool,
+                      ),
+                  },
+              ],
+          },
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:267:21
+    │
+267 │         let token1: ERC20 = ERC20(self.token1)
+    │                     ^^^^^ attributes hash: 3621211662183276994
+    │
+    = Contract(
+          Contract {
+              name: "ERC20",
+              functions: [
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "balanceOf",
+                      params: [
+                          (
+                              "account",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  },
+                  FunctionAttributes {
+                      is_public: true,
+                      name: "transfer",
+                      params: [
+                          (
+                              "recipient",
+                              Base(
+                                  Address,
+                              ),
+                          ),
+                          (
+                              "amount",
+                              Base(
+                                  Numeric(
+                                      U256,
+                                  ),
+                              ),
+                          ),
+                      ],
+                      return_type: Base(
+                          Bool,
+                      ),
+                  },
+              ],
+          },
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:271:16
+    │
+271 │         let z: u256
     │                ^^^^ attributes hash: 17942395924573474124
+    │
+    = Base(
+          Numeric(
+              U256,
+          ),
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:274:20
+    │
+274 │             let x: u256 = val / 2 + 1
+    │                    ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -21802,30 +21802,30 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:315:17
+    ┌─ demos/uniswap.fe:315:21
     │
-315 │         token0: address = token_a if token_a < token_b else token_b
-    │                 ^^^^^^^ attributes hash: 16931239362436195516
-    │
-    = Base(
-          Address,
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:316:17
-    │
-316 │         token1: address = token_a if token_a > token_b else token_b
-    │                 ^^^^^^^ attributes hash: 16931239362436195516
+315 │         let token0: address = token_a if token_a < token_b else token_b
+    │                     ^^^^^^^ attributes hash: 16931239362436195516
     │
     = Base(
           Address,
       )
 
 note: 
-    ┌─ demos/uniswap.fe:320:15
+    ┌─ demos/uniswap.fe:316:21
     │
-320 │         salt: u256 = keccak256((token0, token1).abi_encode())
-    │               ^^^^ attributes hash: 17942395924573474124
+316 │         let token1: address = token_a if token_a > token_b else token_b
+    │                     ^^^^^^^ attributes hash: 16931239362436195516
+    │
+    = Base(
+          Address,
+      )
+
+note: 
+    ┌─ demos/uniswap.fe:320:19
+    │
+320 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                   ^^^^ attributes hash: 17942395924573474124
     │
     = Base(
           Numeric(
@@ -21834,10 +21834,10 @@ note:
       )
 
 note: 
-    ┌─ demos/uniswap.fe:321:15
+    ┌─ demos/uniswap.fe:321:19
     │
-321 │         pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │               ^^^^^^^^^^^^^ attributes hash: 8136175709061532011
+321 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                   ^^^^^^^^^^^^^ attributes hash: 8136175709061532011
     │
     = Contract(
           Contract {

--- a/crates/analyzer/tests/snapshots/analysis__while_loop.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop.snap
@@ -26,10 +26,10 @@ ModuleAttributes {
 }
 
 note: 
-  ┌─ features/while_loop.fe:3:21
+  ┌─ features/while_loop.fe:3:25
   │
-3 │         val: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
+3 │         let val: u256 = 0
+  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -249,7 +249,7 @@ note:
   ┌─ features/while_loop.fe:2:5
   │  
 2 │ ╭     pub def bar() -> u256:
-3 │ │         val: u256 = 0
+3 │ │         let val: u256 = 0
 4 │ │         while val < 2:
 5 │ │             val = val + 1
 6 │ │             if val == 2:
@@ -271,8 +271,8 @@ note:
 note: 
   ┌─ features/while_loop.fe:3:9
   │
-3 │         val: u256 = 0
-  │         ^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+3 │         let val: u256 = 0
+  │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -285,7 +285,7 @@ note:
   │  
 1 │ ╭ contract Foo:
 2 │ │     pub def bar() -> u256:
-3 │ │         val: u256 = 0
+3 │ │         let val: u256 = 0
 4 │ │         while val < 2:
   · │
 7 │ │                 val = 3
@@ -324,10 +324,10 @@ note:
     )
 
 note: 
-  ┌─ features/while_loop.fe:3:14
+  ┌─ features/while_loop.fe:3:18
   │
-3 │         val: u256 = 0
-  │              ^^^^ attributes hash: 17942395924573474124
+3 │         let val: u256 = 0
+  │                  ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
@@ -26,10 +26,10 @@ ModuleAttributes {
 }
 
 note: 
-  ┌─ features/while_loop_with_break.fe:3:21
+  ┌─ features/while_loop_with_break.fe:3:25
   │
-3 │         val: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
+3 │         let val: u256 = 0
+  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -171,7 +171,7 @@ note:
   ┌─ features/while_loop_with_break.fe:2:5
   │  
 2 │ ╭     pub def bar() -> u256:
-3 │ │         val: u256 = 0
+3 │ │         let val: u256 = 0
 4 │ │         while val < 2:
 5 │ │             val = val + 1
 6 │ │             break
@@ -192,8 +192,8 @@ note:
 note: 
   ┌─ features/while_loop_with_break.fe:3:9
   │
-3 │         val: u256 = 0
-  │         ^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+3 │         let val: u256 = 0
+  │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -206,7 +206,7 @@ note:
   │  
 1 │ ╭ contract Foo:
 2 │ │     pub def bar() -> u256:
-3 │ │         val: u256 = 0
+3 │ │         let val: u256 = 0
 4 │ │         while val < 2:
 5 │ │             val = val + 1
 6 │ │             break
@@ -245,10 +245,10 @@ note:
     )
 
 note: 
-  ┌─ features/while_loop_with_break.fe:3:14
+  ┌─ features/while_loop_with_break.fe:3:18
   │
-3 │         val: u256 = 0
-  │              ^^^^ attributes hash: 17942395924573474124
+3 │         let val: u256 = 0
+  │                  ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
@@ -26,10 +26,10 @@ ModuleAttributes {
 }
 
 note: 
-  ┌─ features/while_loop_with_break_2.fe:3:21
+  ┌─ features/while_loop_with_break_2.fe:3:25
   │
-3 │         val: u256 = 0
-  │                     ^ attributes hash: 16797824492585953824
+3 │         let val: u256 = 0
+  │                         ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -217,7 +217,7 @@ note:
   ┌─ features/while_loop_with_break_2.fe:2:5
   │  
 2 │ ╭     pub def bar() -> u256:
-3 │ │         val: u256 = 0
+3 │ │         let val: u256 = 0
 4 │ │         while val < 2:
 5 │ │             val = val + 1
 6 │ │             if val == 1:
@@ -239,8 +239,8 @@ note:
 note: 
   ┌─ features/while_loop_with_break_2.fe:3:9
   │
-3 │         val: u256 = 0
-  │         ^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+3 │         let val: u256 = 0
+  │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -253,7 +253,7 @@ note:
   │  
 1 │ ╭ contract Foo:
 2 │ │     pub def bar() -> u256:
-3 │ │         val: u256 = 0
+3 │ │         let val: u256 = 0
 4 │ │         while val < 2:
   · │
 7 │ │                 break
@@ -292,10 +292,10 @@ note:
     )
 
 note: 
-  ┌─ features/while_loop_with_break_2.fe:3:14
+  ┌─ features/while_loop_with_break_2.fe:3:18
   │
-3 │         val: u256 = 0
-  │              ^^^^ attributes hash: 17942395924573474124
+3 │         let val: u256 = 0
+  │                  ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
@@ -26,10 +26,10 @@ ModuleAttributes {
 }
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:3:19
+  ┌─ features/while_loop_with_continue.fe:3:23
   │
-3 │         i: u256 = 0
-  │                   ^ attributes hash: 16797824492585953824
+3 │         let i: u256 = 0
+  │                       ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -42,10 +42,10 @@ note:
     }
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:4:25
+  ┌─ features/while_loop_with_continue.fe:4:29
   │
-4 │         counter: u256 = 0
-  │                         ^ attributes hash: 16797824492585953824
+4 │         let counter: u256 = 0
+  │                             ^ attributes hash: 16797824492585953824
   │
   = ExpressionAttributes {
         typ: Base(
@@ -297,8 +297,8 @@ note:
    ┌─ features/while_loop_with_continue.fe:2:5
    │  
  2 │ ╭     pub def bar() -> u256:
- 3 │ │         i: u256 = 0
- 4 │ │         counter: u256 = 0
+ 3 │ │         let i: u256 = 0
+ 4 │ │         let counter: u256 = 0
  5 │ │ 
    · │
 10 │ │             counter = counter + 1
@@ -319,8 +319,8 @@ note:
 note: 
   ┌─ features/while_loop_with_continue.fe:3:9
   │
-3 │         i: u256 = 0
-  │         ^^^^^^^^^^^ attributes hash: 17942395924573474124
+3 │         let i: u256 = 0
+  │         ^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -331,8 +331,8 @@ note:
 note: 
   ┌─ features/while_loop_with_continue.fe:4:9
   │
-4 │         counter: u256 = 0
-  │         ^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
+4 │         let counter: u256 = 0
+  │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -345,8 +345,8 @@ note:
    │  
  1 │ ╭ contract Foo:
  2 │ │     pub def bar() -> u256:
- 3 │ │         i: u256 = 0
- 4 │ │         counter: u256 = 0
+ 3 │ │         let i: u256 = 0
+ 4 │ │         let counter: u256 = 0
    · │
 10 │ │             counter = counter + 1
 11 │ │         return counter
@@ -384,10 +384,10 @@ note:
     )
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:3:12
+  ┌─ features/while_loop_with_continue.fe:3:16
   │
-3 │         i: u256 = 0
-  │            ^^^^ attributes hash: 17942395924573474124
+3 │         let i: u256 = 0
+  │                ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(
@@ -396,10 +396,10 @@ note:
     )
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:4:18
+  ┌─ features/while_loop_with_continue.fe:4:22
   │
-4 │         counter: u256 = 0
-  │                  ^^^^ attributes hash: 17942395924573474124
+4 │         let counter: u256 = 0
+  │                      ^^^^ attributes hash: 17942395924573474124
   │
   = Base(
         Numeric(

--- a/crates/analyzer/tests/snapshots/errors__array_mixed_types.snap
+++ b/crates/analyzer/tests/snapshots/errors__array_mixed_types.snap
@@ -4,15 +4,15 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: type mismatch
-  ┌─ [snippet]:3:19
+  ┌─ [snippet]:3:23
   │
-3 │   x: u16[3] = [1, address(0), "hi"]
-  │                   ^^^^^^^^^^ this has type `address`; expected type `u16`
+3 │   let x: u16[3] = [1, address(0), "hi"]
+  │                       ^^^^^^^^^^ this has type `address`; expected type `u16`
 
 error: type mismatch
-  ┌─ [snippet]:3:31
+  ┌─ [snippet]:3:35
   │
-3 │   x: u16[3] = [1, address(0), "hi"]
-  │                               ^^^^ this has type `String<2>`; expected type `u16`
+3 │   let x: u16[3] = [1, address(0), "hi"]
+  │                                   ^^^^ this has type `String<2>`; expected type `u16`
 
 

--- a/crates/analyzer/tests/snapshots/errors__array_non_primitive.snap
+++ b/crates/analyzer/tests/snapshots/errors__array_non_primitive.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: arrays can only hold primitive types
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: (u8, u8)[10]
-  │      ^^^^^^^^ can't be stored in an array
+3 │   let x: (u8, u8)[10]
+  │          ^^^^^^^^ can't be stored in an array
 
 

--- a/crates/analyzer/tests/snapshots/errors__array_size_mismatch.snap
+++ b/crates/analyzer/tests/snapshots/errors__array_size_mismatch.snap
@@ -4,15 +4,15 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: type mismatch
-  ┌─ [snippet]:3:14
+  ┌─ [snippet]:3:18
   │
-3 │   x: u8[3] = []
-  │              ^^ this has type `u8[0]`; expected type `u8[3]`
+3 │   let x: u8[3] = []
+  │                  ^^ this has type `u8[0]`; expected type `u8[3]`
 
 error: type mismatch
-  ┌─ [snippet]:4:14
+  ┌─ [snippet]:4:18
   │
-4 │   y: u8[3] = [1, 2]
-  │              ^^^^^^ this has type `u8[2]`; expected type `u8[3]`
+4 │   let y: u8[3] = [1, 2]
+  │                  ^^^^^^ this has type `u8[2]`; expected type `u8[3]`
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_map.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_map.snap
@@ -4,17 +4,17 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `Map` expects 2 arguments, but 3 were provided
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: Map<u8, u8, u8>
-  │      ^^^ --  --  -- supplied 3 arguments
-  │      │            
-  │      expects 2 arguments
+3 │   let x: Map<u8, u8, u8>
+  │          ^^^ --  --  -- supplied 3 arguments
+  │          │            
+  │          expects 2 arguments
 
 error: Expected a value with a fixed size
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: Map<u8, u8, u8>
-  │      ^^^^^^^^^^^^^^^
+3 │   let x: Map<u8, u8, u8>
+  │          ^^^^^^^^^^^^^^^
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_map2.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_map2.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `map` key and value must be types
-  ┌─ [snippet]:3:19
+  ┌─ [snippet]:3:23
   │
-3 │   x: Map<address, 100>
-  │                   ^^^ this should be a type name
+3 │   let x: Map<address, 100>
+  │                       ^^^ this should be a type name
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_map3.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_map3.snap
@@ -4,11 +4,11 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `Map` expects 2 arguments, but 0 were provided
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: Map<>
-  │      ^^^-- supplied 0 arguments
-  │      │   
-  │      expects 2 arguments
+3 │   let x: Map<>
+  │          ^^^-- supplied 0 arguments
+  │          │   
+  │          expects 2 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_map4.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_map4.snap
@@ -4,11 +4,11 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `Map` expects 2 arguments, but 1 was provided
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: Map<y>
-  │      ^^^ - supplied 1 argument
-  │      │    
-  │      expects 2 arguments
+3 │   let x: Map<y>
+  │          ^^^ - supplied 1 argument
+  │          │    
+  │          expects 2 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_map5.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_map5.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `map` key must be a primitive type
-  ┌─ [snippet]:3:10
+  ┌─ [snippet]:3:14
   │
-3 │   x: Map<Map<u8, u8>, address>
-  │          ^^^^^^^^^^^ this can't be used as a map key
+3 │   let x: Map<Map<u8, u8>, address>
+  │              ^^^^^^^^^^^ this can't be used as a map key
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_map6.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_map6.snap
@@ -4,15 +4,15 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `map` key and value must be types
-  ┌─ [snippet]:3:10
-  │
-3 │   x: Map<10, 20>
-  │          ^^ this should be a type name
-
-error: `map` key and value must be types
   ┌─ [snippet]:3:14
   │
-3 │   x: Map<10, 20>
+3 │   let x: Map<10, 20>
   │              ^^ this should be a type name
+
+error: `map` key and value must be types
+  ┌─ [snippet]:3:18
+  │
+3 │   let x: Map<10, 20>
+  │                  ^^ this should be a type name
 
 

--- a/crates/analyzer/tests/snapshots/errors__cannot_move2.snap
+++ b/crates/analyzer/tests/snapshots/errors__cannot_move2.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: can't move value onto stack
-  ┌─ compile_errors/cannot_move2.fe:6:18
+  ┌─ compile_errors/cannot_move2.fe:6:22
   │
-6 │     c:u256[20] = x + y
-  │                  ^ Value to be moved
+6 │     let c:u256[20] = x + y
+  │                      ^ Value to be moved
   │
   = Note: Can't move `u256[10]` types on the stack
 

--- a/crates/analyzer/tests/snapshots/errors__circular_dependency_create.snap
+++ b/crates/analyzer/tests/snapshots/errors__circular_dependency_create.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `Foo.create(...)` called within `Foo` creates an illegal circular dependency
-  ┌─ compile_errors/circular_dependency_create.fe:3:20
+  ┌─ compile_errors/circular_dependency_create.fe:3:24
   │
-3 │         foo: Foo = Foo.create(0)
-  │                    ^^^^^^^^^^ Contract creation
+3 │         let foo: Foo = Foo.create(0)
+  │                        ^^^^^^^^^^ Contract creation
   │
   = Note: Consider using a dedicated factory contract to create instances of `Foo`
 

--- a/crates/analyzer/tests/snapshots/errors__circular_dependency_create2.snap
+++ b/crates/analyzer/tests/snapshots/errors__circular_dependency_create2.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `Foo.create2(...)` called within `Foo` creates an illegal circular dependency
-  ┌─ compile_errors/circular_dependency_create2.fe:3:20
+  ┌─ compile_errors/circular_dependency_create2.fe:3:24
   │
-3 │         foo: Foo = Foo.create2(2, 0)
-  │                    ^^^^^^^^^^^ Contract creation
+3 │         let foo: Foo = Foo.create2(2, 0)
+  │                        ^^^^^^^^^^^ Contract creation
   │
   = Note: Consider using a dedicated factory contract to create instances of `Foo`
 

--- a/crates/analyzer/tests/snapshots/errors__clone_arg_count.snap
+++ b/crates/analyzer/tests/snapshots/errors__clone_arg_count.snap
@@ -4,11 +4,11 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `clone` expects 0 arguments, but 1 was provided
-  ┌─ [snippet]:4:18
+  ┌─ [snippet]:4:22
   │
-4 │   y: u256[2] = x.clone(y)
-  │                  ^^^^^ - supplied 1 argument
-  │                  │      
-  │                  expects 0 arguments
+4 │   let y: u256[2] = x.clone(y)
+  │                      ^^^^^ - supplied 1 argument
+  │                      │      
+  │                      expects 0 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_var_in_child_scope.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_var_in_child_scope.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: a variable with the same name already exists in this scope
-  ┌─ compile_errors/duplicate_var_in_child_scope.fe:6:13
+  ┌─ compile_errors/duplicate_var_in_child_scope.fe:6:17
   │
-6 │             sum: u256 = 0
-  │             ^^^ Conflicting definition of `sum` variables
+6 │             let sum: u256 = 0
+  │                 ^^^ Conflicting definition of `sum` variables
   │
   = Note: Give one of the `sum` variables a different name
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_var_in_contract_method.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_var_in_contract_method.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: a variable with the same name already exists in this scope
-  ┌─ compile_errors/duplicate_var_in_contract_method.fe:4:9
+  ┌─ compile_errors/duplicate_var_in_contract_method.fe:4:13
   │
-4 │         foo: u8
-  │         ^^^ Conflicting definition of `foo` variables
+4 │         let foo: u8
+  │             ^^^ Conflicting definition of `foo` variables
   │
   = Note: Give one of the `foo` variables a different name
 

--- a/crates/analyzer/tests/snapshots/errors__overflow_i8_neg.snap
+++ b/crates/analyzer/tests/snapshots/errors__overflow_i8_neg.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: literal out of range for `i8`
-  ┌─ [snippet]:3:11
+  ┌─ [snippet]:3:15
   │
-3 │   x: i8 = -129
-  │           ^^^^ does not fit into type `i8`
+3 │   let x: i8 = -129
+  │               ^^^^ does not fit into type `i8`
 
 

--- a/crates/analyzer/tests/snapshots/errors__overflow_i8_pos.snap
+++ b/crates/analyzer/tests/snapshots/errors__overflow_i8_pos.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: literal out of range for `i8`
-  ┌─ [snippet]:3:11
+  ┌─ [snippet]:3:15
   │
-3 │   x: i8 = 128
-  │           ^^^ does not fit into type `i8`
+3 │   let x: i8 = 128
+  │               ^^^ does not fit into type `i8`
 
 

--- a/crates/analyzer/tests/snapshots/errors__overflow_u128_neg.snap
+++ b/crates/analyzer/tests/snapshots/errors__overflow_u128_neg.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: literal out of range for `u128`
-  ┌─ [snippet]:3:13
+  ┌─ [snippet]:3:17
   │
-3 │   x: u128 = -1
-  │             ^^ does not fit into type `u128`
+3 │   let x: u128 = -1
+  │                 ^^ does not fit into type `u128`
 
 

--- a/crates/analyzer/tests/snapshots/errors__overflow_u8_assignment.snap
+++ b/crates/analyzer/tests/snapshots/errors__overflow_u8_assignment.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: literal out of range for `u8`
-  ┌─ [snippet]:3:11
+  ┌─ [snippet]:3:15
   │
-3 │   x: u8 = 260
-  │           ^^^ does not fit into type `u8`
+3 │   let x: u8 = 260
+  │               ^^^ does not fit into type `u8`
 
 

--- a/crates/analyzer/tests/snapshots/errors__pow_with_signed_exponent.snap
+++ b/crates/analyzer/tests/snapshots/errors__pow_with_signed_exponent.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The right hand side of this operation must be unsigned
+error: cannot find value `exp` in this scope
   ┌─ [snippet]:5:11
   │
 5 │   base ** exp
-  │           ^^^ incompatible signed numeric
+  │           ^^^ undefined
 
 

--- a/crates/analyzer/tests/snapshots/errors__struct_call_bad_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_call_bad_args.snap
@@ -4,26 +4,26 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `House` expects 2 arguments, but 3 were provided
-  ┌─ compile_errors/struct_call_bad_args.fe:8:27
+  ┌─ compile_errors/struct_call_bad_args.fe:8:31
   │
-8 │         my_house: House = House(price=false, vacant=100, bar=address(0))
-  │                           ^^^^^ -----------  ----------  -------------- supplied 3 arguments
-  │                           │                               
-  │                           expects 2 arguments
+8 │         let my_house: House = House(price=false, vacant=100, bar=address(0))
+  │                               ^^^^^ -----------  ----------  -------------- supplied 3 arguments
+  │                               │                               
+  │                               expects 2 arguments
 
 error: argument label mismatch
-  ┌─ compile_errors/struct_call_bad_args.fe:8:33
+  ┌─ compile_errors/struct_call_bad_args.fe:8:37
   │
-8 │         my_house: House = House(price=false, vacant=100, bar=address(0))
-  │                                 ^^^^^ expected `vacant`
+8 │         let my_house: House = House(price=false, vacant=100, bar=address(0))
+  │                                     ^^^^^ expected `vacant`
   │
   = Note: arguments must be provided in order.
 
 error: argument label mismatch
-  ┌─ compile_errors/struct_call_bad_args.fe:8:46
+  ┌─ compile_errors/struct_call_bad_args.fe:8:50
   │
-8 │         my_house: House = House(price=false, vacant=100, bar=address(0))
-  │                                              ^^^^^^ expected `price`
+8 │         let my_house: House = House(price=false, vacant=100, bar=address(0))
+  │                                                  ^^^^^^ expected `price`
   │
   = Note: arguments must be provided in order.
 

--- a/crates/analyzer/tests/snapshots/errors__struct_call_without_kw_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_call_without_kw_args.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: missing argument label
-  ┌─ compile_errors/struct_call_without_kw_args.fe:8:33
+  ┌─ compile_errors/struct_call_without_kw_args.fe:8:37
   │
-8 │         my_house: House = House(true, price=1000000)
-  │                                 ^ add `vacant=` here
+8 │         let my_house: House = House(true, price=1000000)
+  │                                     ^ add `vacant=` here
   │
   = Note: this label is optional if the argument is a variable named `vacant`.
 

--- a/crates/analyzer/tests/snapshots/errors__type_constructor_arg_count.snap
+++ b/crates/analyzer/tests/snapshots/errors__type_constructor_arg_count.snap
@@ -4,11 +4,11 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `u8` expects 1 argument, but 2 were provided
-  ┌─ [snippet]:3:11
+  ┌─ [snippet]:3:15
   │
-3 │   x: u8 = u8(1, 10)
-  │           ^^ -  -- supplied 2 arguments
-  │           │      
-  │           expects 1 argument
+3 │   let x: u8 = u8(1, 10)
+  │               ^^ -  -- supplied 2 arguments
+  │               │      
+  │               expects 1 argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__type_constructor_from_variable.snap
+++ b/crates/analyzer/tests/snapshots/errors__type_constructor_from_variable.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: type mismatch
-  ┌─ [snippet]:4:16
+  ┌─ [snippet]:4:20
   │
-4 │   y: u16 = u16(x)
-  │                ^ expected a number literal
+4 │   let y: u16 = u16(x)
+  │                    ^ expected a number literal
 
 

--- a/crates/analyzer/tests/snapshots/errors__undefined_generic_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_generic_type.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: undefined generic type
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: foobar<u256> = 10
-  │      ^^^^^^ this type name has not been defined
+3 │   let x: foobar<u256> = 10
+  │          ^^^^^^ this type name has not been defined
 
 

--- a/crates/analyzer/tests/snapshots/errors__undefined_name.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_name.snap
@@ -4,15 +4,15 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: cannot find value `y` in this scope
-  ┌─ [snippet]:3:12
+  ┌─ [snippet]:3:16
   │
-3 │   x: u16 = y
-  │            ^ undefined
+3 │   let x: u16 = y
+  │                ^ undefined
 
 error: cannot find value `y` in this scope
-  ┌─ [snippet]:4:12
+  ┌─ [snippet]:4:16
   │
-4 │   z: u16 = y
-  │            ^ undefined
+4 │   let z: u16 = y
+  │                ^ undefined
 
 

--- a/crates/analyzer/tests/snapshots/errors__undefined_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_type.snap
@@ -4,9 +4,9 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: undefined type
-  ┌─ [snippet]:3:6
+  ┌─ [snippet]:3:10
   │
-3 │   x: foobar = 10
-  │      ^^^^^^ this type name has not been defined
+3 │   let x: foobar = 10
+  │          ^^^^^^ this type name has not been defined
 
 

--- a/crates/parser/src/lexer/token.rs
+++ b/crates/parser/src/lexer/token.rs
@@ -199,6 +199,8 @@ pub enum TokenKind {
     GtGtEq,
     #[token("->")]
     Arrow,
+    #[token("let")]
+    Let,
 }
 
 impl TokenKind {
@@ -234,6 +236,7 @@ impl TokenKind {
             Contract => "contract",
             Def => "def",
             Const => "const",
+            Let => "let",
             Elif => "elif",
             Else => "else",
             Emit => "emit",

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -90,6 +90,15 @@ test_parse_err! { stmt_vardecl_attr, functions::parse_stmt, true, "f.s : u" }
 test_parse_err! { stmt_vardecl_tuple, functions::parse_stmt, true, "(a, x+1) : u256" }
 test_parse_err! { stmt_vardecl_tuple_empty, functions::parse_stmt, true, "(a, ()) : u256" }
 test_parse_err! { stmt_vardecl_subscript, functions::parse_stmt, true, "a[1] : u256" }
+test_parse_err! { stmt_vardecl_missing_type_annotation, functions::parse_stmt, true, "let x = 1" }
+test_parse_err! { stmt_vardecl_missing_type_annotation_2, functions::parse_stmt, true, "let x" }
+test_parse_err! { stmt_vardecl_missing_type_annotation_3, functions::parse_stmt, true, "let x:" }
+test_parse_err! { stmt_vardecl_invalid_type_annotation, functions::parse_stmt, true, "let x: y + z" }
+test_parse_err! { stmt_vardecl_invalid_name, functions::parse_stmt, true, "let x + y: u8" }
+
+
+
+
 
 // assert_snapshot! doesn't like the invalid escape code
 #[test]

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -113,9 +113,9 @@ test_parse! { stmt_if, functions::parse_stmt, "if a:\n b" }
 test_parse! { stmt_if2, functions::parse_stmt, "if a:\n b \nelif c:\n d \nelif e: \n f \nelse:\n g" }
 test_parse! { stmt_while, functions::parse_stmt, "while a > 5:\n a -= 1" }
 test_parse! { stmt_for, functions::parse_stmt, "for a in b[0]:\n pass" }
-test_parse! { stmt_var_decl_name, functions::parse_stmt, "foo: u256" }
-test_parse! { stmt_var_decl_tuple, functions::parse_stmt, "(foo, bar): (u256, u256) = (10, 10)" }
-test_parse! { stmt_var_decl_tuples, functions::parse_stmt, "(a, (b, (c, d))): x" }
+test_parse! { stmt_var_decl_name, functions::parse_stmt, "let foo: u256 = 1" }
+test_parse! { stmt_var_decl_tuple, functions::parse_stmt, "let (foo, bar): (u256, u256) = (10, 10)" }
+test_parse! { stmt_var_decl_tuples, functions::parse_stmt, "let (a, (b, (c, d))): x" }
 
 test_parse! { type_def, types::parse_type_alias, "type X = Map<address, u256>" }
 test_parse! { type_name, types::parse_type_desc, "MyType" }

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_attr.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_attr.snap
@@ -1,15 +1,14 @@
 ---
-source: parser/tests/cases/errors.rs
+source: crates/parser/tests/cases/errors.rs
 expression: "err_string(stringify!(stmt_vardecl_attr), functions::parse_stmt, true,\n           \"f.s : u\")"
 
 ---
-error: failed to parse variable declaration
+error: Variable declaration must begin with `let`
   ┌─ stmt_vardecl_attr:1:1
   │
 1 │ f.s : u
-  │ ^^^ invalid variable declaration target
+  │ ^^^ invalid variable declaration
   │
-  = The left side of a variable declaration can be either a name
-    or a non-empty tuple.
+  = Example: `let x: u8 = 1`
 
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_invalid_name.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_invalid_name.snap
@@ -1,0 +1,15 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_invalid_name), functions::parse_stmt, true,\n           \"let x + y: u8\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_invalid_name:1:5
+  │
+1 │ let x + y: u8
+  │     ^^^^^ invalid variable declaration target
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_invalid_type_annotation.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_invalid_type_annotation.snap
@@ -1,0 +1,14 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_invalid_type_annotation),\n           functions::parse_stmt, true, \"let x: y + z\")"
+
+---
+error: unexpected token while parsing variable declaration
+  ┌─ stmt_vardecl_invalid_type_annotation:1:10
+  │
+1 │ let x: y + z
+  │          ^ unexpected token
+  │
+  = expected a newline
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_missing_type_annotation.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_missing_type_annotation.snap
@@ -1,0 +1,15 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_missing_type_annotation),\n           functions::parse_stmt, true, \"let x = 1\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_missing_type_annotation:1:5
+  │
+1 │ let x = 1
+  │     ^ Must be followed by type annotation
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_missing_type_annotation_2.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_missing_type_annotation_2.snap
@@ -1,0 +1,15 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_missing_type_annotation_2),\n           functions::parse_stmt, true, \"let x\")"
+
+---
+error: failed to parse variable declaration
+  ┌─ stmt_vardecl_missing_type_annotation_2:1:5
+  │
+1 │ let x
+  │     ^ Must be followed by type annotation
+  │
+  = The left side of a variable declaration can be either a name
+    or a non-empty tuple.
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_missing_type_annotation_3.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_missing_type_annotation_3.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_vardecl_missing_type_annotation_3),\n           functions::parse_stmt, true, \"let x:\")"
+
+---
+error: unexpected end of file
+  ┌─ stmt_vardecl_missing_type_annotation_3:1:7
+  │
+1 │ let x:
+  │       ^
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_subscript.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_subscript.snap
@@ -1,15 +1,14 @@
 ---
-source: parser/tests/cases/errors.rs
+source: crates/parser/tests/cases/errors.rs
 expression: "err_string(stringify!(stmt_vardecl_subscript), functions::parse_stmt, true,\n           \"a[1] : u256\")"
 
 ---
-error: failed to parse variable declaration
+error: Variable declaration must begin with `let`
   ┌─ stmt_vardecl_subscript:1:1
   │
 1 │ a[1] : u256
-  │ ^^^^ invalid variable declaration target
+  │ ^^^^ invalid variable declaration
   │
-  = The left side of a variable declaration can be either a name
-    or a non-empty tuple.
+  = Example: `let x: u8 = 1`
 
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple.snap
@@ -1,15 +1,14 @@
 ---
-source: parser/tests/cases/errors.rs
+source: crates/parser/tests/cases/errors.rs
 expression: "err_string(stringify!(stmt_vardecl_tuple), functions::parse_stmt, true,\n           \"(a, x+1) : u256\")"
 
 ---
-error: failed to parse variable declaration
-  ┌─ stmt_vardecl_tuple:1:5
+error: Variable declaration must begin with `let`
+  ┌─ stmt_vardecl_tuple:1:1
   │
 1 │ (a, x+1) : u256
-  │     ^^^ invalid variable declaration target
+  │ ^^^^^^^^ invalid variable declaration
   │
-  = The left side of a variable declaration can be either a name
-    or a non-empty tuple.
+  = Example: `let x: u8 = 1`
 
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple_empty.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_vardecl_tuple_empty.snap
@@ -1,15 +1,14 @@
 ---
-source: parser/tests/cases/errors.rs
+source: crates/parser/tests/cases/errors.rs
 expression: "err_string(stringify!(stmt_vardecl_tuple_empty), functions::parse_stmt, true,\n           \"(a, ()) : u256\")"
 
 ---
-error: failed to parse variable declaration
-  ┌─ stmt_vardecl_tuple_empty:1:5
+error: Variable declaration must begin with `let`
+  ┌─ stmt_vardecl_tuple_empty:1:1
   │
 1 │ (a, ()) : u256
-  │     ^^ invalid variable declaration target
+  │ ^^^^^^^ invalid variable declaration
   │
-  = The left side of a variable declaration can be either a name
-    or a non-empty tuple.
+  = Example: `let x: u8 = 1`
 
 

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_name.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_name.snap
@@ -1,6 +1,6 @@
 ---
-source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(stmt_var_decl_name), functions::parse_stmt, \"foo: u256\")"
+source: crates/parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_var_decl_name), functions::parse_stmt,\n           \"let foo: u256 = 1\")"
 
 ---
 Node(
@@ -8,8 +8,8 @@ Node(
     target: Node(
       kind: Name("foo"),
       span: Span(
-        start: 0,
-        end: 3,
+        start: 4,
+        end: 7,
       ),
     ),
     typ: Node(
@@ -17,14 +17,20 @@ Node(
         base: "u256",
       ),
       span: Span(
-        start: 5,
-        end: 9,
+        start: 9,
+        end: 13,
       ),
     ),
-    value: None,
+    value: Some(Node(
+      kind: Num("1"),
+      span: Span(
+        start: 16,
+        end: 17,
+      ),
+    )),
   ),
   span: Span(
     start: 0,
-    end: 9,
+    end: 17,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuple.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuple.snap
@@ -1,6 +1,6 @@
 ---
-source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(stmt_var_decl_tuple), functions::parse_stmt,\n           \"(foo, bar): (u256, u256) = (10, 10)\")"
+source: crates/parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_var_decl_tuple), functions::parse_stmt,\n           \"let (foo, bar): (u256, u256) = (10, 10)\")"
 
 ---
 Node(
@@ -10,21 +10,21 @@ Node(
         Node(
           kind: Name("foo"),
           span: Span(
-            start: 1,
-            end: 4,
+            start: 5,
+            end: 8,
           ),
         ),
         Node(
           kind: Name("bar"),
           span: Span(
-            start: 6,
-            end: 9,
+            start: 10,
+            end: 13,
           ),
         ),
       ]),
       span: Span(
-        start: 0,
-        end: 10,
+        start: 4,
+        end: 14,
       ),
     ),
     typ: Node(
@@ -35,8 +35,8 @@ Node(
               base: "u256",
             ),
             span: Span(
-              start: 13,
-              end: 17,
+              start: 17,
+              end: 21,
             ),
           ),
           Node(
@@ -44,15 +44,15 @@ Node(
               base: "u256",
             ),
             span: Span(
-              start: 19,
-              end: 23,
+              start: 23,
+              end: 27,
             ),
           ),
         ],
       ),
       span: Span(
-        start: 12,
-        end: 24,
+        start: 16,
+        end: 28,
       ),
     ),
     value: Some(Node(
@@ -61,27 +61,27 @@ Node(
           Node(
             kind: Num("10"),
             span: Span(
-              start: 28,
-              end: 30,
+              start: 32,
+              end: 34,
             ),
           ),
           Node(
             kind: Num("10"),
             span: Span(
-              start: 32,
-              end: 34,
+              start: 36,
+              end: 38,
             ),
           ),
         ],
       ),
       span: Span(
-        start: 27,
-        end: 35,
+        start: 31,
+        end: 39,
       ),
     )),
   ),
   span: Span(
     start: 0,
-    end: 35,
+    end: 39,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuples.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_var_decl_tuples.snap
@@ -1,6 +1,6 @@
 ---
-source: parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(stmt_var_decl_tuples), functions::parse_stmt,\n           \"(a, (b, (c, d))): x\")"
+source: crates/parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_var_decl_tuples), functions::parse_stmt,\n           \"let (a, (b, (c, d))): x\")"
 
 ---
 Node(
@@ -10,8 +10,8 @@ Node(
         Node(
           kind: Name("a"),
           span: Span(
-            start: 1,
-            end: 2,
+            start: 5,
+            end: 6,
           ),
         ),
         Node(
@@ -19,8 +19,8 @@ Node(
             Node(
               kind: Name("b"),
               span: Span(
-                start: 5,
-                end: 6,
+                start: 9,
+                end: 10,
               ),
             ),
             Node(
@@ -28,33 +28,33 @@ Node(
                 Node(
                   kind: Name("c"),
                   span: Span(
-                    start: 9,
-                    end: 10,
+                    start: 13,
+                    end: 14,
                   ),
                 ),
                 Node(
                   kind: Name("d"),
                   span: Span(
-                    start: 12,
-                    end: 13,
+                    start: 16,
+                    end: 17,
                   ),
                 ),
               ]),
               span: Span(
-                start: 8,
-                end: 14,
+                start: 12,
+                end: 18,
               ),
             ),
           ]),
           span: Span(
-            start: 4,
-            end: 15,
+            start: 8,
+            end: 19,
           ),
         ),
       ]),
       span: Span(
-        start: 0,
-        end: 16,
+        start: 4,
+        end: 20,
       ),
     ),
     typ: Node(
@@ -62,14 +62,14 @@ Node(
         base: "x",
       ),
       span: Span(
-        start: 18,
-        end: 19,
+        start: 22,
+        end: 23,
       ),
     ),
     value: None,
   ),
   span: Span(
     start: 0,
-    end: 19,
+    end: 23,
   ),
 )

--- a/crates/test-files/fixtures/compile_errors/call_undefined_function_on_memory_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/call_undefined_function_on_memory_struct.fe
@@ -3,5 +3,5 @@ struct Something:
 
 contract Bar:
   pub def test():
-    thingy: Something = Something(val=u8(1))
+    let thingy: Something = Something(val=u8(1))
     thingy.doesnt_exist()

--- a/crates/test-files/fixtures/compile_errors/cannot_move2.fe
+++ b/crates/test-files/fixtures/compile_errors/cannot_move2.fe
@@ -1,6 +1,6 @@
 contract Foo:
 
   pub def foo():
-    x:u256[10]
-    y:u256[10]
-    c:u256[20] = x + y
+    let x:u256[10]
+    let y:u256[10]
+    let c:u256[20] = x + y

--- a/crates/test-files/fixtures/compile_errors/circular_dependency_create.fe
+++ b/crates/test-files/fixtures/compile_errors/circular_dependency_create.fe
@@ -1,5 +1,5 @@
 contract Foo:
     pub def bar() -> address:
-        foo: Foo = Foo.create(0)
+        let foo: Foo = Foo.create(0)
 
         return address(foo)

--- a/crates/test-files/fixtures/compile_errors/circular_dependency_create2.fe
+++ b/crates/test-files/fixtures/compile_errors/circular_dependency_create2.fe
@@ -1,5 +1,5 @@
 contract Foo:
     pub def bar() -> address:
-        foo: Foo = Foo.create2(2, 0)
+        let foo: Foo = Foo.create2(2, 0)
 
         return address(foo)

--- a/crates/test-files/fixtures/compile_errors/duplicate_var_in_child_scope.fe
+++ b/crates/test-files/fixtures/compile_errors/duplicate_var_in_child_scope.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub def bar():
-        my_array: u256[3]
-        sum: u256 = 0
+        let my_array: u256[3]
+        let sum: u256 = 0
         for i in my_array:
-            sum: u256 = 0
+            let sum: u256 = 0

--- a/crates/test-files/fixtures/compile_errors/duplicate_var_in_contract_method.fe
+++ b/crates/test-files/fixtures/compile_errors/duplicate_var_in_contract_method.fe
@@ -1,4 +1,4 @@
 contract Foo:
     pub def bar():
-        foo: u8
-        foo: u8
+        let foo: u8
+        let foo: u8

--- a/crates/test-files/fixtures/compile_errors/not_in_scope.fe
+++ b/crates/test-files/fixtures/compile_errors/not_in_scope.fe
@@ -2,7 +2,7 @@ contract Foo:
 
     pub def bar() -> u256:
         if true:
-            y: u256 = 1
+            let y: u256 = 1
         else:
-            y: u256 = 1
+            let y: u256 = 1
         return y

--- a/crates/test-files/fixtures/compile_errors/not_in_scope_2.fe
+++ b/crates/test-files/fixtures/compile_errors/not_in_scope_2.fe
@@ -1,8 +1,8 @@
 contract Foo:
 
     pub def bar() -> u256:
-        i: u256 = 0
+        let i: u256 = 0
         while i < 1:
             i = 1
-            y: u256 = 1
+            let y: u256 = 1
         return y

--- a/crates/test-files/fixtures/compile_errors/struct_call_bad_args.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_call_bad_args.fe
@@ -5,4 +5,4 @@ struct House:
 contract Foo:
 
     pub def bar():
-        my_house: House = House(price=false, vacant=100, bar=address(0))
+        let my_house: House = House(price=false, vacant=100, bar=address(0))

--- a/crates/test-files/fixtures/compile_errors/struct_call_without_kw_args.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_call_without_kw_args.fe
@@ -5,4 +5,4 @@ struct House:
 contract Foo:
 
     pub def bar():
-        my_house: House = House(true, price=1000000)
+        let my_house: House = House(true, price=1000000)

--- a/crates/test-files/fixtures/demos/uniswap.fe
+++ b/crates/test-files/fixtures/demos/uniswap.fe
@@ -122,9 +122,9 @@ contract UniswapV2Pair:
     # update reserves and, on the first call per block, price accumulators
     def _update(balance0: u256, balance1: u256, reserve0: u256, reserve1: u256):
         # changed from u32s
-        block_timestamp: u256 = block.timestamp % 2**32
+        let block_timestamp: u256 = block.timestamp % 2**32
         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
-        time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+        let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
             # `*` never overflows, and + overflow is desired
             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
@@ -137,17 +137,17 @@ contract UniswapV2Pair:
 
     # if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
     def _mint_fee(reserve0: u256, reserve1: u256) -> bool:
-        fee_to: address = UniswapV2Factory(self.factory).fee_to()
-        fee_on: bool = fee_to != address(0)
-        k_last: u256 = self.k_last # gas savings
+        let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+        let fee_on: bool = fee_to != address(0)
+        let k_last: u256 = self.k_last # gas savings
         if fee_on:
             if k_last != 0:
-                root_k: u256 = self.sqrt(reserve0 * reserve1)
-                root_k_last: u256 = self.sqrt(k_last)
+                let root_k: u256 = self.sqrt(reserve0 * reserve1)
+                let root_k_last: u256 = self.sqrt(k_last)
                 if root_k > root_k_last:
-                    numerator: u256 = self.total_supply * root_k - root_k_last
-                    denominator: u256 = root_k * 5 + root_k_last
-                    liquidity: u256 = numerator / denominator
+                    let numerator: u256 = self.total_supply * root_k - root_k_last
+                    let denominator: u256 = root_k * 5 + root_k_last
+                    let liquidity: u256 = numerator / denominator
                     if liquidity > 0:
                         self._mint(fee_to, liquidity)
         elif k_last != 0:
@@ -157,17 +157,17 @@ contract UniswapV2Pair:
 
     # this low-level function should be called from a contract which performs important safety checks
     pub def mint(to: address) -> u256:
-        MINIMUM_LIQUIDITY: u256 = 1000
-        reserve0: u256 = self.reserve0
-        reserve1: u256 = self.reserve1
-        balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-        balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-        amount0: u256 = balance0 - self.reserve0
-        amount1: u256 = balance1 - self.reserve1
+        let MINIMUM_LIQUIDITY: u256 = 1000
+        let reserve0: u256 = self.reserve0
+        let reserve1: u256 = self.reserve1
+        let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+        let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+        let amount0: u256 = balance0 - self.reserve0
+        let amount1: u256 = balance1 - self.reserve1
 
-        fee_on: bool = self._mint_fee(reserve0, reserve1)
-        total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-        liquidity: u256 = 0
+        let fee_on: bool = self._mint_fee(reserve0, reserve1)
+        let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+        let liquidity: u256 = 0
         if total_supply == 0:
             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
@@ -187,18 +187,18 @@ contract UniswapV2Pair:
 
     # this low-level function should be called from a contract which performs important safety checks
     pub def burn(to: address) -> (u256, u256):
-        reserve0: u256 = self.reserve0
-        reserve1: u256 = self.reserve1
-        token0: ERC20 = ERC20(self.token0)
-        token1: ERC20 = ERC20(self.token1)
-        balance0: u256 = token0.balanceOf(self.address)
-        balance1: u256 = token1.balanceOf(self.address)
-        liquidity: u256 = self.balances[self.address]
+        let reserve0: u256 = self.reserve0
+        let reserve1: u256 = self.reserve1
+        let token0: ERC20 = ERC20(self.token0)
+        let token1: ERC20 = ERC20(self.token1)
+        let balance0: u256 = token0.balanceOf(self.address)
+        let balance1: u256 = token1.balanceOf(self.address)
+        let liquidity: u256 = self.balances[self.address]
 
-        fee_on: bool = self._mint_fee(reserve0, reserve1)
-        total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-        amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-        amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+        let fee_on: bool = self._mint_fee(reserve0, reserve1)
+        let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+        let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+        let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
         self._burn(self.address, liquidity)
         token0.transfer(to, amount0)
@@ -219,12 +219,12 @@ contract UniswapV2Pair:
     # pub def swap(amount0_out: u256, amount1_out: u256, to: address, data: bytes):
     pub def swap(amount0_out: u256, amount1_out: u256, to: address):
         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-        reserve0: u256 = self.reserve0
-        reserve1: u256 = self.reserve1
+        let reserve0: u256 = self.reserve0
+        let reserve1: u256 = self.reserve1
         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
 
-        token0: ERC20 = ERC20(self.token0)
-        token1: ERC20 = ERC20(self.token1)
+        let token0: ERC20 = ERC20(self.token0)
+        let token1: ERC20 = ERC20(self.token1)
 
         # TODO: we should be using `token0.address` (https://github.com/ethereum/fe/issues/287)
         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
@@ -237,16 +237,16 @@ contract UniswapV2Pair:
 #        if data.length > 0:
 #            IUniswapV2Callee(to).uniswapV2Call(msg.sender, amount0_out, amount1_out, data)
 
-        balance0: u256 = token0.balanceOf(self.address)
-        balance1: u256 = token1.balanceOf(self.address)
+        let balance0: u256 = token0.balanceOf(self.address)
+        let balance1: u256 = token1.balanceOf(self.address)
 
-        amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-        amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+        let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+        let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
 
         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
 
-        balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-        balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+        let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+        let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
 
         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
 
@@ -255,23 +255,23 @@ contract UniswapV2Pair:
 
     # force balances to match reserves
     pub def skim(to: address):
-        token0: ERC20 = ERC20(self.token0) # gas savings
-        token1: ERC20 = ERC20(self.token1) # gas savings
+        let token0: ERC20 = ERC20(self.token0) # gas savings
+        let token1: ERC20 = ERC20(self.token1) # gas savings
 
         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
 
     # force reserves to match balances
     pub def sync():
-        token0: ERC20 = ERC20(self.token0)
-        token1: ERC20 = ERC20(self.token1)
+        let token0: ERC20 = ERC20(self.token0)
+        let token1: ERC20 = ERC20(self.token1)
         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
 
     def sqrt(val: u256) -> u256:
-        z: u256
+        let z: u256
         if (val > 3):
             z = val
-            x: u256 = val / 2 + 1
+            let x: u256 = val / 2 + 1
             while (x < z):
                 z = x
                 x = (val / x + x) / 2
@@ -312,13 +312,13 @@ contract UniswapV2Factory:
     pub def create_pair(token_a: address, token_b: address) -> address:
         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
 
-        token0: address = token_a if token_a < token_b else token_b
-        token1: address = token_a if token_a > token_b else token_b
+        let token0: address = token_a if token_a < token_b else token_b
+        let token1: address = token_a if token_a > token_b else token_b
         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
 
-        salt: u256 = keccak256((token0, token1).abi_encode())
-        pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+        let salt: u256 = keccak256((token0, token1).abi_encode())
+        let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
         pair.initialize(token0, token1)
 
         self.pairs[token0][token1] = address(pair)

--- a/crates/test-files/fixtures/features/aug_assign.fe
+++ b/crates/test-files/fixtures/features/aug_assign.fe
@@ -51,7 +51,7 @@ contract Foo:
         return self.my_num
 
     pub def add_from_mem(a: u256, b: u256) -> u256:
-        my_array: u256[10]
+        let my_array: u256[10]
         my_array[7] = a
         my_array[7] += b
         return my_array[7]

--- a/crates/test-files/fixtures/features/create2_contract.fe
+++ b/crates/test-files/fixtures/features/create2_contract.fe
@@ -5,5 +5,5 @@ contract Foo:
 contract FooFactory:
     pub def create2_foo() -> address:
         # value and salt
-        foo: Foo = Foo.create2(0, 52)
+        let foo: Foo = Foo.create2(0, 52)
         return address(foo)

--- a/crates/test-files/fixtures/features/create_contract.fe
+++ b/crates/test-files/fixtures/features/create_contract.fe
@@ -4,5 +4,5 @@ contract Foo:
 
 contract FooFactory:
     pub def create_foo() -> address:
-        foo: Foo = Foo.create(0)
+        let foo: Foo = Foo.create(0)
         return address(foo)

--- a/crates/test-files/fixtures/features/events.fe
+++ b/crates/test-files/fixtures/features/events.fe
@@ -26,7 +26,7 @@ contract Foo:
         emit Mix(num1=26, addr, num2=42, my_bytes)
 
     pub def emit_addresses(addr1: address, addr2: address):
-        addrs: address[2]
+        let addrs: address[2]
         addrs[0] = addr1
         addrs[1] = addr2
         emit Addresses(addrs)

--- a/crates/test-files/fixtures/features/external_contract.fe
+++ b/crates/test-files/fixtures/features/external_contract.fe
@@ -8,7 +8,7 @@ contract Foo:
         emit MyEvent(my_num, my_addrs, my_string)
 
     pub def build_array(a: u256, b: u256) -> u256[3]:
-        my_array: u256[3]
+        let my_array: u256[3]
         my_array[0] = a
         my_array[1] = a * b
         my_array[2] = b
@@ -21,7 +21,7 @@ contract FooProxy:
         my_addrs: address[5],
         my_string: String<11>
     ):
-        foo: Foo = Foo(foo_address)
+        let foo: Foo = Foo(foo_address)
         foo.emit_event(my_num, my_addrs, my_string)
 
     pub def call_build_array(
@@ -29,5 +29,5 @@ contract FooProxy:
          a: u256,
          b: u256,
     ) -> u256[3]:
-        foo: Foo = Foo(foo_address)
+        let foo: Foo = Foo(foo_address)
         return foo.build_array(a, b)

--- a/crates/test-files/fixtures/features/for_loop_with_break.fe
+++ b/crates/test-files/fixtures/features/for_loop_with_break.fe
@@ -1,11 +1,11 @@
 contract Foo:
 
     pub def bar() -> u256:
-        my_array: u256[3]
+        let my_array: u256[3]
         my_array[0] = 5
         my_array[1] = 10
         my_array[2] = 15
-        sum: u256 = 0
+        let sum: u256 = 0
         for i in my_array:
             sum = sum + i
             if sum == 15:

--- a/crates/test-files/fixtures/features/for_loop_with_continue.fe
+++ b/crates/test-files/fixtures/features/for_loop_with_continue.fe
@@ -1,13 +1,13 @@
 contract Foo:
 
     pub def bar() -> u256:
-        my_array: u256[5]
+        let my_array: u256[5]
         my_array[0] = 2
         my_array[1] = 3
         my_array[2] = 5
         my_array[3] = 6
         my_array[4] = 9
-        sum: u256 = 0
+        let sum: u256 = 0
         for i in my_array:
             if i % 2 == 0:
                 continue

--- a/crates/test-files/fixtures/features/for_loop_with_static_array.fe
+++ b/crates/test-files/fixtures/features/for_loop_with_static_array.fe
@@ -1,11 +1,11 @@
 contract Foo:
 
     pub def bar() -> u256:
-        my_array: u256[3]
+        let my_array: u256[3]
         my_array[0] = 5
         my_array[1] = 10
         my_array[2] = 15
-        sum: u256 = 0
+        let sum: u256 = 0
         for i in my_array:
             sum = sum + i
         return sum

--- a/crates/test-files/fixtures/features/if_statement_with_block_declaration.fe
+++ b/crates/test-files/fixtures/features/if_statement_with_block_declaration.fe
@@ -2,8 +2,8 @@ contract Foo:
 
     pub def bar() -> u256:
         if true:
-            y: u256 = 1
+            let y: u256 = 1
             return y
         else:
-            y: u256 = 1
+            let y: u256 = 1
             return y

--- a/crates/test-files/fixtures/features/int_literal_coercion.fe
+++ b/crates/test-files/fixtures/features/int_literal_coercion.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub def bar() -> u32:
-        c: u32 = 30
+        let c: u32 = 30
         c = 300
-        d: (u128, u64, u32) = (100, 200, c)
+        let d: (u128, u64, u32) = (100, 200, c)
         return d.item2

--- a/crates/test-files/fixtures/features/math.fe
+++ b/crates/test-files/fixtures/features/math.fe
@@ -2,10 +2,10 @@ contract Math:
 
     # https://github.com/Uniswap/uniswap-v2-core/blob/4dd59067c76dea4a0e8e4bfdda41877a6b16dedc/contracts/libraries/Math.sol#L11-L22
     pub def sqrt(val: u256) -> u256:
-        z: u256
+        let z: u256
         if (val > 3):
             z = val
-            x: u256 = val / 2 + 1
+            let x: u256 = val / 2 + 1
             while (x < z):
                 z = x
                 x = (val / x + x) / 2

--- a/crates/test-files/fixtures/features/multi_param.fe
+++ b/crates/test-files/fixtures/features/multi_param.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub def bar(x: u256, y: u256, z: u256) -> u256[3]:
-        my_array: u256[3]
+        let my_array: u256[3]
         my_array[0] = x
         my_array[1] = y
         my_array[2] = z

--- a/crates/test-files/fixtures/features/return_array.fe
+++ b/crates/test-files/fixtures/features/return_array.fe
@@ -1,5 +1,5 @@
 contract Foo:
     pub def bar(x: u256) -> u256[5]:
-        my_array: u256[5]
+        let my_array: u256[5]
         my_array[3] = x
         return my_array

--- a/crates/test-files/fixtures/features/return_sum_list_expression_1.fe
+++ b/crates/test-files/fixtures/features/return_sum_list_expression_1.fe
@@ -1,8 +1,8 @@
 contract Foo:
 
     pub def bar() -> u256:
-        my_array: u256[20] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-        sum: u256 = 0
+        let my_array: u256[20] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        let sum: u256 = 0
         for i in my_array:
             sum = sum + i
         return sum

--- a/crates/test-files/fixtures/features/return_sum_list_expression_2.fe
+++ b/crates/test-files/fixtures/features/return_sum_list_expression_2.fe
@@ -4,7 +4,7 @@ contract Foo:
         return self.count([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
 
     def count(values: u256[20]) -> u256:
-        sum: u256 = 0
+        let sum: u256 = 0
         for i in values:
             sum = sum + i
         return sum

--- a/crates/test-files/fixtures/features/structs.fe
+++ b/crates/test-files/fixtures/features/structs.fe
@@ -42,7 +42,7 @@ contract Foo:
         assert self.my_house.vacant
 
     pub def bar() -> u256:
-        building: House = House(
+        let building: House = House(
             price=300,
             size=500,
             rooms=u8(20),
@@ -65,7 +65,7 @@ contract Foo:
         return building.size
 
     pub def encode_house() -> u8[128]:
-        house: House = House(
+        let house: House = House(
             price=300,
             size=500,
             rooms=u8(20),
@@ -74,7 +74,7 @@ contract Foo:
         return house.abi_encode()
 
     pub def hashed_house() -> u256:
-        house: House = House(
+        let house: House = House(
             price=300,
             size=500,
             rooms=u8(20),

--- a/crates/test-files/fixtures/features/tuple_destructuring.fe
+++ b/crates/test-files/fixtures/features/tuple_destructuring.fe
@@ -1,10 +1,10 @@
 contract Foo:
     pub def bar() -> u256:
-        (x, y): (u256, bool) = (42, true)
+        let (x, y): (u256, bool) = (42, true)
         return x
 
     pub def baz(n: u256, b: bool) -> u256:
-        (x, y): (u256, bool) = self.make_tuple(n, b)
+        let (x, y): (u256, bool) = self.make_tuple(n, b)
         return x
 
     def make_tuple(n: u256, b: bool) -> (u256, bool):

--- a/crates/test-files/fixtures/features/while_loop.fe
+++ b/crates/test-files/fixtures/features/while_loop.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub def bar() -> u256:
-        val: u256 = 0
+        let val: u256 = 0
         while val < 2:
             val = val + 1
             if val == 2:

--- a/crates/test-files/fixtures/features/while_loop_with_break.fe
+++ b/crates/test-files/fixtures/features/while_loop_with_break.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub def bar() -> u256:
-        val: u256 = 0
+        let val: u256 = 0
         while val < 2:
             val = val + 1
             break

--- a/crates/test-files/fixtures/features/while_loop_with_break_2.fe
+++ b/crates/test-files/fixtures/features/while_loop_with_break_2.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub def bar() -> u256:
-        val: u256 = 0
+        let val: u256 = 0
         while val < 2:
             val = val + 1
             if val == 1:

--- a/crates/test-files/fixtures/features/while_loop_with_continue.fe
+++ b/crates/test-files/fixtures/features/while_loop_with_continue.fe
@@ -1,7 +1,7 @@
 contract Foo:
     pub def bar() -> u256:
-        i: u256 = 0
-        counter: u256 = 0
+        let i: u256 = 0
+        let counter: u256 = 0
 
         while i < 2:
             i = i + 1

--- a/crates/test-files/fixtures/lowering/aug_assign.fe
+++ b/crates/test-files/fixtures/lowering/aug_assign.fe
@@ -51,7 +51,7 @@ contract Foo:
         return self.my_num
 
     pub def add_from_mem(a: u256, b: u256) -> u256:
-        my_array: u256[10]
+        let my_array: u256[10]
         my_array[7] = a
         my_array[7] += b
         return my_array[7]

--- a/crates/test-files/fixtures/lowering/aug_assign_lowered.fe
+++ b/crates/test-files/fixtures/lowering/aug_assign_lowered.fe
@@ -51,7 +51,7 @@ contract Foo:
         return self.my_num
 
     pub def add_from_mem(a: u256, b: u256) -> u256:
-        my_array: u256[10]
+        let my_array: u256[10]
         my_array[7] = a
         my_array[7] = my_array[7] + b
         return my_array[7]

--- a/crates/test-files/fixtures/lowering/base_tuple.fe
+++ b/crates/test-files/fixtures/lowering/base_tuple.fe
@@ -12,7 +12,7 @@ contract Foo:
         return (999999, false, u8(42), address(26))
 
     pub def bing():
-        foo: (address, address, u16, i32, bool) = (address(0), address(0), u16(0), i32(0), false)
+        let foo: (address, address, u16, i32, bool) = (address(0), address(0), u16(0), i32(0), false)
 
     pub def bop(
         my_tuple1: (u256, bool),

--- a/crates/test-files/fixtures/lowering/base_tuple_lowered.fe
+++ b/crates/test-files/fixtures/lowering/base_tuple_lowered.fe
@@ -46,7 +46,7 @@ contract Foo:
         )
 
     pub def bing() -> ():
-        foo: tuple_address_address_u16_i32_bool_ = tuple_address_address_u16_i32_bool_(
+        let foo: tuple_address_address_u16_i32_bool_ = tuple_address_address_u16_i32_bool_(
             item0=address(0),
             item1=address(0),
             item2=u16(0),

--- a/crates/test-files/fixtures/lowering/list_expressions.fe
+++ b/crates/test-files/fixtures/lowering/list_expressions.fe
@@ -1,4 +1,4 @@
 contract Foo:
 
     pub def foo():
-        x: u256[3] = [10, 20, 30]
+        let x: u256[3] = [10, 20, 30]

--- a/crates/test-files/fixtures/lowering/list_expressions_lowered.fe
+++ b/crates/test-files/fixtures/lowering/list_expressions_lowered.fe
@@ -1,10 +1,10 @@
 contract Foo:
     pub def foo() -> ():
-        x: u256[3] = self.list_expr_array_u256_3(10, 20, 30)
+        let x: u256[3] = self.list_expr_array_u256_3(10, 20, 30)
         return ()
 
     def list_expr_array_u256_3(val0: u256, val1: u256, val2: u256) -> u256[3]:
-        generated_array: u256[3]
+        let generated_array: u256[3]
         generated_array[0] = val0
         generated_array[1] = val1
         generated_array[2] = val2

--- a/crates/test-files/fixtures/stress/data_copying_stress.fe
+++ b/crates/test-files/fixtures/stress/data_copying_stress.fe
@@ -29,8 +29,8 @@ contract Foo:
         self.my_u256 = self.my_other_u256
 
     pub def multiple_references_shared_memory(my_array: u256[10]):
-        my_2nd_array: u256[10] = my_array
-        my_3rd_array: u256[10] = my_2nd_array
+        let my_2nd_array: u256[10] = my_array
+        let my_3rd_array: u256[10] = my_2nd_array
 
         assert my_array[3] != 5
         my_array[3] = 5
@@ -55,7 +55,7 @@ contract Foo:
         return my_array
 
     pub def assign_my_nums_and_return() -> u256[5]:
-        my_nums_mem: u256[5]
+        let my_nums_mem: u256[5]
         self.my_nums[0] = 42
         self.my_nums[1] = 26
         self.my_nums[2] = 0

--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -56,7 +56,7 @@ contract FooProxy:
         return self.foo.get_tuple()
 
     pub def call_get_array():
-        my_array: u16[4] = self.foo.get_array()
+        let my_array: u16[4] = self.foo.get_array()
         assert my_array[0] == u16(1)
         assert my_array[1] == u16(2)
         assert my_array[2] == u16(3)

--- a/crates/test-files/fixtures/stress/tuple_stress.fe
+++ b/crates/test-files/fixtures/stress/tuple_stress.fe
@@ -31,8 +31,8 @@ contract Foo:
         return self.my_sto_tuple.to_mem()
 
     pub def build_tuple_and_emit():
-        my_num: u256 = self.my_sto_tuple.item0
-        my_tuple: (u256, bool, address) = (
+        let my_num: u256 = self.my_sto_tuple.item0
+        let my_tuple: (u256, bool, address) = (
             self.my_sto_tuple.item0,
             true and false,
             address(26)


### PR DESCRIPTION
### What was wrong?

Described in this issue: https://github.com/ethereum/fe/issues/501

Briefly, there is no explicit syntactic distinction between variable declarations and reassignments.


### How was it fixed?

Added the requirement that variable declarations are preceded by `let` keyword, e.g., `let x: u8 = 1`. Updated all fixtures and demo contracts to be compatible with this change.

### To do

Update documentation & website examples to reflect this change.