### PR TITLE
Add analyzer checks for shadowing of built-ins and generic arg lists where they don't belong

### DIFF
--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -8,7 +8,7 @@ pub enum ValueMethod {
     AbiEncode,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, EnumString, IntoStaticStr, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumString, IntoStaticStr, Hash)]
 #[strum(serialize_all = "snake_case")]
 pub enum GlobalMethod {
     Keccak256,

--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -1,4 +1,54 @@
-use strum::{EnumString, IntoStaticStr};
+use std::str::FromStr;
+use strum::{AsRefStr, EnumString, IntoStaticStr};
+
+#[derive(Debug, PartialEq, EnumString, AsRefStr)]
+#[strum(serialize_all = "lowercase")]
+pub enum ReservedName {
+    Type,
+    Object,
+    // Module, // someday: "std"
+    Function,
+}
+
+/// Check if a name shadows a built-in type, object, or function.
+/// Ideally, some of these things will move into a .fe standard library,
+/// and we won't need some of this special name collision logic.
+pub fn reserved_name(name: &str) -> Option<ReservedName> {
+    if TypeName::from_str(name).is_ok() {
+        Some(ReservedName::Type)
+    } else if Object::from_str(name).is_ok() {
+        Some(ReservedName::Object)
+    } else if GlobalMethod::from_str(name).is_ok() {
+        Some(ReservedName::Function)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, PartialEq, EnumString)]
+#[strum(serialize_all = "lowercase")]
+pub enum TypeName {
+    // Array, // when syntax is changed
+    #[strum(serialize = "Map")]
+    Map,
+    #[strum(serialize = "String")]
+    String_,
+
+    Address,
+    Bool,
+    I8,
+    I16,
+    I32,
+    I64,
+    I128,
+    I256,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+}
 
 #[derive(Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "snake_case")]

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -1,3 +1,4 @@
+use crate::builtins;
 use crate::context::AnalyzerContext;
 use crate::db::{Analysis, AnalyzerDb};
 use crate::errors;
@@ -37,7 +38,19 @@ pub fn contract_function_map(
 
     for func in contract.all_functions(db).iter() {
         let def = &func.data(db).ast;
-        if def.name() == "__init__" {
+        let def_name = def.name();
+        if def_name == "__init__" {
+            continue;
+        }
+        if let Some(reserved) = builtins::reserved_name(def_name) {
+            scope.error(
+                &format!(
+                    "function name conflicts with built-in {}",
+                    reserved.as_ref()
+                ),
+                def.kind.name.span,
+                &format!("`{}` is a built-in {}", def_name, reserved.as_ref()),
+            );
             continue;
         }
 

--- a/crates/analyzer/src/errors.rs
+++ b/crates/analyzer/src/errors.rs
@@ -56,7 +56,7 @@ impl FatalError {
 
 /// Error to be returned from APIs that should reject duplicate definitions
 #[derive(Debug)]
-pub struct AlreadyDefined(pub Span);
+pub struct AlreadyDefined;
 
 /// Error indicating that a value can not move between memory and storage
 #[derive(Debug)]

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -119,6 +119,14 @@ impl TypeDefId {
         }
     }
 
+    pub fn name_span(&self, db: &dyn AnalyzerDb) -> Span {
+        match self {
+            TypeDefId::Alias(id) => id.data(db).ast.kind.name.span,
+            TypeDefId::Struct(id) => id.data(db).ast.kind.name.span,
+            TypeDefId::Contract(id) => id.data(db).ast.kind.name.span,
+        }
+    }
+
     pub fn span(&self, db: &dyn AnalyzerDb) -> Span {
         match self {
             TypeDefId::Alias(id) => id.data(db).ast.span,

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -5,7 +5,8 @@ use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use std::convert::TryFrom;
 use std::fmt;
-use strum::IntoStaticStr;
+use std::str::FromStr;
+use strum::{EnumString, IntoStaticStr};
 use vec1::Vec1;
 
 pub fn u256_min() -> BigInt {
@@ -59,7 +60,8 @@ pub enum Base {
     Unit,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, IntoStaticStr)]
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, IntoStaticStr, EnumString)]
+#[strum(serialize_all = "snake_case")]
 pub enum Integer {
     U256,
     U128,
@@ -94,8 +96,6 @@ pub struct Tuple {
     pub items: Vec1<FixedSize>,
 }
 
-// Struct and Contract only exist to impl Display below;
-// we could refactor code that uses Display and remove them.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Struct {
     pub name: String,
@@ -595,5 +595,18 @@ impl fmt::Display for Contract {
 impl fmt::Display for Struct {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)
+    }
+}
+
+impl FromStr for Base {
+    type Err = strum::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bool" => Ok(Base::Bool),
+            "address" => Ok(Base::Address),
+            "()" => Ok(Base::Unit),
+            _ => Ok(Base::Numeric(Integer::from_str(s)?)),
+        }
     }
 }

--- a/crates/analyzer/src/traversal/assignments.rs
+++ b/crates/analyzer/src/traversal/assignments.rs
@@ -93,7 +93,15 @@ pub fn aug_assign(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(
         let value_attributes = expressions::expr(scope, value, Some(&target_attributes.typ))?;
 
         if let Err(err) = operations::bin(&target_attributes.typ, &op.kind, &value_attributes.typ) {
-            add_bin_operations_errors(scope, target, value, err);
+            add_bin_operations_errors(
+                scope,
+                &op.kind,
+                target.span,
+                &target_attributes.typ,
+                value.span,
+                &value_attributes.typ,
+                err,
+            );
         }
         return Ok(());
     }

--- a/crates/analyzer/src/traversal/declarations.rs
+++ b/crates/analyzer/src/traversal/declarations.rs
@@ -1,5 +1,5 @@
 use crate::context::AnalyzerContext;
-use crate::errors::{AlreadyDefined, FatalError};
+use crate::errors::FatalError;
 use crate::namespace::scopes::BlockScope;
 use crate::namespace::types::FixedSize;
 use crate::traversal::{expressions, types};
@@ -54,16 +54,8 @@ fn add_var(
 ) -> Result<(), FatalError> {
     match &target.kind {
         fe::VarDeclTarget::Name(name) => {
-            if let Err(AlreadyDefined(prev_span)) = scope.add_var(name, typ, target.span) {
-                scope.fancy_error(
-                    "duplicate variable definition",
-                    vec![
-                        Label::primary(prev_span, &format!("`{}` first defined here", name)),
-                        Label::secondary(target.span, &format!("`{}` redefined here", name)),
-                    ],
-                    vec![],
-                );
-            }
+            // this logs a message on err, so it's safe to ignore here.
+            let _ = scope.add_var(name, typ, target.span);
             Ok(())
         }
         fe::VarDeclTarget::Tuple(items) => {

--- a/crates/analyzer/src/traversal/declarations.rs
+++ b/crates/analyzer/src/traversal/declarations.rs
@@ -55,8 +55,6 @@ fn add_var(
     match &target.kind {
         fe::VarDeclTarget::Name(name) => {
             if let Err(AlreadyDefined(prev_span)) = scope.add_var(name, typ, target.span) {
-                // TODO: this should probably be a fatal error; continuing here might result
-                //  in confusing type mismatch errors
                 scope.fancy_error(
                     "duplicate variable definition",
                     vec![

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -591,7 +591,13 @@ fn expr_bin_operation(
         let typ = match operations::bin(&left_attributes.typ, &op.kind, &right_attributes.typ) {
             Err(err) => {
                 return Err(FatalError::new(add_bin_operations_errors(
-                    scope, left, right, err,
+                    scope,
+                    &op.kind,
+                    left.span,
+                    &left_attributes.typ,
+                    right.span,
+                    &right_attributes.typ,
+                    err,
                 )));
             }
             Ok(val) => val,

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -707,14 +707,14 @@ fn expr_call(
 
 fn expr_call_builtin_function(
     scope: &mut BlockScope,
-    typ: GlobalMethod,
+    function: GlobalMethod,
     name_span: Span,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<ExpressionAttributes, FatalError> {
     let argument_attributes = expr_call_args(scope, args)?;
-    match typ {
+    match function {
         GlobalMethod::Keccak256 => {
-            validate_arg_count(scope, typ.into(), name_span, args, 1);
+            validate_arg_count(scope, function.into(), name_span, args, 1);
             expect_no_label_on_first_arg(scope, args);
 
             if let Some(arg_typ) = argument_attributes.first().map(|attr| &attr.typ) {
@@ -725,13 +725,14 @@ fn expr_call_builtin_function(
                         ..
                     })
                 ) {
+                    let fn_name: &str = function.into();
                     scope.fancy_error(
                         &format!(
-                            "`{}` can not be used as a parameter to `keccak(..)`",
-                            arg_typ
+                            "`{}` can not be used as an argument to `{}`",
+                            arg_typ, fn_name,
                         ),
                         vec![Label::primary(args.span, "wrong type")],
-                        vec!["Note: keccak(..) expects a byte array as parameter".into()],
+                        vec![format!("Note: `{}` expects a byte array argument", fn_name)],
                     );
                 }
             };
@@ -839,15 +840,18 @@ fn expr_call_type_constructor(
                 Location::Value,
             ))
         }
-        Type::Struct(_) => unreachable!(), // handled above
-
-        // TODO: These type should be handled explicitly, either here or in expr_name_call_type.
-        // `Map<x, y>()` and `bool()` will (probably) currently result in an undefined fn error.
+        Type::Base(Base::Bool) => Err(FatalError::new(scope.error(
+            "`bool` type is not callable",
+            name_span,
+            "",
+        ))),
+        Type::Base(Base::Unit) => unreachable!(), // rejected in expr_call_type
+        Type::Map(_) => unreachable!(),           // rejected in expr_name_call_type
+        Type::Tuple(_) => unreachable!(),         // rejected in expr_call_type
+        Type::Struct(_) => unreachable!(),        // handled above
+        // The current array type syntax is parsed as an index operation in this case (eg `u8[10](5)`),
+        // and won't end up here.
         Type::Array(_) => unreachable!(),
-        Type::Tuple(_) => unreachable!(),
-        Type::Map(_) => unreachable!(),
-        Type::Base(Base::Bool) => unreachable!(),
-        Type::Base(Base::Unit) => unreachable!(),
     }
 }
 
@@ -1282,15 +1286,15 @@ fn expr_call_type(
     generic_args: Option<&Node<Vec<fe::GenericArg>>>,
 ) -> Result<CallType, FatalError> {
     let call_type = match &func.kind {
-        fe::Expr::Name(name) => expr_name_call_type(scope, name, generic_args),
+        fe::Expr::Name(name) => expr_name_call_type(scope, name, func.span, generic_args),
         fe::Expr::Attribute { .. } => expr_attribute_call_type(scope, func),
         _ => {
             let expression = expr(scope, func, None)?;
             Err(FatalError::new(scope.fancy_error(
-                &format!("the {} type is not callable", expression.typ),
+                &format!("`{}` type is not callable", expression.typ),
                 vec![Label::primary(
                     func.span,
-                    format!("this has type {}", expression.typ),
+                    format!("this has type `{}`", expression.typ),
                 )],
                 vec![],
             )))
@@ -1304,69 +1308,71 @@ fn expr_call_type(
 fn expr_name_call_type(
     scope: &mut BlockScope,
     name: &str,
+    name_span: Span,
     generic_args: Option<&Node<Vec<fe::GenericArg>>>,
 ) -> Result<CallType, FatalError> {
-    // TODO: we're ignoring error cases like `u256<x>(10)` here
-    match (name, generic_args) {
-        ("keccak256", _) => Ok(CallType::BuiltinFunction {
-            func: GlobalMethod::Keccak256,
-        }),
-        ("address", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Address),
-        }),
-        ("u256", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::U256)),
-        }),
-        ("u128", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::U128)),
-        }),
-        ("u64", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::U64)),
-        }),
-        ("u32", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::U32)),
-        }),
-        ("u16", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::U16)),
-        }),
-        ("u8", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::U8)),
-        }),
-        ("i256", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::I256)),
-        }),
-        ("i128", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::I128)),
-        }),
-        ("i64", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::I64)),
-        }),
-        ("i32", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::I32)),
-        }),
-        ("i16", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::I16)),
-        }),
-        ("i8", _) => Ok(CallType::TypeConstructor {
-            typ: Type::Base(Base::Numeric(Integer::I8)),
-        }),
-        ("String", Some(args_node)) => match &args_node.kind[..] {
-            [fe::GenericArg::Int(len)] => Ok(CallType::TypeConstructor {
-                typ: Type::String(FeString { max_size: len.kind }),
-            }),
-            _ => Err(FatalError::new(scope.fancy_error(
-                "invalid `String` type argument",
-                vec![Label::primary(args_node.span, "expected an integer")],
-                vec!["Example: String<100>".into()],
+    if let Ok(base_type) = Base::from_str(name) {
+        if let Some(args) = generic_args {
+            scope.error(
+                &format!("`{}` type does not expect generic arguments", base_type),
+                args.span,
+                "unexpected generic argument list",
+            );
+        }
+        Ok(CallType::TypeConstructor {
+            typ: Type::Base(base_type),
+        })
+    } else if let Ok(func) = GlobalMethod::from_str(name) {
+        if let Some(args) = generic_args {
+            scope.error(
+                &format!("`{}` function does not expect generic arguments", name),
+                args.span,
+                "unexpected generic argument list",
+            );
+        }
+        Ok(CallType::BuiltinFunction { func: func })
+    } else {
+        match name {
+            "String" => match generic_args {
+                None => Err(FatalError::new(scope.fancy_error(
+                    "`String` type requires a max size argument",
+                    vec![Label::primary(name_span, "")],
+                    vec!["Example: String<100>".into()],
+                ))),
+                Some(args) => match &args.kind[..] {
+                    [fe::GenericArg::Int(len)] => Ok(CallType::TypeConstructor {
+                        typ: Type::String(FeString { max_size: len.kind }),
+                    }),
+                    _ => Err(FatalError::new(scope.fancy_error(
+                        "invalid `String` type argument",
+                        vec![Label::primary(args.span, "expected an integer")],
+                        vec!["Example: String<100>".into()],
+                    ))),
+                },
+            },
+            "Map" => Err(FatalError::new(scope.fancy_error(
+                "`Map` type is not callable",
+                vec![Label::primary(name_span, "")],
+                vec![],
             ))),
-        },
-        (value, _) => {
-            if let Some(typ) = scope.resolve_type(value) {
-                Ok(CallType::TypeConstructor { typ: typ? })
-            } else {
-                Ok(CallType::Pure {
-                    func_name: value.to_string(),
-                })
+            _ => {
+                // user types and functions can't be generic yet,
+                // so any generic args are erroneous
+                if let Some(args) = generic_args {
+                    scope.fancy_error(
+                        "unexpected generic arguments",
+                        vec![Label::primary(args.span, "")],
+                        vec![],
+                    );
+                }
+
+                if let Some(typ) = scope.resolve_type(name) {
+                    Ok(CallType::TypeConstructor { typ: typ? })
+                } else {
+                    Ok(CallType::Pure {
+                        func_name: name.to_string(),
+                    })
+                }
             }
         }
     }

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -1,5 +1,5 @@
 use crate::context::{AnalyzerContext, ExpressionAttributes, Location};
-use crate::errors::{AlreadyDefined, FatalError};
+use crate::errors::FatalError;
 use crate::namespace::scopes::{BlockScope, BlockScopeType};
 use crate::namespace::types::{Base, FixedSize, Type};
 use crate::traversal::call_args::LabelPolicy;
@@ -56,16 +56,9 @@ fn for_loop(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), Fat
             };
 
             let mut body_scope = scope.new_child(BlockScopeType::Loop);
-            if let Err(AlreadyDefined(dup_span)) =
-                body_scope.add_var(&target.kind, target_type, target.span)
-            {
-                body_scope.duplicate_name_error(
-                    &format!("duplicate definition of variable `{}`", target.kind),
-                    &target.kind,
-                    dup_span,
-                    target.span,
-                );
-            }
+            // add_var emits a msg on err; we can ignore the Result.
+            let _ = body_scope.add_var(&target.kind, target_type, target.span);
+
             // Traverse the statements within the `for loop` body scope.
             traverse_statements(&mut body_scope, body)
         }

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -4,132 +4,144 @@ use crate::namespace::types::{Array, Base, FeString, FixedSize, Map, Tuple, Type
 use crate::traversal::call_args::validate_arg_count;
 use fe_common::diagnostics::Label;
 use fe_parser::ast as fe;
-use fe_parser::node::Node;
+use fe_parser::node::{Node, Span};
 use std::convert::TryFrom;
 use std::str::FromStr;
 use vec1::Vec1;
+
+pub fn resolve_type_name(
+    context: &mut dyn AnalyzerContext,
+    name: &str,
+    name_span: Span,
+    generic_args: Option<&Node<Vec<fe::GenericArg>>>,
+) -> Option<Result<Type, TypeError>> {
+    match (name, generic_args) {
+        ("String", Some(args)) => match &args.kind[..] {
+            [fe::GenericArg::Int(len)] => Some(Ok(Type::String(FeString { max_size: len.kind }))),
+            _ => Some(Err(TypeError::new(context.fancy_error(
+                "invalid `String` type argument",
+                vec![Label::primary(args.span, "expected an integer")],
+                vec!["Example: String<100>".into()],
+            )))),
+        },
+        ("String", None) => Some(Err(TypeError::new(context.fancy_error(
+            "`String` type requires a max size argument",
+            vec![Label::primary(name_span, "")],
+            vec!["Example: String<100>".into()],
+        )))),
+        ("Map", Some(args)) => {
+            let diag_voucher = validate_arg_count(context, name, name_span, args, 2);
+
+            let key = match args.kind.get(0) {
+                Some(fe::GenericArg::TypeDesc(type_node)) => match type_desc(context, type_node) {
+                    Ok(Type::Base(base)) => base,
+                    Err(err) => return Some(Err(err)),
+                    _ => {
+                        return Some(Err(TypeError::new(context.error(
+                            "`Map` key must be a primitive type",
+                            type_node.span,
+                            "this can't be used as a Map key",
+                        ))));
+                    }
+                },
+                Some(fe::GenericArg::Int(node)) => {
+                    return Some(Err(TypeError::new(context.error(
+                        "`Map` key must be a type",
+                        node.span,
+                        "this should be a type name",
+                    ))));
+                }
+                None => return Some(Err(TypeError::new(diag_voucher.unwrap()))),
+            };
+            let value = match args.kind.get(1) {
+                Some(fe::GenericArg::TypeDesc(type_node)) => match type_desc(context, type_node) {
+                    Ok(typ) => typ,
+                    Err(err) => return Some(Err(err)),
+                },
+                Some(fe::GenericArg::Int(node)) => {
+                    return Some(Err(TypeError::new(context.error(
+                        "`Map` value must be a type",
+                        node.span,
+                        "this should be a type name",
+                    ))));
+                }
+                None => return Some(Err(TypeError::new(diag_voucher.unwrap()))),
+            };
+            Some(Ok(Type::Map(Map {
+                key,
+                value: Box::new(value),
+            })))
+        }
+        ("Map", None) => Some(Err(TypeError::new(context.fancy_error(
+            "`Map` type requires key and value type arguments",
+            vec![Label::primary(name_span, "")],
+            vec!["Example: Map<address, u256>".into()],
+        )))),
+        (_, _) => {
+            let typ = if let Ok(base_type) = Base::from_str(name) {
+                Type::Base(base_type)
+            } else {
+                match context.resolve_type(name) {
+                    Some(Ok(typ)) => typ,
+                    Some(Err(err)) => return Some(Err(err)),
+                    None => return None,
+                }
+            };
+
+            if let Some(args) = generic_args {
+                // User-defined types can't be generic yet
+                context.fancy_error(
+                    &format!("`{}` type is not generic", typ),
+                    vec![Label::primary(args.span, "unexpected type argument list")],
+                    vec![format!("Hint: use `{}`", typ)],
+                );
+            }
+            Some(Ok(typ))
+        }
+    }
+}
+
+fn resolve_type_name_or_err(
+    context: &mut dyn AnalyzerContext,
+    name: &str,
+    name_span: Span,
+    generic_args: Option<&Node<Vec<fe::GenericArg>>>,
+) -> Result<Type, TypeError> {
+    if let Some(typ) = resolve_type_name(context, name, name_span, generic_args) {
+        typ
+    } else {
+        Err(TypeError::new(context.error(
+            "undefined type",
+            name_span,
+            "this type name has not been defined",
+        )))
+    }
+}
 
 /// Maps a type description node to an enum type.
 pub fn type_desc(
     context: &mut dyn AnalyzerContext,
     desc: &Node<fe::TypeDesc>,
 ) -> Result<Type, TypeError> {
-    let typ = match &desc.kind {
-        fe::TypeDesc::Base { base } => {
-            if let Ok(base_type) = Base::from_str(base) {
-                Type::Base(base_type)
-            } else {
-                match base.as_str() {
-                    "String" => {
-                        return Err(TypeError::new(context.fancy_error(
-                            "`String` type requires a max size argument",
-                            vec![Label::primary(desc.span, "")],
-                            vec!["Example: String<100>".into()],
-                        )))
-                    }
-                    "Map" => {
-                        return Err(TypeError::new(context.fancy_error(
-                            "`Map` type requires key and value type arguments",
-                            vec![Label::primary(desc.span, "")],
-                            vec!["Example: Map<address, u256>".into()],
-                        )))
-                    }
-                    _ => {
-                        if let Some(typ) = context.resolve_type(base) {
-                            typ?
-                        } else {
-                            return Err(TypeError::new(context.error(
-                                "undefined type",
-                                desc.span,
-                                "this type name has not been defined",
-                            )));
-                        }
-                    }
-                }
-            }
-        }
+    match &desc.kind {
+        fe::TypeDesc::Base { base } => resolve_type_name_or_err(context, base, desc.span, None),
         fe::TypeDesc::Array { typ, dimension } => {
             if let Type::Base(base) = type_desc(context, typ)? {
-                Type::Array(Array {
+                Ok(Type::Array(Array {
                     inner: base,
                     size: *dimension,
-                })
+                }))
             } else {
-                return Err(TypeError::new(context.error(
+                Err(TypeError::new(context.error(
                     "arrays can only hold primitive types",
                     typ.span,
                     "can't be stored in an array",
-                )));
+                )))
             }
         }
-        fe::TypeDesc::Generic { base, args } => match base.kind.as_str() {
-            "Map" => {
-                let diag_voucher = validate_arg_count(context, &base.kind, base.span, args, 2);
-
-                let key = match args.kind.get(0) {
-                    Some(fe::GenericArg::TypeDesc(type_node)) => {
-                        match type_desc(context, type_node)? {
-                            Type::Base(base) => base,
-                            _ => {
-                                return Err(TypeError::new(context.error(
-                                    "`Map` key must be a primitive type",
-                                    type_node.span,
-                                    "this can't be used as a Map key",
-                                )));
-                            }
-                        }
-                    }
-                    Some(fe::GenericArg::Int(node)) => {
-                        return Err(TypeError::new(context.error(
-                            "`Map` key must be a type",
-                            node.span,
-                            "this should be a type name",
-                        )));
-                    }
-                    None => return Err(TypeError::new(diag_voucher.unwrap())),
-                };
-                let value = match args.kind.get(1) {
-                    Some(fe::GenericArg::TypeDesc(type_node)) => type_desc(context, type_node)?,
-                    Some(fe::GenericArg::Int(node)) => {
-                        return Err(TypeError::new(context.error(
-                            "`Map` value must be a type",
-                            node.span,
-                            "this should be a type name",
-                        )));
-                    }
-                    None => return Err(TypeError::new(diag_voucher.unwrap())),
-                };
-
-                Type::Map(Map {
-                    key,
-                    value: Box::new(value),
-                })
-            }
-            "String" => match &args.kind[..] {
-                [fe::GenericArg::Int(len)] => Type::String(FeString { max_size: len.kind }),
-                _ => {
-                    return Err(TypeError::new(context.fancy_error(
-                        "invalid `String` type argument",
-                        vec![Label::primary(args.span, "expected an integer")],
-                        vec!["Example: String<100>".into()],
-                    )));
-                }
-            },
-            other => {
-                if let Ok(base_type) = Base::from_str(other) {
-                    return Err(TypeError::new(context.fancy_error(
-                        &format!("`{}` type is not generic", base_type),
-                        vec![Label::primary(args.span, "unexpected type argument list")],
-                        vec![format!("Hint: use `{}`", base_type)],
-                    )));
-                }
-                return Err(TypeError::new(context.error(
-                    "undefined generic type",
-                    base.span,
-                    "this type name has not been defined",
-                )));
-            }
-        },
+        fe::TypeDesc::Generic { base, args } => {
+            resolve_type_name_or_err(context, &base.kind, base.span, Some(args))
+        }
         fe::TypeDesc::Tuple { items } => {
             let types = items
                 .iter()
@@ -142,12 +154,10 @@ pub fn type_desc(
                     ))),
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            Type::Tuple(Tuple {
+            Ok(Type::Tuple(Tuple {
                 items: Vec1::try_from_vec(types).expect("tuple is empty"),
-            })
+            }))
         }
-        fe::TypeDesc::Unit => Type::unit(),
-    };
-
-    Ok(typ)
+        fe::TypeDesc::Unit => Ok(Type::unit()),
+    }
 }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -68,17 +68,12 @@ macro_rules! test_stmt {
 test_stmt! { array_non_primitive, "let x: (u8, u8)[10]" }
 test_stmt! { array_mixed_types, "let x: u16[3] = [1, address(0), \"hi\"]" }
 test_stmt! { array_size_mismatch, "let x: u8[3] = []\nlet y: u8[3] = [1, 2]" }
+test_stmt! { array_constructor_call, "u8[3]([1, 2, 3])" }
 test_stmt! { assert_reason_not_string, "assert true, 1" }
 test_stmt! { assign_int, "5 = 6" }
 test_stmt! { assign_call, "self.f() = 10" }
 test_stmt! { assign_type_mismatch, "let x: u256 = 10\nx = address(0)" }
 test_stmt! { aug_assign_non_numeric, "let a: u256 = 1\nlet b: bool = true\na += b" }
-test_stmt! { bad_map, "let x: Map<u8, u8, u8>" }
-test_stmt! { bad_map2, "let x: Map<address, 100>" }
-test_stmt! { bad_map3, "let x: Map<>" }
-test_stmt! { bad_map4, "let x: Map<y>" }
-test_stmt! { bad_map5, "let x: Map<Map<u8, u8>, address>" }
-test_stmt! { bad_map6, "let x: Map<10, 20>" }
 test_stmt! { binary_op_add_uints, "let a: u256 = 1\nlet b: u8 = 2\na + b" }
 test_stmt! { binary_op_lshift_bool, "let a: bool = true\nlet b: i256\na << b" }
 test_stmt! { binary_op_lshift_with_int, "let a: u256 = 1\nlet b: i256 = 2\na << b" }
@@ -86,14 +81,32 @@ test_stmt! { binary_op_pow_int, "let a: u256 = 1\nlet b: i256 = 2\na ** b" }
 test_stmt! { binary_op_boolean_mismatch1, "10 and true" }
 test_stmt! { binary_op_boolean_mismatch2, "false or 1" }
 test_stmt! { binary_op_boolean_mismatch3, "1 or 2" }
+test_stmt! { bool_constructor, "bool(true)" }
+test_stmt! { bool_cast, "bool(0)" }
 test_stmt! { break_without_loop, "break" }
 test_stmt! { break_without_loop_2, "if true:\n  break" }
 test_stmt! { call_undefined_function_on_contract, "self.doesnt_exist()" }
+test_stmt! { call_address_with_wrong_type, "address(true)" }
+test_stmt! { call_keccak_without_parameter, "keccak256()" }
+test_stmt! { call_keccak_with_wrong_type, "keccak256(true)" }
+test_stmt! { call_keccak_with_2_args, "keccak256(1, 2)" }
+test_stmt! { call_keccak_with_generic_args, "keccak256<10>(1)" }
 test_stmt! { clone_arg_count, "let x: u256[2] = [5, 6]\nlet y: u256[2] = x.clone(y)" }
 test_stmt! { continue_without_loop, "continue" }
 test_stmt! { continue_without_loop_2, "if true:\n  continue" }
 test_stmt! { emit_undefined_event, "emit MyEvent()" }
-test_stmt! { keccak_called_with_wrong_type, "let x: u256[1]\nkeccak256(foo=x, 10)" }
+test_stmt! { int_type_generic_arg_list, "let x: u256<>" }
+test_stmt! { int_type_generic_arg, "let x: u256<10>" }
+test_stmt! { int_type_constructor_generic_arg_list, "u256<>(10)" }
+test_stmt! { int_type_constructor_generic_arg, "u256<1>(10)" }
+test_stmt! { map_three_type_args, "let x: Map<u8, u8, u8>" }
+test_stmt! { map_int_type_arg, "let x: Map<address, 100>" }
+test_stmt! { map_int_type_args, "let x: Map<10, 20>" }
+test_stmt! { map_no_type_args, "let x: Map<>" }
+test_stmt! { map_no_type_arg_list, "let x: Map" }
+test_stmt! { map_one_type_arg, "let x: Map<y>" }
+test_stmt! { map_map_key_type, "let x: Map<Map<u8, u8>, address>" }
+test_stmt! { map_constructor, "Map<u8, u8>()" }
 test_stmt! { non_bool_and, "let x: bool = true\nlet y: u256 = 1\nx = x and y" }
 test_stmt! { non_bool_or, "let x: bool = true\nlet y: u256 = 1\nx = x or y" }
 test_stmt! { overflow_i128_neg, "i128(-170141183460469231731687303715884105729)" }
@@ -126,7 +139,21 @@ test_stmt! { overflow_u8_assignment, "let x: u8 = 260" }
 test_stmt! { pow_with_signed_exponent, "let base: i128\nlet xp: i128\nbase ** exp" }
 // Exponent can be unsigned but needs to be same size or smaller
 test_stmt! { pow_with_wrong_capacity, "let base: i128\nlet exp: u256\nbase ** exp" }
+// test_stmt! { shadow_builtin_type_with_var, "let u8: u8 = 10" }
+// test_stmt! { shadow_builtin_function_with_var, "let keccak256: u8 = 10" }
+// test_file! { shadow_builtin_type }
+// test_file! { shadow_builtin_function }
 test_stmt! { string_capacity_mismatch, "String<3>(\"too long\")" }
+test_stmt! { string_non_int_type_arg, "let x: String<u8>" }
+test_stmt! { string_no_type_arg_list, "let x: String" }
+test_stmt! { string_no_type_args, "let x: String<>" }
+test_stmt! { string_two_int_type_args, "let x: String<1, 2>" }
+test_stmt! { string_two_type_args, "let x: String<1, u8>" }
+test_stmt! { string_constructor_non_int_type_arg, "String<foo>()" } // issue #532
+test_stmt! { string_constructor_no_type_arg_list, "String()" }
+test_stmt! { string_constructor_no_type_args, "String<>()" }
+test_stmt! { string_constructor_two_int_type_args, "String<1, 2>()" }
+test_stmt! { string_constructor_two_type_args, "String<1, u8>()" }
 test_stmt! { ternary_type_mismatch, "10 if 100 else true" }
 test_stmt! { type_constructor_from_variable, "let x: u8\nlet y: u16 = u16(x)" }
 test_stmt! { type_constructor_arg_count, "let x: u8 = u8(1, 10)" }
@@ -136,6 +163,7 @@ test_stmt! { undefined_generic_type, "let x: foobar<u256> = 10" }
 test_stmt! { undefined_name, "let x: u16 = y\nlet z: u16 = y" }
 test_stmt! { undefined_type, "let x: foobar = 10" }
 test_stmt! { unexpected_return, "return 1" }
+test_stmt! { unit_type_constructor, "()()" }
 test_stmt! { revert_reason_not_struct, "revert 1" }
 test_stmt! { invalid_ascii, "String<2>(\"ä\")" }
 test_stmt! { invert_non_numeric, "~true" }
@@ -144,12 +172,9 @@ test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }
 test_file! { bad_tuple_attr3 }
 test_file! { call_builtin_object }
-test_file! { call_address_with_wrong_type }
 test_file! { call_create_with_wrong_type }
 test_file! { call_create2_with_wrong_type }
 test_file! { call_event_with_wrong_types }
-test_file! { call_keccak_without_parameter }
-test_file! { call_keccak_with_wrong_type }
 test_file! { call_undefined_function_on_external_contract }
 test_file! { call_undefined_function_on_memory_struct }
 test_file! { call_undefined_function_on_storage_struct }
@@ -178,7 +203,6 @@ test_file! { invalid_compiler_version }
 test_file! { invalid_block_field }
 test_file! { invalid_chain_field }
 test_file! { invalid_contract_field }
-test_file! { invalid_generic_string }
 test_file! { invalid_msg_field }
 test_file! { invalid_string_field }
 test_file! { invalid_struct_field }
@@ -205,7 +229,6 @@ test_file! { return_from_init }
 test_file! { return_lt_mixed_types }
 test_file! { return_type_undefined }
 test_file! { return_type_not_fixedsize }
-test_file! { string_constructor_bad_type_arg }
 test_file! { undefined_type_param }
 
 test_file! { strict_boolean_if_else }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -139,10 +139,11 @@ test_stmt! { overflow_u8_assignment, "let x: u8 = 260" }
 test_stmt! { pow_with_signed_exponent, "let base: i128\nlet xp: i128\nbase ** exp" }
 // Exponent can be unsigned but needs to be same size or smaller
 test_stmt! { pow_with_wrong_capacity, "let base: i128\nlet exp: u256\nbase ** exp" }
-// test_stmt! { shadow_builtin_type_with_var, "let u8: u8 = 10" }
-// test_stmt! { shadow_builtin_function_with_var, "let keccak256: u8 = 10" }
-// test_file! { shadow_builtin_type }
-// test_file! { shadow_builtin_function }
+test_stmt! { shadow_builtin_type_with_var, "let u8: u8 = 10" }
+test_stmt! { shadow_builtin_fn_with_var, "let keccak256: u8 = 10" }
+test_stmt! { shadow_builtin_object_with_var, "let self: u8 = 10" }
+test_file! { shadow_builtin_type }
+test_file! { shadow_builtin_function }
 test_stmt! { string_capacity_mismatch, "String<3>(\"too long\")" }
 test_stmt! { string_non_int_type_arg, "let x: String<u8>" }
 test_stmt! { string_no_type_arg_list, "let x: String" }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -169,6 +169,7 @@ test_file! { duplicate_struct_in_module }
 test_file! { duplicate_typedef_in_module }
 test_file! { duplicate_var_in_child_scope }
 test_file! { duplicate_var_in_contract_method }
+test_file! { duplicate_var_in_for_loop }
 test_file! { emit_bad_args }
 test_file! { external_call_type_error }
 test_file! { external_call_wrong_number_of_params }

--- a/crates/analyzer/tests/snapshots/errors__array_constructor_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__array_constructor_call.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: cannot find value `u8` in this scope
+  ┌─ [snippet]:3:3
+  │
+3 │   u8[3]([1, 2, 3])
+  │   ^^ undefined
+
+

--- a/crates/analyzer/tests/snapshots/errors__aug_assign_non_numeric.snap
+++ b/crates/analyzer/tests/snapshots/errors__aug_assign_non_numeric.snap
@@ -3,10 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The types for this operation must be numeric
+error: `+` operands must be numeric
   ┌─ [snippet]:5:3
   │
 5 │   a += b
-  │   ^    ^
+  │   ^    ^ this has type `bool`
+  │   │     
+  │   this has type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__binary_op_add_uints.snap
+++ b/crates/analyzer/tests/snapshots/errors__binary_op_add_uints.snap
@@ -3,10 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The types for this operation must be equal
+error: `+` operand types must be equal
   ┌─ [snippet]:5:3
   │
 5 │   a + b
-  │   ^   ^
+  │   ^   ^ this has type `u8`
+  │   │    
+  │   this has type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__binary_op_lshift_bool.snap
+++ b/crates/analyzer/tests/snapshots/errors__binary_op_lshift_bool.snap
@@ -3,10 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The types for this operation must be numeric
+error: `<<` operands must be numeric
   ┌─ [snippet]:5:3
   │
 5 │   a << b
-  │   ^    ^
+  │   ^    ^ this has type `i256`
+  │   │     
+  │   this has type `bool`
 
 

--- a/crates/analyzer/tests/snapshots/errors__binary_op_lshift_with_int.snap
+++ b/crates/analyzer/tests/snapshots/errors__binary_op_lshift_with_int.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The right hand side of this operation must be unsigned
+error: The right hand side of the `<<` operation must be unsigned
   ┌─ [snippet]:5:8
   │
 5 │   a << b
-  │        ^ incompatible signed numeric
+  │        ^ this has signed type `i256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__binary_op_pow_int.snap
+++ b/crates/analyzer/tests/snapshots/errors__binary_op_pow_int.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The right hand side of this operation must be unsigned
+error: The right hand side of the `**` operation must be unsigned
   ┌─ [snippet]:5:8
   │
 5 │   a ** b
-  │        ^ incompatible signed numeric
+  │        ^ this has signed type `i256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__bool_cast.snap
+++ b/crates/analyzer/tests/snapshots/errors__bool_cast.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `bool` type is not callable
+  ┌─ [snippet]:3:3
+  │
+3 │   bool(0)
+  │   ^^^^
+
+

--- a/crates/analyzer/tests/snapshots/errors__bool_constructor.snap
+++ b/crates/analyzer/tests/snapshots/errors__bool_constructor.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `bool` type is not callable
+  ┌─ [snippet]:3:3
+  │
+3 │   bool(true)
+  │   ^^^^
+
+

--- a/crates/analyzer/tests/snapshots/errors__break_without_loop.snap
+++ b/crates/analyzer/tests/snapshots/errors__break_without_loop.snap
@@ -7,6 +7,6 @@ error: `break` outside of a loop
   ┌─ [snippet]:3:3
   │
 3 │   break
-  │   ^^^^^ cannot `break` outside of a `for` or `while` loop
+  │   ^^^^^ `break` can only be used inside of a `for` or `while` loop
 
 

--- a/crates/analyzer/tests/snapshots/errors__break_without_loop_2.snap
+++ b/crates/analyzer/tests/snapshots/errors__break_without_loop_2.snap
@@ -7,6 +7,6 @@ error: `break` outside of a loop
   ┌─ [snippet]:4:5
   │
 4 │     break
-  │     ^^^^^ cannot `break` outside of a `for` or `while` loop
+  │     ^^^^^ `break` can only be used inside of a `for` or `while` loop
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_address_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_address_with_wrong_type.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/analyzer/tests/errors.rs
-expression: "error_string(&path, &src)"
+expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `bool` can not be used as a parameter to `address(..)`
-  ┌─ compile_errors/call_address_with_wrong_type.fe:3:17
+  ┌─ [snippet]:3:11
   │
-3 │         address(true)
-  │                 ^^^^ wrong type
+3 │   address(true)
+  │           ^^^^ wrong type
   │
   = Note: address(..) expects a parameter of a contract type, numeric or address
 

--- a/crates/analyzer/tests/snapshots/errors__call_keccak_with_2_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_keccak_with_2_args.snap
@@ -1,0 +1,22 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `keccak256` expects 1 argument, but 2 were provided
+  ┌─ [snippet]:3:3
+  │
+3 │   keccak256(1, 2)
+  │   ^^^^^^^^^ -  - supplied 2 arguments
+  │   │             
+  │   expects 1 argument
+
+error: `u256` can not be used as an argument to `keccak256`
+  ┌─ [snippet]:3:12
+  │
+3 │   keccak256(1, 2)
+  │            ^^^^^^ wrong type
+  │
+  = Note: `keccak256` expects a byte array argument
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_keccak_with_generic_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_keccak_with_generic_args.snap
@@ -1,0 +1,20 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `keccak256` function does not expect generic arguments
+  ┌─ [snippet]:3:12
+  │
+3 │   keccak256<10>(1)
+  │            ^^^^ unexpected generic argument list
+
+error: `u256` can not be used as an argument to `keccak256`
+  ┌─ [snippet]:3:16
+  │
+3 │   keccak256<10>(1)
+  │                ^^^ wrong type
+  │
+  = Note: `keccak256` expects a byte array argument
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_keccak_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_keccak_with_wrong_type.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/analyzer/tests/errors.rs
-expression: "error_string(&path, &src)"
+expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `bool` can not be used as a parameter to `keccak(..)`
-  ┌─ compile_errors/call_keccak_with_wrong_type.fe:7:17
+error: `bool` can not be used as an argument to `keccak256`
+  ┌─ [snippet]:3:12
   │
-7 │        keccak256(true)
-  │                 ^^^^^^ wrong type
+3 │   keccak256(true)
+  │            ^^^^^^ wrong type
   │
-  = Note: keccak(..) expects a byte array as parameter
+  = Note: `keccak256` expects a byte array argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_keccak_without_parameter.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_keccak_without_parameter.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/analyzer/tests/errors.rs
-expression: "error_string(&path, &src)"
+expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `keccak256` expects 1 argument, but 0 were provided
-  ┌─ compile_errors/call_keccak_without_parameter.fe:7:8
+  ┌─ [snippet]:3:3
   │
-7 │        keccak256()
-  │        ^^^^^^^^^-- supplied 0 arguments
-  │        │         
-  │        expects 1 argument
+3 │   keccak256()
+  │   ^^^^^^^^^-- supplied 0 arguments
+  │   │         
+  │   expects 1 argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__continue_without_loop.snap
+++ b/crates/analyzer/tests/snapshots/errors__continue_without_loop.snap
@@ -7,6 +7,6 @@ error: `continue` outside of a loop
   ┌─ [snippet]:3:3
   │
 3 │   continue
-  │   ^^^^^^^^ cannot `continue` outside of a `for` or `while` loop
+  │   ^^^^^^^^ `continue` can only be used inside of a `for` or `while` loop
 
 

--- a/crates/analyzer/tests/snapshots/errors__continue_without_loop_2.snap
+++ b/crates/analyzer/tests/snapshots/errors__continue_without_loop_2.snap
@@ -7,6 +7,6 @@ error: `continue` outside of a loop
   ┌─ [snippet]:4:5
   │
 4 │     continue
-  │     ^^^^^^^^ cannot `continue` outside of a `for` or `while` loop
+  │     ^^^^^^^^ `continue` can only be used inside of a `for` or `while` loop
 
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_var_in_child_scope.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_var_in_child_scope.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: duplicate variable definition
+error: duplicate definition of variable `sum`
   ┌─ compile_errors/duplicate_var_in_child_scope.fe:4:13
   │
 4 │         let sum: u256 = 0

--- a/crates/analyzer/tests/snapshots/errors__duplicate_var_in_child_scope.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_var_in_child_scope.snap
@@ -9,7 +9,15 @@ error: duplicate variable definition
 4 │         let sum: u256 = 0
   │             ^^^ `sum` first defined here
 5 │         for i in my_array:
-6 │             let sum: u256 = 0
+6 │             let sum: u64 = 0
   │                 --- `sum` redefined here
+
+error: `+` operand types must be equal
+  ┌─ compile_errors/duplicate_var_in_child_scope.fe:7:13
+  │
+7 │             sum += i
+  │             ^^^    ^ this has type `u64`
+  │             │       
+  │             this has type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_var_in_contract_method.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_var_in_contract_method.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: duplicate variable definition
+error: duplicate definition of variable `foo`
   ┌─ compile_errors/duplicate_var_in_contract_method.fe:3:13
   │
 3 │         let foo: u8

--- a/crates/analyzer/tests/snapshots/errors__duplicate_var_in_for_loop.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_var_in_for_loop.snap
@@ -1,0 +1,23 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: duplicate definition of variable `x`
+  ┌─ compile_errors/duplicate_var_in_for_loop.fe:3:9
+  │
+3 │     let x: u256 = 10
+  │         ^ `x` first defined here
+  ·
+7 │     for x in xs:
+  │         - `x` redefined here
+
+error: `+` operand types must be equal
+  ┌─ compile_errors/duplicate_var_in_for_loop.fe:8:7
+  │
+8 │       sum += x
+  │       ^^^    ^ this has type `u256`
+  │       │       
+  │       this has type `u8`
+
+

--- a/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `u256` type does not expect generic arguments
+  ┌─ [snippet]:3:7
+  │
+3 │   u256<1>(10)
+  │       ^^^ unexpected generic argument list
+
+

--- a/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg_list.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `u256` type does not expect generic arguments
+  ┌─ [snippet]:3:7
+  │
+3 │   u256<>(10)
+  │       ^^ unexpected generic argument list
+
+

--- a/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg_list.snap
@@ -3,10 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `u256` type does not expect generic arguments
+error: `u256` type is not generic
   ┌─ [snippet]:3:7
   │
 3 │   u256<>(10)
-  │       ^^ unexpected generic argument list
+  │       ^^ unexpected type argument list
+  │
+  = Hint: use `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__int_type_generic_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_generic_arg.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `u256` type is not generic
+  ┌─ [snippet]:3:14
+  │
+3 │   let x: u256<10>
+  │              ^^^^ unexpected type argument list
+  │
+  = Hint: use `u256`
+
+

--- a/crates/analyzer/tests/snapshots/errors__int_type_generic_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_generic_arg_list.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `u256` type is not generic
+  ┌─ [snippet]:3:14
+  │
+3 │   let x: u256<>
+  │              ^^ unexpected type argument list
+  │
+  = Hint: use `u256`
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_constructor.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_constructor.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` type is not callable
+  ┌─ [snippet]:3:3
+  │
+3 │   Map<u8, u8>()
+  │   ^^^
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_int_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_int_type_arg.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` value must be a type
+  ┌─ [snippet]:3:23
+  │
+3 │   let x: Map<address, 100>
+  │                       ^^^ this should be a type name
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_int_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_int_type_args.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` key must be a type
+  ┌─ [snippet]:3:14
+  │
+3 │   let x: Map<10, 20>
+  │              ^^ this should be a type name
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_map_key_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_map_key_type.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` key must be a primitive type
+  ┌─ [snippet]:3:14
+  │
+3 │   let x: Map<Map<u8, u8>, address>
+  │              ^^^^^^^^^^^ this can't be used as a Map key
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_no_type_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_no_type_arg_list.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` type requires key and value type arguments
+  ┌─ [snippet]:3:10
+  │
+3 │   let x: Map
+  │          ^^^
+  │
+  = Example: Map<address, u256>
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_no_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_no_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` expects 2 arguments, but 0 were provided
+  ┌─ [snippet]:3:10
+  │
+3 │   let x: Map<>
+  │          ^^^-- supplied 0 arguments
+  │          │   
+  │          expects 2 arguments
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_one_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_one_type_arg.snap
@@ -1,0 +1,20 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` expects 2 arguments, but 1 was provided
+  ┌─ [snippet]:3:10
+  │
+3 │   let x: Map<y>
+  │          ^^^ - supplied 1 argument
+  │          │    
+  │          expects 2 arguments
+
+error: undefined type
+  ┌─ [snippet]:3:14
+  │
+3 │   let x: Map<y>
+  │              ^ this type name has not been defined
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_three_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_three_type_args.snap
@@ -1,0 +1,20 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `Map` expects 2 arguments, but 3 were provided
+  ┌─ [snippet]:3:10
+  │
+3 │   let x: Map<u8, u8, u8>
+  │          ^^^ --  --  -- supplied 3 arguments
+  │          │            
+  │          expects 2 arguments
+
+error: invalid variable type
+  ┌─ [snippet]:3:10
+  │
+3 │   let x: Map<u8, u8, u8>
+  │          ^^^^^^^^^^^^^^^ `Map` type can only be used as a contract field
+
+

--- a/crates/analyzer/tests/snapshots/errors__not_callable.snap
+++ b/crates/analyzer/tests/snapshots/errors__not_callable.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: the u256 type is not callable
+error: `u256` type is not callable
   ┌─ compile_errors/not_callable.fe:4:9
   │
 4 │         5()
-  │         ^ this has type u256
+  │         ^ this has type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__pow_with_wrong_capacity.snap
+++ b/crates/analyzer/tests/snapshots/errors__pow_with_wrong_capacity.snap
@@ -3,10 +3,14 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: The right hand side of this operation must fit into the left
-  ┌─ [snippet]:5:11
+error: incompatible `**` operand types
+  ┌─ [snippet]:5:3
   │
 5 │   base ** exp
-  │           ^^^ size too large
+  │   ^^^^    ^^^ this has type `u256`
+  │   │        
+  │   this has type `i128`
+  │
+  = The type of the right hand side cannot be larger than the left (`i128`)
 
 

--- a/crates/analyzer/tests/snapshots/errors__return_addition_with_mixed_types.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_addition_with_mixed_types.snap
@@ -3,10 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: The types for this operation must be equal
+error: `+` operand types must be equal
   ┌─ compile_errors/return_addition_with_mixed_types.fe:3:16
   │
 3 │         return x + y
-  │                ^   ^
+  │                ^   ^ this has type `u128`
+  │                │    
+  │                this has type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_fn_with_var.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_fn_with_var.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: variable name conflicts with built-in function
+  ┌─ [snippet]:3:7
+  │
+3 │   let keccak256: u8 = 10
+  │       ^^^^^^^^^ `keccak256` is a built-in function
+
+

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_function.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_function.snap
@@ -1,0 +1,30 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: function name conflicts with built-in function
+  ┌─ compile_errors/shadow_builtin_function.fe:2:10
+  │
+2 │   pub fn keccak256(bytes: u8[4]) -> u8[4]:
+  │          ^^^^^^^^^ `keccak256` is a built-in function
+
+error: function name conflicts with built-in type
+  ┌─ compile_errors/shadow_builtin_function.fe:5:10
+  │
+5 │   pub fn u256(x: u8) -> u256:
+  │          ^^^^ `u256` is a built-in type
+
+error: function name conflicts with built-in type
+  ┌─ compile_errors/shadow_builtin_function.fe:8:10
+  │
+8 │   pub fn bool(x: u8) -> bool:
+  │          ^^^^ `bool` is a built-in type
+
+error: function name conflicts with built-in object
+   ┌─ compile_errors/shadow_builtin_function.fe:11:10
+   │
+11 │   pub fn self() -> bool:
+   │          ^^^^ `self` is a built-in object
+
+

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_object_with_var.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_object_with_var.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `u256` type is not generic
+error: variable name conflicts with built-in object
   ┌─ [snippet]:3:7
   │
-3 │   u256<1>(10)
-  │       ^^^ unexpected type argument list
-  │
-  = Hint: use `u256`
+3 │   let self: u8 = 10
+  │       ^^^^ `self` is a built-in object
 
 

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_type.snap
@@ -1,0 +1,60 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: type name conflicts with built-in type
+  ┌─ compile_errors/shadow_builtin_type.fe:1:6
+  │
+1 │ type u256 = u8
+  │      ^^^^ `u256` is a built-in type
+
+error: type name conflicts with built-in type
+  ┌─ compile_errors/shadow_builtin_type.fe:2:6
+  │
+2 │ type String = u256
+  │      ^^^^^^ `String` is a built-in type
+
+error: type name conflicts with built-in type
+  ┌─ compile_errors/shadow_builtin_type.fe:3:6
+  │
+3 │ type Map = u256
+  │      ^^^ `Map` is a built-in type
+
+error: type name conflicts with built-in type
+  ┌─ compile_errors/shadow_builtin_type.fe:4:6
+  │
+4 │ type bool = u256
+  │      ^^^^ `bool` is a built-in type
+
+error: type name conflicts with built-in function
+  ┌─ compile_errors/shadow_builtin_type.fe:6:6
+  │
+6 │ type keccak256 = u8
+  │      ^^^^^^^^^ `keccak256` is a built-in function
+
+error: type name conflicts with built-in object
+  ┌─ compile_errors/shadow_builtin_type.fe:7:6
+  │
+7 │ type block = u8
+  │      ^^^^^ `block` is a built-in object
+
+error: type name conflicts with built-in object
+  ┌─ compile_errors/shadow_builtin_type.fe:8:6
+  │
+8 │ type msg = u8
+  │      ^^^ `msg` is a built-in object
+
+error: type name conflicts with built-in object
+  ┌─ compile_errors/shadow_builtin_type.fe:9:6
+  │
+9 │ type chain = u8
+  │      ^^^^^ `chain` is a built-in object
+
+error: type name conflicts with built-in object
+   ┌─ compile_errors/shadow_builtin_type.fe:10:6
+   │
+10 │ type self = u8
+   │      ^^^^ `self` is a built-in object
+
+

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_type_with_var.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_type_with_var.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `u256` type is not generic
+error: variable name conflicts with built-in type
   ┌─ [snippet]:3:7
   │
-3 │   u256<1>(10)
-  │       ^^^ unexpected type argument list
-  │
-  = Hint: use `u256`
+3 │   let u8: u8 = 10
+  │       ^^ `u8` is a built-in type
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_arg_list.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `String` type requires a max size argument
+  ┌─ [snippet]:3:3
+  │
+3 │   String()
+  │   ^^^^^^
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:9
+  │
+3 │   String<>()
+  │         ^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_non_int_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_non_int_type_arg.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:9
+  │
+3 │   String<foo>()
+  │         ^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_two_int_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_two_int_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:9
+  │
+3 │   String<1, 2>()
+  │         ^^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_two_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_two_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:9
+  │
+3 │   String<1, u8>()
+  │         ^^^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_no_type_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_no_type_arg_list.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `String` type requires a max size argument
+  ┌─ [snippet]:3:10
+  │
+3 │   let x: String
+  │          ^^^^^^
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_no_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_no_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:16
+  │
+3 │   let x: String<>
+  │                ^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_non_int_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_non_int_type_arg.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:16
+  │
+3 │   let x: String<u8>
+  │                ^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_two_int_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_two_int_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:16
+  │
+3 │   let x: String<1, 2>
+  │                ^^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__string_two_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_two_type_args.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: invalid `String` type argument
+  ┌─ [snippet]:3:16
+  │
+3 │   let x: String<1, u8>
+  │                ^^^^^^^ expected an integer
+  │
+  = Example: String<100>
+
+

--- a/crates/analyzer/tests/snapshots/errors__undefined_generic_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_generic_type.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: undefined generic type
+error: undefined type
   ┌─ [snippet]:3:10
   │
 3 │   let x: foobar<u256> = 10

--- a/crates/analyzer/tests/snapshots/errors__unit_type_constructor.snap
+++ b/crates/analyzer/tests/snapshots/errors__unit_type_constructor.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `()` type is not callable
+  ┌─ [snippet]:3:3
+  │
+3 │   ()()
+  │   ^^ this has type `()`
+
+

--- a/crates/test-files/fixtures/compile_errors/call_address_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_address_with_wrong_type.fe
@@ -1,3 +1,0 @@
-contract Foo:
-    pub fn foo():
-        address(true)

--- a/crates/test-files/fixtures/compile_errors/call_keccak_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_keccak_with_wrong_type.fe
@@ -1,7 +1,0 @@
-contract Bar:
-    pass
-
-contract Foo:
-
-    pub fn foo():
-       keccak256(true)

--- a/crates/test-files/fixtures/compile_errors/call_keccak_without_parameter.fe
+++ b/crates/test-files/fixtures/compile_errors/call_keccak_without_parameter.fe
@@ -1,7 +1,0 @@
-contract Bar:
-    pass
-
-contract Foo:
-
-    pub fn foo():
-       keccak256()

--- a/crates/test-files/fixtures/compile_errors/duplicate_var_in_child_scope.fe
+++ b/crates/test-files/fixtures/compile_errors/duplicate_var_in_child_scope.fe
@@ -1,6 +1,7 @@
 contract Foo:
     pub fn bar():
-        let my_array: u256[3]
+        let my_array: u64[3]
         let sum: u256 = 0
         for i in my_array:
-            let sum: u256 = 0
+            let sum: u64 = 0
+            sum += i

--- a/crates/test-files/fixtures/compile_errors/duplicate_var_in_for_loop.fe
+++ b/crates/test-files/fixtures/compile_errors/duplicate_var_in_for_loop.fe
@@ -1,0 +1,8 @@
+contract C:
+  fn f():
+    let x: u256 = 10
+
+    let xs: u8[4] = [1, 2, 3, 4]
+    let sum: u8 = 0
+    for x in xs:
+      sum += x

--- a/crates/test-files/fixtures/compile_errors/invalid_generic_string.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_generic_string.fe
@@ -1,3 +1,0 @@
-contract Foo:
-  val: String<foo>
-  foo: String<10, 20>

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_function.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_function.fe
@@ -1,0 +1,9 @@
+contract C:
+  pub fn keccak256(bytes: u8[4]) -> u8[4]:
+    return [1, 2, 3, 4]
+
+  pub fn u256(x: u8) -> u256:
+    return 10
+
+  pub fn bool(x: u8) -> bool:
+    return x != 0

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_function.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_function.fe
@@ -7,3 +7,6 @@ contract C:
 
   pub fn bool(x: u8) -> bool:
     return x != 0
+
+  pub fn self() -> bool:
+    return false

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
@@ -2,3 +2,9 @@ type u256 = u8
 type String = u256
 type Map = u256
 type bool = u256
+
+type keccak256 = u8
+type block = u8
+type msg = u8
+type chain = u8
+type self = u8

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
@@ -1,0 +1,4 @@
+type u256 = u8
+type String = u256
+type Map = u256
+type bool = u256

--- a/crates/test-files/fixtures/compile_errors/string_constructor_bad_type_arg.fe
+++ b/crates/test-files/fixtures/compile_errors/string_constructor_bad_type_arg.fe
@@ -1,5 +1,0 @@
-# https://github.com/ethereum/fe/issues/532
-
-contract ERC20:
-    pub fn return_casted_static_string() -> String<100>:
-        return String<H00>("foo")

--- a/newsfragments/539.feature.md
+++ b/newsfragments/539.feature.md
@@ -1,0 +1,12 @@
+The analyzer now disallows defining a type, variable, or function whose
+name conflicts with a built-in type, function, or object.
+
+Example:
+
+```
+error: type name conflicts with built-in type
+┌─ compile_errors/shadow_builtin_type.fe:1:6
+│
+1 │ type u256 = u8
+│      ^^^^ `u256` is a built-in type
+```


### PR DESCRIPTION
### What was wrong?

The analyzer allowed things like:

```
type u8 = u256
let u256: u8 = 10
fn u8(u8: u256) -> u8:
let keccak256: u256 = keccak256(x)
let x: u256 = u256<1, 2, 3>(10)
```

### How was it fixed?

Added more checks to type, function, and var defs. This implementation isn't super satisfying; I was able to consolidate some duplicate logic, but we still have to perform this kind of check in 3 places, which doesn't seem ideal.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
