### PR TITLE
Don't ignore non-fatal parser errors when analysis succeeds

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -50,6 +50,11 @@ pub fn compile(
         }
     };
 
+    if !errors.is_empty() {
+        // There was a non-fatal parser error (eg missing parens in a fn def `fn foo: ...`)
+        return Err(CompileError(errors));
+    }
+
     // build abi
     let json_abis = fe_abi::build(&db, module_id).expect("failed to generate abi");
 

--- a/newsfragments/535.bugfix.md
+++ b/newsfragments/535.bugfix.md
@@ -1,0 +1,2 @@
+Non-fatal parser errors (eg missing parentheses when defining a function that takes no arguments: `fn foo:`)
+are no longer ignored if the semantic analysis stage succeeds.


### PR DESCRIPTION
### What was wrong?

closes #523 

Non-fatal parser errors were being ignored when the analysis stage succeeded. I assume this was my fault again (#402 :disappointed:). We probably need tests for the driver crate.

### How was it fixed?

In the simplest way possible. I've done nothing to ensure that something similar won't happen again in the future.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)