### PR TITLE
`self` declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /target
 **/*.rs.bk
 tarpaulin-report.html
+/output
+/docs/tmp_snippets

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -157,7 +157,8 @@ impl fmt::Display for ExpressionAttributes {
 pub enum CallType {
     BuiltinFunction { func: GlobalMethod },
     TypeConstructor { typ: Type },
-    SelfAttribute { func_name: String },
+    SelfAttribute { func_name: String, self_span: Span },
+    Pure { func_name: String },
     ValueAttribute,
     TypeAttribute { typ: Type, func_name: String },
 }

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -69,6 +69,10 @@ pub trait AnalyzerDb {
     fn contract_function_map(&self, id: ContractId) -> Analysis<Rc<IndexMap<String, FunctionId>>>;
     #[salsa::invoke(queries::contracts::contract_public_function_map)]
     fn contract_public_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
+    #[salsa::invoke(queries::contracts::contract_pure_function_map)]
+    fn contract_pure_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
+    #[salsa::invoke(queries::contracts::contract_self_function_map)]
+    fn contract_self_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
     #[salsa::invoke(queries::contracts::contract_init_function)]
     fn contract_init_function(&self, id: ContractId) -> Analysis<Option<FunctionId>>;
 

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -77,6 +77,32 @@ pub fn contract_public_function_map(
     )
 }
 
+pub fn contract_pure_function_map(
+    db: &dyn AnalyzerDb,
+    contract: ContractId,
+) -> Rc<IndexMap<String, FunctionId>> {
+    Rc::new(
+        contract
+            .functions(db)
+            .iter()
+            .filter_map(|(name, func)| func.is_pure(db).then(|| (name.clone(), *func)))
+            .collect(),
+    )
+}
+
+pub fn contract_self_function_map(
+    db: &dyn AnalyzerDb,
+    contract: ContractId,
+) -> Rc<IndexMap<String, FunctionId>> {
+    Rc::new(
+        contract
+            .functions(db)
+            .iter()
+            .filter_map(|(name, func)| (!func.is_pure(db)).then(|| (name.clone(), *func)))
+            .collect(),
+    )
+}
+
 pub fn contract_init_function(
     db: &dyn AnalyzerDb,
     contract: ContractId,

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -2,6 +2,7 @@ use crate::context;
 use crate::errors::{self, TypeError};
 use crate::impl_intern_key;
 use crate::namespace::types;
+use crate::namespace::types::SelfDecl;
 use crate::traversal::pragma::check_pragma_version;
 use crate::AnalyzerDb;
 use fe_common::diagnostics::Diagnostic;
@@ -242,6 +243,26 @@ impl ContractId {
         self.public_functions(db).get(name).copied()
     }
 
+    /// Functions that do not have a self parameter.
+    pub fn pure_functions(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<String, FunctionId>> {
+        db.contract_pure_function_map(*self)
+    }
+
+    /// Get a pure function by its name.
+    pub fn pure_function(&self, db: &dyn AnalyzerDb, name: &str) -> Option<FunctionId> {
+        self.pure_functions(db).get(name).copied()
+    }
+
+    /// Functions that have a self parameter.
+    pub fn self_functions(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<String, FunctionId>> {
+        db.contract_self_function_map(*self)
+    }
+
+    /// Get a function that takes self by its name.
+    pub fn self_function(&self, db: &dyn AnalyzerDb, name: &str) -> Option<FunctionId> {
+        self.self_functions(db).get(name).copied()
+    }
+
     /// A `Vec` of every function defined in the contract, including duplicates and the init function.
     pub fn all_functions(&self, db: &dyn AnalyzerDb) -> Rc<Vec<FunctionId>> {
         db.contract_all_functions(*self)
@@ -324,6 +345,10 @@ impl FunctionId {
 
     pub fn is_public(&self, db: &dyn AnalyzerDb) -> bool {
         self.data(db).ast.kind.is_pub
+    }
+
+    pub fn is_pure(&self, db: &dyn AnalyzerDb) -> bool {
+        self.signature(db).self_decl == SelfDecl::None
     }
 
     pub fn data(&self, db: &dyn AnalyzerDb) -> Rc<Function> {

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -79,6 +79,14 @@ impl<'a> FunctionScope<'a> {
         self.function.parent(self.db).function(self.db, name)
     }
 
+    pub fn self_contract_function(&self, name: &str) -> Option<FunctionId> {
+        self.function.parent(self.db).self_function(self.db, name)
+    }
+
+    pub fn pure_contract_function(&self, name: &str) -> Option<FunctionId> {
+        self.function.parent(self.db).pure_function(self.db, name)
+    }
+
     pub fn resolve_event(&self, name: &str) -> Option<EventId> {
         self.function.parent(self.db).event(self.db, name)
     }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -116,8 +116,15 @@ pub struct FeString {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FunctionSignature {
+    pub self_decl: SelfDecl,
     pub params: Vec<FunctionParam>,
     pub return_type: Result<FixedSize, TypeError>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub enum SelfDecl {
+    None,
+    Mutable,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -50,7 +50,7 @@ macro_rules! test_stmt {
         #[wasm_bindgen_test]
         fn $name() {
             let src = format!(
-                "contract C:\n pub fn f():\n  {}",
+                "contract C:\n pub fn f(self):\n  {}",
                 $stmt.replace('\n', "\n  ")
             );
             if cfg!(target_arch = "wasm32") {
@@ -215,3 +215,8 @@ test_file! { abi_encode_from_storage }
 test_file! { assert_sto_msg_no_copy }
 test_file! { for_loop_sto_iter_no_copy }
 test_file! { revert_sto_error_no_copy }
+
+test_file! { call_to_mut_fn_without_self }
+test_file! { call_to_pure_fn_on_self }
+test_file! { missing_self }
+test_file! { self_not_first }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -187,6 +187,7 @@ test_file! { invalid_var_declaration_1 }
 test_file! { invalid_var_declaration_2 }
 test_file! { issue_451 }
 test_file! { mislabeled_call_args }
+test_file! { mislabeled_call_args_self }
 test_file! { mislabeled_call_args_external_contract_call }
 test_file! { mismatch_return_type }
 test_file! { missing_return }

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -102,11 +102,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:23:5
    │  
-23 │ ╭     pub fn set_my_addrs(my_addrs: address[5]):
+23 │ ╭     pub fn set_my_addrs(self, my_addrs: address[5]):
 24 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 7792454252220620713
+   │ ╰────────────────────────────────^ attributes hash: 8230149271433625082
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_addrs",
@@ -130,11 +131,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:26:5
    │  
-26 │ ╭     pub fn get_my_addrs() -> address[5]:
+26 │ ╭     pub fn get_my_addrs(self) -> address[5]:
 27 │ │         return self.my_addrs.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 2287525696829879728
+   │ ╰─────────────────────────────────────^ attributes hash: 14938423529265024589
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Array(
@@ -149,11 +151,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:29:5
    │  
-29 │ ╭     pub fn set_my_u128(my_u128: u128):
+29 │ ╭     pub fn set_my_u128(self, my_u128: u128):
 30 │ │         self.my_u128 = my_u128
-   │ ╰──────────────────────────────^ attributes hash: 1483578428416970862
+   │ ╰──────────────────────────────^ attributes hash: 9586494768459567014
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_u128",
@@ -176,11 +179,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:32:5
    │  
-32 │ ╭     pub fn get_my_u128() -> u128:
+32 │ ╭     pub fn get_my_u128(self) -> u128:
 33 │ │         return self.my_u128
-   │ ╰───────────────────────────^ attributes hash: 16590220569563418042
+   │ ╰───────────────────────────^ attributes hash: 1703680575433883116
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -194,11 +198,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:35:5
    │  
-35 │ ╭     pub fn set_my_string(my_string: String<10>):
+35 │ ╭     pub fn set_my_string(self, my_string: String<10>):
 36 │ │         self.my_string = my_string
-   │ ╰──────────────────────────────────^ attributes hash: 1220080414581004615
+   │ ╰──────────────────────────────────^ attributes hash: 12755746761294548533
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_string",
@@ -221,11 +226,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:38:5
    │  
-38 │ ╭     pub fn get_my_string() -> String<10>:
+38 │ ╭     pub fn get_my_string(self) -> String<10>:
 39 │ │         return self.my_string.to_mem()
-   │ ╰──────────────────────────────────────^ attributes hash: 9281401346944239687
+   │ ╰──────────────────────────────────────^ attributes hash: 7751556256223364605
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              String(
@@ -239,11 +245,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:41:5
    │  
-41 │ ╭     pub fn set_my_u16s(my_u16s: u16[255]):
+41 │ ╭     pub fn set_my_u16s(self, my_u16s: u16[255]):
 42 │ │         self.my_u16s = my_u16s
-   │ ╰──────────────────────────────^ attributes hash: 4003332420113060329
+   │ ╰──────────────────────────────^ attributes hash: 15627129425342656114
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_u16s",
@@ -269,11 +276,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:44:5
    │  
-44 │ ╭     pub fn get_my_u16s() -> u16[255]:
+44 │ ╭     pub fn get_my_u16s(self) -> u16[255]:
 45 │ │         return self.my_u16s.to_mem()
-   │ ╰────────────────────────────────────^ attributes hash: 16639309595415919877
+   │ ╰────────────────────────────────────^ attributes hash: 1712184078290376685
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Array(
@@ -290,11 +298,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:47:5
    │  
-47 │ ╭     pub fn set_my_bool(my_bool: bool):
+47 │ ╭     pub fn set_my_bool(self, my_bool: bool):
 48 │ │         self.my_bool = my_bool
-   │ ╰──────────────────────────────^ attributes hash: 10090082643311988957
+   │ ╰──────────────────────────────^ attributes hash: 6416448266362982339
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_bool",
@@ -315,11 +324,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:50:5
    │  
-50 │ ╭     pub fn get_my_bool() -> bool:
+50 │ ╭     pub fn get_my_bool(self) -> bool:
 51 │ │         return self.my_bool
-   │ ╰───────────────────────────^ attributes hash: 9286995118813931448
+   │ ╰───────────────────────────^ attributes hash: 4761504089579832229
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -331,11 +341,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:53:5
    │  
-53 │ ╭     pub fn set_my_bytes(my_bytes: u8[100]):
+53 │ ╭     pub fn set_my_bytes(self, my_bytes: u8[100]):
 54 │ │         self.my_bytes = my_bytes
-   │ ╰────────────────────────────────^ attributes hash: 16041897644211461890
+   │ ╰────────────────────────────────^ attributes hash: 5447714587686147158
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_bytes",
@@ -361,11 +372,12 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:56:5
    │  
-56 │ ╭     pub fn get_my_bytes() -> u8[100]:
+56 │ ╭     pub fn get_my_bytes(self) -> u8[100]:
 57 │ │         return self.my_bytes.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 18288654186894625799
+   │ ╰─────────────────────────────────────^ attributes hash: 11897278640933106358
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Array(
@@ -389,9 +401,10 @@ note:
 63 │ │             my_bool=true,
 64 │ │             my_addr=address(123456)
 65 │ │         )
-   │ ╰─────────^ attributes hash: 8198766938367957550
+   │ ╰─────────^ attributes hash: 12792745713144811261
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Struct(
@@ -415,9 +428,10 @@ note:
 70 │ │         my_struct.my_bool = false
 71 │ │         my_struct.my_addr = address(9999)
 72 │ │         return my_struct
-   │ ╰────────────────────────^ attributes hash: 12745288013791427549
+   │ ╰────────────────────────^ attributes hash: 6786804746141497115
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_struct",
@@ -450,16 +464,17 @@ note:
 note: 
    ┌─ stress/abi_encoding_stress.fe:74:5
    │  
-74 │ ╭     pub fn emit_my_event():
+74 │ ╭     pub fn emit_my_event(self):
 75 │ │         emit MyEvent(
 76 │ │             my_addrs=self.my_addrs.to_mem(),
 77 │ │             my_u128=self.my_u128,
    · │
 81 │ │             my_bytes=self.my_bytes.to_mem()
 82 │ │         )
-   │ ╰─────────^ attributes hash: 17883060253504188551
+   │ ╰─────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/address_bytes10_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: address) -> u8[10]:
+4 │ ╭     pub fn read_bar(self, key: address) -> u8[10]:
 5 │ │         return self.bar[key].to_mem()
-  │ ╰─────────────────────────────────────^ attributes hash: 6717884890054312629
+  │ ╰─────────────────────────────────────^ attributes hash: 8899857923785283493
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -42,11 +43,12 @@ note:
 note: 
   ┌─ features/address_bytes10_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: address, value: u8[10]):
+7 │ ╭     pub fn write_bar(self, key: address, value: u8[10]):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 11691503617473568421
+  │ ╰─────────────────────────────^ attributes hash: 8250642936007969286
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__assert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__assert.snap
@@ -20,9 +20,10 @@ note:
   │  
 5 │ ╭     pub fn bar(baz: u256):
 6 │ │         assert baz > 5
-  │ ╰──────────────────────^ attributes hash: 9441450842937114435
+  │ ╰──────────────────────^ attributes hash: 3718407254252637682
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "baz",
@@ -47,9 +48,10 @@ note:
   │  
 8 │ ╭     pub fn revert_with_static_string(baz: u256):
 9 │ │         assert baz > 5, "Must be greater than five"
-  │ ╰───────────────────────────────────────────────────^ attributes hash: 9441450842937114435
+  │ ╰───────────────────────────────────────────────────^ attributes hash: 3718407254252637682
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "baz",
@@ -74,9 +76,10 @@ note:
    │  
 11 │ ╭     pub fn revert_with(baz: u256, reason: String<1000>):
 12 │ │         assert baz > 5, reason
-   │ ╰──────────────────────────────^ attributes hash: 76867006336817864
+   │ ╰──────────────────────────────^ attributes hash: 10846245641845463539
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "baz",
@@ -109,12 +112,13 @@ note:
 note: 
    ┌─ features/assert.fe:14:5
    │  
-14 │ ╭     pub fn assert_sto_bool():
+14 │ ╭     pub fn assert_sto_bool(self):
 15 │ │         self.my_bool = false
 16 │ │         assert self.my_bool
-   │ ╰───────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰───────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -126,12 +130,13 @@ note:
 note: 
    ┌─ features/assert.fe:18:5
    │  
-18 │ ╭     pub fn assert_sto_string_msg():
+18 │ ╭     pub fn assert_sto_string_msg(self):
 19 │ │         self.my_string = "hello"
 20 │ │         assert false, self.my_string.to_mem()
-   │ ╰─────────────────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰─────────────────────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
+++ b/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
@@ -15,9 +15,10 @@ note:
 4 │ ╭     pub fn add(a: u256, b: u256) -> u256:
 5 │ │         a += b
 6 │ │         return a
-  │ ╰────────────────^ attributes hash: 15056346078233080632
+  │ ╰────────────────^ attributes hash: 10094331793610550579
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "a",
@@ -55,9 +56,10 @@ note:
  8 │ ╭     pub fn sub(a: u256, b: u256) -> u256:
  9 │ │         a -= b
 10 │ │         return a
-   │ ╰────────────────^ attributes hash: 15056346078233080632
+   │ ╰────────────────^ attributes hash: 10094331793610550579
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -95,9 +97,10 @@ note:
 12 │ ╭     pub fn mul(a: u256, b: u256) -> u256:
 13 │ │         a *= b
 14 │ │         return a
-   │ ╰────────────────^ attributes hash: 15056346078233080632
+   │ ╰────────────────^ attributes hash: 10094331793610550579
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -135,9 +138,10 @@ note:
 16 │ ╭     pub fn div(a: u256, b: u256) -> u256:
 17 │ │         a /= b
 18 │ │         return a
-   │ ╰────────────────^ attributes hash: 15056346078233080632
+   │ ╰────────────────^ attributes hash: 10094331793610550579
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -175,9 +179,10 @@ note:
 20 │ ╭     pub fn mod(a: u256, b: u256) -> u256:
 21 │ │         a %= b
 22 │ │         return a
-   │ ╰────────────────^ attributes hash: 15056346078233080632
+   │ ╰────────────────^ attributes hash: 10094331793610550579
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -215,9 +220,10 @@ note:
 24 │ ╭     pub fn pow(a: u256, b: u256) -> u256:
 25 │ │         a **= b
 26 │ │         return a
-   │ ╰────────────────^ attributes hash: 15056346078233080632
+   │ ╰────────────────^ attributes hash: 10094331793610550579
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -255,9 +261,10 @@ note:
 28 │ ╭     pub fn lshift(a: u8, b: u8) -> u8:
 29 │ │         a <<= b
 30 │ │         return a
-   │ ╰────────────────^ attributes hash: 15179202576655649603
+   │ ╰────────────────^ attributes hash: 9159210808631090718
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -295,9 +302,10 @@ note:
 32 │ ╭     pub fn rshift(a: u8, b: u8) -> u8:
 33 │ │         a >>= b
 34 │ │         return a
-   │ ╰────────────────^ attributes hash: 15179202576655649603
+   │ ╰────────────────^ attributes hash: 9159210808631090718
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -335,9 +343,10 @@ note:
 36 │ ╭     pub fn bit_or(a: u8, b: u8) -> u8:
 37 │ │         a |= b
 38 │ │         return a
-   │ ╰────────────────^ attributes hash: 15179202576655649603
+   │ ╰────────────────^ attributes hash: 9159210808631090718
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -375,9 +384,10 @@ note:
 40 │ ╭     pub fn bit_xor(a: u8, b: u8) -> u8:
 41 │ │         a ^= b
 42 │ │         return a
-   │ ╰────────────────^ attributes hash: 15179202576655649603
+   │ ╰────────────────^ attributes hash: 9159210808631090718
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -415,9 +425,10 @@ note:
 44 │ ╭     pub fn bit_and(a: u8, b: u8) -> u8:
 45 │ │         a &= b
 46 │ │         return a
-   │ ╰────────────────^ attributes hash: 15179202576655649603
+   │ ╰────────────────^ attributes hash: 9159210808631090718
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -452,13 +463,14 @@ note:
 note: 
    ┌─ features/aug_assign.fe:48:5
    │  
-48 │ ╭     pub fn add_from_sto(a: u256, b: u256) -> u256:
+48 │ ╭     pub fn add_from_sto(self, a: u256, b: u256) -> u256:
 49 │ │         self.my_num = a
 50 │ │         self.my_num += b
 51 │ │         return self.my_num
-   │ ╰──────────────────────────^ attributes hash: 15056346078233080632
+   │ ╰──────────────────────────^ attributes hash: 2855001974628647253
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "a",
@@ -498,9 +510,10 @@ note:
 55 │ │         my_array[7] = a
 56 │ │         my_array[7] += b
 57 │ │         return my_array[7]
-   │ ╰──────────────────────────^ attributes hash: 15056346078233080632
+   │ ╰──────────────────────────^ attributes hash: 10094331793610550579
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",

--- a/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(my_num: u256, my_bool: bool) -> (u256, bool):
 3 │ │         return (my_num, my_bool)
-  │ ╰────────────────────────────────^ attributes hash: 9587629585902824154
+  │ ╰────────────────────────────────^ attributes hash: 2243442022954131718
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "my_num",

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/call_statement_with_args.fe:4:5
   │  
-4 │ ╭     fn assign(val: u256):
+4 │ ╭     fn assign(self, val: u256):
 5 │ │         self.baz[0] = val
-  │ ╰─────────────────────────^ attributes hash: 5870011042633637402
+  │ ╰─────────────────────────^ attributes hash: 254453825868610726
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "val",
@@ -39,12 +40,13 @@ note:
 note: 
   ┌─ features/call_statement_with_args.fe:7:5
   │  
-7 │ ╭     pub fn bar() -> u256:
+7 │ ╭     pub fn bar(self) -> u256:
 8 │ │         self.assign(100)
 9 │ │         return self.baz[0]
-  │ ╰──────────────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────────────^ attributes hash: 16482263331346774611
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(
@@ -113,10 +115,14 @@ note:
   ┌─ features/call_statement_with_args.fe:8:9
   │
 8 │         self.assign(100)
-  │         ^^^^^^^^^^^ attributes hash: 13402545317341859599
+  │         ^^^^^^^^^^^ attributes hash: 8420354620523897173
   │
   = SelfAttribute {
         func_name: "assign",
+        self_span: Span {
+            start: 137,
+            end: 141,
+        },
     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
@@ -12,12 +12,13 @@ note:
 note: 
   ┌─ features/call_statement_with_args_2.fe:4:5
   │  
-4 │ ╭     fn assign(val: u256) -> u256:
+4 │ ╭     fn assign(self, val: u256) -> u256:
 5 │ │         self.baz[0] = val
 6 │ │         return val
-  │ ╰──────────────────^ attributes hash: 6248121154456130073
+  │ ╰──────────────────^ attributes hash: 13803375927344563415
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "val",
@@ -42,12 +43,13 @@ note:
 note: 
    ┌─ features/call_statement_with_args_2.fe:8:5
    │  
- 8 │ ╭     pub fn bar() -> u256:
+ 8 │ ╭     pub fn bar(self) -> u256:
  9 │ │         self.assign(100)
 10 │ │         return self.baz[0]
-   │ ╰──────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────────────^ attributes hash: 16482263331346774611
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -122,10 +124,14 @@ note:
   ┌─ features/call_statement_with_args_2.fe:9:9
   │
 9 │         self.assign(100)
-  │         ^^^^^^^^^^^ attributes hash: 13402545317341859599
+  │         ^^^^^^^^^^^ attributes hash: 511266823031776296
   │
   = SelfAttribute {
         func_name: "assign",
+        self_span: Span {
+            start: 164,
+            end: 168,
+        },
     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/call_statement_without_args.fe:4:5
   │  
-4 │ ╭     fn assign():
+4 │ ╭     fn assign(self):
 5 │ │         self.baz[0] = 100
-  │ ╰─────────────────────────^ attributes hash: 17883060253504188551
+  │ ╰─────────────────────────^ attributes hash: 4369441865732737140
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(
@@ -28,12 +29,13 @@ note:
 note: 
   ┌─ features/call_statement_without_args.fe:7:5
   │  
-7 │ ╭     pub fn bar() -> u256:
+7 │ ╭     pub fn bar(self) -> u256:
 8 │ │         self.assign()
 9 │ │         return self.baz[0]
-  │ ╰──────────────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────────────^ attributes hash: 16482263331346774611
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(
@@ -96,10 +98,14 @@ note:
   ┌─ features/call_statement_without_args.fe:8:9
   │
 8 │         self.assign()
-  │         ^^^^^^^^^^^ attributes hash: 13402545317341859599
+  │         ^^^^^^^^^^^ attributes hash: 17318279018058750260
   │
   = SelfAttribute {
         func_name: "assign",
+        self_span: Span {
+            start: 126,
+            end: 130,
+        },
     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
+++ b/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
@@ -8,9 +8,10 @@ note:
   │  
 3 │ ╭     pub fn add_u256(left: u256, right: u256) -> u256:
 4 │ │         return left + right
-  │ ╰───────────────────────────^ attributes hash: 10934394392719230350
+  │ ╰───────────────────────────^ attributes hash: 3568881859844729307
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "left",
@@ -47,9 +48,10 @@ note:
   │  
 6 │ ╭     pub fn add_u128(left: u128, right: u128) -> u128:
 7 │ │         return left + right
-  │ ╰───────────────────────────^ attributes hash: 3844087086888288806
+  │ ╰───────────────────────────^ attributes hash: 17129592850815340223
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "left",
@@ -86,9 +88,10 @@ note:
    │  
  9 │ ╭     pub fn add_u64(left: u64, right: u64) -> u64:
 10 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 7090360049943337373
+   │ ╰───────────────────────────^ attributes hash: 14666166959439406742
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -125,9 +128,10 @@ note:
    │  
 12 │ ╭     pub fn add_u32(left: u32, right: u32) -> u32:
 13 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 1924425134457147261
+   │ ╰───────────────────────────^ attributes hash: 2033723386058016238
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -164,9 +168,10 @@ note:
    │  
 15 │ ╭     pub fn add_u16(left: u16, right: u16) -> u16:
 16 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 2007900231672655657
+   │ ╰───────────────────────────^ attributes hash: 2208322929283836441
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -203,9 +208,10 @@ note:
    │  
 18 │ ╭     pub fn add_u8(left: u8, right: u8) -> u8:
 19 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 1045834994105525345
+   │ ╰───────────────────────────^ attributes hash: 16477852824764552468
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -242,9 +248,10 @@ note:
    │  
 21 │ ╭     pub fn add_i256(left: i256, right: i256) -> i256:
 22 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 13926565639439232492
+   │ ╰───────────────────────────^ attributes hash: 13756051924186323535
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -281,9 +288,10 @@ note:
    │  
 24 │ ╭     pub fn add_i128(left: i128, right: i128) -> i128:
 25 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 3214814928241611038
+   │ ╰───────────────────────────^ attributes hash: 470029936044980118
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -320,9 +328,10 @@ note:
    │  
 27 │ ╭     pub fn add_i64(left: i64, right: i64) -> i64:
 28 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 11957634529458381280
+   │ ╰───────────────────────────^ attributes hash: 15016550520446375601
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -359,9 +368,10 @@ note:
    │  
 30 │ ╭     pub fn add_i32(left: i32, right: i32) -> i32:
 31 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 1408981139897494799
+   │ ╰───────────────────────────^ attributes hash: 5408722229298808308
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -398,9 +408,10 @@ note:
    │  
 33 │ ╭     pub fn add_i16(left: i16, right: i16) -> i16:
 34 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 6628839244879101310
+   │ ╰───────────────────────────^ attributes hash: 6512603022216737285
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -437,9 +448,10 @@ note:
    │  
 36 │ ╭     pub fn add_i8(left: i8, right: i8) -> i8:
 37 │ │         return left + right
-   │ ╰───────────────────────────^ attributes hash: 14117217432290539755
+   │ ╰───────────────────────────^ attributes hash: 6610364095665106106
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -476,9 +488,10 @@ note:
    │  
 39 │ ╭     pub fn sub_u256(left: u256, right: u256) -> u256:
 40 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 10934394392719230350
+   │ ╰───────────────────────────^ attributes hash: 3568881859844729307
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -515,9 +528,10 @@ note:
    │  
 42 │ ╭     pub fn sub_u128(left: u128, right: u128) -> u128:
 43 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 3844087086888288806
+   │ ╰───────────────────────────^ attributes hash: 17129592850815340223
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -554,9 +568,10 @@ note:
    │  
 45 │ ╭     pub fn sub_u64(left: u64, right: u64) -> u64:
 46 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 7090360049943337373
+   │ ╰───────────────────────────^ attributes hash: 14666166959439406742
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -593,9 +608,10 @@ note:
    │  
 48 │ ╭     pub fn sub_u32(left: u32, right: u32) -> u32:
 49 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 1924425134457147261
+   │ ╰───────────────────────────^ attributes hash: 2033723386058016238
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -632,9 +648,10 @@ note:
    │  
 51 │ ╭     pub fn sub_u16(left: u16, right: u16) -> u16:
 52 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 2007900231672655657
+   │ ╰───────────────────────────^ attributes hash: 2208322929283836441
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -671,9 +688,10 @@ note:
    │  
 54 │ ╭     pub fn sub_u8(left: u8, right: u8) -> u8:
 55 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 1045834994105525345
+   │ ╰───────────────────────────^ attributes hash: 16477852824764552468
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -710,9 +728,10 @@ note:
    │  
 57 │ ╭     pub fn sub_i256(left: i256, right: i256) -> i256:
 58 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 13926565639439232492
+   │ ╰───────────────────────────^ attributes hash: 13756051924186323535
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -749,9 +768,10 @@ note:
    │  
 60 │ ╭     pub fn sub_i128(left: i128, right: i128) -> i128:
 61 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 3214814928241611038
+   │ ╰───────────────────────────^ attributes hash: 470029936044980118
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -788,9 +808,10 @@ note:
    │  
 63 │ ╭     pub fn sub_i64(left: i64, right: i64) -> i64:
 64 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 11957634529458381280
+   │ ╰───────────────────────────^ attributes hash: 15016550520446375601
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -827,9 +848,10 @@ note:
    │  
 66 │ ╭     pub fn sub_i32(left: i32, right: i32) -> i32:
 67 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 1408981139897494799
+   │ ╰───────────────────────────^ attributes hash: 5408722229298808308
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -866,9 +888,10 @@ note:
    │  
 69 │ ╭     pub fn sub_i16(left: i16, right: i16) -> i16:
 70 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 6628839244879101310
+   │ ╰───────────────────────────^ attributes hash: 6512603022216737285
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -905,9 +928,10 @@ note:
    │  
 72 │ ╭     pub fn sub_i8(left: i8, right: i8) -> i8:
 73 │ │         return left - right
-   │ ╰───────────────────────────^ attributes hash: 14117217432290539755
+   │ ╰───────────────────────────^ attributes hash: 6610364095665106106
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -944,9 +968,10 @@ note:
    │  
 75 │ ╭     pub fn div_u256(left: u256, right: u256) -> u256:
 76 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 10934394392719230350
+   │ ╰───────────────────────────^ attributes hash: 3568881859844729307
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -983,9 +1008,10 @@ note:
    │  
 78 │ ╭     pub fn div_u128(left: u128, right: u128) -> u128:
 79 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 3844087086888288806
+   │ ╰───────────────────────────^ attributes hash: 17129592850815340223
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1022,9 +1048,10 @@ note:
    │  
 81 │ ╭     pub fn div_u64(left: u64, right: u64) -> u64:
 82 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 7090360049943337373
+   │ ╰───────────────────────────^ attributes hash: 14666166959439406742
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1061,9 +1088,10 @@ note:
    │  
 84 │ ╭     pub fn div_u32(left: u32, right: u32) -> u32:
 85 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 1924425134457147261
+   │ ╰───────────────────────────^ attributes hash: 2033723386058016238
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1100,9 +1128,10 @@ note:
    │  
 87 │ ╭     pub fn div_u16(left: u16, right: u16) -> u16:
 88 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 2007900231672655657
+   │ ╰───────────────────────────^ attributes hash: 2208322929283836441
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1139,9 +1168,10 @@ note:
    │  
 90 │ ╭     pub fn div_u8(left: u8, right: u8) -> u8:
 91 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 1045834994105525345
+   │ ╰───────────────────────────^ attributes hash: 16477852824764552468
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1178,9 +1208,10 @@ note:
    │  
 93 │ ╭     pub fn div_i256(left: i256, right: i256) -> i256:
 94 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 13926565639439232492
+   │ ╰───────────────────────────^ attributes hash: 13756051924186323535
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1217,9 +1248,10 @@ note:
    │  
 96 │ ╭     pub fn div_i128(left: i128, right: i128) -> i128:
 97 │ │         return left / right
-   │ ╰───────────────────────────^ attributes hash: 3214814928241611038
+   │ ╰───────────────────────────^ attributes hash: 470029936044980118
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "left",
@@ -1256,9 +1288,10 @@ note:
     │  
  99 │ ╭     pub fn div_i64(left: i64, right: i64) -> i64:
 100 │ │         return left / right
-    │ ╰───────────────────────────^ attributes hash: 11957634529458381280
+    │ ╰───────────────────────────^ attributes hash: 15016550520446375601
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1295,9 +1328,10 @@ note:
     │  
 102 │ ╭     pub fn div_i32(left: i32, right: i32) -> i32:
 103 │ │         return left / right
-    │ ╰───────────────────────────^ attributes hash: 1408981139897494799
+    │ ╰───────────────────────────^ attributes hash: 5408722229298808308
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1334,9 +1368,10 @@ note:
     │  
 105 │ ╭     pub fn div_i16(left: i16, right: i16) -> i16:
 106 │ │         return left / right
-    │ ╰───────────────────────────^ attributes hash: 6628839244879101310
+    │ ╰───────────────────────────^ attributes hash: 6512603022216737285
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1373,9 +1408,10 @@ note:
     │  
 108 │ ╭     pub fn div_i8(left: i8, right: i8) -> i8:
 109 │ │         return left / right
-    │ ╰───────────────────────────^ attributes hash: 14117217432290539755
+    │ ╰───────────────────────────^ attributes hash: 6610364095665106106
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1412,9 +1448,10 @@ note:
     │  
 111 │ ╭     pub fn mul_u256(left: u256, right: u256) -> u256:
 112 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 10934394392719230350
+    │ ╰───────────────────────────^ attributes hash: 3568881859844729307
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1451,9 +1488,10 @@ note:
     │  
 114 │ ╭     pub fn mul_u128(left: u128, right: u128) -> u128:
 115 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 3844087086888288806
+    │ ╰───────────────────────────^ attributes hash: 17129592850815340223
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1490,9 +1528,10 @@ note:
     │  
 117 │ ╭     pub fn mul_u64(left: u64, right: u64) -> u64:
 118 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 7090360049943337373
+    │ ╰───────────────────────────^ attributes hash: 14666166959439406742
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1529,9 +1568,10 @@ note:
     │  
 120 │ ╭     pub fn mul_u32(left: u32, right: u32) -> u32:
 121 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 1924425134457147261
+    │ ╰───────────────────────────^ attributes hash: 2033723386058016238
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1568,9 +1608,10 @@ note:
     │  
 123 │ ╭     pub fn mul_u16(left: u16, right: u16) -> u16:
 124 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 2007900231672655657
+    │ ╰───────────────────────────^ attributes hash: 2208322929283836441
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1607,9 +1648,10 @@ note:
     │  
 126 │ ╭     pub fn mul_u8(left: u8, right: u8) -> u8:
 127 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 1045834994105525345
+    │ ╰───────────────────────────^ attributes hash: 16477852824764552468
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1646,9 +1688,10 @@ note:
     │  
 129 │ ╭     pub fn mul_i256(left: i256, right: i256) -> i256:
 130 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 13926565639439232492
+    │ ╰───────────────────────────^ attributes hash: 13756051924186323535
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1685,9 +1728,10 @@ note:
     │  
 132 │ ╭     pub fn mul_i128(left: i128, right: i128) -> i128:
 133 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 3214814928241611038
+    │ ╰───────────────────────────^ attributes hash: 470029936044980118
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1724,9 +1768,10 @@ note:
     │  
 135 │ ╭     pub fn mul_i64(left: i64, right: i64) -> i64:
 136 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 11957634529458381280
+    │ ╰───────────────────────────^ attributes hash: 15016550520446375601
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1763,9 +1808,10 @@ note:
     │  
 138 │ ╭     pub fn mul_i32(left: i32, right: i32) -> i32:
 139 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 1408981139897494799
+    │ ╰───────────────────────────^ attributes hash: 5408722229298808308
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1802,9 +1848,10 @@ note:
     │  
 141 │ ╭     pub fn mul_i16(left: i16, right: i16) -> i16:
 142 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 6628839244879101310
+    │ ╰───────────────────────────^ attributes hash: 6512603022216737285
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1841,9 +1888,10 @@ note:
     │  
 144 │ ╭     pub fn mul_i8(left: i8, right: i8) -> i8:
 145 │ │         return left * right
-    │ ╰───────────────────────────^ attributes hash: 14117217432290539755
+    │ ╰───────────────────────────^ attributes hash: 6610364095665106106
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1880,9 +1928,10 @@ note:
     │  
 147 │ ╭     pub fn mod_u256(left: u256, right: u256) -> u256:
 148 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 10934394392719230350
+    │ ╰───────────────────────────^ attributes hash: 3568881859844729307
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1919,9 +1968,10 @@ note:
     │  
 150 │ ╭     pub fn mod_u128(left: u128, right: u128) -> u128:
 151 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 3844087086888288806
+    │ ╰───────────────────────────^ attributes hash: 17129592850815340223
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1958,9 +2008,10 @@ note:
     │  
 153 │ ╭     pub fn mod_u64(left: u64, right: u64) -> u64:
 154 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 7090360049943337373
+    │ ╰───────────────────────────^ attributes hash: 14666166959439406742
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -1997,9 +2048,10 @@ note:
     │  
 156 │ ╭     pub fn mod_u32(left: u32, right: u32) -> u32:
 157 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 1924425134457147261
+    │ ╰───────────────────────────^ attributes hash: 2033723386058016238
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2036,9 +2088,10 @@ note:
     │  
 159 │ ╭     pub fn mod_u16(left: u16, right: u16) -> u16:
 160 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 2007900231672655657
+    │ ╰───────────────────────────^ attributes hash: 2208322929283836441
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2075,9 +2128,10 @@ note:
     │  
 162 │ ╭     pub fn mod_u8(left: u8, right: u8) -> u8:
 163 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 1045834994105525345
+    │ ╰───────────────────────────^ attributes hash: 16477852824764552468
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2114,9 +2168,10 @@ note:
     │  
 165 │ ╭     pub fn mod_i256(left: i256, right: i256) -> i256:
 166 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 13926565639439232492
+    │ ╰───────────────────────────^ attributes hash: 13756051924186323535
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2153,9 +2208,10 @@ note:
     │  
 168 │ ╭     pub fn mod_i128(left: i128, right: i128) -> i128:
 169 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 3214814928241611038
+    │ ╰───────────────────────────^ attributes hash: 470029936044980118
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2192,9 +2248,10 @@ note:
     │  
 171 │ ╭     pub fn mod_i64(left: i64, right: i64) -> i64:
 172 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 11957634529458381280
+    │ ╰───────────────────────────^ attributes hash: 15016550520446375601
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2231,9 +2288,10 @@ note:
     │  
 174 │ ╭     pub fn mod_i32(left: i32, right: i32) -> i32:
 175 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 1408981139897494799
+    │ ╰───────────────────────────^ attributes hash: 5408722229298808308
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2270,9 +2328,10 @@ note:
     │  
 177 │ ╭     pub fn mod_i16(left: i16, right: i16) -> i16:
 178 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 6628839244879101310
+    │ ╰───────────────────────────^ attributes hash: 6512603022216737285
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2309,9 +2368,10 @@ note:
     │  
 180 │ ╭     pub fn mod_i8(left: i8, right: i8) -> i8:
 181 │ │         return left % right
-    │ ╰───────────────────────────^ attributes hash: 14117217432290539755
+    │ ╰───────────────────────────^ attributes hash: 6610364095665106106
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2348,9 +2408,10 @@ note:
     │  
 183 │ ╭     pub fn pow_u256(left: u256, right: u256) -> u256:
 184 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 10934394392719230350
+    │ ╰────────────────────────────^ attributes hash: 3568881859844729307
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2387,9 +2448,10 @@ note:
     │  
 186 │ ╭     pub fn pow_u128(left: u128, right: u128) -> u128:
 187 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 3844087086888288806
+    │ ╰────────────────────────────^ attributes hash: 17129592850815340223
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2426,9 +2488,10 @@ note:
     │  
 189 │ ╭     pub fn pow_u64(left: u64, right: u64) -> u64:
 190 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 7090360049943337373
+    │ ╰────────────────────────────^ attributes hash: 14666166959439406742
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2465,9 +2528,10 @@ note:
     │  
 192 │ ╭     pub fn pow_u32(left: u32, right: u32) -> u32:
 193 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 1924425134457147261
+    │ ╰────────────────────────────^ attributes hash: 2033723386058016238
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2504,9 +2568,10 @@ note:
     │  
 195 │ ╭     pub fn pow_u16(left: u16, right: u16) -> u16:
 196 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 2007900231672655657
+    │ ╰────────────────────────────^ attributes hash: 2208322929283836441
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2543,9 +2608,10 @@ note:
     │  
 198 │ ╭     pub fn pow_u8(left: u8, right: u8) -> u8:
 199 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 1045834994105525345
+    │ ╰────────────────────────────^ attributes hash: 16477852824764552468
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2582,9 +2648,10 @@ note:
     │  
 201 │ ╭     pub fn pow_i256(left: i256, right: u256) -> i256:
 202 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 16826090789493664662
+    │ ╰────────────────────────────^ attributes hash: 13328792098034894314
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2621,9 +2688,10 @@ note:
     │  
 204 │ ╭     pub fn pow_i128(left: i128, right: u128) -> i128:
 205 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 17118097490571815230
+    │ ╰────────────────────────────^ attributes hash: 5162497528451028741
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2660,9 +2728,10 @@ note:
     │  
 207 │ ╭     pub fn pow_i64(left: i64, right: u64) -> i64:
 208 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 7954836210445785693
+    │ ╰────────────────────────────^ attributes hash: 3582235670066718134
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2699,9 +2768,10 @@ note:
     │  
 210 │ ╭     pub fn pow_i32(left: i32, right: u32) -> i32:
 211 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 16765733214596552581
+    │ ╰────────────────────────────^ attributes hash: 9104251235952663662
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2738,9 +2808,10 @@ note:
     │  
 213 │ ╭     pub fn pow_i16(left: i16, right: u16) -> i16:
 214 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 13501313120497633316
+    │ ╰────────────────────────────^ attributes hash: 1798106810832003212
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",
@@ -2777,9 +2848,10 @@ note:
     │  
 216 │ ╭     pub fn pow_i8(left: i8, right: u8) -> i8:
 217 │ │         return left ** right
-    │ ╰────────────────────────────^ attributes hash: 12382712145774122490
+    │ ╰────────────────────────────^ attributes hash: 4658061017856467890
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "left",

--- a/crates/analyzer/tests/snapshots/analysis__constructor.snap
+++ b/crates/analyzer/tests/snapshots/analysis__constructor.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/constructor.fe:4:5
   │  
-4 │ ╭     pub fn __init__(baz: u256, bing: u256):
+4 │ ╭     pub fn __init__(self, baz: u256, bing: u256):
 5 │ │         self.bar[42] = baz + bing
-  │ ╰─────────────────────────────────^ attributes hash: 13860805323528878631
+  │ ╰─────────────────────────────────^ attributes hash: 13108393064012885630
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "baz",
@@ -49,11 +50,12 @@ note:
 note: 
   ┌─ features/constructor.fe:7:5
   │  
-7 │ ╭     pub fn read_bar() -> u256:
+7 │ ╭     pub fn read_bar(self) -> u256:
 8 │ │         return self.bar[42]
-  │ ╰───────────────────────────^ attributes hash: 4553090961241945225
+  │ ╰───────────────────────────^ attributes hash: 16482263331346774611
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn get_my_num() -> u256:
 3 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 4553090961241945225
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -28,9 +29,10 @@ note:
 7 │ │         # value and salt
 8 │ │         let foo: Foo = Foo.create2(0, 52)
 9 │ │         return address(foo)
-  │ ╰───────────────────────────^ attributes hash: 2195077967527136217
+  │ ╰───────────────────────────^ attributes hash: 14219262914863437447
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn get_my_num() -> u256:
 3 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 4553090961241945225
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -27,9 +28,10 @@ note:
 6 │ ╭     pub fn create_foo() -> address:
 7 │ │         let foo: Foo = Foo.create(0)
 8 │ │         return address(foo)
-  │ ╰───────────────────────────^ attributes hash: 2195077967527136217
+  │ ╰───────────────────────────^ attributes hash: 14219262914863437447
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
@@ -14,9 +14,10 @@ note:
   │  
 2 │ ╭     pub fn get_my_num() -> u256:
 3 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 4553090961241945225
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -30,11 +31,12 @@ note:
 note: 
   ┌─ features/create_contract_from_init.fe:8:5
   │  
-8 │ ╭     pub fn __init__():
+8 │ ╭     pub fn __init__(self):
 9 │ │         self.foo_addr = address(Foo.create(0))
-  │ ╰──────────────────────────────────────────────^ attributes hash: 17883060253504188551
+  │ ╰──────────────────────────────────────────────^ attributes hash: 4369441865732737140
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(
@@ -46,11 +48,12 @@ note:
 note: 
    ┌─ features/create_contract_from_init.fe:11:5
    │  
-11 │ ╭     pub fn get_foo_addr() -> address:
+11 │ ╭     pub fn get_foo_addr(self) -> address:
 12 │ │         return self.foo_addr
-   │ ╰────────────────────────────^ attributes hash: 2195077967527136217
+   │ ╰────────────────────────────^ attributes hash: 17651916811868111914
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -55,15 +55,16 @@ note:
    ┌─ stress/data_copying_stress.fe:16:5
    │  
 16 │ ╭     pub fn set_my_vals(
-17 │ │         my_string: String<42>,
-18 │ │         my_other_string: String<42>,
-19 │ │         my_u256: u256,
+17 │ │         self,
+18 │ │         my_string: String<42>,
+19 │ │         my_other_string: String<42>,
    · │
-24 │ │         self.my_u256 = my_u256
-25 │ │         self.my_other_u256 = my_other_u256
-   │ ╰──────────────────────────────────────────^ attributes hash: 11884175539472018634
+25 │ │         self.my_u256 = my_u256
+26 │ │         self.my_other_u256 = my_other_u256
+   │ ╰──────────────────────────────────────────^ attributes hash: 17137180982713149068
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_string",
@@ -114,14 +115,15 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:27:5
+   ┌─ stress/data_copying_stress.fe:28:5
    │  
-27 │ ╭     pub fn set_to_my_other_vals():
-28 │ │         self.my_string = self.my_other_string
-29 │ │         self.my_u256 = self.my_other_u256
-   │ ╰─────────────────────────────────────────^ attributes hash: 17883060253504188551
+28 │ ╭     pub fn set_to_my_other_vals(self):
+29 │ │         self.my_string = self.my_other_string
+30 │ │         self.my_u256 = self.my_other_u256
+   │ ╰─────────────────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -131,18 +133,19 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:31:5
+   ┌─ stress/data_copying_stress.fe:32:5
    │  
-31 │ ╭     pub fn multiple_references_shared_memory(my_array: u256[10]):
-32 │ │         let my_2nd_array: u256[10] = my_array
-33 │ │         let my_3rd_array: u256[10] = my_2nd_array
-34 │ │ 
+32 │ ╭     pub fn multiple_references_shared_memory(my_array: u256[10]):
+33 │ │         let my_2nd_array: u256[10] = my_array
+34 │ │         let my_3rd_array: u256[10] = my_2nd_array
+35 │ │ 
    · │
-43 │ │         assert my_2nd_array[3] == 50
-44 │ │         assert my_3rd_array[3] == 50
-   │ ╰────────────────────────────────────^ attributes hash: 9113446910234840700
+44 │ │         assert my_2nd_array[3] == 50
+45 │ │         assert my_3rd_array[3] == 50
+   │ ╰────────────────────────────────────^ attributes hash: 12151087699347513484
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_array",
@@ -166,14 +169,15 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:46:5
+   ┌─ stress/data_copying_stress.fe:47:5
    │  
-46 │ ╭     pub fn mutate_and_return(my_array: u256[10]) -> u256[10]:
-47 │ │         my_array[3] = 5
-48 │ │         return my_array
-   │ ╰───────────────────────^ attributes hash: 21666037945659926
+47 │ ╭     pub fn mutate_and_return(my_array: u256[10]) -> u256[10]:
+48 │ │         my_array[3] = 5
+49 │ │         return my_array
+   │ ╰───────────────────────^ attributes hash: 982203845332646099
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_array",
@@ -202,13 +206,14 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:50:5
+   ┌─ stress/data_copying_stress.fe:51:5
    │  
-50 │ ╭     pub fn clone_and_return(my_array: u256[10]) -> u256[10]:
-51 │ │         return my_array.clone()
-   │ ╰───────────────────────────────^ attributes hash: 21666037945659926
+51 │ ╭     pub fn clone_and_return(my_array: u256[10]) -> u256[10]:
+52 │ │         return my_array.clone()
+   │ ╰───────────────────────────────^ attributes hash: 982203845332646099
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_array",
@@ -237,14 +242,15 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:53:5
+   ┌─ stress/data_copying_stress.fe:54:5
    │  
-53 │ ╭     pub fn clone_mutate_and_return(my_array: u256[10]) -> u256[10]:
-54 │ │         my_array.clone()[3] = 5
-55 │ │         return my_array
-   │ ╰───────────────────────^ attributes hash: 21666037945659926
+54 │ ╭     pub fn clone_mutate_and_return(my_array: u256[10]) -> u256[10]:
+55 │ │         my_array.clone()[3] = 5
+56 │ │         return my_array
+   │ ╰───────────────────────^ attributes hash: 982203845332646099
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_array",
@@ -273,18 +279,19 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:57:5
+   ┌─ stress/data_copying_stress.fe:58:5
    │  
-57 │ ╭     pub fn assign_my_nums_and_return() -> u256[5]:
-58 │ │         let my_nums_mem: u256[5]
-59 │ │         self.my_nums[0] = 42
-60 │ │         self.my_nums[1] = 26
+58 │ ╭     pub fn assign_my_nums_and_return(self) -> u256[5]:
+59 │ │         let my_nums_mem: u256[5]
+60 │ │         self.my_nums[0] = 42
+61 │ │         self.my_nums[1] = 26
    · │
-64 │ │         my_nums_mem = self.my_nums.to_mem()
-65 │ │         return my_nums_mem
-   │ ╰──────────────────────────^ attributes hash: 4738189056135306967
+65 │ │         my_nums_mem = self.my_nums.to_mem()
+66 │ │         return my_nums_mem
+   │ ╰──────────────────────────^ attributes hash: 1843734974850057968
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Array(
@@ -299,16 +306,17 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:67:5
+   ┌─ stress/data_copying_stress.fe:68:5
    │  
-67 │ ╭     pub fn emit_my_event():
-68 │ │         self.emit_my_event_internal(
-69 │ │             self.my_string.to_mem(),
-70 │ │             self.my_u256.to_mem()
-71 │ │         )
-   │ ╰─────────^ attributes hash: 17883060253504188551
+68 │ ╭     pub fn emit_my_event(self):
+69 │ │         emit_my_event_internal(
+70 │ │             self.my_string.to_mem(),
+71 │ │             self.my_u256.to_mem()
+72 │ │         )
+   │ ╰─────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -318,13 +326,14 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:73:5
+   ┌─ stress/data_copying_stress.fe:74:5
    │  
-73 │ ╭     fn emit_my_event_internal(some_string: String<42>, some_u256: u256):
-74 │ │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │ ╰──────────────────────────────────────────────────────────────^ attributes hash: 5409206322988374919
+74 │ ╭     fn emit_my_event_internal(some_string: String<42>, some_u256: u256):
+75 │ │         emit MyEvent(my_string=some_string, my_u256=some_u256)
+   │ ╰──────────────────────────────────────────────────────────────^ attributes hash: 18022359820804226717
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "some_string",
@@ -355,13 +364,14 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:76:5
+   ┌─ stress/data_copying_stress.fe:77:5
    │  
-76 │ ╭     pub fn set_my_addrs(my_addrs: address[3]):
-77 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 6574906467163987131
+77 │ ╭     pub fn set_my_addrs(self, my_addrs: address[3]):
+78 │ │         self.my_addrs = my_addrs
+   │ ╰────────────────────────────────^ attributes hash: 5533219732473050758
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_addrs",
@@ -383,13 +393,14 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:79:5
+   ┌─ stress/data_copying_stress.fe:80:5
    │  
-79 │ ╭     pub fn get_my_second_addr() -> address:
-80 │ │         return self.my_addrs[1]
-   │ ╰───────────────────────────────^ attributes hash: 2195077967527136217
+80 │ ╭     pub fn get_my_second_addr(self) -> address:
+81 │ │         return self.my_addrs[1]
+   │ ╰───────────────────────────────^ attributes hash: 17651916811868111914
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -399,648 +410,648 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:22:9
+   ┌─ stress/data_copying_stress.fe:23:9
    │
-22 │         self.my_string = my_string
+23 │         self.my_string = my_string
    │         ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:22:26
+   ┌─ stress/data_copying_stress.fe:23:26
    │
-22 │         self.my_string = my_string
+23 │         self.my_string = my_string
    │                          ^^^^^^^^^ String<42>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:23:9
-   │
-23 │         self.my_other_string = my_other_string
-   │         ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:23:32
-   │
-23 │         self.my_other_string = my_other_string
-   │                                ^^^^^^^^^^^^^^^ String<42>: Memory => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:24:9
    │
-24 │         self.my_u256 = my_u256
-   │         ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
+24 │         self.my_other_string = my_other_string
+   │         ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:24:24
+   ┌─ stress/data_copying_stress.fe:24:32
    │
-24 │         self.my_u256 = my_u256
-   │                        ^^^^^^^ u256: Value => None
+24 │         self.my_other_string = my_other_string
+   │                                ^^^^^^^^^^^^^^^ String<42>: Memory => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:25:9
    │
-25 │         self.my_other_u256 = my_other_u256
+25 │         self.my_u256 = my_u256
+   │         ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:25:24
+   │
+25 │         self.my_u256 = my_u256
+   │                        ^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:26:9
+   │
+26 │         self.my_other_u256 = my_other_u256
    │         ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:25:30
+   ┌─ stress/data_copying_stress.fe:26:30
    │
-25 │         self.my_other_u256 = my_other_u256
+26 │         self.my_other_u256 = my_other_u256
    │                              ^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:28:9
-   │
-28 │         self.my_string = self.my_other_string
-   │         ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:28:26
-   │
-28 │         self.my_string = self.my_other_string
-   │                          ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:29:9
    │
-29 │         self.my_u256 = self.my_other_u256
+29 │         self.my_string = self.my_other_string
+   │         ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:29:26
+   │
+29 │         self.my_string = self.my_other_string
+   │                          ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:30:9
+   │
+30 │         self.my_u256 = self.my_other_u256
    │         ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:29:24
+   ┌─ stress/data_copying_stress.fe:30:24
    │
-29 │         self.my_u256 = self.my_other_u256
+30 │         self.my_u256 = self.my_other_u256
    │                        ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:32:38
-   │
-32 │         let my_2nd_array: u256[10] = my_array
-   │                                      ^^^^^^^^ u256[10]: Memory => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:33:38
    │
-33 │         let my_3rd_array: u256[10] = my_2nd_array
+33 │         let my_2nd_array: u256[10] = my_array
+   │                                      ^^^^^^^^ u256[10]: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:34:38
+   │
+34 │         let my_3rd_array: u256[10] = my_2nd_array
    │                                      ^^^^^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:35:16
+   ┌─ stress/data_copying_stress.fe:36:16
    │
-35 │         assert my_array[3] != 5
+36 │         assert my_array[3] != 5
    │                ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:35:25
+   ┌─ stress/data_copying_stress.fe:36:25
    │
-35 │         assert my_array[3] != 5
+36 │         assert my_array[3] != 5
    │                         ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:35:16
+   ┌─ stress/data_copying_stress.fe:36:16
    │
-35 │         assert my_array[3] != 5
+36 │         assert my_array[3] != 5
    │                ^^^^^^^^^^^ u256: Memory => Some(Value)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:35:31
+   ┌─ stress/data_copying_stress.fe:36:31
    │
-35 │         assert my_array[3] != 5
+36 │         assert my_array[3] != 5
    │                               ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:35:16
+   ┌─ stress/data_copying_stress.fe:36:16
    │
-35 │         assert my_array[3] != 5
+36 │         assert my_array[3] != 5
    │                ^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:36:9
+   ┌─ stress/data_copying_stress.fe:37:9
    │
-36 │         my_array[3] = 5
+37 │         my_array[3] = 5
    │         ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:36:18
+   ┌─ stress/data_copying_stress.fe:37:18
    │
-36 │         my_array[3] = 5
+37 │         my_array[3] = 5
    │                  ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:36:9
+   ┌─ stress/data_copying_stress.fe:37:9
    │
-36 │         my_array[3] = 5
+37 │         my_array[3] = 5
    │         ^^^^^^^^^^^ u256: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:36:23
+   ┌─ stress/data_copying_stress.fe:37:23
    │
-36 │         my_array[3] = 5
+37 │         my_array[3] = 5
    │                       ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:37:16
+   ┌─ stress/data_copying_stress.fe:38:16
    │
-37 │         assert my_array[3] == 5
+38 │         assert my_array[3] == 5
    │                ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:37:25
+   ┌─ stress/data_copying_stress.fe:38:25
    │
-37 │         assert my_array[3] == 5
+38 │         assert my_array[3] == 5
    │                         ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:37:16
+   ┌─ stress/data_copying_stress.fe:38:16
    │
-37 │         assert my_array[3] == 5
+38 │         assert my_array[3] == 5
    │                ^^^^^^^^^^^ u256: Memory => Some(Value)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:37:31
+   ┌─ stress/data_copying_stress.fe:38:31
    │
-37 │         assert my_array[3] == 5
+38 │         assert my_array[3] == 5
    │                               ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:37:16
+   ┌─ stress/data_copying_stress.fe:38:16
    │
-37 │         assert my_array[3] == 5
+38 │         assert my_array[3] == 5
    │                ^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^ u256[10]: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:29
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                             ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:35
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                                   ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:16
    │
-39 │         assert my_3rd_array[3] == 5
+39 │         assert my_2nd_array[3] == 5
    │                ^^^^^^^^^^^^ u256[10]: Memory => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:29
    │
-39 │         assert my_3rd_array[3] == 5
+39 │         assert my_2nd_array[3] == 5
    │                             ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:16
    │
-39 │         assert my_3rd_array[3] == 5
+39 │         assert my_2nd_array[3] == 5
    │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:35
    │
-39 │         assert my_3rd_array[3] == 5
+39 │         assert my_2nd_array[3] == 5
    │                                   ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:16
    │
-39 │         assert my_3rd_array[3] == 5
+39 │         assert my_2nd_array[3] == 5
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:41:9
+   ┌─ stress/data_copying_stress.fe:40:16
    │
-41 │         my_3rd_array[3] = 50
-   │         ^^^^^^^^^^^^ u256[10]: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:41:22
-   │
-41 │         my_3rd_array[3] = 50
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:41:9
-   │
-41 │         my_3rd_array[3] = 50
-   │         ^^^^^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:41:27
-   │
-41 │         my_3rd_array[3] = 50
-   │                           ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:16
-   │
-42 │         assert my_array[3] == 50
-   │                ^^^^^^^^ u256[10]: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:25
-   │
-42 │         assert my_array[3] == 50
-   │                         ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:16
-   │
-42 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:31
-   │
-42 │         assert my_array[3] == 50
-   │                               ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:16
-   │
-42 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:16
-   │
-43 │         assert my_2nd_array[3] == 50
+40 │         assert my_3rd_array[3] == 5
    │                ^^^^^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:43:29
+   ┌─ stress/data_copying_stress.fe:40:29
    │
-43 │         assert my_2nd_array[3] == 50
+40 │         assert my_3rd_array[3] == 5
    │                             ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:43:16
+   ┌─ stress/data_copying_stress.fe:40:16
    │
-43 │         assert my_2nd_array[3] == 50
+40 │         assert my_3rd_array[3] == 5
    │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:43:35
+   ┌─ stress/data_copying_stress.fe:40:35
    │
-43 │         assert my_2nd_array[3] == 50
-   │                                   ^^ u256: Value => None
+40 │         assert my_3rd_array[3] == 5
+   │                                   ^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:40:16
+   │
+40 │         assert my_3rd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:42:9
+   │
+42 │         my_3rd_array[3] = 50
+   │         ^^^^^^^^^^^^ u256[10]: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:42:22
+   │
+42 │         my_3rd_array[3] = 50
+   │                      ^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:42:9
+   │
+42 │         my_3rd_array[3] = 50
+   │         ^^^^^^^^^^^^^^^ u256: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:42:27
+   │
+42 │         my_3rd_array[3] = 50
+   │                           ^^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:43:16
    │
-43 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+43 │         assert my_array[3] == 50
+   │                ^^^^^^^^ u256[10]: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:43:25
+   │
+43 │         assert my_array[3] == 50
+   │                         ^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:43:16
+   │
+43 │         assert my_array[3] == 50
+   │                ^^^^^^^^^^^ u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:43:31
+   │
+43 │         assert my_array[3] == 50
+   │                               ^^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:43:16
+   │
+43 │         assert my_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:16
    │
-44 │         assert my_3rd_array[3] == 50
+44 │         assert my_2nd_array[3] == 50
    │                ^^^^^^^^^^^^ u256[10]: Memory => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:29
    │
-44 │         assert my_3rd_array[3] == 50
+44 │         assert my_2nd_array[3] == 50
    │                             ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:16
    │
-44 │         assert my_3rd_array[3] == 50
+44 │         assert my_2nd_array[3] == 50
    │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:35
    │
-44 │         assert my_3rd_array[3] == 50
+44 │         assert my_2nd_array[3] == 50
    │                                   ^^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:16
    │
-44 │         assert my_3rd_array[3] == 50
+44 │         assert my_2nd_array[3] == 50
    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:47:9
+   ┌─ stress/data_copying_stress.fe:45:16
    │
-47 │         my_array[3] = 5
+45 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^ u256[10]: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:45:29
+   │
+45 │         assert my_3rd_array[3] == 50
+   │                             ^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:45:16
+   │
+45 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:45:35
+   │
+45 │         assert my_3rd_array[3] == 50
+   │                                   ^^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:45:16
+   │
+45 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:48:9
+   │
+48 │         my_array[3] = 5
    │         ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:47:18
+   ┌─ stress/data_copying_stress.fe:48:18
    │
-47 │         my_array[3] = 5
+48 │         my_array[3] = 5
    │                  ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:47:9
+   ┌─ stress/data_copying_stress.fe:48:9
    │
-47 │         my_array[3] = 5
+48 │         my_array[3] = 5
    │         ^^^^^^^^^^^ u256: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:47:23
+   ┌─ stress/data_copying_stress.fe:48:23
    │
-47 │         my_array[3] = 5
+48 │         my_array[3] = 5
    │                       ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:48:16
+   ┌─ stress/data_copying_stress.fe:49:16
    │
-48 │         return my_array
+49 │         return my_array
    │                ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:51:16
+   ┌─ stress/data_copying_stress.fe:52:16
    │
-51 │         return my_array.clone()
+52 │         return my_array.clone()
    │                ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:51:16
+   ┌─ stress/data_copying_stress.fe:52:16
    │
-51 │         return my_array.clone()
+52 │         return my_array.clone()
    │                ^^^^^^^^^^^^^^^^ u256[10]: Memory => Some(Memory)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:9
+   ┌─ stress/data_copying_stress.fe:55:9
    │
-54 │         my_array.clone()[3] = 5
+55 │         my_array.clone()[3] = 5
    │         ^^^^^^^^ u256[10]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:9
+   ┌─ stress/data_copying_stress.fe:55:9
    │
-54 │         my_array.clone()[3] = 5
+55 │         my_array.clone()[3] = 5
    │         ^^^^^^^^^^^^^^^^ u256[10]: Memory => Some(Memory)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:26
+   ┌─ stress/data_copying_stress.fe:55:26
    │
-54 │         my_array.clone()[3] = 5
+55 │         my_array.clone()[3] = 5
    │                          ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:9
+   ┌─ stress/data_copying_stress.fe:55:9
    │
-54 │         my_array.clone()[3] = 5
+55 │         my_array.clone()[3] = 5
    │         ^^^^^^^^^^^^^^^^^^^ u256: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:31
+   ┌─ stress/data_copying_stress.fe:55:31
    │
-54 │         my_array.clone()[3] = 5
+55 │         my_array.clone()[3] = 5
    │                               ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:55:16
+   ┌─ stress/data_copying_stress.fe:56:16
    │
-55 │         return my_array
+56 │         return my_array
    │                ^^^^^^^^ u256[10]: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:59:9
-   │
-59 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:59:22
-   │
-59 │         self.my_nums[0] = 42
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:59:9
-   │
-59 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:59:27
-   │
-59 │         self.my_nums[0] = 42
-   │                           ^^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:60:9
    │
-60 │         self.my_nums[1] = 26
+60 │         self.my_nums[0] = 42
    │         ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:60:22
    │
-60 │         self.my_nums[1] = 26
+60 │         self.my_nums[0] = 42
    │                      ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:60:9
    │
-60 │         self.my_nums[1] = 26
+60 │         self.my_nums[0] = 42
    │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:60:27
    │
-60 │         self.my_nums[1] = 26
+60 │         self.my_nums[0] = 42
    │                           ^^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:61:9
    │
-61 │         self.my_nums[2] = 0
+61 │         self.my_nums[1] = 26
    │         ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:61:22
    │
-61 │         self.my_nums[2] = 0
+61 │         self.my_nums[1] = 26
    │                      ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:61:9
    │
-61 │         self.my_nums[2] = 0
+61 │         self.my_nums[1] = 26
    │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:61:27
    │
-61 │         self.my_nums[2] = 0
-   │                           ^ u256: Value => None
+61 │         self.my_nums[1] = 26
+   │                           ^^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:62:9
    │
-62 │         self.my_nums[3] = 1
+62 │         self.my_nums[2] = 0
    │         ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:62:22
    │
-62 │         self.my_nums[3] = 1
+62 │         self.my_nums[2] = 0
    │                      ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:62:9
    │
-62 │         self.my_nums[3] = 1
+62 │         self.my_nums[2] = 0
    │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:62:27
    │
-62 │         self.my_nums[3] = 1
+62 │         self.my_nums[2] = 0
    │                           ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:63:9
    │
-63 │         self.my_nums[4] = 255
+63 │         self.my_nums[3] = 1
    │         ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:63:22
    │
-63 │         self.my_nums[4] = 255
+63 │         self.my_nums[3] = 1
    │                      ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:63:9
    │
-63 │         self.my_nums[4] = 255
+63 │         self.my_nums[3] = 1
    │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:63:27
    │
-63 │         self.my_nums[4] = 255
-   │                           ^^^ u256: Value => None
+63 │         self.my_nums[3] = 1
+   │                           ^ u256: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:64:9
    │
-64 │         my_nums_mem = self.my_nums.to_mem()
+64 │         self.my_nums[4] = 255
+   │         ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:64:22
+   │
+64 │         self.my_nums[4] = 255
+   │                      ^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:64:9
+   │
+64 │         self.my_nums[4] = 255
+   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:64:27
+   │
+64 │         self.my_nums[4] = 255
+   │                           ^^^ u256: Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:65:9
+   │
+65 │         my_nums_mem = self.my_nums.to_mem()
    │         ^^^^^^^^^^^ u256[5]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:64:23
+   ┌─ stress/data_copying_stress.fe:65:23
    │
-64 │         my_nums_mem = self.my_nums.to_mem()
+65 │         my_nums_mem = self.my_nums.to_mem()
    │                       ^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:64:23
+   ┌─ stress/data_copying_stress.fe:65:23
    │
-64 │         my_nums_mem = self.my_nums.to_mem()
+65 │         my_nums_mem = self.my_nums.to_mem()
    │                       ^^^^^^^^^^^^^^^^^^^^^ u256[5]: Storage { nonce: Some(4) } => Some(Memory)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:65:16
+   ┌─ stress/data_copying_stress.fe:66:16
    │
-65 │         return my_nums_mem
+66 │         return my_nums_mem
    │                ^^^^^^^^^^^ u256[5]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:69:13
+   ┌─ stress/data_copying_stress.fe:70:13
    │
-69 │             self.my_string.to_mem(),
+70 │             self.my_string.to_mem(),
    │             ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:69:13
+   ┌─ stress/data_copying_stress.fe:70:13
    │
-69 │             self.my_string.to_mem(),
+70 │             self.my_string.to_mem(),
    │             ^^^^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => Some(Memory)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:70:13
+   ┌─ stress/data_copying_stress.fe:71:13
    │
-70 │             self.my_u256.to_mem()
+71 │             self.my_u256.to_mem()
    │             ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:70:13
+   ┌─ stress/data_copying_stress.fe:71:13
    │
-70 │             self.my_u256.to_mem()
+71 │             self.my_u256.to_mem()
    │             ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:68:9
+   ┌─ stress/data_copying_stress.fe:69:9
    │  
-68 │ ╭         self.emit_my_event_internal(
-69 │ │             self.my_string.to_mem(),
-70 │ │             self.my_u256.to_mem()
-71 │ │         )
+69 │ ╭         emit_my_event_internal(
+70 │ │             self.my_string.to_mem(),
+71 │ │             self.my_u256.to_mem()
+72 │ │         )
    │ ╰─────────^ (): Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:74:32
+   ┌─ stress/data_copying_stress.fe:75:32
    │
-74 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
+75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
    │                                ^^^^^^^^^^^ String<42>: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:74:53
+   ┌─ stress/data_copying_stress.fe:75:53
    │
-74 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
+75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
    │                                                     ^^^^^^^^^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:77:9
+   ┌─ stress/data_copying_stress.fe:78:9
    │
-77 │         self.my_addrs = my_addrs
+78 │         self.my_addrs = my_addrs
    │         ^^^^^^^^^^^^^ address[3]: Storage { nonce: Some(5) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:77:25
+   ┌─ stress/data_copying_stress.fe:78:25
    │
-77 │         self.my_addrs = my_addrs
+78 │         self.my_addrs = my_addrs
    │                         ^^^^^^^^ address[3]: Memory => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:80:16
+   ┌─ stress/data_copying_stress.fe:81:16
    │
-80 │         return self.my_addrs[1]
+81 │         return self.my_addrs[1]
    │                ^^^^^^^^^^^^^ address[3]: Storage { nonce: Some(5) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:80:30
+   ┌─ stress/data_copying_stress.fe:81:30
    │
-80 │         return self.my_addrs[1]
+81 │         return self.my_addrs[1]
    │                              ^ u256: Value => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:80:16
+   ┌─ stress/data_copying_stress.fe:81:16
    │
-80 │         return self.my_addrs[1]
+81 │         return self.my_addrs[1]
    │                ^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Some(Value)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:74:9
+   ┌─ stress/data_copying_stress.fe:75:9
    │
-74 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
+75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 595206297963940250
    │
    = Event {
@@ -1072,69 +1083,69 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:32:27
-   │
-32 │         let my_2nd_array: u256[10] = my_array
-   │                           ^^^^^^^^ u256[10]
-
-note: 
    ┌─ stress/data_copying_stress.fe:33:27
    │
-33 │         let my_3rd_array: u256[10] = my_2nd_array
+33 │         let my_2nd_array: u256[10] = my_array
    │                           ^^^^^^^^ u256[10]
 
 note: 
-   ┌─ stress/data_copying_stress.fe:58:26
+   ┌─ stress/data_copying_stress.fe:34:27
    │
-58 │         let my_nums_mem: u256[5]
+34 │         let my_3rd_array: u256[10] = my_2nd_array
+   │                           ^^^^^^^^ u256[10]
+
+note: 
+   ┌─ stress/data_copying_stress.fe:59:26
+   │
+59 │         let my_nums_mem: u256[5]
    │                          ^^^^^^^ u256[5]
 
 note: 
-   ┌─ stress/data_copying_stress.fe:51:16
+   ┌─ stress/data_copying_stress.fe:52:16
    │
-51 │         return my_array.clone()
+52 │         return my_array.clone()
    │                ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
 
 note: 
-   ┌─ stress/data_copying_stress.fe:54:9
+   ┌─ stress/data_copying_stress.fe:55:9
    │
-54 │         my_array.clone()[3] = 5
+55 │         my_array.clone()[3] = 5
    │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
 
 note: 
-   ┌─ stress/data_copying_stress.fe:64:23
+   ┌─ stress/data_copying_stress.fe:65:23
    │
-64 │         my_nums_mem = self.my_nums.to_mem()
+65 │         my_nums_mem = self.my_nums.to_mem()
    │                       ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
 
 note: 
-   ┌─ stress/data_copying_stress.fe:68:9
+   ┌─ stress/data_copying_stress.fe:69:9
    │
-68 │         self.emit_my_event_internal(
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17599861255131653403
+69 │         emit_my_event_internal(
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15175926995091823840
    │
-   = SelfAttribute {
+   = Pure {
          func_name: "emit_my_event_internal",
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:69:13
+   ┌─ stress/data_copying_stress.fe:70:13
    │
-69 │             self.my_string.to_mem(),
+70 │             self.my_string.to_mem(),
    │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
 
 note: 
-   ┌─ stress/data_copying_stress.fe:70:13
+   ┌─ stress/data_copying_stress.fe:71:13
    │
-70 │             self.my_u256.to_mem()
+71 │             self.my_u256.to_mem()
    │             ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -78,14 +78,15 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:21:5
    │  
-21 │ ╭     pub fn __init__(name: String<100>, symbol: String<100>):
+21 │ ╭     pub fn __init__(self, name: String<100>, symbol: String<100>):
 22 │ │         self._name = name
 23 │ │         self._symbol = symbol
 24 │ │         self._decimals = u8(18)
 25 │ │         self._mint(msg.sender, 1000000000000000000000000)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 3273606564690912097
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 5200858442325067440
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "name",
@@ -118,11 +119,12 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:27:5
    │  
-27 │ ╭     pub fn name() -> String<100>:
+27 │ ╭     pub fn name(self) -> String<100>:
 28 │ │         return self._name.to_mem()
-   │ ╰──────────────────────────────────^ attributes hash: 547051866614494389
+   │ ╰──────────────────────────────────^ attributes hash: 12632360895853494516
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              String(
@@ -136,11 +138,12 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:30:5
    │  
-30 │ ╭     pub fn symbol() -> String<100>:
+30 │ ╭     pub fn symbol(self) -> String<100>:
 31 │ │         return self._symbol.to_mem()
-   │ ╰────────────────────────────────────^ attributes hash: 547051866614494389
+   │ ╰────────────────────────────────────^ attributes hash: 12632360895853494516
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              String(
@@ -154,11 +157,12 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:33:5
    │  
-33 │ ╭     pub fn decimals() -> u8:
+33 │ ╭     pub fn decimals(self) -> u8:
 34 │ │         return self._decimals
-   │ ╰─────────────────────────────^ attributes hash: 207849059327209983
+   │ ╰─────────────────────────────^ attributes hash: 6791549355703693154
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -172,11 +176,12 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:36:5
    │  
-36 │ ╭     pub fn totalSupply() -> u256:
+36 │ ╭     pub fn totalSupply(self) -> u256:
 37 │ │         return self._total_supply
-   │ ╰─────────────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰─────────────────────────────────^ attributes hash: 16482263331346774611
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -190,11 +195,12 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:39:5
    │  
-39 │ ╭     pub fn balanceOf(account: address) -> u256:
+39 │ ╭     pub fn balanceOf(self, account: address) -> u256:
 40 │ │         return self._balances[account]
-   │ ╰──────────────────────────────────────^ attributes hash: 3270716362116162777
+   │ ╰──────────────────────────────────────^ attributes hash: 11484923544867751175
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "account",
@@ -217,12 +223,13 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:42:5
    │  
-42 │ ╭     pub fn transfer(recipient: address, value: u256) -> bool:
+42 │ ╭     pub fn transfer(self, recipient: address, value: u256) -> bool:
 43 │ │         self._transfer(msg.sender, recipient, value)
 44 │ │         return true
-   │ ╰───────────────────^ attributes hash: 4820155873652504726
+   │ ╰───────────────────^ attributes hash: 1991308505230085281
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "recipient",
@@ -253,11 +260,12 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:46:5
    │  
-46 │ ╭     pub fn allowance(owner: address, spender: address) -> u256:
+46 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256:
 47 │ │         return self._allowances[owner][spender]
-   │ ╰───────────────────────────────────────────────^ attributes hash: 14386390033603643930
+   │ ╰───────────────────────────────────────────────^ attributes hash: 9282693738387957668
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "owner",
@@ -288,12 +296,13 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:49:5
    │  
-49 │ ╭     pub fn approve(spender: address, value: u256) -> bool:
+49 │ ╭     pub fn approve(self, spender: address, value: u256) -> bool:
 50 │ │         self._approve(msg.sender, spender, value)
 51 │ │         return true
-   │ ╰───────────────────^ attributes hash: 11178591286876422786
+   │ ╰───────────────────^ attributes hash: 10662679418650794263
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "spender",
@@ -324,15 +333,16 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:53:5
    │  
-53 │ ╭     pub fn transferFrom(sender: address, recipient: address, value: u256) -> bool:
+53 │ ╭     pub fn transferFrom(self, sender: address, recipient: address, value: u256) -> bool:
 54 │ │         assert self._allowances[sender][msg.sender] >= value
 55 │ │ 
 56 │ │         self._transfer(sender, recipient, value)
 57 │ │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
 58 │ │         return true
-   │ ╰───────────────────^ attributes hash: 6064139117296579527
+   │ ╰───────────────────^ attributes hash: 91095815201716281
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "sender",
@@ -371,12 +381,13 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:60:5
    │  
-60 │ ╭     pub fn increaseAllowance(spender: address, addedValue: u256) -> bool:
+60 │ ╭     pub fn increaseAllowance(self, spender: address, addedValue: u256) -> bool:
 61 │ │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
 62 │ │         return true
-   │ ╰───────────────────^ attributes hash: 9683116214595794825
+   │ ╰───────────────────^ attributes hash: 950629619328373893
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "spender",
@@ -407,12 +418,13 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:64:5
    │  
-64 │ ╭     pub fn decreaseAllowance(spender: address, subtractedValue: u256) -> bool:
+64 │ ╭     pub fn decreaseAllowance(self, spender: address, subtractedValue: u256) -> bool:
 65 │ │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
 66 │ │         return true
-   │ ╰───────────────────^ attributes hash: 16344483445513373712
+   │ ╰───────────────────^ attributes hash: 12802591286463221158
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "spender",
@@ -443,16 +455,17 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:68:5
    │  
-68 │ ╭     fn _transfer(sender: address, recipient: address, value: u256):
+68 │ ╭     fn _transfer(self, sender: address, recipient: address, value: u256):
 69 │ │         assert sender != address(0)
 70 │ │         assert recipient != address(0)
 71 │ │ 
    · │
 75 │ │         self._balances[recipient] = self._balances[recipient] + value
 76 │ │         emit Transfer(from=sender, to=recipient, value=value)
-   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 5319660245929540884
+   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 923743412527861440
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "sender",
@@ -491,16 +504,17 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:78:5
    │  
-78 │ ╭     fn _mint(account: address, value: u256):
+78 │ ╭     fn _mint(self, account: address, value: u256):
 79 │ │         assert account != address(0)
 80 │ │ 
-81 │ │         self._before_token_transfer(address(0), account, value)
+81 │ │         _before_token_transfer(address(0), account, value)
    · │
 84 │ │         self._balances[account] = self._balances[account] + value
 85 │ │         emit Transfer(from=address(0), to=account, value=value)
-   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 2703747865659945970
+   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "account",
@@ -531,16 +545,17 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:87:5
    │  
-87 │ ╭     fn _burn(account: address, value: u256):
+87 │ ╭     fn _burn(self, account: address, value: u256):
 88 │ │         assert account != address(0)
 89 │ │ 
-90 │ │         self._before_token_transfer(account, address(0), value)
+90 │ │         _before_token_transfer(account, address(0), value)
    · │
 93 │ │         self._total_supply = self._total_supply - value
 94 │ │         emit Transfer(from=account, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 2703747865659945970
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "account",
@@ -571,15 +586,16 @@ note:
 note: 
     ┌─ demos/erc20_token.fe:96:5
     │  
- 96 │ ╭     fn _approve(owner: address, spender: address, value: u256):
+ 96 │ ╭     fn _approve(self, owner: address, spender: address, value: u256):
  97 │ │         assert owner != address(0)
  98 │ │         assert spender != address(0)
  99 │ │ 
 100 │ │         self._allowances[owner][spender] = value
 101 │ │         emit Approval(owner, spender, value)
-    │ ╰────────────────────────────────────────────^ attributes hash: 14201079106432958367
+    │ ╰────────────────────────────────────────────^ attributes hash: 2670276789438195364
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "owner",
@@ -618,11 +634,12 @@ note:
 note: 
     ┌─ demos/erc20_token.fe:103:5
     │  
-103 │ ╭     fn _setup_decimals(decimals_: u8):
+103 │ ╭     fn _setup_decimals(self, decimals_: u8):
 104 │ │         self._decimals = decimals_
-    │ ╰──────────────────────────────────^ attributes hash: 11792619442907068589
+    │ ╰──────────────────────────────────^ attributes hash: 9774377157681208112
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "decimals_",
@@ -647,9 +664,10 @@ note:
     │  
 106 │ ╭     fn _before_token_transfer(from: address, to: address, value: u256):
 107 │ │         pass
-    │ ╰────────────^ attributes hash: 15422594702274887655
+    │ ╰────────────^ attributes hash: 9175941171634351733
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "from",
@@ -1202,28 +1220,28 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:72:37
+   ┌─ demos/erc20_token.fe:72:32
    │
-72 │         self._before_token_transfer(sender, recipient, value)
-   │                                     ^^^^^^ address: Value => None
+72 │         _before_token_transfer(sender, recipient, value)
+   │                                ^^^^^^ address: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:72:45
+   ┌─ demos/erc20_token.fe:72:40
    │
-72 │         self._before_token_transfer(sender, recipient, value)
-   │                                             ^^^^^^^^^ address: Value => None
+72 │         _before_token_transfer(sender, recipient, value)
+   │                                        ^^^^^^^^^ address: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:72:56
+   ┌─ demos/erc20_token.fe:72:51
    │
-72 │         self._before_token_transfer(sender, recipient, value)
-   │                                                        ^^^^^ u256: Value => None
+72 │         _before_token_transfer(sender, recipient, value)
+   │                                                   ^^^^^ u256: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:72:9
    │
-72 │         self._before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+72 │         _before_token_transfer(sender, recipient, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:74:9
@@ -1364,34 +1382,34 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:81:45
+   ┌─ demos/erc20_token.fe:81:40
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │                                             ^ u256: Value => None
+81 │         _before_token_transfer(address(0), account, value)
+   │                                        ^ u256: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:81:37
+   ┌─ demos/erc20_token.fe:81:32
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │                                     ^^^^^^^^^^ address: Value => None
+81 │         _before_token_transfer(address(0), account, value)
+   │                                ^^^^^^^^^^ address: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:81:49
+   ┌─ demos/erc20_token.fe:81:44
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │                                                 ^^^^^^^ address: Value => None
+81 │         _before_token_transfer(address(0), account, value)
+   │                                            ^^^^^^^ address: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:81:58
+   ┌─ demos/erc20_token.fe:81:53
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │                                                          ^^^^^ u256: Value => None
+81 │         _before_token_transfer(address(0), account, value)
+   │                                                     ^^^^^ u256: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:81:9
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+81 │         _before_token_transfer(address(0), account, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:83:9
@@ -1514,34 +1532,34 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:90:37
+   ┌─ demos/erc20_token.fe:90:32
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │                                     ^^^^^^^ address: Value => None
+90 │         _before_token_transfer(account, address(0), value)
+   │                                ^^^^^^^ address: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:90:54
+   ┌─ demos/erc20_token.fe:90:49
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │                                                      ^ u256: Value => None
+90 │         _before_token_transfer(account, address(0), value)
+   │                                                 ^ u256: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:90:46
+   ┌─ demos/erc20_token.fe:90:41
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │                                              ^^^^^^^^^^ address: Value => None
+90 │         _before_token_transfer(account, address(0), value)
+   │                                         ^^^^^^^^^^ address: Value => None
 
 note: 
-   ┌─ demos/erc20_token.fe:90:58
+   ┌─ demos/erc20_token.fe:90:53
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │                                                          ^^^^^ u256: Value => None
+90 │         _before_token_transfer(account, address(0), value)
+   │                                                     ^^^^^ u256: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:90:9
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+90 │         _before_token_transfer(account, address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:92:9
@@ -1935,10 +1953,14 @@ note:
    ┌─ demos/erc20_token.fe:25:9
    │
 25 │         self._mint(msg.sender, 1000000000000000000000000)
-   │         ^^^^^^^^^^ attributes hash: 1155617642661253645
+   │         ^^^^^^^^^^ attributes hash: 265135702653684875
    │
    = SelfAttribute {
          func_name: "_mint",
+         self_span: Span {
+             start: 544,
+             end: 548,
+         },
      }
 
 note: 
@@ -1961,60 +1983,84 @@ note:
    ┌─ demos/erc20_token.fe:43:9
    │
 43 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 17554789810436603039
+   │         ^^^^^^^^^^^^^^ attributes hash: 5001565696467153522
    │
    = SelfAttribute {
          func_name: "_transfer",
+         self_span: Span {
+             start: 1054,
+             end: 1058,
+         },
      }
 
 note: 
    ┌─ demos/erc20_token.fe:50:9
    │
 50 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 11653095055511118634
+   │         ^^^^^^^^^^^^^ attributes hash: 12868845685407710867
    │
    = SelfAttribute {
          func_name: "_approve",
+         self_span: Span {
+             start: 1312,
+             end: 1316,
+         },
      }
 
 note: 
    ┌─ demos/erc20_token.fe:56:9
    │
 56 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 17554789810436603039
+   │         ^^^^^^^^^^^^^^ attributes hash: 15797901682332754704
    │
    = SelfAttribute {
          func_name: "_transfer",
+         self_span: Span {
+             start: 1534,
+             end: 1538,
+         },
      }
 
 note: 
    ┌─ demos/erc20_token.fe:57:9
    │
 57 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^ attributes hash: 11653095055511118634
+   │         ^^^^^^^^^^^^^ attributes hash: 5014804364001639559
    │
    = SelfAttribute {
          func_name: "_approve",
+         self_span: Span {
+             start: 1583,
+             end: 1587,
+         },
      }
 
 note: 
    ┌─ demos/erc20_token.fe:61:9
    │
 61 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 11653095055511118634
+   │         ^^^^^^^^^^^^^ attributes hash: 7212935123142327759
    │
    = SelfAttribute {
          func_name: "_approve",
+         self_span: Span {
+             start: 1772,
+             end: 1776,
+         },
      }
 
 note: 
    ┌─ demos/erc20_token.fe:65:9
    │
 65 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 11653095055511118634
+   │         ^^^^^^^^^^^^^ attributes hash: 1568376678775244707
    │
    = SelfAttribute {
          func_name: "_approve",
+         self_span: Span {
+             start: 1973,
+             end: 1977,
+         },
      }
 
 note: 
@@ -2044,10 +2090,10 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:72:9
    │
-72 │         self._before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9533469367599954
+72 │         _before_token_transfer(sender, recipient, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 283404834886046277
    │
-   = SelfAttribute {
+   = Pure {
          func_name: "_before_token_transfer",
      }
 
@@ -2066,18 +2112,18 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:81:9
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9533469367599954
+81 │         _before_token_transfer(address(0), account, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 283404834886046277
    │
-   = SelfAttribute {
+   = Pure {
          func_name: "_before_token_transfer",
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:81:37
+   ┌─ demos/erc20_token.fe:81:32
    │
-81 │         self._before_token_transfer(address(0), account, value)
-   │                                     ^^^^^^^ attributes hash: 14203407709342965641
+81 │         _before_token_transfer(address(0), account, value)
+   │                                ^^^^^^^ attributes hash: 14203407709342965641
    │
    = TypeConstructor {
          typ: Base(
@@ -2112,18 +2158,18 @@ note:
 note: 
    ┌─ demos/erc20_token.fe:90:9
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9533469367599954
+90 │         _before_token_transfer(account, address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 283404834886046277
    │
-   = SelfAttribute {
+   = Pure {
          func_name: "_before_token_transfer",
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:90:46
+   ┌─ demos/erc20_token.fe:90:41
    │
-90 │         self._before_token_transfer(account, address(0), value)
-   │                                              ^^^^^^^ attributes hash: 14203407709342965641
+90 │         _before_token_transfer(account, address(0), value)
+   │                                         ^^^^^^^ attributes hash: 14203407709342965641
    │
    = TypeConstructor {
          typ: Base(

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -62,9 +62,10 @@ note:
    │  
 19 │ ╭     pub fn emit_nums():
 20 │ │         emit Nums(num1=26, num2=42)
-   │ ╰───────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰───────────────────────────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -78,9 +79,10 @@ note:
    │  
 22 │ ╭     pub fn emit_bases(addr: address):
 23 │ │         emit Bases(num=26, addr)
-   │ ╰────────────────────────────────^ attributes hash: 1974394024601971155
+   │ ╰────────────────────────────────^ attributes hash: 14507092098124791222
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "addr",
@@ -103,9 +105,10 @@ note:
    │  
 25 │ ╭     pub fn emit_mix(addr: address, my_bytes: u8[100]):
 26 │ │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │ ╰──────────────────────────────────────────────────^ attributes hash: 9471426679017439139
+   │ ╰──────────────────────────────────────────────────^ attributes hash: 11181555056051097974
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "addr",
@@ -144,9 +147,10 @@ note:
 30 │ │         addrs[0] = addr1
 31 │ │         addrs[1] = addr2
 32 │ │         emit Addresses(addrs)
-   │ ╰─────────────────────────────^ attributes hash: 8782263773672116816
+   │ ╰─────────────────────────────^ attributes hash: 13018113254659996848
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "addr1",

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -26,9 +26,10 @@ note:
   │  
 7 │ ╭     pub fn emit_event(my_num: u256, my_addrs: address[5], my_string: String<11>):
 8 │ │         emit MyEvent(my_num, my_addrs, my_string)
-  │ ╰─────────────────────────────────────────────────^ attributes hash: 17428859623886168806
+  │ ╰─────────────────────────────────────────────────^ attributes hash: 18349539147683316743
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "my_num",
@@ -78,9 +79,10 @@ note:
 13 │ │         my_array[1] = a * b
 14 │ │         my_array[2] = b
 15 │ │         return my_array
-   │ ╰───────────────────────^ attributes hash: 9609739735012773294
+   │ ╰───────────────────────^ attributes hash: 7166601560969052500
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "a",
@@ -125,9 +127,10 @@ note:
    · │
 24 │ │         let foo: Foo = Foo(foo_address)
 25 │ │         foo.emit_event(my_num, my_addrs, my_string)
-   │ ╰───────────────────────────────────────────────────^ attributes hash: 14705437284568223339
+   │ ╰───────────────────────────────────────────────────^ attributes hash: 17183077571888547848
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "foo_address",
@@ -186,9 +189,10 @@ note:
 31 │ │     ) -> u256[3]:
 32 │ │         let foo: Foo = Foo(foo_address)
 33 │ │         return foo.build_array(a, b)
-   │ ╰────────────────────────────────────^ attributes hash: 13650137565568360017
+   │ ╰────────────────────────────────────^ attributes hash: 6783560394552784988
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "foo_address",

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
@@ -13,9 +13,10 @@ note:
    · │
 12 │ │                 break
 13 │ │         return sum
-   │ ╰──────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
@@ -13,9 +13,10 @@ note:
    · │
 14 │ │             sum = sum + i
 15 │ │         return sum
-   │ ╰──────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
@@ -13,9 +13,10 @@ note:
    · │
 10 │ │             sum = sum + i
 11 │ │         return sum
-   │ ╰──────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -18,15 +18,16 @@ note:
 note: 
    ┌─ demos/guest_book.fe:11:5
    │  
-11 │ ╭     pub fn sign(book_msg: String<100>):
+11 │ ╭     pub fn sign(self, book_msg: String<100>):
 12 │ │         # All storage access is explicit using `self.<some-key>`
 13 │ │         self.messages[msg.sender] = book_msg
 14 │ │ 
 15 │ │         # Emit the `Signed` event
 16 │ │         emit Signed(book_msg=book_msg)
-   │ ╰──────────────────────────────────────^ attributes hash: 4052420453933544886
+   │ ╰──────────────────────────────────────^ attributes hash: 726352713514806227
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "book_msg",
@@ -49,13 +50,14 @@ note:
 note: 
    ┌─ demos/guest_book.fe:18:5
    │  
-18 │ ╭     pub fn get_msg(addr: address) -> String<100>:
+18 │ ╭     pub fn get_msg(self, addr: address) -> String<100>:
 19 │ │         # Copying data from storage to memory
 20 │ │         # has to be done explicitly via `to_mem()`
 21 │ │         return self.messages[addr].to_mem()
-   │ ╰───────────────────────────────────────────^ attributes hash: 10372952195383146305
+   │ ╰───────────────────────────────────────────^ attributes hash: 13118977016650692130
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "addr",

--- a/crates/analyzer/tests/snapshots/analysis__if_statement.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement.snap
@@ -11,9 +11,10 @@ note:
 5 │ │             return 1
 6 │ │         else:
 7 │ │             return 0
-  │ ╰────────────────────^ attributes hash: 3019427292913193612
+  │ ╰────────────────────^ attributes hash: 16591277757740338966
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "input",

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
@@ -13,9 +13,10 @@ note:
 7 │ │             assert true
 8 │ │ 
 9 │ │         return 0
-  │ ╰────────────────^ attributes hash: 6248121154456130073
+  │ ╰────────────────^ attributes hash: 3075818098030342593
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "val",

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
@@ -13,9 +13,10 @@ note:
 7 │ │         else:
 8 │ │             let y: u256 = 1
 9 │ │             return y
-  │ ╰────────────────────^ attributes hash: 4553090961241945225
+  │ ╰────────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -8,9 +8,10 @@ note:
   │  
 3 │ ╭     pub fn return_hash_from_u8(val: u8[1]) -> u256:
 4 │ │         return keccak256(val)
-  │ ╰─────────────────────────────^ attributes hash: 3365860038500136191
+  │ ╰─────────────────────────────^ attributes hash: 9819456037818510846
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "val",
@@ -40,9 +41,10 @@ note:
   │  
 6 │ ╭     pub fn return_hash_from_foo(val: u8[3]) -> u256:
 7 │ │         return keccak256(val)
-  │ ╰─────────────────────────────^ attributes hash: 14368707390067541026
+  │ ╰─────────────────────────────^ attributes hash: 1978781307898700312
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "val",
@@ -72,9 +74,10 @@ note:
    │  
  9 │ ╭     pub fn return_hash_from_u256(val: u8[32]) -> u256:
 10 │ │         return keccak256(val)
-   │ ╰─────────────────────────────^ attributes hash: 2195893687340139662
+   │ ╰─────────────────────────────^ attributes hash: 9430369799730084939
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "val",

--- a/crates/analyzer/tests/snapshots/analysis__math.snap
+++ b/crates/analyzer/tests/snapshots/analysis__math.snap
@@ -13,9 +13,10 @@ note:
    · │
 13 │ │             z = 1
 14 │ │         return z
-   │ ╰────────────────^ attributes hash: 6248121154456130073
+   │ ╰────────────────^ attributes hash: 3075818098030342593
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "val",
@@ -42,9 +43,10 @@ note:
    │  
 16 │ ╭     pub fn min(x: u256, y: u256) -> u256:
 17 │ │         return x if x < y else y
-   │ ╰────────────────────────────────^ attributes hash: 11686109986999089900
+   │ ╰────────────────────────────────^ attributes hash: 4022593831796629401
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -12,9 +12,10 @@ note:
 5 │ │         my_array[1] = y
 6 │ │         my_array[2] = z
 7 │ │         return my_array
-  │ ╰───────────────────────^ attributes hash: 6824984156660016016
+  │ ╰───────────────────────^ attributes hash: 15956839592293831939
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__nested_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__nested_map.snap
@@ -18,11 +18,12 @@ note:
 note: 
   ┌─ features/nested_map.fe:5:5
   │  
-5 │ ╭     pub fn read_bar(a: address, b: address) -> u256:
+5 │ ╭     pub fn read_bar(self, a: address, b: address) -> u256:
 6 │ │         return self.bar[a][b]
-  │ ╰─────────────────────────────^ attributes hash: 1651558539348251726
+  │ ╰─────────────────────────────^ attributes hash: 10579681573605137522
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "a",
@@ -53,11 +54,12 @@ note:
 note: 
   ┌─ features/nested_map.fe:8:5
   │  
-8 │ ╭     pub fn write_bar(a: address, b: address, value: u256):
+8 │ ╭     pub fn write_bar(self, a: address, b: address, value: u256):
 9 │ │         self.bar[a][b] = value
-  │ ╰──────────────────────────────^ attributes hash: 15634013844749287831
+  │ ╰──────────────────────────────^ attributes hash: 6159174104336834167
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "a",
@@ -96,11 +98,12 @@ note:
 note: 
    ┌─ features/nested_map.fe:11:5
    │  
-11 │ ╭     pub fn read_baz(a: address, b: u256) -> bool:
+11 │ ╭     pub fn read_baz(self, a: address, b: u256) -> bool:
 12 │ │         return self.baz[a][b]
-   │ ╰─────────────────────────────^ attributes hash: 7209940387781148962
+   │ ╰─────────────────────────────^ attributes hash: 4588948300794405674
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "a",
@@ -131,11 +134,12 @@ note:
 note: 
    ┌─ features/nested_map.fe:14:5
    │  
-14 │ ╭     pub fn write_baz(a: address, b: u256, value: bool):
+14 │ ╭     pub fn write_baz(self, a: address, b: u256, value: bool):
 15 │ │         self.baz[a][b] = value
-   │ ╰──────────────────────────────^ attributes hash: 10489623509827031309
+   │ ╰──────────────────────────────^ attributes hash: 6894542203512356705
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "a",

--- a/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
@@ -8,9 +8,10 @@ note:
   │  
 3 │ ╭     pub fn get_u8_min() -> u8:
 4 │ │         return u8(0)
-  │ ╰────────────────────^ attributes hash: 207849059327209983
+  │ ╰────────────────────^ attributes hash: 15462761770183730040
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -26,9 +27,10 @@ note:
   │  
 6 │ ╭     pub fn get_u16_min() -> u16:
 7 │ │         return u16(0)
-  │ ╰─────────────────────^ attributes hash: 14687888308893756364
+  │ ╰─────────────────────^ attributes hash: 10017164652541649600
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -44,9 +46,10 @@ note:
    │  
  9 │ ╭     pub fn get_u32_min() -> u32:
 10 │ │         return u32(0)
-   │ ╰─────────────────────^ attributes hash: 11298375382964468330
+   │ ╰─────────────────────^ attributes hash: 4354472668127410067
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -62,9 +65,10 @@ note:
    │  
 12 │ ╭     pub fn get_u64_min() -> u64:
 13 │ │         return u64(0)
-   │ ╰─────────────────────^ attributes hash: 16659579683950699712
+   │ ╰─────────────────────^ attributes hash: 8805350184699333576
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -80,9 +84,10 @@ note:
    │  
 15 │ ╭     pub fn get_u128_min() -> u128:
 16 │ │         return u128(0)
-   │ ╰──────────────────────^ attributes hash: 16590220569563418042
+   │ ╰──────────────────────^ attributes hash: 11305728023724764506
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -98,9 +103,10 @@ note:
    │  
 18 │ ╭     pub fn get_u256_min() -> u256:
 19 │ │         return u256(0)
-   │ ╰──────────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -116,9 +122,10 @@ note:
    │  
 21 │ ╭     pub fn get_i8_min() -> i8:
 22 │ │         return i8(-128)
-   │ ╰───────────────────────^ attributes hash: 18050713998756114952
+   │ ╰───────────────────────^ attributes hash: 731104252696575145
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -134,9 +141,10 @@ note:
    │  
 24 │ ╭     pub fn get_i16_min() -> i16:
 25 │ │         return i16(-32768)
-   │ ╰──────────────────────────^ attributes hash: 18297427199653836949
+   │ ╰──────────────────────────^ attributes hash: 10826937395839813106
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -152,9 +160,10 @@ note:
    │  
 27 │ ╭     pub fn get_i32_min() -> i32:
 28 │ │         return i32(-2147483648)
-   │ ╰───────────────────────────────^ attributes hash: 1981451737012009869
+   │ ╰───────────────────────────────^ attributes hash: 10625528290137096297
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -170,9 +179,10 @@ note:
    │  
 30 │ ╭     pub fn get_i64_min() -> i64:
 31 │ │         return i64(-9223372036854775808)
-   │ ╰────────────────────────────────────────^ attributes hash: 11756888780421166692
+   │ ╰────────────────────────────────────────^ attributes hash: 13048789010407555817
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -188,9 +198,10 @@ note:
    │  
 33 │ ╭     pub fn get_i128_min() -> i128:
 34 │ │         return i128(-170141183460469231731687303715884105728)
-   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 12139568508098609638
+   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 11475314391007551899
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -206,9 +217,10 @@ note:
    │  
 36 │ ╭     pub fn get_i256_min() -> i256:
 37 │ │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 15881191383768803801
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 8698921636126413081
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -224,9 +236,10 @@ note:
    │  
 39 │ ╭     pub fn get_u8_max() -> u8:
 40 │ │         return u8(255)
-   │ ╰──────────────────────^ attributes hash: 207849059327209983
+   │ ╰──────────────────────^ attributes hash: 15462761770183730040
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -242,9 +255,10 @@ note:
    │  
 42 │ ╭     pub fn get_u16_max() -> u16:
 43 │ │         return u16(65535)
-   │ ╰─────────────────────────^ attributes hash: 14687888308893756364
+   │ ╰─────────────────────────^ attributes hash: 10017164652541649600
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -260,9 +274,10 @@ note:
    │  
 45 │ ╭     pub fn get_u32_max() -> u32:
 46 │ │         return u32(4294967295)
-   │ ╰──────────────────────────────^ attributes hash: 11298375382964468330
+   │ ╰──────────────────────────────^ attributes hash: 4354472668127410067
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -278,9 +293,10 @@ note:
    │  
 48 │ ╭     pub fn get_u64_max() -> u64:
 49 │ │         return u64(18446744073709551615)
-   │ ╰────────────────────────────────────────^ attributes hash: 16659579683950699712
+   │ ╰────────────────────────────────────────^ attributes hash: 8805350184699333576
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -296,9 +312,10 @@ note:
    │  
 51 │ ╭     pub fn get_u128_max() -> u128:
 52 │ │         return u128(340282366920938463463374607431768211455)
-   │ ╰────────────────────────────────────────────────────────────^ attributes hash: 16590220569563418042
+   │ ╰────────────────────────────────────────────────────────────^ attributes hash: 11305728023724764506
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -314,9 +331,10 @@ note:
    │  
 54 │ ╭     pub fn get_u256_max() -> u256:
 55 │ │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -332,9 +350,10 @@ note:
    │  
 57 │ ╭     pub fn get_i8_max() -> i8:
 58 │ │         return i8(127)
-   │ ╰──────────────────────^ attributes hash: 18050713998756114952
+   │ ╰──────────────────────^ attributes hash: 731104252696575145
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -350,9 +369,10 @@ note:
    │  
 60 │ ╭     pub fn get_i16_max() -> i16:
 61 │ │         return i16(32767)
-   │ ╰─────────────────────────^ attributes hash: 18297427199653836949
+   │ ╰─────────────────────────^ attributes hash: 10826937395839813106
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -368,9 +388,10 @@ note:
    │  
 63 │ ╭     pub fn get_i32_max() -> i32:
 64 │ │         return i32(2147483647)
-   │ ╰──────────────────────────────^ attributes hash: 1981451737012009869
+   │ ╰──────────────────────────────^ attributes hash: 10625528290137096297
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -386,9 +407,10 @@ note:
    │  
 66 │ ╭     pub fn get_i64_max() -> i64:
 67 │ │         return i64(9223372036854775807)
-   │ ╰───────────────────────────────────────^ attributes hash: 11756888780421166692
+   │ ╰───────────────────────────────────────^ attributes hash: 13048789010407555817
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -404,9 +426,10 @@ note:
    │  
 69 │ ╭     pub fn get_i128_max() -> i128:
 70 │ │         return i128(170141183460469231731687303715884105727)
-   │ ╰────────────────────────────────────────────────────────────^ attributes hash: 12139568508098609638
+   │ ╰────────────────────────────────────────────────────────────^ attributes hash: 11475314391007551899
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -422,9 +445,10 @@ note:
    │  
 72 │ ╭     pub fn get_i256_max() -> i256:
 73 │ │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 15881191383768803801
+   │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 8698921636126413081
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -24,11 +24,12 @@ note:
 note: 
   ┌─ features/ownable.fe:8:3
   │  
-8 │ ╭   pub fn __init__():
+8 │ ╭   pub fn __init__(self):
 9 │ │     self._owner = msg.sender
-  │ ╰────────────────────────────^ attributes hash: 17883060253504188551
+  │ ╰────────────────────────────^ attributes hash: 4369441865732737140
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(
@@ -40,11 +41,12 @@ note:
 note: 
    ┌─ features/ownable.fe:11:3
    │  
-11 │ ╭   pub fn owner() -> address:
+11 │ ╭   pub fn owner(self) -> address:
 12 │ │     return self._owner
-   │ ╰──────────────────────^ attributes hash: 2195077967527136217
+   │ ╰──────────────────────^ attributes hash: 17651916811868111914
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -56,13 +58,14 @@ note:
 note: 
    ┌─ features/ownable.fe:14:3
    │  
-14 │ ╭   pub fn renounceOwnership():
+14 │ ╭   pub fn renounceOwnership(self):
 15 │ │     assert msg.sender == self._owner
 16 │ │     self._owner = address(0)
 17 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -74,14 +77,15 @@ note:
 note: 
    ┌─ features/ownable.fe:19:3
    │  
-19 │ ╭   pub fn transferOwnership(newOwner: address):
+19 │ ╭   pub fn transferOwnership(self, newOwner: address):
 20 │ │     assert msg.sender == self._owner
 21 │ │     assert newOwner != address(0)
 22 │ │     self._owner = newOwner
 23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 9370789811972031746
+   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 9053558391660990741
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "newOwner",

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256:
 3 │ │         return x + y
-  │ ╰────────────────────^ attributes hash: 9310807767419918179
+  │ ╰────────────────────^ attributes hash: 4860075934425578454
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u128, y: u128) -> u128:
 3 │ │         return x + y
-  │ ╰────────────────────^ attributes hash: 15565569043007838551
+  │ ╰────────────────────^ attributes hash: 10281195141566324513
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x + y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -10,9 +10,10 @@ note:
 3 │ │         let my_array: u256[5]
 4 │ │         my_array[3] = x
 5 │ │         return my_array
-  │ ╰───────────────────────^ attributes hash: 15829867558716906613
+  │ ╰───────────────────────^ attributes hash: 10028801516300138995
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u128, y: u128) -> u128:
 3 │ │         return x & y
-  │ ╰────────────────────^ attributes hash: 15565569043007838551
+  │ ╰────────────────────^ attributes hash: 10281195141566324513
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x & y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x | y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x << y
-  │ ╰─────────────────────^ attributes hash: 11686109986999089900
+  │ ╰─────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: u256) -> i256:
 3 │ │         return x >> y
-  │ ╰─────────────────────^ attributes hash: 8833596757305744375
+  │ ╰─────────────────────^ attributes hash: 4187576449250351494
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x >> y
-  │ ╰─────────────────────^ attributes hash: 11686109986999089900
+  │ ╰─────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x ^ y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_false.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_false.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> bool:
 3 │ │         return false
-  │ ╰────────────────────^ attributes hash: 9286995118813931448
+  │ ╰────────────────────^ attributes hash: 7070150443167981657
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_inverted.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_inverted.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(some_condition: bool) -> bool:
 3 │ │         return not some_condition
-  │ ╰─────────────────────────────────^ attributes hash: 14777001708576289344
+  │ ╰─────────────────────────────────^ attributes hash: 7363475879734480653
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "some_condition",

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: bool, y: bool) -> bool:
 3 │ │         return x and y
-  │ ╰──────────────────────^ attributes hash: 7971031070470623108
+  │ ╰──────────────────────^ attributes hash: 13798846963690222600
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: bool, y: bool) -> bool:
 3 │ │         return x or y
-  │ ╰─────────────────────^ attributes hash: 7971031070470623108
+  │ ╰─────────────────────^ attributes hash: 13798846963690222600
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_true.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_true.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> bool:
 3 │ │         return true
-  │ ╰───────────────────^ attributes hash: 9286995118813931448
+  │ ╰───────────────────^ attributes hash: 7070150443167981657
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn coinbase() -> address:
 3 │ │         return block.coinbase
-  │ ╰─────────────────────────────^ attributes hash: 2195077967527136217
+  │ ╰─────────────────────────────^ attributes hash: 14219262914863437447
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -24,9 +25,10 @@ note:
   │  
 5 │ ╭     pub fn difficulty() -> u256:
 6 │ │         return block.difficulty
-  │ ╰───────────────────────────────^ attributes hash: 4553090961241945225
+  │ ╰───────────────────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -42,9 +44,10 @@ note:
   │  
 8 │ ╭     pub fn number() -> u256:
 9 │ │         return block.number
-  │ ╰───────────────────────────^ attributes hash: 4553090961241945225
+  │ ╰───────────────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -60,9 +63,10 @@ note:
    │  
 11 │ ╭     pub fn timestamp() -> u256:
 12 │ │         return block.timestamp
-   │ ╰──────────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -78,9 +82,10 @@ note:
    │  
 14 │ ╭     pub fn chainid() -> u256:
 15 │ │         return chain.id
-   │ ╰───────────────────────^ attributes hash: 4553090961241945225
+   │ ╰───────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -96,9 +101,10 @@ note:
    │  
 17 │ ╭     pub fn sender() -> address:
 18 │ │         return msg.sender
-   │ ╰─────────────────────────^ attributes hash: 2195077967527136217
+   │ ╰─────────────────────────^ attributes hash: 14219262914863437447
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -112,9 +118,10 @@ note:
    │  
 20 │ ╭     pub fn value() -> u256:
 21 │ │         return msg.value
-   │ ╰────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -130,9 +137,10 @@ note:
    │  
 23 │ ╭     pub fn origin() -> address:
 24 │ │         return tx.origin
-   │ ╰────────────────────────^ attributes hash: 2195077967527136217
+   │ ╰────────────────────────^ attributes hash: 14219262914863437447
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -146,9 +154,10 @@ note:
    │  
 26 │ ╭     pub fn gas_price() -> u256:
 27 │ │         return tx.gas_price
-   │ ╰───────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰───────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256:
 3 │ │         return x / y
-  │ ╰────────────────────^ attributes hash: 9310807767419918179
+  │ ╰────────────────────^ attributes hash: 4860075934425578454
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x / y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
@@ -8,9 +8,10 @@ note:
   │  
 3 │ ╭   pub fn explicit_return_a1():
 4 │ │     return
-  │ ╰──────────^ attributes hash: 17883060253504188551
+  │ ╰──────────^ attributes hash: 15148455653558261645
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -24,9 +25,10 @@ note:
   │  
 6 │ ╭   pub fn explicit_return_a2():
 7 │ │     return ()
-  │ ╰─────────────^ attributes hash: 17883060253504188551
+  │ ╰─────────────^ attributes hash: 15148455653558261645
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -40,9 +42,10 @@ note:
    │  
  9 │ ╭   pub fn explicit_return_b1() -> ():
 10 │ │     return
-   │ ╰──────────^ attributes hash: 17883060253504188551
+   │ ╰──────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -56,9 +59,10 @@ note:
    │  
 12 │ ╭   pub fn explicit_return_b2() -> ():
 13 │ │     return ()
-   │ ╰─────────────^ attributes hash: 17883060253504188551
+   │ ╰─────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -72,9 +76,10 @@ note:
    │  
 15 │ ╭   pub fn implicit_a1():
 16 │ │     pass
-   │ ╰────────^ attributes hash: 17883060253504188551
+   │ ╰────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -88,9 +93,10 @@ note:
    │  
 18 │ ╭   pub fn implicit_a2() -> ():
 19 │ │     pass
-   │ ╰────────^ attributes hash: 17883060253504188551
+   │ ╰────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool:
 3 │ │         return x == y
-  │ ╰─────────────────────^ attributes hash: 10079795692284924191
+  │ ╰─────────────────────^ attributes hash: 17032633651560910701
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool:
 3 │ │         return x > y
-  │ ╰────────────────────^ attributes hash: 10078605265406793117
+  │ ╰────────────────────^ attributes hash: 211782109501053014
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool:
 3 │ │         return x > y
-  │ ╰────────────────────^ attributes hash: 10079795692284924191
+  │ ╰────────────────────^ attributes hash: 17032633651560910701
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool:
 3 │ │         return x >= y
-  │ ╰─────────────────────^ attributes hash: 10078605265406793117
+  │ ╰─────────────────────^ attributes hash: 211782109501053014
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool:
 3 │ │         return x >= y
-  │ ╰─────────────────────^ attributes hash: 10079795692284924191
+  │ ╰─────────────────────^ attributes hash: 17032633651560910701
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> i128:
 3 │ │         return i128(-3)
-  │ ╰───────────────────────^ attributes hash: 12139568508098609638
+  │ ╰───────────────────────^ attributes hash: 11475314391007551899
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> i256:
 3 │ │         return -3
-  │ ╰─────────────────^ attributes hash: 15881191383768803801
+  │ ╰─────────────────^ attributes hash: 8698921636126413081
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u128.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u128) -> u128:
 3 │ │         return x
-  │ ╰────────────────^ attributes hash: 8365742328194771965
+  │ ╰────────────────^ attributes hash: 7698314787365759450
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u16.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u16.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u16) -> u16:
 3 │ │         return x
-  │ ╰────────────────^ attributes hash: 10505456960088439010
+  │ ╰────────────────^ attributes hash: 296602306239352294
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256) -> u256:
 3 │ │         return x
-  │ ╰────────────────^ attributes hash: 2762949736971776026
+  │ ╰────────────────^ attributes hash: 10491700091878076414
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u32.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u32.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u32) -> u32:
 3 │ │         return x
-  │ ╰────────────────^ attributes hash: 13920885540407638237
+  │ ╰────────────────^ attributes hash: 2848779612042989975
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u64.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u64.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u64) -> u64:
 3 │ │         return x
-  │ ╰────────────────^ attributes hash: 5321544225506280220
+  │ ╰────────────────^ attributes hash: 6904023592385922456
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u8.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u8.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u8) -> u8:
 3 │ │         return x
-  │ ╰────────────────^ attributes hash: 1075048652628918227
+  │ ╰────────────────^ attributes hash: 9329224274477991513
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool:
 3 │ │         return x < y
-  │ ╰────────────────────^ attributes hash: 10078605265406793117
+  │ ╰────────────────────^ attributes hash: 211782109501053014
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u128, y: u128) -> bool:
 3 │ │         return x < y
-  │ ╰────────────────────^ attributes hash: 14812784515048627045
+  │ ╰────────────────────^ attributes hash: 8739738183071226339
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool:
 3 │ │         return x < y
-  │ ╰────────────────────^ attributes hash: 10079795692284924191
+  │ ╰────────────────────^ attributes hash: 17032633651560910701
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool:
 3 │ │         return x <= y
-  │ ╰─────────────────────^ attributes hash: 10078605265406793117
+  │ ╰─────────────────────^ attributes hash: 211782109501053014
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool:
 3 │ │         return x <= y
-  │ ╰─────────────────────^ attributes hash: 10079795692284924191
+  │ ╰─────────────────────^ attributes hash: 17032633651560910701
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256:
 3 │ │         return x % y
-  │ ╰────────────────────^ attributes hash: 9310807767419918179
+  │ ╰────────────────────^ attributes hash: 4860075934425578454
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x % y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> u256:
 3 │ │         return msg.sig
-  │ ╰──────────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256:
 3 │ │         return x * y
-  │ ╰────────────────────^ attributes hash: 9310807767419918179
+  │ ╰────────────────────^ attributes hash: 4860075934425578454
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x * y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool:
 3 │ │         return x != y
-  │ ╰─────────────────────^ attributes hash: 10079795692284924191
+  │ ╰─────────────────────^ attributes hash: 17032633651560910701
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i8, y: u8) -> i8:
 3 │ │         return x ** y
-  │ ╰─────────────────────^ attributes hash: 1555487936992246391
+  │ ╰─────────────────────^ attributes hash: 1717983320838236036
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x ** y
-  │ ╰─────────────────────^ attributes hash: 11686109986999089900
+  │ ╰─────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256:
 3 │ │         return x - y
-  │ ╰────────────────────^ attributes hash: 9310807767419918179
+  │ ╰────────────────────^ attributes hash: 4860075934425578454
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256:
 3 │ │         return x - y
-  │ ╰────────────────────^ attributes hash: 11686109986999089900
+  │ ╰────────────────────^ attributes hash: 4022593831796629401
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "x",

--- a/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> u128:
 3 │ │         return u128(42)
-  │ ╰───────────────────────^ attributes hash: 16590220569563418042
+  │ ╰───────────────────────^ attributes hash: 11305728023724764506
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256.snap
@@ -8,9 +8,10 @@ note:
   │  
 2 │ ╭     pub fn bar() -> u256:
 3 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 4553090961241945225
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
@@ -6,11 +6,12 @@ expression: "build_snapshot(\"features/return_u256_from_called_fn.fe\", &src, mo
 note: 
   ┌─ features/return_u256_from_called_fn.fe:4:5
   │  
-4 │ ╭     pub fn bar() -> u256:
-5 │ │         return self.foo()
-  │ ╰─────────────────────────^ attributes hash: 4553090961241945225
+4 │ ╭     pub fn bar(self) -> u256:
+5 │ │         return foo()
+  │ ╰────────────────────^ attributes hash: 16482263331346774611
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(
@@ -26,9 +27,10 @@ note:
   │  
 7 │ ╭     pub fn foo() -> u256:
 8 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 4553090961241945225
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -42,8 +44,8 @@ note:
 note: 
   ┌─ features/return_u256_from_called_fn.fe:5:16
   │
-5 │         return self.foo()
-  │                ^^^^^^^^^^ u256: Value => None
+5 │         return foo()
+  │                ^^^^^ u256: Value => None
 
 note: 
   ┌─ features/return_u256_from_called_fn.fe:8:16
@@ -54,10 +56,10 @@ note:
 note: 
   ┌─ features/return_u256_from_called_fn.fe:5:16
   │
-5 │         return self.foo()
-  │                ^^^^^^^^ attributes hash: 5290763145657400289
+5 │         return foo()
+  │                ^^^ attributes hash: 1664590513608378371
   │
-  = SelfAttribute {
+  = Pure {
         func_name: "foo",
     }
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
@@ -14,9 +14,10 @@ note:
   │  
 3 │ ╭     pub fn foo(val1: u256, val2: u256, val3: u256, val4: u256, val5: u256) -> u256:
 4 │ │         return val1 + val2 + val3 + val4 + val5
-  │ ╰───────────────────────────────────────────────^ attributes hash: 4194611052461768296
+  │ ╰───────────────────────────────────────────────^ attributes hash: 4629287087811571223
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "val1",
@@ -83,9 +84,10 @@ note:
   │  
 6 │ ╭     pub fn cem() -> u256:
 7 │ │         return 100
-  │ ╰──────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -99,12 +101,13 @@ note:
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:9:5
    │  
- 9 │ ╭     pub fn bar() -> u256:
+ 9 │ ╭     pub fn bar(self) -> u256:
 10 │ │         self.baz[0] = 43
-11 │ │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 4553090961241945225
+11 │ │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │ ╰─────────────────────────────────────────────────────^ attributes hash: 16482263331346774611
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -200,82 +203,82 @@ note:
    │                       ^^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:25
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:20
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                         ^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                    ^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:28
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:23
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                            ^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                       ^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:31
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:26
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                               ^^^^^^^^^^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                          ^^^^^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:43
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:33
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                           ^^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                 ^^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:48
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:38
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                ^^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                      ^^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:43
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:33
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                           ^^^^^^^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                 ^^^^^^^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:52
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:42
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                    ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                          ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:61
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:51
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                             ^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                                   ^ u256: Value => None
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:52
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:42
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                                                    ^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
-   │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                          ^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                ^^^^^^^^ attributes hash: 5290763145657400289
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
    │
-   = SelfAttribute {
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                ^^^ attributes hash: 1664590513608378371
+   │
+   = Pure {
          func_name: "foo",
      }
 
 note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:31
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:26
    │
-11 │         return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
-   │                               ^^^^^^^^ attributes hash: 15959357109795915945
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                          ^^^ attributes hash: 3933618496970144567
    │
-   = SelfAttribute {
+   = Pure {
          func_name: "cem",
      }
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -38,9 +38,10 @@ note:
    │  
 12 │ ╭     pub fn bar() -> u256:
 13 │ │         revert
-   │ ╰──────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -56,9 +57,10 @@ note:
    │  
 15 │ ╭     pub fn revert_custom_error():
 16 │ │         revert Error(msg=1, val=true)
-   │ ╰─────────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰─────────────────────────────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -72,9 +74,10 @@ note:
    │  
 18 │ ╭     pub fn revert_other_error():
 19 │ │         revert OtherError(msg=1, val=true)
-   │ ╰──────────────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰──────────────────────────────────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -86,12 +89,13 @@ note:
 note: 
    ┌─ features/revert.fe:21:5
    │  
-21 │ ╭     pub fn revert_other_error_from_sto():
+21 │ ╭     pub fn revert_other_error_from_sto(self):
 22 │ │         self.my_other_error = OtherError(msg=1, val=true)
 23 │ │         revert self.my_other_error.to_mem()
-   │ ╰───────────────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰───────────────────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__self_address.snap
+++ b/crates/analyzer/tests/snapshots/analysis__self_address.snap
@@ -6,11 +6,12 @@ expression: "build_snapshot(\"features/self_address.fe\", &src, module, &db)"
 note: 
   ┌─ features/self_address.fe:2:5
   │  
-2 │ ╭     pub fn my_address() -> address:
+2 │ ╭     pub fn my_address(self) -> address:
 3 │ │         return self.address
-  │ ╰───────────────────────────^ attributes hash: 2195077967527136217
+  │ ╰───────────────────────────^ attributes hash: 17651916811868111914
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -42,11 +42,12 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:11:5
    │  
-11 │ ╭     pub fn write_num(x: u256):
+11 │ ╭     pub fn write_num(self, x: u256):
 12 │ │         self.num = x
-   │ ╰────────────────────^ attributes hash: 5821943627655420089
+   │ ╰────────────────────^ attributes hash: 1151125091578816070
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "x",
@@ -69,11 +70,12 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:14:5
    │  
-14 │ ╭     pub fn read_num() -> u256:
+14 │ ╭     pub fn read_num(self) -> u256:
 15 │ │         return self.num
-   │ ╰───────────────────────^ attributes hash: 4553090961241945225
+   │ ╰───────────────────────^ attributes hash: 16482263331346774611
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -87,11 +89,12 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:17:5
    │  
-17 │ ╭     pub fn write_nums(x: u256[42]):
+17 │ ╭     pub fn write_nums(self, x: u256[42]):
 18 │ │         self.nums = x
-   │ ╰─────────────────────^ attributes hash: 7898033063999954658
+   │ ╰─────────────────────^ attributes hash: 1325911840329576752
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "x",
@@ -117,11 +120,12 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:20:5
    │  
-20 │ ╭     pub fn read_nums() -> u256[42]:
+20 │ ╭     pub fn read_nums(self) -> u256[42]:
 21 │ │         return self.nums.to_mem()
-   │ ╰─────────────────────────────────^ attributes hash: 14849843733783125097
+   │ ╰─────────────────────────────────^ attributes hash: 15090171079052983265
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Array(
@@ -138,11 +142,12 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:23:5
    │  
-23 │ ╭     pub fn write_str(x: String<26>):
+23 │ ╭     pub fn write_str(self, x: String<26>):
 24 │ │         self.str = x
-   │ ╰────────────────────^ attributes hash: 1291316915828296328
+   │ ╰────────────────────^ attributes hash: 14732302597377039844
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "x",
@@ -165,11 +170,12 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:26:5
    │  
-26 │ ╭     pub fn read_str() -> String<26>:
+26 │ ╭     pub fn read_str(self) -> String<26>:
 27 │ │         return self.str.to_mem()
-   │ ╰────────────────────────────────^ attributes hash: 8674728773228239240
+   │ ╰────────────────────────────────^ attributes hash: 5005215627723595894
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              String(
@@ -183,15 +189,16 @@ note:
 note: 
    ┌─ features/sized_vals_in_sto.fe:29:5
    │  
-29 │ ╭     pub fn emit_event():
+29 │ ╭     pub fn emit_event(self):
 30 │ │         emit MyEvent(
 31 │ │             num=self.num,
 32 │ │             nums=self.nums.to_mem(),
 33 │ │             str=self.str.to_mem()
 34 │ │         )
-   │ ╰─────────^ attributes hash: 17883060253504188551
+   │ ╰─────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -50,9 +50,10 @@ note:
    │  
 11 │ ╭     pub fn __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
 12 │ │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │ ╰─────────────────────────────────────────────────────────────────────────────────^ attributes hash: 3164511711782689051
+   │ ╰─────────────────────────────────────────────────────────────────────────────────^ attributes hash: 2002059796134224129
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "s1",
@@ -115,9 +116,10 @@ note:
    │  
 14 │ ╭     pub fn bar(s1: String<100>, s2: String<100>) -> String<100>:
 15 │ │         return s2
-   │ ╰─────────────────^ attributes hash: 5487186020749486199
+   │ ╰─────────────────^ attributes hash: 9796174980111478041
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "s1",
@@ -154,9 +156,10 @@ note:
    │  
 17 │ ╭     pub fn return_static_string() -> String<43>:
 18 │ │         return "The quick brown fox jumps over the lazy dog"
-   │ ╰────────────────────────────────────────────────────────────^ attributes hash: 16003421452775228761
+   │ ╰────────────────────────────────────────────────────────────^ attributes hash: 3426951284599168562
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              String(
@@ -172,9 +175,10 @@ note:
    │  
 20 │ ╭     pub fn return_casted_static_string() -> String<100>:
 21 │ │         return String<100>("foo")
-   │ ╰─────────────────────────────────^ attributes hash: 547051866614494389
+   │ ╰─────────────────────────────────^ attributes hash: 15820744965541513152
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              String(
@@ -191,9 +195,10 @@ note:
 23 │ ╭     pub fn return_special_chars() -> String<18>:
 24 │ │         return "\n\"'\r\t
 25 │ │         foo\\"
-   │ ╰──────────────^ attributes hash: 9448948996761675237
+   │ ╰──────────────^ attributes hash: 14991635520577142188
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              String(

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -36,16 +36,17 @@ note:
 note: 
    ┌─ features/structs.fe:10:5
    │  
-10 │ ╭     pub fn create_house():
+10 │ ╭     pub fn create_house(self):
 11 │ │         self.my_house = House(
 12 │ │             price=1,
 13 │ │             size=2,
    · │
 41 │ │         assert self.my_house.rooms == u8(100)
 42 │ │         assert self.my_house.vacant
-   │ ╰───────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰───────────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -64,9 +65,10 @@ note:
    · │
 64 │ │         assert building.rooms == u8(10)
 65 │ │         return building.size
-   │ ╰────────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰────────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -87,9 +89,10 @@ note:
    · │
 73 │ │         )
 74 │ │         return house.abi_encode()
-   │ ╰─────────────────────────────────^ attributes hash: 17493453129355039047
+   │ ╰─────────────────────────────────^ attributes hash: 6092146250611764360
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Array(
@@ -113,9 +116,10 @@ note:
    · │
 82 │ │         )
 83 │ │         return keccak256(house.abi_encode())
-   │ ╰────────────────────────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰────────────────────────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
@@ -8,9 +8,10 @@ note:
   │  
 3 │ ╭     pub fn bar(input: u256) -> u256:
 4 │ │         return 1 if input > 5 else 0
-  │ ╰────────────────────────────────────^ attributes hash: 3019427292913193612
+  │ ╰────────────────────────────────────^ attributes hash: 16591277757740338966
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "input",

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -24,9 +24,10 @@ note:
 10 │ │         my_address: address
 11 │ │     ) -> (u256, bool, address):
 12 │ │         return (my_num, my_bool, my_address)
-   │ ╰────────────────────────────────────────────^ attributes hash: 14534698649919318558
+   │ ╰────────────────────────────────────────────^ attributes hash: 13483717293020073668
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_num",
@@ -81,9 +82,10 @@ note:
    │  
 14 │ ╭     pub fn read_my_tuple_item0(my_tuple: (u256, bool, address)) -> u256:
 15 │ │         return my_tuple.item0
-   │ ╰─────────────────────────────^ attributes hash: 5114195826335643055
+   │ ╰─────────────────────────────^ attributes hash: 2766506595472512026
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_tuple",
@@ -122,9 +124,10 @@ note:
    │  
 17 │ ╭     pub fn read_my_tuple_item1(my_tuple: (u256, bool, address)) -> bool:
 18 │ │         return my_tuple.item1
-   │ ╰─────────────────────────────^ attributes hash: 15367699380563059967
+   │ ╰─────────────────────────────^ attributes hash: 6352541920629593005
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_tuple",
@@ -161,9 +164,10 @@ note:
    │  
 20 │ ╭     pub fn read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address:
 21 │ │         return my_tuple.item2
-   │ ╰─────────────────────────────^ attributes hash: 18418836367069467314
+   │ ╰─────────────────────────────^ attributes hash: 12452259679831530463
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_tuple",
@@ -199,10 +203,11 @@ note:
    ┌─ stress/tuple_stress.fe:23:5
    │  
 23 │ ╭     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
-24 │ │             return my_tuple.item10
-   │ ╰──────────────────────────────────^ attributes hash: 17624511170692480766
+24 │ │         return my_tuple.item10
+   │ ╰──────────────────────────────^ attributes hash: 14267968335076845493
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_tuple",
@@ -281,9 +286,10 @@ note:
    │  
 26 │ ╭     pub fn emit_my_event(my_tuple: (u256, bool, address)):
 27 │ │         emit MyEvent(my_tuple)
-   │ ╰──────────────────────────────^ attributes hash: 13087875162113275245
+   │ ╰──────────────────────────────^ attributes hash: 11035500091824568233
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_tuple",
@@ -318,12 +324,13 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:29:5
    │  
-29 │ ╭     pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
+29 │ ╭     pub fn set_my_sto_tuple(self, my_u256: u256, my_i32: i32):
 30 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
 31 │ │         self.my_sto_tuple = (my_u256, my_i32)
-   │ ╰─────────────────────────────────────────────^ attributes hash: 4022092093243954425
+   │ ╰─────────────────────────────────────────────^ attributes hash: 5930645998145376015
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "my_u256",
@@ -356,11 +363,12 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:33:5
    │  
-33 │ ╭     pub fn get_my_sto_tuple() -> (u256, i32):
+33 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32):
 34 │ │         return self.my_sto_tuple.to_mem()
-   │ ╰─────────────────────────────────────────^ attributes hash: 16978508948255230610
+   │ ╰─────────────────────────────────────────^ attributes hash: 8140983257972799311
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Tuple(
@@ -385,16 +393,17 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:36:5
    │  
-36 │ ╭     pub fn build_tuple_and_emit():
+36 │ ╭     pub fn build_tuple_and_emit(self):
 37 │ │         let my_num: u256 = self.my_sto_tuple.item0
 38 │ │         let my_tuple: (u256, bool, address) = (
 39 │ │             self.my_sto_tuple.item0,
    · │
 42 │ │         )
-43 │ │         self.emit_my_event(my_tuple)
-   │ ╰────────────────────────────────────^ attributes hash: 17883060253504188551
+43 │ │         emit_my_event(my_tuple)
+   │ ╰───────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -408,9 +417,10 @@ note:
    │  
 45 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
 46 │ │         return my_tuple.abi_encode()
-   │ ╰────────────────────────────────────^ attributes hash: 13695567180922413051
+   │ ╰────────────────────────────────────^ attributes hash: 4037443094215636083
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [
              FunctionParam {
                  name: "my_tuple",
@@ -508,16 +518,16 @@ note:
    │                ^^^^^^^^^^^^^^ address: Memory => Some(Value)
 
 note: 
-   ┌─ stress/tuple_stress.fe:24:20
+   ┌─ stress/tuple_stress.fe:24:16
    │
-24 │             return my_tuple.item10
-   │                    ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory => None
+24 │         return my_tuple.item10
+   │                ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory => None
 
 note: 
-   ┌─ stress/tuple_stress.fe:24:20
+   ┌─ stress/tuple_stress.fe:24:16
    │
-24 │             return my_tuple.item10
-   │                    ^^^^^^^^^^^^^^^ address: Memory => Some(Value)
+24 │         return my_tuple.item10
+   │                ^^^^^^^^^^^^^^^ address: Memory => Some(Value)
 
 note: 
    ┌─ stress/tuple_stress.fe:27:22
@@ -693,16 +703,16 @@ note:
    │ ╰─────────^ (u256, bool, address): Memory => None
 
 note: 
-   ┌─ stress/tuple_stress.fe:43:28
+   ┌─ stress/tuple_stress.fe:43:23
    │
-43 │         self.emit_my_event(my_tuple)
-   │                            ^^^^^^^^ (u256, bool, address): Memory => None
+43 │         emit_my_event(my_tuple)
+   │                       ^^^^^^^^ (u256, bool, address): Memory => None
 
 note: 
    ┌─ stress/tuple_stress.fe:43:9
    │
-43 │         self.emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+43 │         emit_my_event(my_tuple)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
 
 note: 
    ┌─ stress/tuple_stress.fe:46:16
@@ -814,10 +824,10 @@ note:
 note: 
    ┌─ stress/tuple_stress.fe:43:9
    │
-43 │         self.emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^ attributes hash: 608487383688023809
+43 │         emit_my_event(my_tuple)
+   │         ^^^^^^^^^^^^^ attributes hash: 4428583522641384060
    │
-   = SelfAttribute {
+   = Pure {
          func_name: "emit_my_event",
      }
 

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -20,9 +20,10 @@ note:
   │  
 5 │ ╭     pub fn external_bar() -> u256:
 6 │ │         return Bar(address(0)).bar()
-  │ ╰────────────────────────────────────^ attributes hash: 4553090961241945225
+  │ ╰────────────────────────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -38,9 +39,10 @@ note:
   │  
 8 │ ╭     pub fn foo() -> u256:
 9 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 4553090961241945225
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(
@@ -56,9 +58,10 @@ note:
    │  
 15 │ ╭     pub fn external_foo() -> u256:
 16 │ │         return Foo(address(0)).foo()
-   │ ╰────────────────────────────────────^ attributes hash: 4553090961241945225
+   │ ╰────────────────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(
@@ -74,9 +77,10 @@ note:
    │  
 18 │ ╭     pub fn bar() -> u256:
 19 │ │         return 26
-   │ ╰─────────────────^ attributes hash: 4553090961241945225
+   │ ╰─────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -66,15 +66,16 @@ note:
 note: 
    ┌─ features/type_aliases.fe:15:5
    │  
-15 │ ╭     pub fn post(body: PostBody):
+15 │ ╭     pub fn post(self, body: PostBody):
 16 │ │         # id: PostId = keccak256(body.abi_encode())
 17 │ │         let id: PostId = 0
 18 │ │         self.posts[id] = body
 19 │ │         self.authors[msg.sender]
 20 │ │         self.scoreboard[id] = 0
-   │ ╰───────────────────────────────^ attributes hash: 14562420308644804689
+   │ ╰───────────────────────────────^ attributes hash: 771627946712539769
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "body",
@@ -97,13 +98,14 @@ note:
 note: 
    ┌─ features/type_aliases.fe:22:5
    │  
-22 │ ╭     pub fn upvote(id: PostId) -> Score:
+22 │ ╭     pub fn upvote(self, id: PostId) -> Score:
 23 │ │         let score: Score = self.scoreboard[id] + 1
 24 │ │         self.scoreboard[id] = score
 25 │ │         return score
-   │ ╰────────────────────^ attributes hash: 9723759341304918760
+   │ ╰────────────────────^ attributes hash: 8245519384016556717
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "id",
@@ -128,11 +130,12 @@ note:
 note: 
    ┌─ features/type_aliases.fe:27:5
    │  
-27 │ ╭     pub fn get_post(id: PostId) -> PostBody:
+27 │ ╭     pub fn get_post(self, id: PostId) -> PostBody:
 28 │ │         return self.posts[id].to_mem()
-   │ ╰──────────────────────────────────────^ attributes hash: 9466985503508091937
+   │ ╰──────────────────────────────────────^ attributes hash: 10352242143184749414
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "id",

--- a/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/u128_u128_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: u128) -> u128:
+4 │ ╭     pub fn read_bar(self, key: u128) -> u128:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 946551912650384248
+  │ ╰────────────────────────────^ attributes hash: 14613607248451204655
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -41,11 +42,12 @@ note:
 note: 
   ┌─ features/u128_u128_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: u128, value: u128):
+7 │ ╭     pub fn write_bar(self, key: u128, value: u128):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 6409992050423040542
+  │ ╰─────────────────────────────^ attributes hash: 10041566038914781122
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/u16_u16_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: u16) -> u16:
+4 │ ╭     pub fn read_bar(self, key: u16) -> u16:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 9839082566663037677
+  │ ╰────────────────────────────^ attributes hash: 13277112481715403660
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -41,11 +42,12 @@ note:
 note: 
   ┌─ features/u16_u16_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: u16, value: u16):
+7 │ ╭     pub fn write_bar(self, key: u16, value: u16):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 3157214284721683583
+  │ ╰─────────────────────────────^ attributes hash: 14682981866604087396
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/u256_u256_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: u256) -> u256:
+4 │ ╭     pub fn read_bar(self, key: u256) -> u256:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 18158645093584030278
+  │ ╰────────────────────────────^ attributes hash: 9838590781041991414
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -41,11 +42,12 @@ note:
 note: 
   ┌─ features/u256_u256_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: u256, value: u256):
+7 │ ╭     pub fn write_bar(self, key: u256, value: u256):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 1163169652870147056
+  │ ╰─────────────────────────────^ attributes hash: 3191106537475594935
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/u32_u32_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: u32) -> u32:
+4 │ ╭     pub fn read_bar(self, key: u32) -> u32:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 772722927452882066
+  │ ╰────────────────────────────^ attributes hash: 12968923434860104131
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -41,11 +42,12 @@ note:
 note: 
   ┌─ features/u32_u32_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: u32, value: u32):
+7 │ ╭     pub fn write_bar(self, key: u32, value: u32):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 9864815385464028269
+  │ ╰─────────────────────────────^ attributes hash: 13487692495644521282
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/u64_u64_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: u64) -> u64:
+4 │ ╭     pub fn read_bar(self, key: u64) -> u64:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 1284320556037897409
+  │ ╰────────────────────────────^ attributes hash: 17303700247191832614
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -41,11 +42,12 @@ note:
 note: 
   ┌─ features/u64_u64_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: u64, value: u64):
+7 │ ╭     pub fn write_bar(self, key: u64, value: u64):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 5281537807208624772
+  │ ╰─────────────────────────────^ attributes hash: 1768718553543894917
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
@@ -12,11 +12,12 @@ note:
 note: 
   ┌─ features/u8_u8_map.fe:4:5
   │  
-4 │ ╭     pub fn read_bar(key: u8) -> u8:
+4 │ ╭     pub fn read_bar(self, key: u8) -> u8:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 15545269796309193855
+  │ ╰────────────────────────────^ attributes hash: 12371532813153398159
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",
@@ -41,11 +42,12 @@ note:
 note: 
   ┌─ features/u8_u8_map.fe:7:5
   │  
-7 │ ╭     pub fn write_bar(key: u8, value: u8):
+7 │ ╭     pub fn write_bar(self, key: u8, value: u8):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 17826155681843476471
+  │ ╰─────────────────────────────^ attributes hash: 334915651172467174
   │  
   = FunctionSignature {
+        self_decl: Mutable,
         params: [
             FunctionParam {
                 name: "key",

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -266,9 +266,10 @@ note:
   │  
 2 │ ╭     pub fn balanceOf(account: address) -> u256:
 3 │ │         return 0
-  │ ╰────────────────^ attributes hash: 3270716362116162777
+  │ ╰────────────────^ attributes hash: 2140140122946032557
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "account",
@@ -293,9 +294,10 @@ note:
   │  
 5 │ ╭     pub fn transfer(recipient: address, amount: u256) -> bool:
 6 │ │         return false
-  │ ╰────────────────────^ attributes hash: 18206623983116939792
+  │ ╰────────────────────^ attributes hash: 8296406261133122468
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [
             FunctionParam {
                 name: "recipient",
@@ -326,11 +328,12 @@ note:
 note: 
    ┌─ demos/uniswap.fe:63:5
    │  
-63 │ ╭     pub fn __init__():
+63 │ ╭     pub fn __init__(self):
 64 │ │         self.factory = msg.sender
-   │ ╰─────────────────────────────────^ attributes hash: 17883060253504188551
+   │ ╰─────────────────────────────────^ attributes hash: 4369441865732737140
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -342,11 +345,12 @@ note:
 note: 
    ┌─ demos/uniswap.fe:66:5
    │  
-66 │ ╭     pub fn factory() -> address:
+66 │ ╭     pub fn factory(self) -> address:
 67 │ │         return self.factory
-   │ ╰───────────────────────────^ attributes hash: 2195077967527136217
+   │ ╰───────────────────────────^ attributes hash: 17651916811868111914
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -358,11 +362,12 @@ note:
 note: 
    ┌─ demos/uniswap.fe:69:5
    │  
-69 │ ╭     pub fn token0() -> address:
+69 │ ╭     pub fn token0(self) -> address:
 70 │ │         return self.token0
-   │ ╰──────────────────────────^ attributes hash: 2195077967527136217
+   │ ╰──────────────────────────^ attributes hash: 17651916811868111914
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -374,11 +379,12 @@ note:
 note: 
    ┌─ demos/uniswap.fe:72:5
    │  
-72 │ ╭     pub fn token1() -> address:
+72 │ ╭     pub fn token1(self) -> address:
 73 │ │         return self.token1
-   │ ╰──────────────────────────^ attributes hash: 2195077967527136217
+   │ ╰──────────────────────────^ attributes hash: 17651916811868111914
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [],
          return_type: Ok(
              Base(
@@ -390,13 +396,14 @@ note:
 note: 
    ┌─ demos/uniswap.fe:75:5
    │  
-75 │ ╭     fn _mint(to: address, value: u256):
+75 │ ╭     fn _mint(self, to: address, value: u256):
 76 │ │         self.total_supply = self.total_supply + value
 77 │ │         self.balances[to] = self.balances[to] + value
 78 │ │         emit Transfer(from=address(0), to, value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 12325006012704879214
+   │ ╰─────────────────────────────────────────────────^ attributes hash: 1135367514371429330
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "to",
@@ -427,13 +434,14 @@ note:
 note: 
    ┌─ demos/uniswap.fe:80:5
    │  
-80 │ ╭     fn _burn(from: address, value: u256):
+80 │ ╭     fn _burn(self, from: address, value: u256):
 81 │ │         self.balances[from] = self.balances[from] - value
 82 │ │         self.total_supply = self.total_supply - value
 83 │ │         emit Transfer(from, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 17270351444233039583
+   │ ╰─────────────────────────────────────────────────^ attributes hash: 18052677761580718632
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "from",
@@ -464,12 +472,13 @@ note:
 note: 
    ┌─ demos/uniswap.fe:85:5
    │  
-85 │ ╭     fn _approve(owner: address, spender: address, value: u256):
+85 │ ╭     fn _approve(self, owner: address, spender: address, value: u256):
 86 │ │         self.allowances[owner][spender] = value
 87 │ │         emit Approval(owner, spender, value)
-   │ ╰────────────────────────────────────────────^ attributes hash: 14201079106432958367
+   │ ╰────────────────────────────────────────────^ attributes hash: 2670276789438195364
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "owner",
@@ -508,13 +517,14 @@ note:
 note: 
    ┌─ demos/uniswap.fe:89:5
    │  
-89 │ ╭     fn _transfer(from: address, to: address, value: u256):
+89 │ ╭     fn _transfer(self, from: address, to: address, value: u256):
 90 │ │         self.balances[from] = self.balances[from] - value
 91 │ │         self.balances[to] = self.balances[to] + value
 92 │ │         emit Transfer(from, to, value)
-   │ ╰──────────────────────────────────────^ attributes hash: 15422594702274887655
+   │ ╰──────────────────────────────────────^ attributes hash: 1279967340500149849
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "from",
@@ -553,12 +563,13 @@ note:
 note: 
    ┌─ demos/uniswap.fe:94:5
    │  
-94 │ ╭     pub fn approve(spender: address, value: u256) -> bool:
+94 │ ╭     pub fn approve(self, spender: address, value: u256) -> bool:
 95 │ │         self._approve(msg.sender, spender, value)
 96 │ │         return true
-   │ ╰───────────────────^ attributes hash: 11178591286876422786
+   │ ╰───────────────────^ attributes hash: 10662679418650794263
    │  
    = FunctionSignature {
+         self_decl: Mutable,
          params: [
              FunctionParam {
                  name: "spender",
@@ -589,12 +600,13 @@ note:
 note: 
     ┌─ demos/uniswap.fe:98:5
     │  
- 98 │ ╭     pub fn transfer(to: address, value: u256) -> bool:
+ 98 │ ╭     pub fn transfer(self, to: address, value: u256) -> bool:
  99 │ │         self._transfer(msg.sender, to, value)
 100 │ │         return true
-    │ ╰───────────────────^ attributes hash: 13652324078777284205
+    │ ╰───────────────────^ attributes hash: 3518107939221722675
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "to",
@@ -625,15 +637,16 @@ note:
 note: 
     ┌─ demos/uniswap.fe:102:5
     │  
-102 │ ╭     pub fn transferFrom(from: address, to: address, value: u256) -> bool:
+102 │ ╭     pub fn transferFrom(self, from: address, to: address, value: u256) -> bool:
 103 │ │         assert self.allowances[from][msg.sender] >= value
 104 │ │ 
 105 │ │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
 106 │ │         self._transfer(from, to, value)
 107 │ │         return true
-    │ ╰───────────────────^ attributes hash: 16346907181339098414
+    │ ╰───────────────────^ attributes hash: 8152647388321889889
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "from",
@@ -672,11 +685,12 @@ note:
 note: 
     ┌─ demos/uniswap.fe:109:5
     │  
-109 │ ╭     pub fn balanceOf(account: address) -> u256:
+109 │ ╭     pub fn balanceOf(self, account: address) -> u256:
 110 │ │         return self.balances[account]
-    │ ╰─────────────────────────────────────^ attributes hash: 3270716362116162777
+    │ ╰─────────────────────────────────────^ attributes hash: 11484923544867751175
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "account",
@@ -699,11 +713,12 @@ note:
 note: 
     ┌─ demos/uniswap.fe:112:5
     │  
-112 │ ╭     pub fn get_reserves() -> (u256, u256, u256):
+112 │ ╭     pub fn get_reserves(self) -> (u256, u256, u256):
 113 │ │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │ ╰────────────────────────────────────────────────────────────────────────^ attributes hash: 3127943090617884215
+    │ ╰────────────────────────────────────────────────────────────────────────^ attributes hash: 1362480321321505196
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [],
           return_type: Ok(
               Tuple(
@@ -733,13 +748,14 @@ note:
 note: 
     ┌─ demos/uniswap.fe:116:5
     │  
-116 │ ╭     pub fn initialize(token0: address, token1: address):
+116 │ ╭     pub fn initialize(self, token0: address, token1: address):
 117 │ │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
 118 │ │         self.token0 = token0
 119 │ │         self.token1 = token1
-    │ ╰────────────────────────────^ attributes hash: 2750947401374471543
+    │ ╰────────────────────────────^ attributes hash: 9762098062283689454
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "token0",
@@ -768,16 +784,17 @@ note:
 note: 
     ┌─ demos/uniswap.fe:122:5
     │  
-122 │ ╭     fn _update(balance0: u256, balance1: u256, reserve0: u256, reserve1: u256):
+122 │ ╭     fn _update(self, balance0: u256, balance1: u256, reserve0: u256, reserve1: u256):
 123 │ │         # changed from u32s
 124 │ │         let block_timestamp: u256 = block.timestamp % 2**32
 125 │ │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
     · │
 134 │ │         self.block_timestamp_last = block_timestamp
 135 │ │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 107976639431843170
+    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 13082574297248451564
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "balance0",
@@ -830,16 +847,17 @@ note:
 note: 
     ┌─ demos/uniswap.fe:138:5
     │  
-138 │ ╭     fn _mint_fee(reserve0: u256, reserve1: u256) -> bool:
+138 │ ╭     fn _mint_fee(self, reserve0: u256, reserve1: u256) -> bool:
 139 │ │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
 140 │ │         let fee_on: bool = fee_to != address(0)
 141 │ │         let k_last: u256 = self.k_last # gas savings
     · │
 154 │ │ 
 155 │ │         return fee_on
-    │ ╰─────────────────────^ attributes hash: 16138774722461576279
+    │ ╰─────────────────────^ attributes hash: 9365170424361356438
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "reserve0",
@@ -872,16 +890,17 @@ note:
 note: 
     ┌─ demos/uniswap.fe:158:5
     │  
-158 │ ╭     pub fn mint(to: address) -> u256:
+158 │ ╭     pub fn mint(self, to: address) -> u256:
 159 │ │         let MINIMUM_LIQUIDITY: u256 = 1000
 160 │ │         let reserve0: u256 = self.reserve0
 161 │ │         let reserve1: u256 = self.reserve1
     · │
 184 │ │         emit Mint(sender=msg.sender, amount0, amount1)
 185 │ │         return liquidity
-    │ ╰────────────────────────^ attributes hash: 10503721476058267208
+    │ ╰────────────────────────^ attributes hash: 13052412037608309076
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "to",
@@ -904,16 +923,17 @@ note:
 note: 
     ┌─ demos/uniswap.fe:188:5
     │  
-188 │ ╭     pub fn burn(to: address) -> (u256, u256):
+188 │ ╭     pub fn burn(self, to: address) -> (u256, u256):
 189 │ │         let reserve0: u256 = self.reserve0
 190 │ │         let reserve1: u256 = self.reserve1
 191 │ │         let token0: ERC20 = ERC20(self.token0)
     · │
 213 │ │         emit Burn(sender=msg.sender, amount0, amount1, to)
 214 │ │         return (amount0, amount1)
-    │ ╰─────────────────────────────────^ attributes hash: 953615132639126195
+    │ ╰─────────────────────────────────^ attributes hash: 2656431017065792419
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "to",
@@ -947,16 +967,17 @@ note:
 note: 
     ┌─ demos/uniswap.fe:219:5
     │  
-219 │ ╭     pub fn swap(amount0_out: u256, amount1_out: u256, to: address):
+219 │ ╭     pub fn swap(self, amount0_out: u256, amount1_out: u256, to: address):
 220 │ │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
 221 │ │         let reserve0: u256 = self.reserve0
 222 │ │         let reserve1: u256 = self.reserve1
     · │
 252 │ │         self._update(balance0, balance1, reserve0, reserve1)
 253 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 6900968008281218364
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13380171127738201451
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "amount0_out",
@@ -997,15 +1018,16 @@ note:
 note: 
     ┌─ demos/uniswap.fe:256:5
     │  
-256 │ ╭     pub fn skim(to: address):
+256 │ ╭     pub fn skim(self, to: address):
 257 │ │         let token0: ERC20 = ERC20(self.token0) # gas savings
 258 │ │         let token1: ERC20 = ERC20(self.token1) # gas savings
 259 │ │ 
 260 │ │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
 261 │ │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 10827547217198146082
+    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 2346286316485274384
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "to",
@@ -1026,13 +1048,14 @@ note:
 note: 
     ┌─ demos/uniswap.fe:264:5
     │  
-264 │ ╭     pub fn sync():
+264 │ ╭     pub fn sync(self):
 265 │ │         let token0: ERC20 = ERC20(self.token0)
 266 │ │         let token1: ERC20 = ERC20(self.token1)
 267 │ │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 17883060253504188551
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 4369441865732737140
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [],
           return_type: Ok(
               Base(
@@ -1051,9 +1074,10 @@ note:
     · │
 278 │ │             z = 1
 279 │ │         return z
-    │ ╰────────────────^ attributes hash: 6248121154456130073
+    │ ╰────────────────^ attributes hash: 3075818098030342593
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "val",
@@ -1080,9 +1104,10 @@ note:
     │  
 281 │ ╭     fn min(x: u256, y: u256) -> u256:
 282 │ │         return x if x < y else y
-    │ ╰────────────────────────────────^ attributes hash: 11686109986999089900
+    │ ╰────────────────────────────────^ attributes hash: 4022593831796629401
     │  
     = FunctionSignature {
+          self_decl: None,
           params: [
               FunctionParam {
                   name: "x",
@@ -1117,11 +1142,12 @@ note:
 note: 
     ┌─ demos/uniswap.fe:299:5
     │  
-299 │ ╭     pub fn __init__(fee_to_setter: address):
+299 │ ╭     pub fn __init__(self, fee_to_setter: address):
 300 │ │        self.fee_to_setter = fee_to_setter
-    │ ╰─────────────────────────────────────────^ attributes hash: 7782168487707120671
+    │ ╰─────────────────────────────────────────^ attributes hash: 10732478853163688613
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "fee_to_setter",
@@ -1142,11 +1168,12 @@ note:
 note: 
     ┌─ demos/uniswap.fe:302:5
     │  
-302 │ ╭     pub fn fee_to() -> address:
+302 │ ╭     pub fn fee_to(self) -> address:
 303 │ │         return self.fee_to
-    │ ╰──────────────────────────^ attributes hash: 2195077967527136217
+    │ ╰──────────────────────────^ attributes hash: 17651916811868111914
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [],
           return_type: Ok(
               Base(
@@ -1158,11 +1185,12 @@ note:
 note: 
     ┌─ demos/uniswap.fe:305:5
     │  
-305 │ ╭     pub fn fee_to_setter() -> address:
+305 │ ╭     pub fn fee_to_setter(self) -> address:
 306 │ │         return self.fee_to_setter
-    │ ╰─────────────────────────────────^ attributes hash: 2195077967527136217
+    │ ╰─────────────────────────────────^ attributes hash: 17651916811868111914
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [],
           return_type: Ok(
               Base(
@@ -1174,11 +1202,12 @@ note:
 note: 
     ┌─ demos/uniswap.fe:308:5
     │  
-308 │ ╭     pub fn all_pairs_length() -> u256:
+308 │ ╭     pub fn all_pairs_length(self) -> u256:
 309 │ │         return self.pair_counter
-    │ ╰────────────────────────────────^ attributes hash: 4553090961241945225
+    │ ╰────────────────────────────────^ attributes hash: 16482263331346774611
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [],
           return_type: Ok(
               Base(
@@ -1192,16 +1221,17 @@ note:
 note: 
     ┌─ demos/uniswap.fe:311:5
     │  
-311 │ ╭     pub fn create_pair(token_a: address, token_b: address) -> address:
+311 │ ╭     pub fn create_pair(self, token_a: address, token_b: address) -> address:
 312 │ │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
 313 │ │ 
 314 │ │         let token0: address = token_a if token_a < token_b else token_b
     · │
 328 │ │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
 329 │ │         return address(pair)
-    │ ╰────────────────────────────^ attributes hash: 11728721798336794276
+    │ ╰────────────────────────────^ attributes hash: 12932031939304465073
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "token_a",
@@ -1230,12 +1260,13 @@ note:
 note: 
     ┌─ demos/uniswap.fe:331:5
     │  
-331 │ ╭     pub fn set_fee_to(fee_to: address):
+331 │ ╭     pub fn set_fee_to(self, fee_to: address):
 332 │ │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
 333 │ │         self.fee_to = fee_to
-    │ ╰────────────────────────────^ attributes hash: 9358978543319530970
+    │ ╰────────────────────────────^ attributes hash: 14618921052791880235
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "fee_to",
@@ -1256,12 +1287,13 @@ note:
 note: 
     ┌─ demos/uniswap.fe:335:5
     │  
-335 │ ╭     pub fn set_fee_to_setter(fee_to_setter: address):
+335 │ ╭     pub fn set_fee_to_setter(self, fee_to_setter: address):
 336 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
 337 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 7782168487707120671
+    │ ╰──────────────────────────────────────────^ attributes hash: 10732478853163688613
     │  
     = FunctionSignature {
+          self_decl: Mutable,
           params: [
               FunctionParam {
                   name: "fee_to_setter",
@@ -2306,40 +2338,40 @@ note:
     │                ^^^^^^^^^^^ bool: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:144:46
+    ┌─ demos/uniswap.fe:144:41
     │
-144 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                              ^^^^^^^^ u256: Value => None
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+    │                                         ^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:144:57
+    ┌─ demos/uniswap.fe:144:52
     │
-144 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                                         ^^^^^^^^ u256: Value => None
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+    │                                                    ^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:144:46
+    ┌─ demos/uniswap.fe:144:41
     │
-144 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                              ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+    │                                         ^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:144:36
     │
-144 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:145:51
+    ┌─ demos/uniswap.fe:145:46
     │
-145 │                 let root_k_last: u256 = self.sqrt(k_last)
-    │                                                   ^^^^^^ u256: Value => None
+145 │                 let root_k_last: u256 = sqrt(k_last)
+    │                                              ^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:145:41
     │
-145 │                 let root_k_last: u256 = self.sqrt(k_last)
-    │                                         ^^^^^^^^^^^^^^^^^ u256: Value => None
+145 │                 let root_k_last: u256 = sqrt(k_last)
+    │                                         ^^^^^^^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:146:20
@@ -2662,44 +2694,44 @@ note:
 note: 
     ┌─ demos/uniswap.fe:171:13
     │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │             ^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:171:35
+    ┌─ demos/uniswap.fe:171:30
     │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                   ^^^^^^^ u256: Value => None
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                              ^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:171:45
+    ┌─ demos/uniswap.fe:171:40
     │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                             ^^^^^^^ u256: Value => None
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                                        ^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:171:35
+    ┌─ demos/uniswap.fe:171:30
     │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                   ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:25
-    │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:56
-    │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                                        ^^^^^^^^^^^^^^^^^ u256: Value => None
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                              ^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:171:25
     │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:171:51
+    │
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                                                   ^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:171:25
+    │
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:172:32
@@ -2728,74 +2760,74 @@ note:
 note: 
     ┌─ demos/uniswap.fe:174:13
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
     │             ^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:35
+    ┌─ demos/uniswap.fe:174:30
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                   ^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                              ^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:45
+    ┌─ demos/uniswap.fe:174:40
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                             ^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                        ^^^^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:34
+    ┌─ demos/uniswap.fe:174:29
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:61
+    ┌─ demos/uniswap.fe:174:56
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                             ^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                        ^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:34
+    ┌─ demos/uniswap.fe:174:29
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:72
+    ┌─ demos/uniswap.fe:174:67
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                        ^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                   ^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:82
+    ┌─ demos/uniswap.fe:174:77
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                                  ^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                             ^^^^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:71
+    ┌─ demos/uniswap.fe:174:66
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:98
+    ┌─ demos/uniswap.fe:174:93
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                                                  ^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                                             ^^^^^^^^ u256: Value => None
 
 note: 
-    ┌─ demos/uniswap.fe:174:71
+    ┌─ demos/uniswap.fe:174:66
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:174:25
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:176:16
@@ -5467,13 +5499,13 @@ note:
 note: 
     ┌─ demos/uniswap.fe:144:29
     │
-144 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
     │                             ^^^^ u256
 
 note: 
     ┌─ demos/uniswap.fe:145:34
     │
-145 │                 let root_k_last: u256 = self.sqrt(k_last)
+145 │                 let root_k_last: u256 = sqrt(k_last)
     │                                  ^^^^ u256
 
 note: 
@@ -5768,30 +5800,42 @@ note:
    ┌─ demos/uniswap.fe:95:9
    │
 95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 11653095055511118634
+   │         ^^^^^^^^^^^^^ attributes hash: 10018161393539106403
    │
    = SelfAttribute {
          func_name: "_approve",
+         self_span: Span {
+             start: 2409,
+             end: 2413,
+         },
      }
 
 note: 
    ┌─ demos/uniswap.fe:99:9
    │
 99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 17554789810436603039
+   │         ^^^^^^^^^^^^^^ attributes hash: 10093895704938982127
    │
    = SelfAttribute {
          func_name: "_transfer",
+         self_span: Span {
+             start: 2541,
+             end: 2545,
+         },
      }
 
 note: 
     ┌─ demos/uniswap.fe:106:9
     │
 106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^ attributes hash: 17554789810436603039
+    │         ^^^^^^^^^^^^^^ attributes hash: 12907935190801646102
     │
     = SelfAttribute {
           func_name: "_transfer",
+          self_span: Span {
+              start: 2833,
+              end: 2837,
+          },
       }
 
 note: 
@@ -5834,20 +5878,20 @@ note:
 note: 
     ┌─ demos/uniswap.fe:144:36
     │
-144 │                 let root_k: u256 = self.sqrt(reserve0 * reserve1)
-    │                                    ^^^^^^^^^ attributes hash: 9944310827285951567
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+    │                                    ^^^^ attributes hash: 11539501539171308117
     │
-    = SelfAttribute {
+    = Pure {
           func_name: "sqrt",
       }
 
 note: 
     ┌─ demos/uniswap.fe:145:41
     │
-145 │                 let root_k_last: u256 = self.sqrt(k_last)
-    │                                         ^^^^^^^^^ attributes hash: 9944310827285951567
+145 │                 let root_k_last: u256 = sqrt(k_last)
+    │                                         ^^^^ attributes hash: 11539501539171308117
     │
-    = SelfAttribute {
+    = Pure {
           func_name: "sqrt",
       }
 
@@ -5855,10 +5899,14 @@ note:
     ┌─ demos/uniswap.fe:151:25
     │
 151 │                         self._mint(fee_to, liquidity)
-    │                         ^^^^^^^^^^ attributes hash: 1155617642661253645
+    │                         ^^^^^^^^^^ attributes hash: 5774063433734111386
     │
     = SelfAttribute {
           func_name: "_mint",
+          self_span: Span {
+              start: 5111,
+              end: 5115,
+          },
       }
 
 note: 
@@ -5915,19 +5963,23 @@ note:
     ┌─ demos/uniswap.fe:167:28
     │
 167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ attributes hash: 13891964698023729577
+    │                            ^^^^^^^^^^^^^^ attributes hash: 5706709587227470482
     │
     = SelfAttribute {
           func_name: "_mint_fee",
+          self_span: Span {
+              start: 5772,
+              end: 5776,
+          },
       }
 
 note: 
     ┌─ demos/uniswap.fe:171:25
     │
-171 │             liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^ attributes hash: 9944310827285951567
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                         ^^^^ attributes hash: 11539501539171308117
     │
-    = SelfAttribute {
+    = Pure {
           func_name: "sqrt",
       }
 
@@ -5935,10 +5987,14 @@ note:
     ┌─ demos/uniswap.fe:172:13
     │
 172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^ attributes hash: 1155617642661253645
+    │             ^^^^^^^^^^ attributes hash: 1138819520748010179
     │
     = SelfAttribute {
           func_name: "_mint",
+          self_span: Span {
+              start: 6077,
+              end: 6081,
+          },
       }
 
 note: 
@@ -5956,10 +6012,10 @@ note:
 note: 
     ┌─ demos/uniswap.fe:174:25
     │
-174 │             liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^^^^^^ attributes hash: 13669611707215958911
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                         ^^^ attributes hash: 2385741873862807477
     │
-    = SelfAttribute {
+    = Pure {
           func_name: "min",
       }
 
@@ -5967,20 +6023,28 @@ note:
     ┌─ demos/uniswap.fe:178:9
     │
 178 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^ attributes hash: 1155617642661253645
+    │         ^^^^^^^^^^ attributes hash: 11733924240468847297
     │
     = SelfAttribute {
           func_name: "_mint",
+          self_span: Span {
+              start: 6372,
+              end: 6376,
+          },
       }
 
 note: 
     ┌─ demos/uniswap.fe:179:9
     │
 179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 6764850540347574840
+    │         ^^^^^^^^^^^^ attributes hash: 13255950405190274570
     │
     = SelfAttribute {
           func_name: "_update",
+          self_span: Span {
+              start: 6406,
+              end: 6410,
+          },
       }
 
 note: 
@@ -6037,20 +6101,28 @@ note:
     ┌─ demos/uniswap.fe:197:28
     │
 197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ attributes hash: 13891964698023729577
+    │                            ^^^^^^^^^^^^^^ attributes hash: 5536339678205451361
     │
     = SelfAttribute {
           func_name: "_mint_fee",
+          self_span: Span {
+              start: 7186,
+              end: 7190,
+          },
       }
 
 note: 
     ┌─ demos/uniswap.fe:202:9
     │
 202 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^ attributes hash: 9774977178119003771
+    │         ^^^^^^^^^^ attributes hash: 4813635634628659472
     │
     = SelfAttribute {
           func_name: "_burn",
+          self_span: Span {
+              start: 7671,
+              end: 7675,
+          },
       }
 
 note: 
@@ -6089,10 +6161,14 @@ note:
     ┌─ demos/uniswap.fe:208:9
     │
 208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 6764850540347574840
+    │         ^^^^^^^^^^^^ attributes hash: 15351211589753982846
     │
     = SelfAttribute {
           func_name: "_update",
+          self_span: Span {
+              start: 7890,
+              end: 7894,
+          },
       }
 
 note: 
@@ -6189,10 +6265,14 @@ note:
     ┌─ demos/uniswap.fe:252:9
     │
 252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 6764850540347574840
+    │         ^^^^^^^^^^^^ attributes hash: 5918725660327764465
     │
     = SelfAttribute {
           func_name: "_update",
+          self_span: Span {
+              start: 10100,
+              end: 10104,
+          },
       }
 
 note: 
@@ -6299,10 +6379,14 @@ note:
     ┌─ demos/uniswap.fe:267:9
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 6764850540347574840
+    │         ^^^^^^^^^^^^ attributes hash: 15796683777521125666
     │
     = SelfAttribute {
           func_name: "_update",
+          self_span: Span {
+              start: 10760,
+              end: 10764,
+          },
       }
 
 note: 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop.snap
@@ -13,9 +13,10 @@ note:
 6 │ │             if val == 2:
 7 │ │                 val = 3
 8 │ │         return val
-  │ ╰──────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
@@ -12,9 +12,10 @@ note:
 5 │ │             val = val + 1
 6 │ │             break
 7 │ │         return val
-  │ ╰──────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
@@ -13,9 +13,10 @@ note:
 6 │ │             if val == 1:
 7 │ │                 break
 8 │ │         return val
-  │ ╰──────────────────^ attributes hash: 4553090961241945225
+  │ ╰──────────────────^ attributes hash: 17979516652885443340
   │  
   = FunctionSignature {
+        self_decl: None,
         params: [],
         return_type: Ok(
             Base(

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
@@ -13,9 +13,10 @@ note:
    · │
 10 │ │             counter = counter + 1
 11 │ │         return counter
-   │ ╰──────────────────────^ attributes hash: 4553090961241945225
+   │ ╰──────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
+         self_decl: None,
          params: [],
          return_type: Ok(
              Base(

--- a/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
@@ -6,7 +6,7 @@ expression: "error_string(&path, &src)"
 error: The function `do_private_thingz` on `contract Foo` is private
   ┌─ compile_errors/call_non_pub_fn_on_external_contract.fe:9:21
   │  
-4 │ ╭   fn do_private_thingz():
+4 │ ╭   fn do_private_thingz(self):
 5 │ │      self.val = 100
   │ ╰───────────────────' `do_private_thingz` is defined here
   · │

--- a/crates/analyzer/tests/snapshots/errors__call_to_mut_fn_without_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_to_mut_fn_without_self.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `baz` must be called using `self`
+  ┌─ compile_errors/call_to_mut_fn_without_self.fe:3:9
+  │
+3 │         baz()
+  │         ^^^ function takes self
+  │
+  = Suggestion: try `self.baz(...)` instead of `baz(...)`
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_to_pure_fn_on_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_to_pure_fn_on_self.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `pure` must be called without `self`
+  ┌─ compile_errors/call_to_pure_fn_on_self.fe:6:9
+  │
+6 │         self.pure()
+  │         ^^^^^^^^^ function does not take self
+  │
+  = Suggestion: try `pure(...)` instead of `self.pure(...)`
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_contract.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: no function `doesnt_exist` exists this contract
+error: no function named `doesnt_exist` exists in this contract
   ┌─ [snippet]:3:3
   │
 3 │   self.doesnt_exist()

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args.snap
@@ -4,15 +4,15 @@ expression: "error_string(&path, &src)"
 
 ---
 error: argument label mismatch
-  ┌─ compile_errors/mislabeled_call_args.fe:4:18
+  ┌─ compile_errors/mislabeled_call_args.fe:4:13
   │
-4 │         self.bar(doesnt_exist=1, me_neither=2)
-  │                  ^^^^^^^^^^^^ expected `val1`
+4 │         bar(doesnt_exist=1, me_neither=2)
+  │             ^^^^^^^^^^^^ expected `val1`
 
 error: argument label mismatch
-  ┌─ compile_errors/mislabeled_call_args.fe:4:34
+  ┌─ compile_errors/mislabeled_call_args.fe:4:29
   │
-4 │         self.bar(doesnt_exist=1, me_neither=2)
-  │                                  ^^^^^^^^^^ expected `val2`
+4 │         bar(doesnt_exist=1, me_neither=2)
+  │                             ^^^^^^^^^^ expected `val2`
 
 

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_self.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: argument label mismatch
+  ┌─ compile_errors/mislabeled_call_args_self.fe:4:18
+  │
+4 │         self.bar(doesnt_exist=1, me_neither=2)
+  │                  ^^^^^^^^^^^^ expected `val1`
+
+error: argument label mismatch
+  ┌─ compile_errors/mislabeled_call_args_self.fe:4:34
+  │
+4 │         self.bar(doesnt_exist=1, me_neither=2)
+  │                                  ^^^^^^^^^^ expected `val2`
+
+

--- a/crates/analyzer/tests/snapshots/errors__missing_return.snap
+++ b/crates/analyzer/tests/snapshots/errors__missing_return.snap
@@ -6,9 +6,9 @@ expression: "error_string(&path, &src)"
 error: function body is missing a return or revert statement
   ┌─ compile_errors/missing_return.fe:4:12
   │
-4 │     pub fn bar() -> u256:
-  │            ^^^      ---- expected function to return `u256`
-  │            │         
+4 │     pub fn bar(self) -> u256:
+  │            ^^^          ---- expected function to return `u256`
+  │            │             
   │            all paths of this function must `return` or `revert`
 
 

--- a/crates/analyzer/tests/snapshots/errors__missing_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__missing_self.snap
@@ -1,0 +1,15 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `self` is not defined
+  ┌─ compile_errors/missing_self.fe:3:9
+  │
+3 │         self.mut_fn()
+  │         ^^^^ undefined value
+  │
+  = add `self` to the scope by including it in the function signature
+  = Example: `fn foo(self, bar: bool)`
+
+

--- a/crates/analyzer/tests/snapshots/errors__return_call_to_fn_with_param_type_mismatch.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_call_to_fn_with_param_type_mismatch.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, &src)"
 
 ---
 error: incorrect type for `foo` argument `val`
-  ┌─ compile_errors/return_call_to_fn_with_param_type_mismatch.fe:7:25
+  ┌─ compile_errors/return_call_to_fn_with_param_type_mismatch.fe:7:20
   │
-7 │         return self.foo(100)
-  │                         ^^^ this has type `u256`; expected type `address`
+7 │         return foo(100)
+  │                    ^^^ this has type `u256`; expected type `address`
 
 

--- a/crates/analyzer/tests/snapshots/errors__return_call_to_fn_without_return.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_call_to_fn_without_return.snap
@@ -6,7 +6,7 @@ expression: "error_string(&path, &src)"
 error: expected function to return `u256` but was `()`
   ┌─ compile_errors/return_call_to_fn_without_return.fe:7:9
   │
-7 │         return self.foo()
-  │         ^^^^^^^^^^^^^^^^^
+7 │         return foo()
+  │         ^^^^^^^^^^^^
 
 

--- a/crates/analyzer/tests/snapshots/errors__self_not_first.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_not_first.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: self is not the first parameter
+  ┌─ compile_errors/self_not_first.fe:2:28
+  │
+2 │     pub fn bar(my_num: u8, self):
+  │                            ^^^^ self may only be used as the first parameter
+
+

--- a/crates/lowering/src/mappers/contracts.rs
+++ b/crates/lowering/src/mappers/contracts.rs
@@ -5,6 +5,7 @@ use crate::utils::ZeroSpanNode;
 use fe_analyzer::namespace::items::{ContractFieldId, ContractId, EventId};
 use fe_analyzer::namespace::types::{Array, FixedSize};
 use fe_parser::ast;
+use fe_parser::ast::RegularFunctionArg;
 use fe_parser::node::Node;
 
 /// Lowers a contract definition.
@@ -99,10 +100,10 @@ fn list_expr_to_fn_def(array: &Array) -> ast::Function {
     // Built the AST nodes for the function arguments
     let args = (0..array.size)
         .map(|index| {
-            ast::FunctionArg {
+            ast::FunctionArg::Regular(RegularFunctionArg {
                 name: format!("val{}", index).into_node(),
                 typ: names::fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
-            }
+            })
             .into_node()
         })
         .collect::<Vec<_>>();

--- a/crates/lowering/src/mappers/expressions.rs
+++ b/crates/lowering/src/mappers/expressions.rs
@@ -1,7 +1,6 @@
 use crate::context::FnContext;
 use crate::names::{list_expr_generator_fn_name, tuple_struct_name};
 use crate::utils::ZeroSpanNode;
-use fe_analyzer::builtins::Object;
 use fe_analyzer::namespace::types::{Type, TypeDowncast};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
@@ -172,11 +171,7 @@ fn expr_list(context: &mut FnContext, exp: Node<fe::Expr>) -> fe::Expr {
 
             // Turn List Expression into a function call
             return fe::Expr::Call {
-                func: fe::Expr::Attribute {
-                    value: fe::Expr::Name(Object::Self_.to_string()).into_boxed_node(),
-                    attr: fn_name.into_node(),
-                }
-                .into_boxed_node(),
+                func: fe::Expr::Name(fn_name).into_boxed_node(),
                 generic_args: None,
                 args,
             };

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -154,9 +154,15 @@ pub struct EventField {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
-pub struct FunctionArg {
+pub struct RegularFunctionArg {
     pub name: Node<String>,
     pub typ: Node<TypeDesc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub enum FunctionArg {
+    Regular(RegularFunctionArg),
+    Zelf,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -346,7 +352,10 @@ impl Node<Function> {
 
 impl Node<FunctionArg> {
     pub fn name(&self) -> &str {
-        &self.kind.name.kind
+        match &self.kind {
+            FunctionArg::Regular(arg) => &arg.name.kind,
+            FunctionArg::Zelf => "self",
+        }
     }
 }
 

--- a/crates/parser/src/grammar/Fe.grammar
+++ b/crates/parser/src/grammar/Fe.grammar
@@ -47,7 +47,7 @@ event_field: [event_field_qual] NAME ':' type_desc NEWLINE
 func_def:
     [func_qual] 'fn' NAME '(' [arg_list] ')' ['->' base_type] ':' block
 arg_list: arg_def (',' arg_def)* [',']
-arg_def: NAME ':' type_desc
+arg_def: NAME ':' type_desc | 'self'
 
 type_desc: map_type | base_type
 map_type:

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -187,11 +187,11 @@ contract GuestBook:
     event Signed:
         idx book_msg: BookMsg
 
-    pub fn sign(book_msg: BookMsg):
+    pub fn sign(self, book_msg: BookMsg):
         self.guest_book[msg.sender] = book_msg
 
         emit Signed(book_msg=book_msg)
 
-    pub fn get_msg(addr: address) -> BookMsg:
+    pub fn get_msg(self, addr: address) -> BookMsg:
         return self.guest_book[addr]
 "# }

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def.snap
@@ -15,7 +15,7 @@ Node(
     ),
     args: [
       Node(
-        kind: FunctionArg(
+        kind: Regular(RegularFunctionArg(
           name: Node(
             kind: "x",
             span: Span(
@@ -32,14 +32,14 @@ Node(
               end: 16,
             ),
           ),
-        ),
+        )),
         span: Span(
           start: 9,
           end: 16,
         ),
       ),
       Node(
-        kind: FunctionArg(
+        kind: Regular(RegularFunctionArg(
           name: Node(
             kind: "y",
             span: Span(
@@ -56,7 +56,7 @@ Node(
               end: 28,
             ),
           ),
-        ),
+        )),
         span: Span(
           start: 18,
           end: 28,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(guest_book), module::parse_module,\n           r#\"\ntype BookMsg = bytes[100]\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub fn sign(book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg=book_msg)\n\n    pub fn get_msg(addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
+expression: "ast_string(stringify!(guest_book), module::parse_module,\n           r#\"\ntype BookMsg = bytes[100]\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub fn sign(self, book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg=book_msg)\n\n    pub fn get_msg(self, addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
 
 ---
 Node(
@@ -164,12 +164,19 @@ Node(
                 ),
                 args: [
                   Node(
-                    kind: FunctionArg(
+                    kind: Zelf,
+                    span: Span(
+                      start: 156,
+                      end: 160,
+                    ),
+                  ),
+                  Node(
+                    kind: Regular(RegularFunctionArg(
                       name: Node(
                         kind: "book_msg",
                         span: Span(
-                          start: 156,
-                          end: 164,
+                          start: 162,
+                          end: 170,
                         ),
                       ),
                       typ: Node(
@@ -177,14 +184,14 @@ Node(
                           base: "BookMsg",
                         ),
                         span: Span(
-                          start: 166,
-                          end: 173,
+                          start: 172,
+                          end: 179,
                         ),
                       ),
-                    ),
+                    )),
                     span: Span(
-                      start: 156,
-                      end: 173,
+                      start: 162,
+                      end: 179,
                     ),
                   ),
                 ],
@@ -199,21 +206,21 @@ Node(
                               value: Node(
                                 kind: Name("self"),
                                 span: Span(
-                                  start: 184,
-                                  end: 188,
+                                  start: 190,
+                                  end: 194,
                                 ),
                               ),
                               attr: Node(
                                 kind: "guest_book",
                                 span: Span(
-                                  start: 189,
-                                  end: 199,
+                                  start: 195,
+                                  end: 205,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 184,
-                              end: 199,
+                              start: 190,
+                              end: 205,
                             ),
                           ),
                           index: Node(
@@ -221,40 +228,40 @@ Node(
                               value: Node(
                                 kind: Name("msg"),
                                 span: Span(
-                                  start: 200,
-                                  end: 203,
+                                  start: 206,
+                                  end: 209,
                                 ),
                               ),
                               attr: Node(
                                 kind: "sender",
                                 span: Span(
-                                  start: 204,
-                                  end: 210,
+                                  start: 210,
+                                  end: 216,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 200,
-                              end: 210,
+                              start: 206,
+                              end: 216,
                             ),
                           ),
                         ),
                         span: Span(
-                          start: 184,
-                          end: 211,
+                          start: 190,
+                          end: 217,
                         ),
                       ),
                       value: Node(
                         kind: Name("book_msg"),
                         span: Span(
-                          start: 214,
-                          end: 222,
+                          start: 220,
+                          end: 228,
                         ),
                       ),
                     ),
                     span: Span(
-                      start: 184,
-                      end: 222,
+                      start: 190,
+                      end: 228,
                     ),
                   ),
                   Node(
@@ -262,8 +269,8 @@ Node(
                       name: Node(
                         kind: "Signed",
                         span: Span(
-                          start: 237,
-                          end: 243,
+                          start: 243,
+                          end: 249,
                         ),
                       ),
                       args: Node(
@@ -273,40 +280,40 @@ Node(
                               label: Some(Node(
                                 kind: "book_msg",
                                 span: Span(
-                                  start: 244,
-                                  end: 252,
+                                  start: 250,
+                                  end: 258,
                                 ),
                               )),
                               value: Node(
                                 kind: Name("book_msg"),
                                 span: Span(
-                                  start: 253,
-                                  end: 261,
+                                  start: 259,
+                                  end: 267,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 244,
-                              end: 261,
+                              start: 250,
+                              end: 267,
                             ),
                           ),
                         ],
                         span: Span(
-                          start: 243,
-                          end: 262,
+                          start: 249,
+                          end: 268,
                         ),
                       ),
                     ),
                     span: Span(
-                      start: 232,
-                      end: 262,
+                      start: 238,
+                      end: 268,
                     ),
                   ),
                 ],
               ),
               span: Span(
                 start: 144,
-                end: 262,
+                end: 268,
               ),
             )),
             Function(Node(
@@ -315,18 +322,25 @@ Node(
                 name: Node(
                   kind: "get_msg",
                   span: Span(
-                    start: 275,
-                    end: 282,
+                    start: 281,
+                    end: 288,
                   ),
                 ),
                 args: [
                   Node(
-                    kind: FunctionArg(
+                    kind: Zelf,
+                    span: Span(
+                      start: 289,
+                      end: 293,
+                    ),
+                  ),
+                  Node(
+                    kind: Regular(RegularFunctionArg(
                       name: Node(
                         kind: "addr",
                         span: Span(
-                          start: 283,
-                          end: 287,
+                          start: 295,
+                          end: 299,
                         ),
                       ),
                       typ: Node(
@@ -334,14 +348,14 @@ Node(
                           base: "address",
                         ),
                         span: Span(
-                          start: 289,
-                          end: 296,
+                          start: 301,
+                          end: 308,
                         ),
                       ),
-                    ),
+                    )),
                     span: Span(
-                      start: 283,
-                      end: 296,
+                      start: 295,
+                      end: 308,
                     ),
                   ),
                 ],
@@ -350,8 +364,8 @@ Node(
                     base: "BookMsg",
                   ),
                   span: Span(
-                    start: 301,
-                    end: 308,
+                    start: 313,
+                    end: 320,
                   ),
                 )),
                 body: [
@@ -364,60 +378,60 @@ Node(
                               value: Node(
                                 kind: Name("self"),
                                 span: Span(
-                                  start: 325,
-                                  end: 329,
+                                  start: 337,
+                                  end: 341,
                                 ),
                               ),
                               attr: Node(
                                 kind: "guest_book",
                                 span: Span(
-                                  start: 330,
-                                  end: 340,
+                                  start: 342,
+                                  end: 352,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 325,
-                              end: 340,
+                              start: 337,
+                              end: 352,
                             ),
                           ),
                           index: Node(
                             kind: Name("addr"),
                             span: Span(
-                              start: 341,
-                              end: 345,
+                              start: 353,
+                              end: 357,
                             ),
                           ),
                         ),
                         span: Span(
-                          start: 325,
-                          end: 346,
+                          start: 337,
+                          end: 358,
                         ),
                       )),
                     ),
                     span: Span(
-                      start: 318,
-                      end: 346,
+                      start: 330,
+                      end: 358,
                     ),
                   ),
                 ],
               ),
               span: Span(
-                start: 268,
-                end: 346,
+                start: 274,
+                end: 358,
               ),
             )),
           ],
         ),
         span: Span(
           start: 28,
-          end: 346,
+          end: 358,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 346,
+    end: 358,
   ),
 )

--- a/crates/test-files/fixtures/compile_errors/abi_encode_from_storage.fe
+++ b/crates/test-files/fixtures/compile_errors/abi_encode_from_storage.fe
@@ -1,5 +1,5 @@
 contract Foo:
     my_field: (u256, bool)
 
-    pub fn bar():
+    pub fn bar(self):
         self.my_field.abi_encode()

--- a/crates/test-files/fixtures/compile_errors/assert_sto_msg_no_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/assert_sto_msg_no_copy.fe
@@ -1,5 +1,5 @@
 contract Foo:
     my_string: String<42>
 
-    pub fn bar():
+    pub fn bar(self):
         assert false, self.my_string

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr1.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr1.fe
@@ -2,5 +2,5 @@
 contract foo:
     my_sto_tuple: (u256, i32)
 
-    pub fn bar():
+    pub fn bar(self):
         self.my_sto_tuple.iteo0

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr2.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr2.fe
@@ -2,5 +2,5 @@
 contract foo:
     my_sto_tuple: (u256, i32)
 
-    pub fn bar:
+    pub fn bar(self):
         self.my_sto_tuple.m

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr3.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr3.fe
@@ -2,5 +2,5 @@
 contract foo:
     my_sto_tuple: (u256, i32)
 
-    pub fn bar:
+    pub fn bar(self):
         self.my_sto_tuple.item00

--- a/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_external_contract.fe
+++ b/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_external_contract.fe
@@ -1,7 +1,7 @@
 
 contract Foo:
   val: u8
-  fn do_private_thingz():
+  fn do_private_thingz(self):
      self.val = 100
 
 contract Bar:

--- a/crates/test-files/fixtures/compile_errors/call_to_mut_fn_without_self.fe
+++ b/crates/test-files/fixtures/compile_errors/call_to_mut_fn_without_self.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    fn bar(self):
+        baz()
+
+    fn baz(self):
+        pass

--- a/crates/test-files/fixtures/compile_errors/call_to_pure_fn_on_self.fe
+++ b/crates/test-files/fixtures/compile_errors/call_to_pure_fn_on_self.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    fn pure():
+        pass
+
+    fn bar(self):
+        self.pure()

--- a/crates/test-files/fixtures/compile_errors/call_undefined_function_on_storage_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/call_undefined_function_on_storage_struct.fe
@@ -4,5 +4,5 @@ struct Something:
 contract Bar:
   thingy: Something
 
-  pub fn test():
+  pub fn test(self):
     self.thingy.doesnt_exist()

--- a/crates/test-files/fixtures/compile_errors/cannot_move.fe
+++ b/crates/test-files/fixtures/compile_errors/cannot_move.fe
@@ -1,5 +1,5 @@
 contract Foo:
     data: u256[10]
 
-    pub fn foo() -> u256[10]:
+    pub fn foo(self) -> u256[10]:
         return self.data

--- a/crates/test-files/fixtures/compile_errors/for_loop_sto_iter_no_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/for_loop_sto_iter_no_copy.fe
@@ -1,6 +1,6 @@
 contract Foo:
     my_array: u256[3]
 
-    pub fn bar():
+    pub fn bar(self):
         for i in self.my_array:
             pass

--- a/crates/test-files/fixtures/compile_errors/invalid_contract_field.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_contract_field.fe
@@ -1,5 +1,5 @@
 contract Foo:
   val: u256
 
-  pub fn foo():
+  pub fn foo(self):
     self.bar

--- a/crates/test-files/fixtures/compile_errors/invalid_struct_field.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_struct_field.fe
@@ -4,5 +4,5 @@ struct Bar:
 contract Foo:
   val: Bar
 
-  pub fn foo():
+  pub fn foo(self):
     self.val.foo

--- a/crates/test-files/fixtures/compile_errors/invalid_tuple_field.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_tuple_field.fe
@@ -1,5 +1,5 @@
 contract Foo:
   val: (u256, u8)
 
-  pub fn foo():
+  pub fn foo(self):
     self.val.item5

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args.fe
@@ -1,7 +1,7 @@
 contract Foo:
 
     pub fn baz():
-        self.bar(doesnt_exist=1, me_neither=2)
+        bar(doesnt_exist=1, me_neither=2)
     
     pub fn bar(val1: u256, val2: u256):
         pass

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args_self.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args_self.fe
@@ -1,0 +1,7 @@
+contract Foo:
+
+    pub fn baz(self):
+        self.bar(doesnt_exist=1, me_neither=2)
+
+    pub fn bar(self, val1: u256, val2: u256):
+        pass

--- a/crates/test-files/fixtures/compile_errors/missing_return.fe
+++ b/crates/test-files/fixtures/compile_errors/missing_return.fe
@@ -1,5 +1,5 @@
 contract Foo:
     baz: Map<u256, u256>
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.baz[0] = 1

--- a/crates/test-files/fixtures/compile_errors/missing_self.fe
+++ b/crates/test-files/fixtures/compile_errors/missing_self.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    fn pure_fn():
+        self.mut_fn()
+
+    fn mut_fn(self):
+        pass

--- a/crates/test-files/fixtures/compile_errors/needs_mem_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/needs_mem_copy.fe
@@ -1,8 +1,8 @@
 contract Foo:
     my_sto_array: u256[10]
 
-    pub fn bar(my_array: u256[10]):
+    pub fn bar(self, my_array: u256[10]):
         my_array = self.my_sto_array
 
-    pub fn foo() -> u256[10]:
+    pub fn foo(self) -> u256[10]:
         return self.my_sto_array

--- a/crates/test-files/fixtures/compile_errors/return_call_to_fn_with_param_type_mismatch.fe
+++ b/crates/test-files/fixtures/compile_errors/return_call_to_fn_with_param_type_mismatch.fe
@@ -4,4 +4,4 @@ contract Foo:
         return 42
 
     pub fn bar() -> u256:
-        return self.foo(100)
+        return foo(100)

--- a/crates/test-files/fixtures/compile_errors/return_call_to_fn_without_return.fe
+++ b/crates/test-files/fixtures/compile_errors/return_call_to_fn_without_return.fe
@@ -4,4 +4,4 @@ contract Foo:
         revert
 
     pub fn bar() -> u256:
-        return self.foo()
+        return foo()

--- a/crates/test-files/fixtures/compile_errors/revert_sto_error_no_copy.fe
+++ b/crates/test-files/fixtures/compile_errors/revert_sto_error_no_copy.fe
@@ -4,5 +4,5 @@ struct MyError:
 contract Foo:
     my_error: MyError
 
-    pub fn bar():
+    pub fn bar(self):
         revert self.my_error

--- a/crates/test-files/fixtures/compile_errors/self_not_first.fe
+++ b/crates/test-files/fixtures/compile_errors/self_not_first.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub fn bar(my_num: u8, self):
+        pass

--- a/crates/test-files/fixtures/demos/erc20_token.fe
+++ b/crates/test-files/fixtures/demos/erc20_token.fe
@@ -18,89 +18,89 @@ contract ERC20:
         idx to: address
         value: u256
 
-    pub fn __init__(name: String<100>, symbol: String<100>):
+    pub fn __init__(self, name: String<100>, symbol: String<100>):
         self._name = name
         self._symbol = symbol
         self._decimals = u8(18)
         self._mint(msg.sender, 1000000000000000000000000)
 
-    pub fn name() -> String<100>:
+    pub fn name(self) -> String<100>:
         return self._name.to_mem()
 
-    pub fn symbol() -> String<100>:
+    pub fn symbol(self) -> String<100>:
         return self._symbol.to_mem()
 
-    pub fn decimals() -> u8:
+    pub fn decimals(self) -> u8:
         return self._decimals
 
-    pub fn totalSupply() -> u256:
+    pub fn totalSupply(self) -> u256:
         return self._total_supply
 
-    pub fn balanceOf(account: address) -> u256:
+    pub fn balanceOf(self, account: address) -> u256:
         return self._balances[account]
 
-    pub fn transfer(recipient: address, value: u256) -> bool:
+    pub fn transfer(self, recipient: address, value: u256) -> bool:
         self._transfer(msg.sender, recipient, value)
         return true
 
-    pub fn allowance(owner: address, spender: address) -> u256:
+    pub fn allowance(self, owner: address, spender: address) -> u256:
         return self._allowances[owner][spender]
 
-    pub fn approve(spender: address, value: u256) -> bool:
+    pub fn approve(self, spender: address, value: u256) -> bool:
         self._approve(msg.sender, spender, value)
         return true
 
-    pub fn transferFrom(sender: address, recipient: address, value: u256) -> bool:
+    pub fn transferFrom(self, sender: address, recipient: address, value: u256) -> bool:
         assert self._allowances[sender][msg.sender] >= value
 
         self._transfer(sender, recipient, value)
         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
         return true
 
-    pub fn increaseAllowance(spender: address, addedValue: u256) -> bool:
+    pub fn increaseAllowance(self, spender: address, addedValue: u256) -> bool:
         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
         return true
 
-    pub fn decreaseAllowance(spender: address, subtractedValue: u256) -> bool:
+    pub fn decreaseAllowance(self, spender: address, subtractedValue: u256) -> bool:
         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
         return true
 
-    fn _transfer(sender: address, recipient: address, value: u256):
+    fn _transfer(self, sender: address, recipient: address, value: u256):
         assert sender != address(0)
         assert recipient != address(0)
 
-        self._before_token_transfer(sender, recipient, value)
+        _before_token_transfer(sender, recipient, value)
 
         self._balances[sender] = self._balances[sender] - value
         self._balances[recipient] = self._balances[recipient] + value
         emit Transfer(from=sender, to=recipient, value=value)
 
-    fn _mint(account: address, value: u256):
+    fn _mint(self, account: address, value: u256):
         assert account != address(0)
 
-        self._before_token_transfer(address(0), account, value)
+        _before_token_transfer(address(0), account, value)
 
         self._total_supply = self._total_supply + value
         self._balances[account] = self._balances[account] + value
         emit Transfer(from=address(0), to=account, value=value)
 
-    fn _burn(account: address, value: u256):
+    fn _burn(self, account: address, value: u256):
         assert account != address(0)
 
-        self._before_token_transfer(account, address(0), value)
+        _before_token_transfer(account, address(0), value)
 
         self._balances[account] = self._balances[account] - value
         self._total_supply = self._total_supply - value
         emit Transfer(from=account, to=address(0), value)
 
-    fn _approve(owner: address, spender: address, value: u256):
+    fn _approve(self, owner: address, spender: address, value: u256):
         assert owner != address(0)
         assert spender != address(0)
 
         self._allowances[owner][spender] = value
         emit Approval(owner, spender, value)
 
-    fn _setup_decimals(decimals_: u8):
+    fn _setup_decimals(self, decimals_: u8):
         self._decimals = decimals_
 
     fn _before_token_transfer(from: address, to: address, value: u256):

--- a/crates/test-files/fixtures/demos/guest_book.fe
+++ b/crates/test-files/fixtures/demos/guest_book.fe
@@ -8,14 +8,14 @@ contract GuestBook:
     event Signed:
         book_msg: String<100>
 
-    pub fn sign(book_msg: String<100>):
+    pub fn sign(self, book_msg: String<100>):
         # All storage access is explicit using `self.<some-key>`
         self.messages[msg.sender] = book_msg
 
         # Emit the `Signed` event
         emit Signed(book_msg=book_msg)
 
-    pub fn get_msg(addr: address) -> String<100>:
+    pub fn get_msg(self, addr: address) -> String<100>:
         # Copying data from storage to memory
         # has to be done explicitly via `to_mem()`
         return self.messages[addr].to_mem()

--- a/crates/test-files/fixtures/demos/uniswap.fe
+++ b/crates/test-files/fixtures/demos/uniswap.fe
@@ -60,66 +60,66 @@ contract UniswapV2Pair:
         reserve0: u256
         reserve1: u256
 
-    pub fn __init__():
+    pub fn __init__(self):
         self.factory = msg.sender
 
-    pub fn factory() -> address:
+    pub fn factory(self) -> address:
         return self.factory
 
-    pub fn token0() -> address:
+    pub fn token0(self) -> address:
         return self.token0
 
-    pub fn token1() -> address:
+    pub fn token1(self) -> address:
         return self.token1
 
-    fn _mint(to: address, value: u256):
+    fn _mint(self, to: address, value: u256):
         self.total_supply = self.total_supply + value
         self.balances[to] = self.balances[to] + value
         emit Transfer(from=address(0), to, value)
 
-    fn _burn(from: address, value: u256):
+    fn _burn(self, from: address, value: u256):
         self.balances[from] = self.balances[from] - value
         self.total_supply = self.total_supply - value
         emit Transfer(from, to=address(0), value)
 
-    fn _approve(owner: address, spender: address, value: u256):
+    fn _approve(self, owner: address, spender: address, value: u256):
         self.allowances[owner][spender] = value
         emit Approval(owner, spender, value)
 
-    fn _transfer(from: address, to: address, value: u256):
+    fn _transfer(self, from: address, to: address, value: u256):
         self.balances[from] = self.balances[from] - value
         self.balances[to] = self.balances[to] + value
         emit Transfer(from, to, value)
 
-    pub fn approve(spender: address, value: u256) -> bool:
+    pub fn approve(self, spender: address, value: u256) -> bool:
         self._approve(msg.sender, spender, value)
         return true
 
-    pub fn transfer(to: address, value: u256) -> bool:
+    pub fn transfer(self, to: address, value: u256) -> bool:
         self._transfer(msg.sender, to, value)
         return true
 
-    pub fn transferFrom(from: address, to: address, value: u256) -> bool:
+    pub fn transferFrom(self, from: address, to: address, value: u256) -> bool:
         assert self.allowances[from][msg.sender] >= value
 
         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
         self._transfer(from, to, value)
         return true
 
-    pub fn balanceOf(account: address) -> u256:
+    pub fn balanceOf(self, account: address) -> u256:
         return self.balances[account]
 
-    pub fn get_reserves() -> (u256, u256, u256):
+    pub fn get_reserves(self) -> (u256, u256, u256):
         return (self.reserve0, self.reserve1, self.block_timestamp_last)
 
     # called once by the factory at time of deployment
-    pub fn initialize(token0: address, token1: address):
+    pub fn initialize(self, token0: address, token1: address):
         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
         self.token0 = token0
         self.token1 = token1
 
     # update reserves and, on the first call per block, price accumulators
-    fn _update(balance0: u256, balance1: u256, reserve0: u256, reserve1: u256):
+    fn _update(self, balance0: u256, balance1: u256, reserve0: u256, reserve1: u256):
         # changed from u32s
         let block_timestamp: u256 = block.timestamp % 2**32
         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
@@ -135,14 +135,14 @@ contract UniswapV2Pair:
         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
 
     # if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
-    fn _mint_fee(reserve0: u256, reserve1: u256) -> bool:
+    fn _mint_fee(self, reserve0: u256, reserve1: u256) -> bool:
         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
         let fee_on: bool = fee_to != address(0)
         let k_last: u256 = self.k_last # gas savings
         if fee_on:
             if k_last != 0:
-                let root_k: u256 = self.sqrt(reserve0 * reserve1)
-                let root_k_last: u256 = self.sqrt(k_last)
+                let root_k: u256 = sqrt(reserve0 * reserve1)
+                let root_k_last: u256 = sqrt(k_last)
                 if root_k > root_k_last:
                     let numerator: u256 = self.total_supply * root_k - root_k_last
                     let denominator: u256 = root_k * 5 + root_k_last
@@ -155,7 +155,7 @@ contract UniswapV2Pair:
         return fee_on
 
     # this low-level function should be called from a contract which performs important safety checks
-    pub fn mint(to: address) -> u256:
+    pub fn mint(self, to: address) -> u256:
         let MINIMUM_LIQUIDITY: u256 = 1000
         let reserve0: u256 = self.reserve0
         let reserve1: u256 = self.reserve1
@@ -168,10 +168,10 @@ contract UniswapV2Pair:
         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
         let liquidity: u256 = 0
         if total_supply == 0:
-            liquidity = self.sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+            liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
         else:
-            liquidity = self.min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+            liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
 
         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
 
@@ -185,7 +185,7 @@ contract UniswapV2Pair:
         return liquidity
 
     # this low-level function should be called from a contract which performs important safety checks
-    pub fn burn(to: address) -> (u256, u256):
+    pub fn burn(self, to: address) -> (u256, u256):
         let reserve0: u256 = self.reserve0
         let reserve1: u256 = self.reserve1
         let token0: ERC20 = ERC20(self.token0)
@@ -216,7 +216,7 @@ contract UniswapV2Pair:
     # this low-level function should be called from a contract which performs important safety checks
     # TODO: add support for the bytes type (https://github.com/ethereum/fe/issues/280)
     # pub fn swap(amount0_out: u256, amount1_out: u256, to: address, data: bytes):
-    pub fn swap(amount0_out: u256, amount1_out: u256, to: address):
+    pub fn swap(self, amount0_out: u256, amount1_out: u256, to: address):
         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
         let reserve0: u256 = self.reserve0
         let reserve1: u256 = self.reserve1
@@ -253,7 +253,7 @@ contract UniswapV2Pair:
         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
 
     # force balances to match reserves
-    pub fn skim(to: address):
+    pub fn skim(self, to: address):
         let token0: ERC20 = ERC20(self.token0) # gas savings
         let token1: ERC20 = ERC20(self.token1) # gas savings
 
@@ -261,7 +261,7 @@ contract UniswapV2Pair:
         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
 
     # force reserves to match balances
-    pub fn sync():
+    pub fn sync(self):
         let token0: ERC20 = ERC20(self.token0)
         let token1: ERC20 = ERC20(self.token1)
         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
@@ -296,19 +296,19 @@ contract UniswapV2Factory:
         pair: address
         index: u256
 
-    pub fn __init__(fee_to_setter: address):
+    pub fn __init__(self, fee_to_setter: address):
        self.fee_to_setter = fee_to_setter
 
-    pub fn fee_to() -> address:
+    pub fn fee_to(self) -> address:
         return self.fee_to
 
-    pub fn fee_to_setter() -> address:
+    pub fn fee_to_setter(self) -> address:
         return self.fee_to_setter
 
-    pub fn all_pairs_length() -> u256:
+    pub fn all_pairs_length(self) -> u256:
         return self.pair_counter
 
-    pub fn create_pair(token_a: address, token_b: address) -> address:
+    pub fn create_pair(self, token_a: address, token_b: address) -> address:
         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
 
         let token0: address = token_a if token_a < token_b else token_b
@@ -328,10 +328,10 @@ contract UniswapV2Factory:
         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
         return address(pair)
 
-    pub fn set_fee_to(fee_to: address):
+    pub fn set_fee_to(self, fee_to: address):
         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
         self.fee_to = fee_to
 
-    pub fn set_fee_to_setter(fee_to_setter: address):
+    pub fn set_fee_to_setter(self, fee_to_setter: address):
         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
         self.fee_to_setter = fee_to_setter

--- a/crates/test-files/fixtures/features/address_bytes10_map.fe
+++ b/crates/test-files/fixtures/features/address_bytes10_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<address, u8[10]>
 
-    pub fn read_bar(key: address) -> u8[10]:
+    pub fn read_bar(self, key: address) -> u8[10]:
         return self.bar[key].to_mem()
 
-    pub fn write_bar(key: address, value: u8[10]):
+    pub fn write_bar(self, key: address, value: u8[10]):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/assert.fe
+++ b/crates/test-files/fixtures/features/assert.fe
@@ -11,10 +11,10 @@ contract Foo:
     pub fn revert_with(baz: u256, reason: String<1000>):
         assert baz > 5, reason
 
-    pub fn assert_sto_bool():
+    pub fn assert_sto_bool(self):
         self.my_bool = false
         assert self.my_bool
 
-    pub fn assert_sto_string_msg():
+    pub fn assert_sto_string_msg(self):
         self.my_string = "hello"
         assert false, self.my_string.to_mem()

--- a/crates/test-files/fixtures/features/aug_assign.fe
+++ b/crates/test-files/fixtures/features/aug_assign.fe
@@ -45,7 +45,7 @@ contract Foo:
         a &= b
         return a
 
-    pub fn add_from_sto(a: u256, b: u256) -> u256:
+    pub fn add_from_sto(self, a: u256, b: u256) -> u256:
         self.my_num = a
         self.my_num += b
         return self.my_num

--- a/crates/test-files/fixtures/features/call_statement_with_args.fe
+++ b/crates/test-files/fixtures/features/call_statement_with_args.fe
@@ -1,9 +1,9 @@
 contract Foo:
     baz: Map<u256, u256>
 
-    fn assign(val: u256):
+    fn assign(self, val: u256):
         self.baz[0] = val
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.assign(100)
         return self.baz[0]

--- a/crates/test-files/fixtures/features/call_statement_with_args_2.fe
+++ b/crates/test-files/fixtures/features/call_statement_with_args_2.fe
@@ -1,10 +1,10 @@
 contract Foo:
     baz: Map<u256, u256>
 
-    fn assign(val: u256) -> u256:
+    fn assign(self, val: u256) -> u256:
         self.baz[0] = val
         return val
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.assign(100)
         return self.baz[0]

--- a/crates/test-files/fixtures/features/call_statement_without_args.fe
+++ b/crates/test-files/fixtures/features/call_statement_without_args.fe
@@ -1,9 +1,9 @@
 contract Foo:
     baz: Map<u256, u256>
 
-    fn assign():
+    fn assign(self):
         self.baz[0] = 100
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.assign()
         return self.baz[0]

--- a/crates/test-files/fixtures/features/constructor.fe
+++ b/crates/test-files/fixtures/features/constructor.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u256, u256>
 
-    pub fn __init__(baz: u256, bing: u256):
+    pub fn __init__(self, baz: u256, bing: u256):
         self.bar[42] = baz + bing
 
-    pub fn read_bar() -> u256:
+    pub fn read_bar(self) -> u256:
         return self.bar[42]

--- a/crates/test-files/fixtures/features/create_contract_from_init.fe
+++ b/crates/test-files/fixtures/features/create_contract_from_init.fe
@@ -5,8 +5,8 @@ contract Foo:
 contract FooFactory:
     foo_addr: address
 
-    pub fn __init__():
+    pub fn __init__(self):
         self.foo_addr = address(Foo.create(0))
 
-    pub fn get_foo_addr() -> address:
+    pub fn get_foo_addr(self) -> address:
         return self.foo_addr

--- a/crates/test-files/fixtures/features/for_loop_with_static_array_from_sto.fe
+++ b/crates/test-files/fixtures/features/for_loop_with_static_array_from_sto.fe
@@ -1,7 +1,7 @@
 contract Foo:
     my_array: u256[3]
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.my_array = [1,2,3]
         let sum: u256 = 0
         for i in self.my_array.to_mem():

--- a/crates/test-files/fixtures/features/if_statement_test_from_sto.fe
+++ b/crates/test-files/fixtures/features/if_statement_test_from_sto.fe
@@ -3,7 +3,7 @@ contract Foo:
     my_bool2: bool
     my_bool3: bool
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.my_bool1 = false
         self.my_bool2 = false
         self.my_bool3 = true

--- a/crates/test-files/fixtures/features/map_tuple.fe
+++ b/crates/test-files/fixtures/features/map_tuple.fe
@@ -1,6 +1,6 @@
 contract Foo:
     tuples: Map<u256, (address, u256)>
 
-    pub fn bar(x: u256) -> u256:
+    pub fn bar(self, x: u256) -> u256:
         self.tuples[0] = (address(100), x)
         return self.tuples[0].item1

--- a/crates/test-files/fixtures/features/nested_map.fe
+++ b/crates/test-files/fixtures/features/nested_map.fe
@@ -2,14 +2,14 @@ contract Foo:
     bar: Map<address, Map<address, u256>>
     baz: Map<address, Map<u256, bool>>
 
-    pub fn read_bar(a: address, b: address) -> u256:
+    pub fn read_bar(self, a: address, b: address) -> u256:
         return self.bar[a][b]
 
-    pub fn write_bar(a: address, b: address, value: u256):
+    pub fn write_bar(self, a: address, b: address, value: u256):
         self.bar[a][b] = value
 
-    pub fn read_baz(a: address, b: u256) -> bool:
+    pub fn read_baz(self, a: address, b: u256) -> bool:
         return self.baz[a][b]
 
-    pub fn write_baz(a: address, b: u256, value: bool):
+    pub fn write_baz(self, a: address, b: u256, value: bool):
         self.baz[a][b] = value

--- a/crates/test-files/fixtures/features/ownable.fe
+++ b/crates/test-files/fixtures/features/ownable.fe
@@ -5,18 +5,18 @@ contract Ownable:
     idx previousOwner: address
     idx newOwner: address
 
-  pub fn __init__():
+  pub fn __init__(self):
     self._owner = msg.sender
 
-  pub fn owner() -> address:
+  pub fn owner(self) -> address:
     return self._owner
 
-  pub fn renounceOwnership():
+  pub fn renounceOwnership(self):
     assert msg.sender == self._owner
     self._owner = address(0)
     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
 
-  pub fn transferOwnership(newOwner: address):
+  pub fn transferOwnership(self, newOwner: address):
     assert msg.sender == self._owner
     assert newOwner != address(0)
     self._owner = newOwner

--- a/crates/test-files/fixtures/features/pure_fn.fe
+++ b/crates/test-files/fixtures/features/pure_fn.fe
@@ -1,0 +1,3 @@
+contract Foo:
+    pub fn bar(x: u256, y: u256) -> u256:
+        return x + y

--- a/crates/test-files/fixtures/features/pure_fn_internal_call.fe
+++ b/crates/test-files/fixtures/features/pure_fn_internal_call.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    pub fn bar(self, x: u256, y: u256) -> u256:
+        return pure_bar(x, y)
+
+    pub fn pure_bar(x: u256, y: u256) -> u256:
+        return x + y

--- a/crates/test-files/fixtures/features/return_sum_list_expression_1.fe
+++ b/crates/test-files/fixtures/features/return_sum_list_expression_1.fe
@@ -1,7 +1,7 @@
 contract Foo:
     num_two: u256
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.num_two = 2
         let my_array: u256[20] = [1, self.num_two, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         let sum: u256 = 0

--- a/crates/test-files/fixtures/features/return_sum_list_expression_2.fe
+++ b/crates/test-files/fixtures/features/return_sum_list_expression_2.fe
@@ -1,7 +1,7 @@
 contract Foo:
 
-    pub fn bar() -> u256:
-        return self.count([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+    pub fn bar(self) -> u256:
+        return count([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
 
     fn count(values: u256[20]) -> u256:
         let sum: u256 = 0

--- a/crates/test-files/fixtures/features/return_u256_from_called_fn.fe
+++ b/crates/test-files/fixtures/features/return_u256_from_called_fn.fe
@@ -1,8 +1,8 @@
 contract Foo:
 
     # We intentionally define `bar` before `foo` to test that order isn't important
-    pub fn bar() -> u256:
-        return self.foo()
+    pub fn bar(self) -> u256:
+        return foo()
 
     pub fn foo() -> u256:
         return 42

--- a/crates/test-files/fixtures/features/return_u256_from_called_fn_with_args.fe
+++ b/crates/test-files/fixtures/features/return_u256_from_called_fn_with_args.fe
@@ -6,6 +6,6 @@ contract Foo:
     pub fn cem() -> u256:
         return 100
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.baz[0] = 43
-        return self.foo(5, 2, self.cem(), 25 + 25, self.baz[0])
+        return foo(5, 2, cem(), 25 + 25, self.baz[0])

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -18,6 +18,6 @@ contract Foo:
     pub fn revert_other_error():
         revert OtherError(msg=1, val=true)
 
-    pub fn revert_other_error_from_sto():
+    pub fn revert_other_error_from_sto(self):
         self.my_other_error = OtherError(msg=1, val=true)
         revert self.my_other_error.to_mem()

--- a/crates/test-files/fixtures/features/self_address.fe
+++ b/crates/test-files/fixtures/features/self_address.fe
@@ -1,3 +1,3 @@
 contract Foo:
-    pub fn my_address() -> address:
+    pub fn my_address(self) -> address:
         return self.address

--- a/crates/test-files/fixtures/features/sized_vals_in_sto.fe
+++ b/crates/test-files/fixtures/features/sized_vals_in_sto.fe
@@ -8,25 +8,25 @@ contract Foo:
         nums: u256[42]
         str: String<26>
 
-    pub fn write_num(x: u256):
+    pub fn write_num(self, x: u256):
         self.num = x
 
-    pub fn read_num() -> u256:
+    pub fn read_num(self) -> u256:
         return self.num
 
-    pub fn write_nums(x: u256[42]):
+    pub fn write_nums(self, x: u256[42]):
         self.nums = x
 
-    pub fn read_nums() -> u256[42]:
+    pub fn read_nums(self) -> u256[42]:
         return self.nums.to_mem()
 
-    pub fn write_str(x: String<26>):
+    pub fn write_str(self, x: String<26>):
         self.str = x
 
-    pub fn read_str() -> String<26>:
+    pub fn read_str(self) -> String<26>:
         return self.str.to_mem()
 
-    pub fn emit_event():
+    pub fn emit_event(self):
         emit MyEvent(
             num=self.num,
             nums=self.nums.to_mem(),

--- a/crates/test-files/fixtures/features/structs.fe
+++ b/crates/test-files/fixtures/features/structs.fe
@@ -7,7 +7,7 @@ struct House:
 contract Foo:
     my_house: House
 
-    pub fn create_house():
+    pub fn create_house(self):
         self.my_house = House(
             price=1,
             size=2,

--- a/crates/test-files/fixtures/features/tuple_destructuring.fe
+++ b/crates/test-files/fixtures/features/tuple_destructuring.fe
@@ -4,7 +4,7 @@ contract Foo:
         return x
 
     pub fn baz(n: u256, b: bool) -> u256:
-        let (x, y): (u256, bool) = self.make_tuple(n, b)
+        let (x, y): (u256, bool) = make_tuple(n, b)
         return x
 
     fn make_tuple(n: u256, b: bool) -> (u256, bool):

--- a/crates/test-files/fixtures/features/type_aliases.fe
+++ b/crates/test-files/fixtures/features/type_aliases.fe
@@ -12,17 +12,17 @@ contract Forum:
     authors: AuthorPosts
     scoreboard: Scoreboard
 
-    pub fn post(body: PostBody):
+    pub fn post(self, body: PostBody):
         # id: PostId = keccak256(body.abi_encode())
         let id: PostId = 0
         self.posts[id] = body
         self.authors[msg.sender]
         self.scoreboard[id] = 0
 
-    pub fn upvote(id: PostId) -> Score:
+    pub fn upvote(self, id: PostId) -> Score:
         let score: Score = self.scoreboard[id] + 1
         self.scoreboard[id] = score
         return score
 
-    pub fn get_post(id: PostId) -> PostBody:
+    pub fn get_post(self, id: PostId) -> PostBody:
         return self.posts[id].to_mem()

--- a/crates/test-files/fixtures/features/u128_u128_map.fe
+++ b/crates/test-files/fixtures/features/u128_u128_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u128, u128>
 
-    pub fn read_bar(key: u128) -> u128:
+    pub fn read_bar(self, key: u128) -> u128:
         return self.bar[key]
 
-    pub fn write_bar(key: u128, value: u128):
+    pub fn write_bar(self, key: u128, value: u128):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/u16_u16_map.fe
+++ b/crates/test-files/fixtures/features/u16_u16_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u16, u16>
 
-    pub fn read_bar(key: u16) -> u16:
+    pub fn read_bar(self, key: u16) -> u16:
         return self.bar[key]
 
-    pub fn write_bar(key: u16, value: u16):
+    pub fn write_bar(self, key: u16, value: u16):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/u256_u256_map.fe
+++ b/crates/test-files/fixtures/features/u256_u256_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u256, u256>
 
-    pub fn read_bar(key: u256) -> u256:
+    pub fn read_bar(self, key: u256) -> u256:
         return self.bar[key]
 
-    pub fn write_bar(key: u256, value: u256):
+    pub fn write_bar(self, key: u256, value: u256):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/u32_u32_map.fe
+++ b/crates/test-files/fixtures/features/u32_u32_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u32, u32>
 
-    pub fn read_bar(key: u32) -> u32:
+    pub fn read_bar(self, key: u32) -> u32:
         return self.bar[key]
 
-    pub fn write_bar(key: u32, value: u32):
+    pub fn write_bar(self, key: u32, value: u32):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/u64_u64_map.fe
+++ b/crates/test-files/fixtures/features/u64_u64_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u64, u64>
 
-    pub fn read_bar(key: u64) -> u64:
+    pub fn read_bar(self, key: u64) -> u64:
         return self.bar[key]
 
-    pub fn write_bar(key: u64, value: u64):
+    pub fn write_bar(self, key: u64, value: u64):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/u8_u8_map.fe
+++ b/crates/test-files/fixtures/features/u8_u8_map.fe
@@ -1,8 +1,8 @@
 contract Foo:
     bar: Map<u8, u8>
 
-    pub fn read_bar(key: u8) -> u8:
+    pub fn read_bar(self, key: u8) -> u8:
         return self.bar[key]
 
-    pub fn write_bar(key: u8, value: u8):
+    pub fn write_bar(self, key: u8, value: u8):
         self.bar[key] = value

--- a/crates/test-files/fixtures/features/while_loop_test_from_sto.fe
+++ b/crates/test-files/fixtures/features/while_loop_test_from_sto.fe
@@ -1,7 +1,7 @@
 contract Foo:
     my_bool: bool
 
-    pub fn bar() -> u256:
+    pub fn bar(self) -> u256:
         self.my_bool = false
 
         while self.my_bool:

--- a/crates/test-files/fixtures/lowering/array_tuple.fe
+++ b/crates/test-files/fixtures/lowering/array_tuple.fe
@@ -1,6 +1,6 @@
 contract Foo:
     tuples: (u256, address)[10]
 
-    pub fn bar(x: u256) -> u256:
+    pub fn bar(self, x: u256) -> u256:
         self.tuples[0] = (x, address(x))
         return self.tuples[0].item0

--- a/crates/test-files/fixtures/lowering/array_tuple_lowered.fe
+++ b/crates/test-files/fixtures/lowering/array_tuple_lowered.fe
@@ -5,6 +5,6 @@ struct tuple_u256_address_:
 contract Foo:
     tuples: tuple_u256_address_[10]
 
-    pub fn bar(x: u256) -> u256:
+    pub fn bar(self, x: u256) -> u256:
         self.tuples[0] = tuple_u256_address_(item0 = x, item1 = address(x))
         return self.tuples[0].item0

--- a/crates/test-files/fixtures/lowering/aug_assign.fe
+++ b/crates/test-files/fixtures/lowering/aug_assign.fe
@@ -45,7 +45,7 @@ contract Foo:
         a &= b
         return a
 
-    pub fn add_from_sto(a: u256, b: u256) -> u256:
+    pub fn add_from_sto(self, a: u256, b: u256) -> u256:
         self.my_num = a
         self.my_num += b
         return self.my_num

--- a/crates/test-files/fixtures/lowering/aug_assign_lowered.fe
+++ b/crates/test-files/fixtures/lowering/aug_assign_lowered.fe
@@ -45,7 +45,7 @@ contract Foo:
         a = a & b
         return a
 
-    pub fn add_from_sto(a: u256, b: u256) -> u256:
+    pub fn add_from_sto(self, a: u256, b: u256) -> u256:
         self.my_num = a
         self.my_num = self.my_num + b
         return self.my_num

--- a/crates/test-files/fixtures/lowering/list_expressions.fe
+++ b/crates/test-files/fixtures/lowering/list_expressions.fe
@@ -1,4 +1,3 @@
 contract Foo:
-
     pub fn foo():
         let x: u256[3] = [10, 20, 30]

--- a/crates/test-files/fixtures/lowering/list_expressions_lowered.fe
+++ b/crates/test-files/fixtures/lowering/list_expressions_lowered.fe
@@ -1,6 +1,6 @@
 contract Foo:
     pub fn foo() -> ():
-        let x: u256[3] = self.list_expr_array_u256_3(10, 20, 30)
+        let x: u256[3] = list_expr_array_u256_3(10, 20, 30)
         return ()
 
     fn list_expr_array_u256_3(val0: u256, val1: u256, val2: u256) -> u256[3]:

--- a/crates/test-files/fixtures/lowering/map_tuple.fe
+++ b/crates/test-files/fixtures/lowering/map_tuple.fe
@@ -1,6 +1,6 @@
 contract Foo:
     tuples: Map<u256, (address, (u256, u8))>
 
-    pub fn bar(x: u256) -> u256:
+    pub fn bar(self, x: u256) -> u256:
         self.tuples[0] = (address(100), (x, 5))
         return self.tuples[0].item1.item0

--- a/crates/test-files/fixtures/lowering/map_tuple_lowered.fe
+++ b/crates/test-files/fixtures/lowering/map_tuple_lowered.fe
@@ -9,7 +9,7 @@ struct tuple_address_tuple_u256_u8__:
 contract Foo:
     tuples: Map<u256, tuple_address_tuple_u256_u8__>
 
-    pub fn bar(x: u256) -> u256:
+    pub fn bar(self, x: u256) -> u256:
         self.tuples[0] = tuple_address_tuple_u256_u8__(
           item0 = address(100),
           item1 = tuple_u256_u8_(item0 = x, item1 = 5),

--- a/crates/test-files/fixtures/lowering/nested_tuple.fe
+++ b/crates/test-files/fixtures/lowering/nested_tuple.fe
@@ -1,6 +1,6 @@
 contract Foo:
     tup: (u256, (u8, bool), (address, (u8, u8)))
 
-    pub fn bar(x: u256) -> u8:
+    pub fn bar(self, x: u256) -> u8:
         self.tup = (1, (0, true), (address(0), (10, 100)))
         return self.tup.item2.item1.item0

--- a/crates/test-files/fixtures/lowering/nested_tuple_lowered.fe
+++ b/crates/test-files/fixtures/lowering/nested_tuple_lowered.fe
@@ -18,9 +18,13 @@ struct tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___:
 contract Foo:
     tup: tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___
 
-    pub fn bar(x: u256) -> u8:
-        self.tup = tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___(item0 = 1,
-                            item1 = tuple_u8_bool_(item0 = 0, item1 = true),
-                            item2 = tuple_address_tuple_u8_u8__(item0 = address(0),
-                                             item1 = tuple_u8_u8_(item0 = 10, item1 = 100)))
+    pub fn bar(self, x: u256) -> u8:
+        self.tup = tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___(
+            item0 = 1,
+            item1 = tuple_u8_bool_(item0 = 0, item1 = true),
+            item2 = tuple_address_tuple_u8_u8__(
+                item0 = address(0),
+                item1 = tuple_u8_u8_(item0 = 10, item1 = 100)
+            )
+        )
         return self.tup.item2.item1.item0

--- a/crates/test-files/fixtures/stress/abi_encoding_stress.fe
+++ b/crates/test-files/fixtures/stress/abi_encoding_stress.fe
@@ -20,40 +20,40 @@ contract Foo:
         my_bool: bool
         my_bytes: u8[100]
 
-    pub fn set_my_addrs(my_addrs: address[5]):
+    pub fn set_my_addrs(self, my_addrs: address[5]):
         self.my_addrs = my_addrs
 
-    pub fn get_my_addrs() -> address[5]:
+    pub fn get_my_addrs(self) -> address[5]:
         return self.my_addrs.to_mem()
 
-    pub fn set_my_u128(my_u128: u128):
+    pub fn set_my_u128(self, my_u128: u128):
         self.my_u128 = my_u128
 
-    pub fn get_my_u128() -> u128:
+    pub fn get_my_u128(self) -> u128:
         return self.my_u128
 
-    pub fn set_my_string(my_string: String<10>):
+    pub fn set_my_string(self, my_string: String<10>):
         self.my_string = my_string
 
-    pub fn get_my_string() -> String<10>:
+    pub fn get_my_string(self) -> String<10>:
         return self.my_string.to_mem()
 
-    pub fn set_my_u16s(my_u16s: u16[255]):
+    pub fn set_my_u16s(self, my_u16s: u16[255]):
         self.my_u16s = my_u16s
 
-    pub fn get_my_u16s() -> u16[255]:
+    pub fn get_my_u16s(self) -> u16[255]:
         return self.my_u16s.to_mem()
 
-    pub fn set_my_bool(my_bool: bool):
+    pub fn set_my_bool(self, my_bool: bool):
         self.my_bool = my_bool
 
-    pub fn get_my_bool() -> bool:
+    pub fn get_my_bool(self) -> bool:
         return self.my_bool
 
-    pub fn set_my_bytes(my_bytes: u8[100]):
+    pub fn set_my_bytes(self, my_bytes: u8[100]):
         self.my_bytes = my_bytes
 
-    pub fn get_my_bytes() -> u8[100]:
+    pub fn get_my_bytes(self) -> u8[100]:
         return self.my_bytes.to_mem()
 
     pub fn get_my_struct() -> MyStruct:
@@ -71,7 +71,7 @@ contract Foo:
         my_struct.my_addr = address(9999)
         return my_struct
 
-    pub fn emit_my_event():
+    pub fn emit_my_event(self):
         emit MyEvent(
             my_addrs=self.my_addrs.to_mem(),
             my_u128=self.my_u128,

--- a/crates/test-files/fixtures/stress/data_copying_stress.fe
+++ b/crates/test-files/fixtures/stress/data_copying_stress.fe
@@ -14,6 +14,7 @@ contract Foo:
         my_u256: u256
 
     pub fn set_my_vals(
+        self,
         my_string: String<42>,
         my_other_string: String<42>,
         my_u256: u256,
@@ -24,7 +25,7 @@ contract Foo:
         self.my_u256 = my_u256
         self.my_other_u256 = my_other_u256
 
-    pub fn set_to_my_other_vals():
+    pub fn set_to_my_other_vals(self):
         self.my_string = self.my_other_string
         self.my_u256 = self.my_other_u256
 
@@ -54,7 +55,7 @@ contract Foo:
         my_array.clone()[3] = 5
         return my_array
 
-    pub fn assign_my_nums_and_return() -> u256[5]:
+    pub fn assign_my_nums_and_return(self) -> u256[5]:
         let my_nums_mem: u256[5]
         self.my_nums[0] = 42
         self.my_nums[1] = 26
@@ -64,8 +65,8 @@ contract Foo:
         my_nums_mem = self.my_nums.to_mem()
         return my_nums_mem
 
-    pub fn emit_my_event():
-        self.emit_my_event_internal(
+    pub fn emit_my_event(self):
+        emit_my_event_internal(
             self.my_string.to_mem(),
             self.my_u256.to_mem()
         )
@@ -73,8 +74,8 @@ contract Foo:
     fn emit_my_event_internal(some_string: String<42>, some_u256: u256):
         emit MyEvent(my_string=some_string, my_u256=some_u256)
 
-    pub fn set_my_addrs(my_addrs: address[3]):
+    pub fn set_my_addrs(self, my_addrs: address[3]):
         self.my_addrs = my_addrs
 
-    pub fn get_my_second_addr() -> address:
+    pub fn get_my_second_addr(self) -> address:
         return self.my_addrs[1]

--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -2,19 +2,19 @@ contract Foo:
     my_tuple: (u256, address)
     my_string: String<100>
 
-    pub fn get_my_string() -> String<100>:
+    pub fn get_my_string(self) -> String<100>:
         return self.my_string.to_mem()
 
-    pub fn set_my_string(some_string: String<100>):
+    pub fn set_my_string(self, some_string: String<100>):
         self.my_string = some_string
 
-    pub fn get_my_tuple() -> (u256, address):
+    pub fn get_my_tuple(self) -> (u256, address):
         return self.my_tuple.to_mem()
 
-    pub fn set_my_tuple(some_tuple: (u256, address)):
+    pub fn set_my_tuple(self, some_tuple: (u256, address)):
         self.my_tuple = some_tuple
 
-    pub fn set_my_string_and_tuple(some_string: String<100>, some_tuple: (u256, address)):
+    pub fn set_my_string_and_tuple(self, some_string: String<100>, some_tuple: (u256, address)):
         self.my_string = some_string
         self.my_tuple = some_tuple
 
@@ -31,31 +31,35 @@ contract Foo:
 contract FooProxy:
     foo: Foo
 
-    pub fn __init__(foo_addr: address):
+    pub fn __init__(self, foo_addr: address):
         self.foo = Foo(foo_addr)
 
-    pub fn call_set_my_string(some_string: String<100>):
+    pub fn call_set_my_string(self, some_string: String<100>):
         self.foo.set_my_string(some_string)
 
-    pub fn call_get_my_string() -> String<100>:
+    pub fn call_get_my_string(self) -> String<100>:
         return self.foo.get_my_string()
 
-    pub fn call_set_my_tuple(some_tuple: (u256, address)):
+    pub fn call_set_my_tuple(self, some_tuple: (u256, address)):
         self.foo.set_my_tuple(some_tuple)
 
-    pub fn call_get_my_tuple() -> (u256, address):
+    pub fn call_get_my_tuple(self) -> (u256, address):
         return self.foo.get_my_tuple()
 
-    pub fn call_set_my_string_and_tuple(some_string: String<100>, some_tuple: (u256, address)):
+    pub fn call_set_my_string_and_tuple(
+        self,
+        some_string: String<100>,
+        some_tuple: (u256, address)
+    ):
         self.foo.set_my_string_and_tuple(some_string, some_tuple)
 
-    pub fn call_get_string() -> String<10>:
+    pub fn call_get_string(self) -> String<10>:
         return self.foo.get_string()
 
-    pub fn call_get_tuple() -> (u256, u256, bool):
+    pub fn call_get_tuple(self) -> (u256, u256, bool):
         return self.foo.get_tuple()
 
-    pub fn call_get_array():
+    pub fn call_get_array(self):
         let my_array: u16[4] = self.foo.get_array()
         assert my_array[0] == u16(1)
         assert my_array[1] == u16(2)

--- a/crates/test-files/fixtures/stress/tuple_stress.fe
+++ b/crates/test-files/fixtures/stress/tuple_stress.fe
@@ -21,26 +21,26 @@ contract Foo:
         return my_tuple.item2
 
     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address:
-            return my_tuple.item10
+        return my_tuple.item10
 
     pub fn emit_my_event(my_tuple: (u256, bool, address)):
         emit MyEvent(my_tuple)
 
-    pub fn set_my_sto_tuple(my_u256: u256, my_i32: i32):
+    pub fn set_my_sto_tuple(self, my_u256: u256, my_i32: i32):
         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
         self.my_sto_tuple = (my_u256, my_i32)
 
-    pub fn get_my_sto_tuple() -> (u256, i32):
+    pub fn get_my_sto_tuple(self) -> (u256, i32):
         return self.my_sto_tuple.to_mem()
 
-    pub fn build_tuple_and_emit():
+    pub fn build_tuple_and_emit(self):
         let my_num: u256 = self.my_sto_tuple.item0
         let my_tuple: (u256, bool, address) = (
             self.my_sto_tuple.item0,
             true and false,
             address(26)
         )
-        self.emit_my_event(my_tuple)
+        emit_my_event(my_tuple)
 
     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> u8[96]:
         return my_tuple.abi_encode()

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -161,6 +161,8 @@ fn test_assert() {
     case("return_msg_sig.fe", &[], uint_token(4273672062)),
     case("return_sum_list_expression_1.fe", &[], uint_token(210)),
     case("return_sum_list_expression_2.fe", &[], uint_token(210)),
+    case("pure_fn.fe", &[uint_token(42), uint_token(26)], uint_token(68)),
+    case("pure_fn_internal_call.fe", &[uint_token(42), uint_token(26)], uint_token(68)),
     // unary invert
     case("return_invert_i256.fe", &[int_token(1)], int_token(-2)),
     case("return_invert_i128.fe", &[int_token(1)], int_token(-2)),

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -103,7 +103,7 @@ fn expr_call(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
             typ: Type::Struct(val),
         } => struct_operations::new(&val, yul_args),
         CallType::TypeConstructor { .. } => yul_args[0].to_owned(),
-        CallType::SelfAttribute { func_name } => {
+        CallType::SelfAttribute { func_name, .. } | CallType::Pure { func_name } => {
             let func_name = names::func_name(&func_name);
             expression! { [func_name]([yul_args...]) }
         }

--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -37,10 +37,10 @@ Let's recall that we finished our guest book in the previous chapter with the fo
 contract GuestBook:
   messages: Map<address, String<100>>
 
-  pub fn sign(book_msg: String<100>):
+  pub fn sign(self, book_msg: String<100>):
       self.messages[msg.sender] = book_msg
 
-  pub fn get_msg(addr: address) -> String<100>:
+  pub fn get_msg(self, addr: address) -> String<100>:
       return self.messages[addr].to_mem()
 ```
 

--- a/docs/src/quickstart/first_contract.md
+++ b/docs/src/quickstart/first_contract.md
@@ -78,7 +78,7 @@ Let's focus on the functionality of our world changing application and add a met
 contract GuestBook:
   messages: Map<address, String<100>>
 
-  pub fn sign(book_msg: String<100>):
+  pub fn sign(self, book_msg: String<100>):
       self.messages[msg.sender] = book_msg
 ```
 
@@ -122,10 +122,10 @@ To make the guest book more useful we will also add a method `get_msg` to read e
 contract GuestBook:
   messages: Map<address, String<100>>
 
-  pub fn sign(book_msg: String<100>):
+  pub fn sign(self, book_msg: String<100>):
       self.messages[msg.sender] = book_msg
 
-  pub fn get_msg(addr: address) -> String<100>:
+  pub fn get_msg(self, addr: address) -> String<100>:
       return self.messages[addr]
 ```
 
@@ -153,10 +153,10 @@ The code should compile fine when we change it accordingly.
 contract GuestBook:
   messages: Map<address, String<100>>
 
-  pub fn sign(book_msg: String<100>):
+  pub fn sign(self, book_msg: String<100>):
       self.messages[msg.sender] = book_msg
 
-  pub fn get_msg(addr: address) -> String<100>:
+  pub fn get_msg(self, addr: address) -> String<100>:
       return self.messages[addr].to_mem()
 ```
 

--- a/docs/src/spec/contracts.md
+++ b/docs/src/spec/contracts.md
@@ -35,11 +35,11 @@ contract GuestBook:
     event Signed:
         book_msg: String<100>
 
-    pub fn sign(book_msg: String<100>):
+    pub fn sign(self, book_msg: String<100>):
         self.messages[msg.sender] = book_msg
         emit Signed(book_msg=book_msg)
 
-    pub fn get_msg(addr: address) -> String<100>:
+    pub fn get_msg(self, addr: address) -> String<100>:
         return self.messages[addr].to_mem()
 ```
 

--- a/docs/src/spec/expr_attribute.md
+++ b/docs/src/spec/expr_attribute.md
@@ -27,8 +27,8 @@ contract Foo:
         # Different examples of attribute expressions
         let bool_1: bool = some_tuple.item0
         let x1: u256 = some_point.x
-        let point1: u256 = self.get_point().x
-        let point2: u256 = self.some_point.x
+        let point1: u256 = get_point().x
+        let point2: u256 = some_point.x
 
 ```
 

--- a/docs/src/spec/expr_call.md
+++ b/docs/src/spec/expr_call.md
@@ -26,7 +26,7 @@ Example:
 contract Foo:
 
     pub fn baz():
-        self.bar(100, val2=300)
+        bar(100, val2=300)
 
     pub fn bar(val1: u256, val2: u256):
         pass

--- a/docs/src/spec/expr_index.md
+++ b/docs/src/spec/expr_index.md
@@ -14,7 +14,7 @@ contract Foo:
 
     balances: Map<address, u256>
 
-    pub fn baz(values: u256[10]):
+    pub fn baz(self, values: u256[10]):
         # Assign value at slot 5
         values[5] = 1000
         # Read value at slot 5

--- a/docs/src/spec/expr_list.md
+++ b/docs/src/spec/expr_list.md
@@ -31,7 +31,7 @@ contract Foo:
     pub fn baz():
         let val1: u256 = 2
         # A list expression
-        let foo: u256[3] = [1, val1, self.get_val3()]
+        let foo: u256[3] = [1, val1, get_val3()]
 ```
 
 [_Expression_]: expressions.md

--- a/docs/src/spec/expr_tuple.md
+++ b/docs/src/spec/expr_tuple.md
@@ -40,7 +40,7 @@ contract Foo:
         let some_tuple: (u256, bool) = (1, false)
 
         # Accessing the first tuple field via the `item0` field
-        self.baz(some_tuple.item0)
+        baz(some_tuple.item0)
 
     pub fn baz(input: u256):
         pass

--- a/docs/src/spec/functions.md
+++ b/docs/src/spec/functions.md
@@ -30,7 +30,7 @@
 > &nbsp;&nbsp; &nbsp;&nbsp; | [_Expression_]\
 >
 > _FunctionParameters_ :\
-> &nbsp;&nbsp; _FunctionParam_ (`,` _FunctionParam_)<sup>\*</sup> `,`<sup>?</sup>
+> &nbsp;&nbsp;  `self`<sup>?</sup> | `self,`<sup>?</sup>   _FunctionParam_ (`,` _FunctionParam_)<sup>\*</sup> `,`<sup>?</sup>
 >
 > _FunctionParam_ :\
 > &nbsp;&nbsp; [IDENTIFIER] `:` [_Type_]

--- a/docs/src/spec/functions.md
+++ b/docs/src/spec/functions.md
@@ -59,6 +59,22 @@ fn answer_to_life_the_universe_and_everything() -> u256:
     return 42
 ```
 
+A function may accept `self` as a parameter. This gives the function the ability 
+to read and mutate contract storage.
+
+Example:
+
+```python
+contract Foo:
+    my_stored_num: u256
+
+    pub fn my_pure_func():
+        pass
+        
+    pub fn my_self_func(self):
+        self.my_stored_num = 26
+```
+
 [NEWLINE]: tokens.md#newline
 [INDENT]: tokens.md#indent
 [DEDENT]: tokens.md#dedent

--- a/docs/src/spec/hashmap_type.md
+++ b/docs/src/spec/hashmap_type.md
@@ -18,16 +18,16 @@ contract Foo:
     bar: Map<address, Map<address, u256>>
     baz: Map<address, Map<u256, bool>>
 
-    pub fn read_bar(a: address, b: address) -> u256:
+    pub fn read_bar(self, a: address, b: address) -> u256:
         return self.bar[a][b]
 
-    pub fn write_bar(a: address, b: address, value: u256):
+    pub fn write_bar(self, a: address, b: address, value: u256):
         self.bar[a][b] = value
 
-    pub fn read_baz(a: address, b: u256) -> bool:
+    pub fn read_baz(self, a: address, b: u256) -> bool:
         return self.baz[a][b]
 
-    pub fn write_baz(a: address, b: u256, value: bool):
+    pub fn write_baz(self, a: address, b: u256, value: bool):
         self.baz[a][b] = value
 ```
 

--- a/docs/src/spec/statement_assign.md
+++ b/docs/src/spec/statement_assign.md
@@ -13,7 +13,7 @@ Example:
 contract Foo:
   some_array: u256[10]
 
-  pub fn bar():
+  pub fn bar(self):
     let val1: u256 = 10
     # Assignment of stack variable
     val1 = 10

--- a/docs/src/spec/statement_break.md
+++ b/docs/src/spec/statement_break.md
@@ -19,12 +19,12 @@ contract Foo:
         while sum < 10:
             sum += 1
 
-            if self.some_abort_condition():
+            if some_abort_condition():
                 break
 
         return sum
 
-    fn some_abort_condition -> bool:
+    fn some_abort_condition() -> bool:
         # some complex logic
         return true
 ```
@@ -39,12 +39,12 @@ contract Foo:
         for i in values:
             sum = sum + i
 
-            if self.some_abort_condition():
+            if some_abort_condition():
                 break
 
         return sum
 
-    fn some_abort_condition -> bool:
+    fn some_abort_condition() -> bool:
         # some complex logic
         return true
 ```

--- a/docs/src/spec/statement_continue.md
+++ b/docs/src/spec/statement_continue.md
@@ -19,12 +19,12 @@ contract Foo:
         while sum < 10:
             sum += 1
 
-            if self.some_skip_condition():
+            if some_skip_condition():
                 continue
 
         return sum
 
-    fn some_skip_condition -> bool:
+    fn some_skip_condition() -> bool:
         # some complex logic
         return true
 ```
@@ -39,12 +39,12 @@ contract Foo:
         for i in values:
             sum = sum + i
 
-            if self.some_skip_condition():
+            if some_skip_condition():
                 continue
 
         return sum
 
-    fn some_skip_condition -> bool:
+    fn some_skip_condition() -> bool:
         # some complex logic
         return true
 ```

--- a/docs/src/spec/statement_return.md
+++ b/docs/src/spec/statement_return.md
@@ -12,11 +12,11 @@ An example of a `return` statement without explicit use of an expression:
 
 ```python
 contract Foo:
-    fn transfer(to: address, value: u256):
+    fn transfer(self, to: address, value: u256):
         if not self.in_whitelist(to):
             return
 
-    fn in_whitelist(to: address) -> bool:
+    fn in_whitelist(self, to: address) -> bool:
         # revert used as placeholder for actual logic
         revert
 ```
@@ -25,11 +25,11 @@ The above can also be written in a slightly more verbose form:
 
 ```python
 contract Foo:
-    fn transfer(to: address, value: u256) -> ():
+    fn transfer(self, to: address, value: u256) -> ():
         if not self.in_whitelist(to):
             return ()
 
-    fn in_whitelist(to: address) -> bool:
+    fn in_whitelist(self, to: address) -> bool:
         # revert used as placeholder for actual logic
         revert
 ```

--- a/docs/src/spec/statement_revert.md
+++ b/docs/src/spec/statement_revert.md
@@ -12,7 +12,7 @@ An example of a `revert` statement without revert data:
 
 ```
 contract Foo:
-    fn transfer(to : address, value : u256):
+    fn transfer(self, to : address, value : u256):
         if not self.in_whitelist(to):
             revert
         # more logic here
@@ -22,7 +22,7 @@ An example of a `revert` statement with revert data:
 
 ```
 contract Foo:
-    fn transfer(to : address, value : u256):
+    fn transfer(self, to : address, value : u256):
         if not self.in_whitelist(to):
             revert ApplicationError(code=5)
         # more logic here

--- a/docs/validate_doc_examples.py
+++ b/docs/validate_doc_examples.py
@@ -31,7 +31,7 @@ SKIP_LIST = [
     'stack.md_e985510948163c9aa6f7bbd245a3ce1a6bc9b064.fe',
     'functions.md_5a6a3b458a39ef0ec9696e59e36e747a8f7779c9.fe',
     'first_contract.md_1fe46f24899f78d00da0444bf5fa1dfe40eb0a2a.fe',
-    'first_contract.md_de4b2217b3aeb9a989bdffbf1142e34731d725f5.fe',
+    'first_contract.md_2992d9a656129dc8e4192e598f90b394bc151750.fe'
 ]
 
 class CodeSnippet(NamedTuple):

--- a/newsfragments/520.feature.md
+++ b/newsfragments/520.feature.md
@@ -1,0 +1,18 @@
+The `self` variable is no longer implicitly defined in code blocks. It must now be declared
+as the first parameter in a function signature.
+
+Example:
+
+```
+contract Foo:
+    my_stored_num: u256
+
+    pub fn bar(self, my_num: u256):
+        self.my_stored_num = my_num
+        
+    pub fn baz(self):
+        self.bar(my_pure_func())
+        
+    pub fn my_pure_func() -> u256:
+        return 42 + 26
+```


### PR DESCRIPTION
### What was wrong?

`self` was implicitly defined in all function scopes, which made it impossible to write pure functions.

### How was it fixed?

1.) added `self` args to the function definition grammar
2.) added checking around the use of `self`
3.) fixed things that broke

I also went ahead and updated the Json ABI builder to label functions that do not take a `self` parameter as pure. This is something that I'm not sure we want right now though, as functions can still read msg and chain data (which conflicts with the definition of pure). For this reason, I'm considering dropping the [commit](https://github.com/ethereum/fe/pull/520/commits/1fedb01b96c0f981fe031ff7dfc2225da41af2de) responsible for this change, but have not 100% made up my mind. Feel free to provide input.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
- [x] Update grammar 
