### PR TITLE
Check labels in function calls on self and external contracts

### DIFF
--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -2,6 +2,7 @@ use crate::context::{AnalyzerContext, ExpressionAttributes, Label, Location};
 use crate::errors::{AlreadyDefined, FatalError};
 use crate::namespace::scopes::{BlockScope, BlockScopeType};
 use crate::namespace::types::{Base, FixedSize, Type};
+use crate::traversal::call_args::LabelPolicy;
 use crate::traversal::{assignments, call_args, declarations, expressions};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -148,6 +149,7 @@ fn emit(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalEr
                 name.span,
                 args,
                 &event.typ(scope.db()).fields,
+                LabelPolicy::AllowUnlabledIfNameEqual,
             )?;
         } else {
             scope.error(

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -185,6 +185,8 @@ test_file! { invalid_tx_field }
 test_file! { invalid_var_declaration_1 }
 test_file! { invalid_var_declaration_2 }
 test_file! { issue_451 }
+test_file! { mislabeled_call_args }
+test_file! { mislabeled_call_args_external_contract_call }
 test_file! { mismatch_return_type }
 test_file! { missing_return }
 test_file! { missing_return_in_else }

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: argument label mismatch
+  ┌─ compile_errors/mislabeled_call_args.fe:4:18
+  │
+4 │         self.bar(doesnt_exist=1, me_neither=2)
+  │                  ^^^^^^^^^^^^ expected `val1`
+
+error: argument label mismatch
+  ┌─ compile_errors/mislabeled_call_args.fe:4:34
+  │
+4 │         self.bar(doesnt_exist=1, me_neither=2)
+  │                                  ^^^^^^^^^^ expected `val2`
+
+

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_external_contract_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_external_contract_call.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: argument label mismatch
+   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:10:25
+   │
+10 │     Foo(address(0)).baz(doesnt_exist=1, me_neither=4)
+   │                         ^^^^^^^^^^^^ expected `val1`
+
+error: argument label mismatch
+   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:10:41
+   │
+10 │     Foo(address(0)).baz(doesnt_exist=1, me_neither=4)
+   │                                         ^^^^^^^^^^ expected `val2`
+
+

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+    pub fn baz():
+        self.bar(doesnt_exist=1, me_neither=2)
+    
+    pub fn bar(val1: u256, val2: u256):
+        pass

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
@@ -1,0 +1,10 @@
+
+contract Foo:
+  val: u8
+
+  pub fn baz(val1: u256, val2: u256):
+    pass
+
+contract Bar:
+  pub fn test():
+    Foo(address(0)).baz(doesnt_exist=1, me_neither=4)

--- a/newsfragments/517.bugfix.md
+++ b/newsfragments/517.bugfix.md
@@ -1,0 +1,20 @@
+Check call argument labels for function calls.
+
+Previously the compiler would not check any labels that were used
+when making function calls on `self` or external contracts.
+
+This can be especially problematic if gives developers the impression
+that they could apply function arguments in any order as long as they
+are named which is **not** the case. 
+
+```
+contract Foo:
+
+    pub fn baz():
+        self.bar(val2=1, doesnt_even_exist=2)
+    
+    pub fn bar(val1: u256, val2: u256):
+        pass
+```
+
+Code as the one above is now rightfully rejected by the compiler.


### PR DESCRIPTION
### What was wrong?

As explained in #517, function calls on `self` or external contracts do not check the labels, allowing developers to apply any kind of label and in the worst case leave the user with the impression that they could use labels to call functions with the arguments ordered as they wish (which isn't the case).

### How was it fixed?

Added checks in the analyzer and added tests.