### PR TITLE
Tuple item leading zeroes #470

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -602,7 +602,7 @@ fn expr_attribute(
 
 /// Pull the item index from the attribute string (e.g. "item4" -> "4").
 fn tuple_item_index(item: &str) -> Option<usize> {
-    if item.len() < 5 || &item[..4] != "item" {
+    if item.len() < 5 || &item[..4] != "item" || (item.len() > 5 && &item[4..5] == "0") {
         None
     } else {
         item[4..].parse::<usize>().ok()

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -138,6 +138,7 @@ test_stmt! { invalid_ascii, "String<2>(\"ä\")" }
 
 test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }
+test_file! { bad_tuple_attr3 }
 test_file! { call_builtin_object }
 test_file! { call_address_with_wrong_type }
 test_file! { call_create_with_wrong_type }

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -206,6 +206,77 @@ ModuleAttributes {
                     },
                     FunctionAttributes {
                         is_public: true,
+                        name: "read_my_tuple_item10",
+                        params: [
+                            (
+                                "my_tuple",
+                                Tuple(
+                                    Tuple {
+                                        items: [
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Numeric(
+                                                    U256,
+                                                ),
+                                            ),
+                                            Base(
+                                                Address,
+                                            ),
+                                        ],
+                                    },
+                                ),
+                            ),
+                        ],
+                        return_type: Base(
+                            Address,
+                        ),
+                    },
+                    FunctionAttributes {
+                        is_public: true,
                         name: "read_my_tuple_item2",
                         params: [
                             (
@@ -471,9 +542,95 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:24:22
+   ┌─ stress/tuple_stress.fe:24:20
    │
-24 │         emit MyEvent(my_tuple)
+24 │             return my_tuple.item10
+   │                    ^^^^^^^^ attributes hash: 428904706091901490
+   │
+   = ExpressionAttributes {
+         typ: Tuple(
+             Tuple {
+                 items: [
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                     Base(
+                         Address,
+                     ),
+                 ],
+             },
+         ),
+         location: Memory,
+         move_location: None,
+     }
+
+note: 
+   ┌─ stress/tuple_stress.fe:24:20
+   │
+24 │             return my_tuple.item10
+   │                    ^^^^^^^^^^^^^^^ attributes hash: 8187231029880378585
+   │
+   = ExpressionAttributes {
+         typ: Base(
+             Address,
+         ),
+         location: Memory,
+         move_location: Some(
+             Value,
+         ),
+     }
+
+note: 
+   ┌─ stress/tuple_stress.fe:27:22
+   │
+27 │         emit MyEvent(my_tuple)
    │                      ^^^^^^^^ attributes hash: 9401177389635192626
    │
    = ExpressionAttributes {
@@ -499,9 +656,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:16
+   ┌─ stress/tuple_stress.fe:30:16
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^ attributes hash: 17784680135386019789
    │
    = ExpressionAttributes {
@@ -530,9 +687,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:16
+   ┌─ stress/tuple_stress.fe:30:16
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9658275715484404641
    │
    = ExpressionAttributes {
@@ -552,9 +709,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:48
+   ┌─ stress/tuple_stress.fe:30:48
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                ^ attributes hash: 1230752710897721197
    │
    = ExpressionAttributes {
@@ -568,9 +725,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:43
+   ┌─ stress/tuple_stress.fe:30:43
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                           ^^^^^^^ attributes hash: 1230752710897721197
    │
    = ExpressionAttributes {
@@ -584,9 +741,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:16
+   ┌─ stress/tuple_stress.fe:30:16
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -598,9 +755,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:55
+   ┌─ stress/tuple_stress.fe:30:55
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                       ^^^^^^^^^^^^^^^^^ attributes hash: 17784680135386019789
    │
    = ExpressionAttributes {
@@ -629,9 +786,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:55
+   ┌─ stress/tuple_stress.fe:30:55
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                       ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14147635845373973720
    │
    = ExpressionAttributes {
@@ -651,9 +808,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:86
+   ┌─ stress/tuple_stress.fe:30:86
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                                                      ^ attributes hash: 16606532750379249980
    │
    = ExpressionAttributes {
@@ -667,9 +824,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:82
+   ┌─ stress/tuple_stress.fe:30:82
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                                                  ^^^^^^ attributes hash: 16606532750379249980
    │
    = ExpressionAttributes {
@@ -683,9 +840,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:55
+   ┌─ stress/tuple_stress.fe:30:55
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -697,9 +854,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:16
+   ┌─ stress/tuple_stress.fe:30:16
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -711,9 +868,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:28:9
+   ┌─ stress/tuple_stress.fe:31:9
    │
-28 │         self.my_sto_tuple = (my_u256, my_i32)
+31 │         self.my_sto_tuple = (my_u256, my_i32)
    │         ^^^^^^^^^^^^^^^^^ attributes hash: 17784680135386019789
    │
    = ExpressionAttributes {
@@ -742,9 +899,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:28:30
+   ┌─ stress/tuple_stress.fe:31:30
    │
-28 │         self.my_sto_tuple = (my_u256, my_i32)
+31 │         self.my_sto_tuple = (my_u256, my_i32)
    │                              ^^^^^^^ attributes hash: 1230752710897721197
    │
    = ExpressionAttributes {
@@ -758,9 +915,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:28:39
+   ┌─ stress/tuple_stress.fe:31:39
    │
-28 │         self.my_sto_tuple = (my_u256, my_i32)
+31 │         self.my_sto_tuple = (my_u256, my_i32)
    │                                       ^^^^^^ attributes hash: 16606532750379249980
    │
    = ExpressionAttributes {
@@ -774,9 +931,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:28:29
+   ┌─ stress/tuple_stress.fe:31:29
    │
-28 │         self.my_sto_tuple = (my_u256, my_i32)
+31 │         self.my_sto_tuple = (my_u256, my_i32)
    │                             ^^^^^^^^^^^^^^^^^ attributes hash: 6681993647907033817
    │
    = ExpressionAttributes {
@@ -801,9 +958,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:31:16
+   ┌─ stress/tuple_stress.fe:34:16
    │
-31 │         return self.my_sto_tuple.to_mem()
+34 │         return self.my_sto_tuple.to_mem()
    │                ^^^^^^^^^^^^^^^^^ attributes hash: 17784680135386019789
    │
    = ExpressionAttributes {
@@ -832,9 +989,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:31:16
+   ┌─ stress/tuple_stress.fe:34:16
    │
-31 │         return self.my_sto_tuple.to_mem()
+34 │         return self.my_sto_tuple.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15753884771514765367
    │
    = ExpressionAttributes {
@@ -865,9 +1022,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:28
+   ┌─ stress/tuple_stress.fe:37:28
    │
-34 │         let my_num: u256 = self.my_sto_tuple.item0
+37 │         let my_num: u256 = self.my_sto_tuple.item0
    │                            ^^^^^^^^^^^^^^^^^ attributes hash: 17784680135386019789
    │
    = ExpressionAttributes {
@@ -896,9 +1053,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:28
+   ┌─ stress/tuple_stress.fe:37:28
    │
-34 │         let my_num: u256 = self.my_sto_tuple.item0
+37 │         let my_num: u256 = self.my_sto_tuple.item0
    │                            ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9658275715484404641
    │
    = ExpressionAttributes {
@@ -918,9 +1075,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:36:13
+   ┌─ stress/tuple_stress.fe:39:13
    │
-36 │             self.my_sto_tuple.item0,
+39 │             self.my_sto_tuple.item0,
    │             ^^^^^^^^^^^^^^^^^ attributes hash: 17784680135386019789
    │
    = ExpressionAttributes {
@@ -949,9 +1106,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:36:13
+   ┌─ stress/tuple_stress.fe:39:13
    │
-36 │             self.my_sto_tuple.item0,
+39 │             self.my_sto_tuple.item0,
    │             ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9658275715484404641
    │
    = ExpressionAttributes {
@@ -971,9 +1128,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:37:13
+   ┌─ stress/tuple_stress.fe:40:13
    │
-37 │             true and false,
+40 │             true and false,
    │             ^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -985,9 +1142,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:37:22
+   ┌─ stress/tuple_stress.fe:40:22
    │
-37 │             true and false,
+40 │             true and false,
    │                      ^^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -999,9 +1156,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:37:13
+   ┌─ stress/tuple_stress.fe:40:13
    │
-37 │             true and false,
+40 │             true and false,
    │             ^^^^^^^^^^^^^^ attributes hash: 519621297275845584
    │
    = ExpressionAttributes {
@@ -1013,9 +1170,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:38:21
+   ┌─ stress/tuple_stress.fe:41:21
    │
-38 │             address(26)
+41 │             address(26)
    │                     ^^ attributes hash: 1230752710897721197
    │
    = ExpressionAttributes {
@@ -1029,9 +1186,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:38:13
+   ┌─ stress/tuple_stress.fe:41:13
    │
-38 │             address(26)
+41 │             address(26)
    │             ^^^^^^^^^^^ attributes hash: 16804606599831072828
    │
    = ExpressionAttributes {
@@ -1043,14 +1200,14 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:47
+   ┌─ stress/tuple_stress.fe:38:47
    │  
-35 │           let my_tuple: (u256, bool, address) = (
+38 │           let my_tuple: (u256, bool, address) = (
    │ ╭───────────────────────────────────────────────^
-36 │ │             self.my_sto_tuple.item0,
-37 │ │             true and false,
-38 │ │             address(26)
-39 │ │         )
+39 │ │             self.my_sto_tuple.item0,
+40 │ │             true and false,
+41 │ │             address(26)
+42 │ │         )
    │ ╰─────────^ attributes hash: 9401177389635192626
    │  
    = ExpressionAttributes {
@@ -1076,9 +1233,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:40:28
+   ┌─ stress/tuple_stress.fe:43:28
    │
-40 │         self.emit_my_event(my_tuple)
+43 │         self.emit_my_event(my_tuple)
    │                            ^^^^^^^^ attributes hash: 9401177389635192626
    │
    = ExpressionAttributes {
@@ -1104,9 +1261,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:40:9
+   ┌─ stress/tuple_stress.fe:43:9
    │
-40 │         self.emit_my_event(my_tuple)
+43 │         self.emit_my_event(my_tuple)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4703226498732669424
    │
    = ExpressionAttributes {
@@ -1118,9 +1275,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:43:16
+   ┌─ stress/tuple_stress.fe:46:16
    │
-43 │         return my_tuple.abi_encode()
+46 │         return my_tuple.abi_encode()
    │                ^^^^^^^^ attributes hash: 9401177389635192626
    │
    = ExpressionAttributes {
@@ -1146,9 +1303,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:43:16
+   ┌─ stress/tuple_stress.fe:46:16
    │
-43 │         return my_tuple.abi_encode()
+46 │         return my_tuple.abi_encode()
    │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 7411471366339884327
    │
    = ExpressionAttributes {
@@ -1165,9 +1322,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:24:9
+   ┌─ stress/tuple_stress.fe:27:9
    │
-24 │         emit MyEvent(my_tuple)
+27 │         emit MyEvent(my_tuple)
    │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1448730452803770990
    │
    = EventDef {
@@ -1368,8 +1525,87 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:23:5
    │  
-23 │ ╭     pub fn emit_my_event(my_tuple: (u256, bool, address)):
-24 │ │         emit MyEvent(my_tuple)
+23 │ ╭     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+24 │ │             return my_tuple.item10
+   │ ╰──────────────────────────────────^ attributes hash: 7198827106690655421
+   │  
+   = FunctionAttributes {
+         is_public: true,
+         name: "read_my_tuple_item10",
+         params: [
+             (
+                 "my_tuple",
+                 Tuple(
+                     Tuple {
+                         items: [
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Numeric(
+                                     U256,
+                                 ),
+                             ),
+                             Base(
+                                 Address,
+                             ),
+                         ],
+                     },
+                 ),
+             ),
+         ],
+         return_type: Base(
+             Address,
+         ),
+     }
+
+note: 
+   ┌─ stress/tuple_stress.fe:26:5
+   │  
+26 │ ╭     pub fn emit_my_event(my_tuple: (u256, bool, address)):
+27 │ │         emit MyEvent(my_tuple)
    │ ╰──────────────────────────────^ attributes hash: 12903921255353311703
    │  
    = FunctionAttributes {
@@ -1403,11 +1639,11 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:26:5
+   ┌─ stress/tuple_stress.fe:29:5
    │  
-26 │ ╭     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
-27 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-28 │ │         self.my_sto_tuple = (my_u256, my_i32)
+29 │ ╭     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
+30 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+31 │ │         self.my_sto_tuple = (my_u256, my_i32)
    │ ╰─────────────────────────────────────────────^ attributes hash: 15227142288998903073
    │  
    = FunctionAttributes {
@@ -1437,10 +1673,10 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:30:5
+   ┌─ stress/tuple_stress.fe:33:5
    │  
-30 │ ╭     pub fn get_my_sto_tuple() -> (u256, i32):
-31 │ │         return self.my_sto_tuple.to_mem()
+33 │ ╭     pub fn get_my_sto_tuple() -> (u256, i32):
+34 │ │         return self.my_sto_tuple.to_mem()
    │ ╰─────────────────────────────────────────^ attributes hash: 7952473050757524292
    │  
    = FunctionAttributes {
@@ -1466,15 +1702,15 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:33:5
+   ┌─ stress/tuple_stress.fe:36:5
    │  
-33 │ ╭     pub fn build_tuple_and_emit():
-34 │ │         let my_num: u256 = self.my_sto_tuple.item0
-35 │ │         let my_tuple: (u256, bool, address) = (
-36 │ │             self.my_sto_tuple.item0,
+36 │ ╭     pub fn build_tuple_and_emit():
+37 │ │         let my_num: u256 = self.my_sto_tuple.item0
+38 │ │         let my_tuple: (u256, bool, address) = (
+39 │ │             self.my_sto_tuple.item0,
    · │
-39 │ │         )
-40 │ │         self.emit_my_event(my_tuple)
+42 │ │         )
+43 │ │         self.emit_my_event(my_tuple)
    │ ╰────────────────────────────────────^ attributes hash: 9587208258001507713
    │  
    = FunctionAttributes {
@@ -1487,10 +1723,10 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:5
+   ┌─ stress/tuple_stress.fe:45:5
    │  
-42 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
-43 │ │         return my_tuple.abi_encode()
+45 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+46 │ │         return my_tuple.abi_encode()
    │ ╰────────────────────────────────────^ attributes hash: 3262486643273900623
    │  
    = FunctionAttributes {
@@ -1529,9 +1765,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:9
+   ┌─ stress/tuple_stress.fe:37:9
    │
-34 │         let my_num: u256 = self.my_sto_tuple.item0
+37 │         let my_num: u256 = self.my_sto_tuple.item0
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -1541,13 +1777,13 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:9
+   ┌─ stress/tuple_stress.fe:38:9
    │  
-35 │ ╭         let my_tuple: (u256, bool, address) = (
-36 │ │             self.my_sto_tuple.item0,
-37 │ │             true and false,
-38 │ │             address(26)
-39 │ │         )
+38 │ ╭         let my_tuple: (u256, bool, address) = (
+39 │ │             self.my_sto_tuple.item0,
+40 │ │             true and false,
+41 │ │             address(26)
+42 │ │         )
    │ ╰─────────^ attributes hash: 11349385661517146274
    │  
    = Tuple(
@@ -1576,9 +1812,9 @@ note:
  3 │ │ 
  4 │ │     event MyEvent:
    · │
-42 │ │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
-43 │ │         return my_tuple.abi_encode()
-   │ ╰────────────────────────────────────^ attributes hash: 13290905967414103606
+45 │ │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+46 │ │         return my_tuple.abi_encode()
+   │ ╰────────────────────────────────────^ attributes hash: 13854303490423674780
    │  
    = ContractAttributes {
          public_functions: [
@@ -1779,6 +2015,77 @@ note:
              },
              FunctionAttributes {
                  is_public: true,
+                 name: "read_my_tuple_item10",
+                 params: [
+                     (
+                         "my_tuple",
+                         Tuple(
+                             Tuple {
+                                 items: [
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Numeric(
+                                             U256,
+                                         ),
+                                     ),
+                                     Base(
+                                         Address,
+                                     ),
+                                 ],
+                             },
+                         ),
+                     ),
+                 ],
+                 return_type: Base(
+                     Address,
+                 ),
+             },
+             FunctionAttributes {
+                 is_public: true,
                  name: "read_my_tuple_item2",
                  params: [
                      (
@@ -1866,9 +2173,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:43
+   ┌─ stress/tuple_stress.fe:30:43
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                           ^^^^ attributes hash: 2391147244535208323
    │
    = TypeConstructor {
@@ -1880,9 +2187,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:27:82
+   ┌─ stress/tuple_stress.fe:30:82
    │
-27 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                                                  ^^^ attributes hash: 14092528269543401556
    │
    = TypeConstructor {
@@ -1894,17 +2201,17 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:31:16
+   ┌─ stress/tuple_stress.fe:34:16
    │
-31 │         return self.my_sto_tuple.to_mem()
+34 │         return self.my_sto_tuple.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
 
 note: 
-   ┌─ stress/tuple_stress.fe:38:13
+   ┌─ stress/tuple_stress.fe:41:13
    │
-38 │             address(26)
+41 │             address(26)
    │             ^^^^^^^ attributes hash: 14203407709342965641
    │
    = TypeConstructor {
@@ -1914,9 +2221,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:40:9
+   ┌─ stress/tuple_stress.fe:43:9
    │
-40 │         self.emit_my_event(my_tuple)
+43 │         self.emit_my_event(my_tuple)
    │         ^^^^^^^^^^^^^^^^^^ attributes hash: 608487383688023809
    │
    = SelfAttribute {
@@ -1924,9 +2231,9 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:43:16
+   ┌─ stress/tuple_stress.fe:46:16
    │
-43 │         return my_tuple.abi_encode()
+46 │         return my_tuple.abi_encode()
    │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
@@ -2310,9 +2617,215 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:23:37
+   ┌─ stress/tuple_stress.fe:23:44
    │
-23 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                            ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:50
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                  ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:56
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                        ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:62
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                              ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:68
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                    ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:74
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                          ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:80
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                                ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:86
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                                      ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:92
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                                            ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:98
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                                                  ^^^^ attributes hash: 4293763436908729629
+   │
+   = Base(
+         Numeric(
+             U256,
+         ),
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:104
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                                                        ^^^^^^^ attributes hash: 928477466454064117
+   │
+   = Base(
+         Address,
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:43
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 2575732153834009286
+   │
+   = Tuple(
+         Tuple {
+             items: [
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Numeric(
+                         U256,
+                     ),
+                 ),
+                 Base(
+                     Address,
+                 ),
+             ],
+         },
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:23:117
+   │
+23 │     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+   │                                                                                                                     ^^^^^^^ attributes hash: 928477466454064117
+   │
+   = Base(
+         Address,
+     )
+
+note: 
+   ┌─ stress/tuple_stress.fe:26:37
+   │
+26 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
    │                                     ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -2322,9 +2835,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:23:43
+   ┌─ stress/tuple_stress.fe:26:43
    │
-23 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
+26 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
    │                                           ^^^^ attributes hash: 5425972608982369985
    │
    = Base(
@@ -2332,9 +2845,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:23:49
+   ┌─ stress/tuple_stress.fe:26:49
    │
-23 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
+26 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
    │                                                 ^^^^^^^ attributes hash: 928477466454064117
    │
    = Base(
@@ -2342,9 +2855,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:23:36
+   ┌─ stress/tuple_stress.fe:26:36
    │
-23 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
+26 │     pub fn emit_my_event(my_tuple: (u256, bool, address)):
    │                                    ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11349385661517146274
    │
    = Tuple(
@@ -2366,9 +2879,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:26:38
+   ┌─ stress/tuple_stress.fe:29:38
    │
-26 │     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
+29 │     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
    │                                      ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -2378,9 +2891,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:26:52
+   ┌─ stress/tuple_stress.fe:29:52
    │
-26 │     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
+29 │     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
    │                                                    ^^^ attributes hash: 3989691230564290788
    │
    = Base(
@@ -2390,9 +2903,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:30:35
+   ┌─ stress/tuple_stress.fe:33:35
    │
-30 │     pub fn get_my_sto_tuple() -> (u256, i32):
+33 │     pub fn get_my_sto_tuple() -> (u256, i32):
    │                                   ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -2402,9 +2915,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:30:41
+   ┌─ stress/tuple_stress.fe:33:41
    │
-30 │     pub fn get_my_sto_tuple() -> (u256, i32):
+33 │     pub fn get_my_sto_tuple() -> (u256, i32):
    │                                         ^^^ attributes hash: 3989691230564290788
    │
    = Base(
@@ -2414,9 +2927,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:30:34
+   ┌─ stress/tuple_stress.fe:33:34
    │
-30 │     pub fn get_my_sto_tuple() -> (u256, i32):
+33 │     pub fn get_my_sto_tuple() -> (u256, i32):
    │                                  ^^^^^^^^^^^ attributes hash: 16310670687691141547
    │
    = Tuple(
@@ -2437,9 +2950,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:39
+   ┌─ stress/tuple_stress.fe:45:39
    │
-42 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+45 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
    │                                       ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -2449,9 +2962,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:45
+   ┌─ stress/tuple_stress.fe:45:45
    │
-42 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+45 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
    │                                             ^^^^ attributes hash: 5425972608982369985
    │
    = Base(
@@ -2459,9 +2972,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:51
+   ┌─ stress/tuple_stress.fe:45:51
    │
-42 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+45 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
    │                                                   ^^^^^^^ attributes hash: 928477466454064117
    │
    = Base(
@@ -2469,9 +2982,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:38
+   ┌─ stress/tuple_stress.fe:45:38
    │
-42 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+45 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
    │                                      ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11349385661517146274
    │
    = Tuple(
@@ -2493,9 +3006,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:64
+   ┌─ stress/tuple_stress.fe:45:64
    │
-42 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+45 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
    │                                                                ^^ attributes hash: 3165084411644393001
    │
    = Base(
@@ -2505,9 +3018,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:42:64
+   ┌─ stress/tuple_stress.fe:45:64
    │
-42 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
+45 │     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
    │                                                                ^^^^^^ attributes hash: 17832129859836256896
    │
    = Array(
@@ -2567,9 +3080,9 @@ note:
     )
 
 note: 
-   ┌─ stress/tuple_stress.fe:34:21
+   ┌─ stress/tuple_stress.fe:37:21
    │
-34 │         let my_num: u256 = self.my_sto_tuple.item0
+37 │         let my_num: u256 = self.my_sto_tuple.item0
    │                     ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -2579,9 +3092,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:24
+   ┌─ stress/tuple_stress.fe:38:24
    │
-35 │         let my_tuple: (u256, bool, address) = (
+38 │         let my_tuple: (u256, bool, address) = (
    │                        ^^^^ attributes hash: 4293763436908729629
    │
    = Base(
@@ -2591,9 +3104,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:30
+   ┌─ stress/tuple_stress.fe:38:30
    │
-35 │         let my_tuple: (u256, bool, address) = (
+38 │         let my_tuple: (u256, bool, address) = (
    │                              ^^^^ attributes hash: 5425972608982369985
    │
    = Base(
@@ -2601,9 +3114,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:36
+   ┌─ stress/tuple_stress.fe:38:36
    │
-35 │         let my_tuple: (u256, bool, address) = (
+38 │         let my_tuple: (u256, bool, address) = (
    │                                    ^^^^^^^ attributes hash: 928477466454064117
    │
    = Base(
@@ -2611,9 +3124,9 @@ note:
      )
 
 note: 
-   ┌─ stress/tuple_stress.fe:35:23
+   ┌─ stress/tuple_stress.fe:38:23
    │
-35 │         let my_tuple: (u256, bool, address) = (
+38 │         let my_tuple: (u256, bool, address) = (
    │                       ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11349385661517146274
    │
    = Tuple(

--- a/crates/analyzer/tests/snapshots/errors__bad_tuple_attr3.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_tuple_attr3.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: No field `item00` exists on this tuple
+  ┌─ compile_errors/bad_tuple_attr3.fe:6:27
+  │
+6 │         self.my_sto_tuple.item00
+  │                           ^^^^^^ undefined field
+  │
+  = Note: Tuple values are accessed via `itemN` properties such as `item0` or `item1`
+
+

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr3.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr3.fe
@@ -1,0 +1,6 @@
+# See ethereum/fe issue #470
+contract foo:
+    my_sto_tuple: (u256, i32)
+
+    pub fn bar:
+        self.my_sto_tuple.item00

--- a/crates/test-files/fixtures/stress/tuple_stress.fe
+++ b/crates/test-files/fixtures/stress/tuple_stress.fe
@@ -20,6 +20,9 @@ contract Foo:
     pub fn read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address:
         return my_tuple.item2
 
+    pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
+            return my_tuple.item10
+
     pub fn emit_my_event(my_tuple: (u256, bool, address)):
         emit MyEvent(my_tuple)
 

--- a/newsfragments/510.bugfix.md
+++ b/newsfragments/510.bugfix.md
@@ -1,0 +1,3 @@
+Fixed a bug in the analyzer which allowed tuple item accessor names with a leading 0,
+resulting in an internal compiler error in a later pass. Example: `my_tuple.item001`.
+These are now rejected with an error message.


### PR DESCRIPTION
### What was wrong?
issue #470  
Leading zeros in tuple indexes should not be allowed.


### How was it fixed?
Check for leading zeros in tuple indexes (like item00 or item001). Small change in expressions.rs + tests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
