### PR TITLE
Fix "analysis failed but no diagnostics were emitted" panics

### DIFF
--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -41,14 +41,11 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
 
             let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ.try_into() {
                 Ok(typ) => Ok(typ),
-                Err(_) => {
-                    scope.error(
-                        "event field type must have a fixed size",
-                        typ_node.span,
-                        "this can't be used as an event field",
-                    );
-                    Err(TypeError)
-                }
+                Err(_) => Err(TypeError::new(scope.error(
+                    "event field type must have a fixed size",
+                    typ_node.span,
+                    "this can't be used as an event field",
+                ))),
             });
 
             // If we've already seen the max number of indexed fields,

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -88,7 +88,13 @@ pub fn module_resolve_type_cycle(
     _module: &ModuleId,
     _name: &String,
 ) -> Option<Result<types::Type, errors::TypeError>> {
-    Some(Err(errors::TypeError))
+    // The only possible type cycle currently is a recursive type alias,
+    // which is handled in queries/types.rs
+    // However, salsa will also call this function if there's such a cycle,
+    // so we can't panic here, and we can't return a TypeError because
+    // there's no way to emit a diagnostic! The only option is to return
+    // None, and handle type cycles in more specifc cycle handlers.
+    None
 }
 
 pub fn module_contracts(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<ContractId>> {

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -94,11 +94,11 @@ pub fn struct_field_type(
     }
     let typ = match type_desc(&mut scope, typ) {
         Ok(types::Type::Base(base)) => Ok(types::FixedSize::Base(base)),
-        Ok(_) => {
-            scope.not_yet_implemented("non-primitive type struct fields", field_data.ast.span);
-            Err(TypeError)
-        }
-        Err(TypeError) => Err(TypeError),
+        Ok(_) => Err(TypeError::new(scope.not_yet_implemented(
+            "non-primitive type struct fields",
+            field_data.ast.span,
+        ))),
+        Err(err) => Err(err),
     };
 
     Analysis {

--- a/crates/analyzer/src/db/queries/types.rs
+++ b/crates/analyzer/src/db/queries/types.rs
@@ -1,5 +1,6 @@
+use crate::context::{AnalyzerContext, TempContext};
 use crate::db::Analysis;
-use crate::errors::{self, TypeError};
+use crate::errors::TypeError;
 use crate::namespace::items::TypeAliasId;
 use crate::namespace::scopes::ItemScope;
 use crate::namespace::types;
@@ -25,12 +26,15 @@ pub fn type_alias_type_cycle(
     _cycle: &[String],
     alias: &TypeAliasId,
 ) -> Analysis<Result<types::Type, TypeError>> {
+    let mut context = TempContext::default();
+    let err = Err(TypeError::new(context.error(
+        "recursive type definition",
+        alias.data(db).ast.span,
+        "",
+    )));
+
     Analysis {
-        value: Err(TypeError),
-        diagnostics: Rc::new(vec![errors::error(
-            "recursive type definition",
-            alias.data(db).ast.span,
-            "",
-        )]),
+        value: err,
+        diagnostics: Rc::new(context.diagnostics),
     }
 }

--- a/crates/analyzer/src/traversal/assignments.rs
+++ b/crates/analyzer/src/traversal/assignments.rs
@@ -78,10 +78,9 @@ pub fn check_assign_target(
         }
         Name(_) => Ok(()),
         _ => {
-            scope.fancy_error("invalid assignment target",
-                              vec![Label::primary(expr.span, "")],
-                              vec!["The left side of an assignment can be a variable name, attribute, subscript, or tuple.".into()]);
-            Err(FatalError::new())
+            Err(FatalError::new(scope.fancy_error("invalid assignment target",
+                                                  vec![Label::primary(expr.span, "")],
+                                                  vec!["The left side of an assignment can be a variable name, attribute, subscript, or tuple.".into()])))
         }
     }
 }

--- a/crates/analyzer/src/traversal/call_args.rs
+++ b/crates/analyzer/src/traversal/call_args.rs
@@ -1,4 +1,4 @@
-use crate::context::AnalyzerContext;
+use crate::context::{AnalyzerContext, DiagnosticVoucher};
 use crate::errors::{FatalError, TypeError};
 use crate::namespace::scopes::BlockScope;
 use crate::namespace::types::{EventField, FixedSize, FunctionParam};
@@ -69,7 +69,7 @@ pub fn validate_arg_count(
     name_span: Span,
     args: &Node<Vec<impl Spanned>>,
     param_count: usize,
-) {
+) -> Option<DiagnosticVoucher> {
     if args.kind.len() != param_count {
         let mut labels = vec![Label::primary(
             name_span,
@@ -92,7 +92,7 @@ pub fn validate_arg_count(
             );
         }
 
-        context.fancy_error(
+        Some(context.fancy_error(
             &format!(
                 "`{}` expects {} {}, but {} {} provided",
                 name,
@@ -103,8 +103,10 @@ pub fn validate_arg_count(
             ),
             labels,
             vec![],
-        );
+        ))
         // TODO: add `defined here` label (need span for definition)
+    } else {
+        None
     }
 }
 

--- a/crates/analyzer/src/traversal/utils.rs
+++ b/crates/analyzer/src/traversal/utils.rs
@@ -2,7 +2,7 @@ use fe_common::diagnostics::Label;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 
-use crate::context::AnalyzerContext;
+use crate::context::{AnalyzerContext, DiagnosticVoucher};
 use crate::errors::{BinaryOperationError, NotFixedSize};
 use crate::namespace::types::{FixedSize, Type};
 use std::convert::TryInto;
@@ -16,7 +16,7 @@ pub fn add_bin_operations_errors(
     left: &Node<fe::Expr>,
     right: &Node<fe::Expr>,
     error: BinaryOperationError,
-) {
+) -> DiagnosticVoucher {
     match error {
         BinaryOperationError::NotEqualAndUnsigned => context.fancy_error(
             "The types for this operation must be equal and unsigned",

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -202,6 +202,10 @@ test_file! { return_call_to_fn_with_param_type_mismatch }
 test_file! { return_call_to_fn_without_return }
 test_file! { return_from_init }
 test_file! { return_lt_mixed_types }
+test_file! { return_type_undefined }
+test_file! { return_type_not_fixedsize }
+test_file! { string_constructor_bad_type_arg }
+test_file! { undefined_type_param }
 
 test_file! { strict_boolean_if_else }
 test_file! { struct_call_bad_args }

--- a/crates/analyzer/tests/snapshots/errors__invalid_generic_string.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_generic_string.snap
@@ -3,11 +3,19 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: Numeric generic type parameter expected
+error: invalid `String` type argument
   ┌─ compile_errors/invalid_generic_string.fe:2:14
   │
 2 │   val: String<foo>
-  │              ^^^^^ invalid type parameter
+  │              ^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+error: invalid `String` type argument
+  ┌─ compile_errors/invalid_generic_string.fe:3:14
+  │
+3 │   foo: String<10, 20>
+  │              ^^^^^^^^ expected an integer
   │
   = Example: String<100>
 

--- a/crates/analyzer/tests/snapshots/errors__return_type_not_fixedsize.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_type_not_fixedsize.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: function return type must have a fixed size
+  ┌─ compile_errors/return_type_not_fixedsize.fe:2:17
+  │
+2 │   pub fn f() -> Map<address, bool>:
+  │                 ^^^^^^^^^^^^^^^^^^ this can't be returned from a function
+
+

--- a/crates/analyzer/tests/snapshots/errors__return_type_undefined.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_type_undefined.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: undefined type
+  ┌─ compile_errors/return_type_undefined.fe:2:17
+  │
+2 │   pub fn f() -> Foo:
+  │                 ^^^ this type name has not been defined
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_bad_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_bad_type_arg.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ compile_errors/string_constructor_bad_type_arg.fe:5:22
+  │
+5 │         return String<H00>("foo")
+  │                      ^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__undefined_type_param.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_type_param.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: undefined type
+  ┌─ compile_errors/undefined_type_param.fe:4:8
+  │
+4 │     x: MysteryType
+  │        ^^^^^^^^^^^ this type name has not been defined
+
+error: undefined type
+  ┌─ compile_errors/undefined_type_param.fe:8:19
+  │
+8 │     pub fn a(val: DoesntExist):
+  │                   ^^^^^^^^^^^ this type name has not been defined
+
+

--- a/crates/test-files/fixtures/compile_errors/invalid_generic_string.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_generic_string.fe
@@ -1,2 +1,3 @@
 contract Foo:
   val: String<foo>
+  foo: String<10, 20>

--- a/crates/test-files/fixtures/compile_errors/return_type_not_fixedsize.fe
+++ b/crates/test-files/fixtures/compile_errors/return_type_not_fixedsize.fe
@@ -1,0 +1,3 @@
+contract C:
+  pub fn f() -> Map<address, bool>:
+    pass

--- a/crates/test-files/fixtures/compile_errors/return_type_undefined.fe
+++ b/crates/test-files/fixtures/compile_errors/return_type_undefined.fe
@@ -1,0 +1,3 @@
+contract C:
+  pub fn f() -> Foo:
+    pass

--- a/crates/test-files/fixtures/compile_errors/string_constructor_bad_type_arg.fe
+++ b/crates/test-files/fixtures/compile_errors/string_constructor_bad_type_arg.fe
@@ -1,0 +1,5 @@
+# https://github.com/ethereum/fe/issues/532
+
+contract ERC20:
+    pub fn return_casted_static_string() -> String<100>:
+        return String<H00>("foo")

--- a/crates/test-files/fixtures/compile_errors/undefined_type_param.fe
+++ b/crates/test-files/fixtures/compile_errors/undefined_type_param.fe
@@ -1,0 +1,18 @@
+# https://github.com/ethereum/fe/issues/530
+
+struct BadField:
+    x: MysteryType
+
+contract Foo:
+    # case 1: using arg with undefined type within the fn body
+    pub fn a(val: DoesntExist):
+        val + 10
+
+    # case 2: calling a fn that has undefined-type arg
+    pub fn b():
+        a(10)
+
+    # case 3: using a struct field that has an undefined type
+    pub fn c():
+        let x: BadField
+        x.x = 10

--- a/newsfragments/534.bugfix.md
+++ b/newsfragments/534.bugfix.md
@@ -1,0 +1,1 @@
+Fixed cases where the analyzer would correctly reject code, but would panic instead of logging an error message.


### PR DESCRIPTION
### What was wrong?

closes #532 -  Here we weren't emitting an error message if the `String` type constructor was ill-formed. Eg `String<x>("hi")` would be rejected without an error message.

closes #530 - Here we were panicking because the fn body diagnostic vec was empty, even though the analysis failed. We shouldn't panic in this case, because an undefined type diagnostic was produced elsewhere (during the analysis of the function signature).

These cases are just symptoms of a problem in the analyzer; we require that a friendly diagnostic be emitted before returning FatalError or TypeError, but can't effectively ensure that that's happening.

### How was it fixed?

FatalError and TypeError now can't be created unless you have a voucher proving that you've emitted a diagnostic. You can receive such a voucher by calling an `AnalyzerContext` error function. For example:

```
Err(TypeError::new(scope.error("something is wrong", span, "this")))
```

I noticed some other error stuff that needs to be improved, and added TODO comments. I'll fix those in a follow-up PR.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
