### PR TITLE
Improved articulation of #overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fe is an emerging smart contract language for the Ethereum blockchain.
 
 ## Overview
 
-Fe is a statically typed language for the Ethereum Virtual Machine (EVM). It is inspired by Python and Rust and is easy to learn -- even for developers who are new to the Ethereum ecosystem.
+Fe is a statically typed language for the Ethereum Virtual Machine (EVM). It is inspired by Python and Rust which makes it easy to learn -- especially for new developers entering the Ethereum ecosystem.
 
 ## Features & Goals
 


### PR DESCRIPTION
### What was wrong?

The articulation of the overview heading was wobbly. Not reflecting precision and grace. 'and' was used twice in succession 'python and rust and' , making it awkward. 

### How was it fixed?

I rephrased while keeping the meaning precisely the same, and avoiding incorrect articulation methods. Minimal tweaking for a far better impact. Read it and see for yourself :)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
