### PR TITLE
Refactor analyzer name resolution (resolve_name/NamedThing)

### DIFF
--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -1,54 +1,4 @@
-use std::str::FromStr;
-use strum::{AsRefStr, EnumString, IntoStaticStr};
-
-#[derive(Debug, PartialEq, EnumString, AsRefStr)]
-#[strum(serialize_all = "lowercase")]
-pub enum ReservedName {
-    Type,
-    Object,
-    // Module, // someday: "std"
-    Function,
-}
-
-/// Check if a name shadows a built-in type, object, or function.
-/// Ideally, some of these things will move into a .fe standard library,
-/// and we won't need some of this special name collision logic.
-pub fn reserved_name(name: &str) -> Option<ReservedName> {
-    if TypeName::from_str(name).is_ok() {
-        Some(ReservedName::Type)
-    } else if Object::from_str(name).is_ok() {
-        Some(ReservedName::Object)
-    } else if GlobalMethod::from_str(name).is_ok() {
-        Some(ReservedName::Function)
-    } else {
-        None
-    }
-}
-
-#[derive(Debug, PartialEq, EnumString)]
-#[strum(serialize_all = "lowercase")]
-pub enum TypeName {
-    // Array, // when syntax is changed
-    #[strum(serialize = "Map")]
-    Map,
-    #[strum(serialize = "String")]
-    String_,
-
-    Address,
-    Bool,
-    I8,
-    I16,
-    I32,
-    I64,
-    I128,
-    I256,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    U256,
-}
+use strum::{AsRefStr, EnumIter, EnumString};
 
 #[derive(Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "snake_case")]
@@ -58,20 +8,20 @@ pub enum ValueMethod {
     AbiEncode,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumString, IntoStaticStr, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, EnumString, AsRefStr, Hash, EnumIter)]
 #[strum(serialize_all = "snake_case")]
 pub enum GlobalMethod {
     Keccak256,
 }
 
-#[derive(strum::ToString, Debug, PartialEq, EnumString)]
+#[derive(Debug, PartialEq, EnumString, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ContractTypeMethod {
     Create,
     Create2,
 }
 
-#[derive(strum::ToString, Debug, PartialEq, EnumString)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumString, EnumIter, AsRefStr)]
 #[strum(serialize_all = "lowercase")]
 pub enum Object {
     Block,

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -1,8 +1,8 @@
 use crate::context::{Analysis, FunctionBody};
 use crate::errors::TypeError;
 use crate::namespace::items::{
-    self, ContractFieldId, ContractId, EventId, FunctionId, ModuleConstantId, ModuleId,
-    StructFieldId, StructId, TypeAliasId, TypeDefId,
+    self, ContractFieldId, ContractId, EventId, FunctionId, Item, ModuleConstantId, ModuleId,
+    StructFieldId, StructId, TypeAliasId,
 };
 use crate::namespace::types;
 use indexmap::IndexMap;
@@ -48,23 +48,16 @@ pub trait AnalyzerDb {
     fn intern_event(&self, data: Rc<items::Event>) -> EventId;
 
     // Module
-    #[salsa::invoke(queries::module::module_all_type_defs)]
-    fn module_all_type_defs(&self, module: ModuleId) -> Rc<Vec<TypeDefId>>;
-    #[salsa::invoke(queries::module::module_type_def_map)]
-    fn module_type_def_map(&self, module: ModuleId) -> Analysis<Rc<IndexMap<String, TypeDefId>>>;
-    #[salsa::invoke(queries::module::module_resolve_type)]
-    #[salsa::cycle(queries::module::module_resolve_type_cycle)]
-    fn module_resolve_type(
-        &self,
-        module: ModuleId,
-        name: String,
-    ) -> Option<Result<types::Type, TypeError>>;
+    #[salsa::invoke(queries::module::module_all_items)]
+    fn module_all_items(&self, module: ModuleId) -> Rc<Vec<Item>>;
+    #[salsa::invoke(queries::module::module_item_map)]
+    fn module_item_map(&self, module: ModuleId) -> Analysis<Rc<IndexMap<String, Item>>>;
+    #[salsa::invoke(queries::module::module_imported_item_map)]
+    fn module_imported_item_map(&self, module: ModuleId) -> Rc<IndexMap<String, Item>>;
     #[salsa::invoke(queries::module::module_contracts)]
     fn module_contracts(&self, module: ModuleId) -> Rc<Vec<ContractId>>;
     #[salsa::invoke(queries::module::module_structs)]
     fn module_structs(&self, module: ModuleId) -> Rc<Vec<StructId>>;
-    #[salsa::invoke(queries::module::module_constants)]
-    fn module_constants(&self, module: ModuleId) -> Rc<Vec<ModuleConstantId>>;
 
     // Module Constant
     #[salsa::invoke(queries::module::module_constant_type)]

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -3,81 +3,126 @@ use crate::context::{Analysis, AnalyzerContext};
 use crate::db::AnalyzerDb;
 use crate::errors::{self, TypeError};
 use crate::namespace::items::{
-    Contract, ContractId, ModuleConstant, ModuleConstantId, ModuleId, Struct, StructId, TypeAlias,
-    TypeDefId,
+    Contract, ContractId, Item, ModuleConstant, ModuleConstantId, ModuleId, Struct, StructId,
+    TypeAlias, TypeDef,
 };
 use crate::namespace::scopes::ItemScope;
 use crate::namespace::types::{self, Type};
 use crate::traversal::types::type_desc;
 use fe_common::diagnostics::Label;
 use fe_parser::ast;
+use indexmap::indexmap;
 use indexmap::map::{Entry, IndexMap};
 use std::rc::Rc;
+use strum::IntoEnumIterator;
 
-pub fn module_all_type_defs(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<TypeDefId>> {
+// Placeholder; someday std::prelude will be a proper module.
+fn std_prelude_items() -> IndexMap<String, Item> {
+    let mut items = indexmap! {
+        "bool".to_string() => Item::Type(TypeDef::Primitive(types::Base::Bool)),
+        "address".to_string() => Item::Type(TypeDef::Primitive(types::Base::Address)),
+    };
+    items.extend(types::Integer::iter().map(|typ| {
+        (
+            typ.as_ref().to_string(),
+            Item::Type(TypeDef::Primitive(types::Base::Numeric(typ))),
+        )
+    }));
+    items.extend(
+        types::GenericType::iter().map(|typ| (typ.name().to_string(), Item::GenericType(typ))),
+    );
+    items.extend(
+        builtins::GlobalMethod::iter()
+            .map(|fun| (fun.as_ref().to_string(), Item::BuiltinFunction(fun))),
+    );
+    items.extend(builtins::Object::iter().map(|obj| (obj.as_ref().to_string(), Item::Object(obj))));
+    items
+}
+
+// This is probably too simple for real module imports
+pub fn module_imported_item_map(_: &dyn AnalyzerDb, _: ModuleId) -> Rc<IndexMap<String, Item>> {
+    Rc::new(std_prelude_items())
+}
+
+pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> {
     let ast::Module { body } = &module.data(db).ast;
-    let ids = body
+
+    let items = body
         .iter()
         .filter_map(|stmt| match stmt {
-            ast::ModuleStmt::TypeAlias(node) => {
-                Some(TypeDefId::Alias(db.intern_type_alias(Rc::new(TypeAlias {
+            ast::ModuleStmt::TypeAlias(node) => Some(Item::Type(TypeDef::Alias(
+                db.intern_type_alias(Rc::new(TypeAlias {
                     ast: node.clone(),
                     module,
-                }))))
-            }
-            ast::ModuleStmt::Contract(node) => {
-                Some(TypeDefId::Contract(db.intern_contract(Rc::new(Contract {
+                })),
+            ))),
+            ast::ModuleStmt::Contract(node) => Some(Item::Type(TypeDef::Contract(
+                db.intern_contract(Rc::new(Contract {
                     name: node.name().to_string(),
                     ast: node.clone(),
                     module,
-                }))))
-            }
-            ast::ModuleStmt::Struct(node) => {
-                Some(TypeDefId::Struct(db.intern_struct(Rc::new(Struct {
+                })),
+            ))),
+            ast::ModuleStmt::Struct(node) => Some(Item::Type(TypeDef::Struct(db.intern_struct(
+                Rc::new(Struct {
                     ast: node.clone(),
                     module,
-                }))))
-            }
-            _ => None,
+                }),
+            )))),
+            ast::ModuleStmt::Constant(node) => Some(Item::Constant(db.intern_module_const(
+                Rc::new(ModuleConstant {
+                    ast: node.clone(),
+                    module,
+                }),
+            ))),
+            ast::ModuleStmt::Pragma(_) => None,
+            ast::ModuleStmt::Use(_) => todo!(),
         })
         .collect();
-    Rc::new(ids)
+    Rc::new(items)
 }
 
-pub fn module_type_def_map(
+pub fn module_item_map(
     db: &dyn AnalyzerDb,
     module: ModuleId,
-) -> Analysis<Rc<IndexMap<String, TypeDefId>>> {
+) -> Analysis<Rc<IndexMap<String, Item>>> {
     let mut diagnostics = vec![];
 
-    let mut map = IndexMap::<String, TypeDefId>::new();
-    for def in module.all_type_defs(db).iter() {
-        let def_name = def.name(db);
-        if let Some(reserved) = builtins::reserved_name(&def_name) {
+    let imports = db.module_imported_item_map(module);
+    let mut map = IndexMap::<String, Item>::new();
+
+    for item in module.all_items(db).iter() {
+        let item_name = item.name(db);
+        if let Some(builtin) = imports.get(&item_name) {
+            let builtin_kind = builtin.item_kind_display_name();
             diagnostics.push(errors::error(
-                &format!("type name conflicts with built-in {}", reserved.as_ref()),
-                def.name_span(db),
-                &format!("`{}` is a built-in {}", def_name, reserved.as_ref()),
+                &format!("type name conflicts with built-in {}", builtin_kind),
+                item.name_span(db).expect("duplicate built-in names?"),
+                &format!("`{}` is a built-in {}", item_name, builtin_kind),
             ));
             continue;
         }
 
-        match map.entry(def.name(db)) {
+        match map.entry(item_name) {
             Entry::Occupied(entry) => {
                 diagnostics.push(errors::fancy_error(
                     "duplicate type name",
                     vec![
                         Label::primary(
-                            entry.get().span(db),
+                            entry.get().name_span(db).unwrap(),
                             format!("`{}` first defined here", entry.key()),
                         ),
-                        Label::secondary(def.span(db), format!("`{}` redefined here", entry.key())),
+                        Label::secondary(
+                            item.name_span(db)
+                                .expect("built-in conflicts with user-defined name?"),
+                            format!("`{}` redefined here", entry.key()),
+                        ),
                     ],
                     vec![],
                 ));
             }
             Entry::Vacant(entry) => {
-                entry.insert(*def);
+                entry.insert(*item);
             }
         }
     }
@@ -87,36 +132,13 @@ pub fn module_type_def_map(
     }
 }
 
-pub fn module_resolve_type(
-    db: &dyn AnalyzerDb,
-    module: ModuleId,
-    name: String,
-) -> Option<Result<types::Type, errors::TypeError>> {
-    Some(module.type_defs(db).get(&name)?.typ(db))
-}
-
-#[allow(clippy::ptr_arg)]
-pub fn module_resolve_type_cycle(
-    _db: &dyn AnalyzerDb,
-    _cycle: &[String],
-    _module: &ModuleId,
-    _name: &String,
-) -> Option<Result<types::Type, errors::TypeError>> {
-    // The only possible type cycle currently is a recursive type alias,
-    // which is handled in queries/types.rs
-    // However, salsa will also call this function if there's such a cycle,
-    // so we can't panic here, and we can't return a TypeError because
-    // there's no way to emit a diagnostic! The only option is to return
-    // None, and handle type cycles in more specifc cycle handlers.
-    None
-}
-
 pub fn module_contracts(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<ContractId>> {
-    let defs = module.all_type_defs(db);
     Rc::new(
-        defs.iter()
-            .filter_map(|def| match def {
-                TypeDefId::Contract(id) => Some(*id),
+        module
+            .all_items(db)
+            .iter()
+            .filter_map(|item| match item {
+                Item::Type(TypeDef::Contract(id)) => Some(*id),
                 _ => None,
             })
             .collect(),
@@ -124,32 +146,16 @@ pub fn module_contracts(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Contrac
 }
 
 pub fn module_structs(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<StructId>> {
-    let defs = module.all_type_defs(db);
     Rc::new(
-        defs.iter()
-            .filter_map(|def| match def {
-                TypeDefId::Struct(id) => Some(*id),
+        module
+            .all_items(db)
+            .iter()
+            .filter_map(|item| match item {
+                Item::Type(TypeDef::Struct(id)) => Some(*id),
                 _ => None,
             })
             .collect(),
     )
-}
-
-pub fn module_constants(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<ModuleConstantId>> {
-    let ast::Module { body } = &module.data(db).ast;
-    let ids = body
-        .iter()
-        .filter_map(|stmt| match stmt {
-            ast::ModuleStmt::Constant(node) => {
-                Some(db.intern_module_const(Rc::new(ModuleConstant {
-                    ast: node.clone(),
-                    module,
-                })))
-            }
-            _ => None,
-        })
-        .collect();
-    Rc::new(ids)
 }
 
 pub fn module_constant_type(

--- a/crates/analyzer/src/errors.rs
+++ b/crates/analyzer/src/errors.rs
@@ -1,6 +1,6 @@
 //! Semantic errors.
 
-use crate::context::DiagnosticVoucher;
+use crate::context::{DiagnosticVoucher, NamedThing};
 use fe_common::diagnostics::{Diagnostic, Label, Severity};
 use fe_common::Span;
 use std::fmt::Display;
@@ -144,4 +144,46 @@ pub fn duplicate_name_error(
         ],
         vec![],
     )
+}
+
+pub fn name_conflict_error(
+    name_kind: &str, // Eg "function parameter" or "variable name"
+    name: &str,
+    original: &NamedThing,
+    original_span: Option<Span>,
+    duplicate_span: Span,
+) -> Diagnostic {
+    if let Some(original_span) = original_span {
+        fancy_error(
+            &format!(
+                "{} name `{}` conflicts with previously defined {}",
+                name_kind,
+                name,
+                original.item_kind_display_name()
+            ),
+            vec![
+                Label::primary(original_span, format!("`{}` first defined here", name)),
+                Label::secondary(duplicate_span, format!("`{}` redefined here", name)),
+            ],
+            vec![],
+        )
+    } else {
+        fancy_error(
+            &format!(
+                "{} name `{}` conflicts with built-in {}",
+                name_kind,
+                name,
+                original.item_kind_display_name()
+            ),
+            vec![Label::primary(
+                duplicate_span,
+                format!(
+                    "`{}` is a built-in {}",
+                    name,
+                    original.item_kind_display_name()
+                ),
+            )],
+            vec![],
+        )
+    }
 }

--- a/crates/analyzer/src/traversal/call_args.rs
+++ b/crates/analyzer/src/traversal/call_args.rs
@@ -57,7 +57,7 @@ pub fn validate_named_args(
     params: &[impl LabeledParameter],
     label_policy: LabelPolicy,
 ) -> Result<(), FatalError> {
-    validate_arg_count(scope, name, name_span, args, params.len());
+    validate_arg_count(scope, name, name_span, args, params.len(), "argument");
     validate_arg_labels(scope, args, params, label_policy);
     validate_arg_types(scope, name, args, params)?;
     Ok(())
@@ -69,6 +69,7 @@ pub fn validate_arg_count(
     name_span: Span,
     args: &Node<Vec<impl Spanned>>,
     param_count: usize,
+    argument_word: &str,
 ) -> Option<DiagnosticVoucher> {
     if args.kind.len() != param_count {
         let mut labels = vec![Label::primary(
@@ -76,7 +77,7 @@ pub fn validate_arg_count(
             format!(
                 "expects {} {}",
                 param_count,
-                pluralize_conditionally("argument", param_count)
+                pluralize_conditionally(argument_word, param_count)
             ),
         )];
         if args.kind.is_empty() {
@@ -88,7 +89,7 @@ pub fn validate_arg_count(
             labels.last_mut().unwrap().message = format!(
                 "supplied {} {}",
                 args.kind.len(),
-                pluralize_conditionally("argument", args.kind.len())
+                pluralize_conditionally(argument_word, args.kind.len())
             );
         }
 
@@ -97,7 +98,7 @@ pub fn validate_arg_count(
                 "`{}` expects {} {}, but {} {} provided",
                 name,
                 param_count,
-                pluralize_conditionally("argument", param_count),
+                pluralize_conditionally(argument_word, param_count),
                 args.kind.len(),
                 pluralize_conditionally(("was", "were"), args.kind.len())
             ),

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -1,131 +1,180 @@
-use crate::context::AnalyzerContext;
+use crate::context::{AnalyzerContext, NamedThing};
 use crate::errors::TypeError;
-use crate::namespace::types::{Array, Base, FeString, FixedSize, Map, Tuple, Type};
+use crate::namespace::items::Item;
+use crate::namespace::types::{
+    Array, FixedSize, GenericArg, GenericParamKind, GenericType, Tuple, Type,
+};
 use crate::traversal::call_args::validate_arg_count;
 use fe_common::diagnostics::Label;
-use fe_parser::ast as fe;
+use fe_common::utils::humanize::pluralize_conditionally;
+use fe_common::Spanned;
+use fe_parser::ast;
 use fe_parser::node::{Node, Span};
 use std::convert::TryFrom;
-use std::str::FromStr;
 use vec1::Vec1;
 
-pub fn resolve_type_name(
+pub fn apply_generic_type_args(
     context: &mut dyn AnalyzerContext,
-    name: &str,
+    generic: GenericType,
     name_span: Span,
-    generic_args: Option<&Node<Vec<fe::GenericArg>>>,
-) -> Option<Result<Type, TypeError>> {
-    match (name, generic_args) {
-        ("String", Some(args)) => match &args.kind[..] {
-            [fe::GenericArg::Int(len)] => Some(Ok(Type::String(FeString { max_size: len.kind }))),
-            _ => Some(Err(TypeError::new(context.fancy_error(
-                "invalid `String` type argument",
-                vec![Label::primary(args.span, "expected an integer")],
-                vec!["Example: String<100>".into()],
-            )))),
-        },
-        ("String", None) => Some(Err(TypeError::new(context.fancy_error(
-            "`String` type requires a max size argument",
-            vec![Label::primary(name_span, "")],
-            vec!["Example: String<100>".into()],
-        )))),
-        ("Map", Some(args)) => {
-            let diag_voucher = validate_arg_count(context, name, name_span, args, 2);
+    args: Option<&Node<Vec<ast::GenericArg>>>,
+) -> Result<Type, TypeError> {
+    let params = generic.params();
 
-            let key = match args.kind.get(0) {
-                Some(fe::GenericArg::TypeDesc(type_node)) => match type_desc(context, type_node) {
-                    Ok(Type::Base(base)) => base,
-                    Err(err) => return Some(Err(err)),
-                    _ => {
-                        return Some(Err(TypeError::new(context.error(
-                            "`Map` key must be a primitive type",
-                            type_node.span,
-                            "this can't be used as a Map key",
-                        ))));
-                    }
-                },
-                Some(fe::GenericArg::Int(node)) => {
-                    return Some(Err(TypeError::new(context.error(
-                        "`Map` key must be a type",
-                        node.span,
-                        "this should be a type name",
-                    ))));
-                }
-                None => return Some(Err(TypeError::new(diag_voucher.unwrap()))),
-            };
-            let value = match args.kind.get(1) {
-                Some(fe::GenericArg::TypeDesc(type_node)) => match type_desc(context, type_node) {
-                    Ok(typ) => typ,
-                    Err(err) => return Some(Err(err)),
-                },
-                Some(fe::GenericArg::Int(node)) => {
-                    return Some(Err(TypeError::new(context.error(
-                        "`Map` value must be a type",
-                        node.span,
-                        "this should be a type name",
-                    ))));
-                }
-                None => return Some(Err(TypeError::new(diag_voucher.unwrap()))),
-            };
-            Some(Ok(Type::Map(Map {
-                key,
-                value: Box::new(value),
-            })))
-        }
-        ("Map", None) => Some(Err(TypeError::new(context.fancy_error(
-            "`Map` type requires key and value type arguments",
-            vec![Label::primary(name_span, "")],
-            vec!["Example: Map<address, u256>".into()],
-        )))),
-        (_, _) => {
-            let typ = if let Ok(base_type) = Base::from_str(name) {
-                Type::Base(base_type)
-            } else {
-                match context.resolve_type(name) {
-                    Some(Ok(typ)) => typ,
-                    Some(Err(err)) => return Some(Err(err)),
-                    None => return None,
-                }
-            };
+    let args = args.ok_or_else(|| {
+        TypeError::new(context.fancy_error(
+            &format!(
+                "missing generic {} for type `{}`",
+                pluralize_conditionally("argument", params.len()),
+                generic.name()
+            ),
+            vec![Label::primary(
+                name_span,
+                &format!(
+                    "expected {} generic {}",
+                    params.len(),
+                    pluralize_conditionally("argument", params.len())
+                ),
+            )],
+            vec![friendly_generic_arg_example_string(generic)],
+        ))
+    })?;
 
-            if let Some(args) = generic_args {
-                // User-defined types can't be generic yet
-                context.fancy_error(
-                    &format!("`{}` type is not generic", typ),
-                    vec![Label::primary(args.span, "unexpected type argument list")],
-                    vec![format!("Hint: use `{}`", typ)],
-                );
-            }
-            Some(Ok(typ))
-        }
+    if let Some(diag) = validate_arg_count(
+        context,
+        generic.name(),
+        name_span,
+        args,
+        params.len(),
+        "generic argument",
+    ) {
+        return Err(TypeError::new(diag));
     }
+
+    let concrete_args = params
+        .iter()
+        .zip(args.kind.iter())
+        .map(|(param, arg)| match (param.kind, arg) {
+            (GenericParamKind::Int, ast::GenericArg::Int(int_node)) => {
+                Ok(GenericArg::Int(int_node.kind))
+            }
+            (GenericParamKind::Int, ast::GenericArg::TypeDesc(_)) => {
+                Err(TypeError::new(context.fancy_error(
+                    &format!("`{}` {} must be an integer", generic.name(), param.name),
+                    vec![Label::primary(arg.span(), "expected an integer")],
+                    vec![],
+                )))
+            }
+            (GenericParamKind::PrimitiveType, ast::GenericArg::TypeDesc(type_node)) => {
+                match type_desc(context, type_node)? {
+                    Type::Base(base) => Ok(GenericArg::Type(Type::Base(base))),
+                    typ => Err(TypeError::new(context.error(
+                        &format!(
+                            "`{}` {} must be a primitive type",
+                            generic.name(),
+                            param.name
+                        ),
+                        type_node.span,
+                        &format!("this has type `{}`; expected a primitive type", typ),
+                    ))),
+                }
+            }
+            (GenericParamKind::AnyType, ast::GenericArg::TypeDesc(type_node)) => {
+                Ok(GenericArg::Type(type_desc(context, type_node)?))
+            }
+            (
+                GenericParamKind::PrimitiveType | GenericParamKind::AnyType,
+                ast::GenericArg::Int(_),
+            ) => Err(TypeError::new(context.fancy_error(
+                &format!("`{}` {} must be a type", generic.name(), param.name),
+                vec![Label::primary(arg.span(), "expected a type name")],
+                vec![],
+            ))),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(generic
+        .apply(&concrete_args)
+        .expect("failed to construct generic type after checking args"))
 }
 
-fn resolve_type_name_or_err(
+fn friendly_generic_arg_example_string(generic: GenericType) -> String {
+    let example_args = generic
+        .params()
+        .iter()
+        .map(|param| match param.kind {
+            GenericParamKind::Int => "32",
+            GenericParamKind::PrimitiveType => "u64",
+            GenericParamKind::AnyType => "String<32>",
+        })
+        .collect::<Vec<&'static str>>();
+
+    format!("Example: `{}<{}>`", generic.name(), example_args.join(", "))
+}
+
+pub fn resolve_concrete_type(
     context: &mut dyn AnalyzerContext,
     name: &str,
     name_span: Span,
-    generic_args: Option<&Node<Vec<fe::GenericArg>>>,
+    generic_args: Option<&Node<Vec<ast::GenericArg>>>,
 ) -> Result<Type, TypeError> {
-    if let Some(typ) = resolve_type_name(context, name, name_span, generic_args) {
-        typ
-    } else {
-        Err(TypeError::new(context.error(
+    let named_item = context.resolve_name(name).ok_or_else(|| {
+        TypeError::new(context.error(
             "undefined type",
             name_span,
-            "this type name has not been defined",
-        )))
+            &format!("`{}` has not been defined", name),
+        ))
+    })?;
+
+    match named_item {
+        NamedThing::Item(Item::Type(id)) => {
+            if let Some(args) = generic_args {
+                context.fancy_error(
+                    &format!("`{}` type is not generic", name),
+                    vec![Label::primary(
+                        args.span,
+                        "unexpected generic argument list",
+                    )],
+                    vec![],
+                );
+            }
+            id.typ(context.db())
+        }
+        NamedThing::Item(Item::GenericType(generic)) => {
+            apply_generic_type_args(context, generic, name_span, generic_args)
+        }
+        _ => Err(TypeError::new(context.fancy_error(
+            &format!("`{}` is not a type name", name),
+            if let Some(def_span) = named_item.name_span(context.db()) {
+                vec![
+                    Label::primary(
+                        def_span,
+                        format!(
+                            "`{}` is defined here as a {}",
+                            name,
+                            named_item.item_kind_display_name()
+                        ),
+                    ),
+                    Label::primary(name_span, format!("`{}` is used here as a type", name)),
+                ]
+            } else {
+                vec![Label::primary(
+                    name_span,
+                    format!("`{}` is a {}", name, named_item.item_kind_display_name()),
+                )]
+            },
+            vec![],
+        ))),
     }
 }
 
 /// Maps a type description node to an enum type.
 pub fn type_desc(
     context: &mut dyn AnalyzerContext,
-    desc: &Node<fe::TypeDesc>,
+    desc: &Node<ast::TypeDesc>,
 ) -> Result<Type, TypeError> {
     match &desc.kind {
-        fe::TypeDesc::Base { base } => resolve_type_name_or_err(context, base, desc.span, None),
-        fe::TypeDesc::Array { typ, dimension } => {
+        ast::TypeDesc::Base { base } => resolve_concrete_type(context, base, desc.span, None),
+        ast::TypeDesc::Array { typ, dimension } => {
             if let Type::Base(base) = type_desc(context, typ)? {
                 Ok(Type::Array(Array {
                     inner: base,
@@ -139,10 +188,10 @@ pub fn type_desc(
                 )))
             }
         }
-        fe::TypeDesc::Generic { base, args } => {
-            resolve_type_name_or_err(context, &base.kind, base.span, Some(args))
+        ast::TypeDesc::Generic { base, args } => {
+            resolve_concrete_type(context, &base.kind, base.span, Some(args))
         }
-        fe::TypeDesc::Tuple { items } => {
+        ast::TypeDesc::Tuple { items } => {
             let types = items
                 .iter()
                 .map(|typ| match FixedSize::try_from(type_desc(context, typ)?) {
@@ -158,6 +207,6 @@ pub fn type_desc(
                 items: Vec1::try_from_vec(types).expect("tuple is empty"),
             }))
         }
-        fe::TypeDesc::Unit => Ok(Type::unit()),
+        ast::TypeDesc::Unit => Ok(Type::unit()),
     }
 }

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -1,5 +1,5 @@
 use fe_analyzer::context;
-use fe_analyzer::namespace::items;
+use fe_analyzer::namespace::items::{self, Item, TypeDef};
 use fe_analyzer::namespace::types::{Event, FixedSize, FunctionSignature, Type};
 use fe_analyzer::{AnalyzerDb, Db};
 use fe_common::diagnostics::{diagnostics_string, print_diagnostics, Diagnostic, Label, Severity};
@@ -165,10 +165,10 @@ fn build_snapshot(path: &str, src: &str, module: items::ModuleId, db: &dyn Analy
 
     // contract and struct types aren't worth printing
     let type_aliases = module
-        .all_type_defs(db)
+        .all_items(db)
         .iter()
         .filter_map(|def| match def {
-            items::TypeDefId::Alias(alias) => {
+            Item::Type(TypeDef::Alias(alias)) => {
                 Some((alias.data(db).ast.span, alias.typ(db).unwrap()))
             }
             _ => None,

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -95,6 +95,8 @@ test_stmt! { clone_arg_count, "let x: u256[2] = [5, 6]\nlet y: u256[2] = x.clone
 test_stmt! { continue_without_loop, "continue" }
 test_stmt! { continue_without_loop_2, "if true:\n  continue" }
 test_stmt! { emit_undefined_event, "emit MyEvent()" }
+test_stmt! { emit_type_name, "emit u8()" }
+test_stmt! { emit_variable, "let x: u8 = 10\nemit x()" }
 test_stmt! { int_type_generic_arg_list, "let x: u256<>" }
 test_stmt! { int_type_generic_arg, "let x: u256<10>" }
 test_stmt! { int_type_constructor_generic_arg_list, "u256<>(10)" }
@@ -222,6 +224,7 @@ test_file! { missing_return_after_if }
 test_file! { module_const_unknown_type }
 test_file! { module_const_non_base_type }
 test_file! { module_const_not_literal }
+test_file! { module_const_call }
 test_file! { needs_mem_copy }
 test_file! { not_callable }
 test_file! { not_in_scope }

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -1128,11 +1128,13 @@ note:
    ┌─ stress/data_copying_stress.fe:69:9
    │
 69 │         emit_my_event_internal(
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15175926995091823840
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1445082349245844857
    │
-   = Pure {
-         func_name: "emit_my_event_internal",
-     }
+   = Pure(
+         FunctionId(
+             8,
+         ),
+     )
 
 note: 
    ┌─ stress/data_copying_stress.fe:70:13

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -2087,11 +2087,13 @@ note:
    ┌─ demos/erc20_token.fe:68:9
    │
 68 │         _before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 283404834886046277
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
    │
-   = Pure {
-         func_name: "_before_token_transfer",
-     }
+   = Pure(
+         FunctionId(
+             17,
+         ),
+     )
 
 note: 
    ┌─ demos/erc20_token.fe:74:27
@@ -2109,11 +2111,13 @@ note:
    ┌─ demos/erc20_token.fe:75:9
    │
 75 │         _before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 283404834886046277
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
    │
-   = Pure {
-         func_name: "_before_token_transfer",
-     }
+   = Pure(
+         FunctionId(
+             17,
+         ),
+     )
 
 note: 
    ┌─ demos/erc20_token.fe:75:32
@@ -2155,11 +2159,13 @@ note:
    ┌─ demos/erc20_token.fe:82:9
    │
 82 │         _before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 283404834886046277
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
    │
-   = Pure {
-         func_name: "_before_token_transfer",
-     }
+   = Pure(
+         FunctionId(
+             17,
+         ),
+     )
 
 note: 
    ┌─ demos/erc20_token.fe:82:41

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -142,30 +142,30 @@ note:
   ┌─ features/keccak.fe:4:16
   │
 4 │         return keccak256(val)
-  │                ^^^^^^^^^ attributes hash: 11888120106960716956
+  │                ^^^^^^^^^ attributes hash: 3985281278010092305
   │
-  = BuiltinFunction {
-        func: Keccak256,
-    }
+  = BuiltinFunction(
+        Keccak256,
+    )
 
 note: 
   ┌─ features/keccak.fe:7:16
   │
 7 │         return keccak256(val)
-  │                ^^^^^^^^^ attributes hash: 11888120106960716956
+  │                ^^^^^^^^^ attributes hash: 3985281278010092305
   │
-  = BuiltinFunction {
-        func: Keccak256,
-    }
+  = BuiltinFunction(
+        Keccak256,
+    )
 
 note: 
    ┌─ features/keccak.fe:10:16
    │
 10 │         return keccak256(val)
-   │                ^^^^^^^^^ attributes hash: 11888120106960716956
+   │                ^^^^^^^^^ attributes hash: 3985281278010092305
    │
-   = BuiltinFunction {
-         func: Keccak256,
-     }
+   = BuiltinFunction(
+         Keccak256,
+     )
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
@@ -57,10 +57,12 @@ note:
   ┌─ features/return_u256_from_called_fn.fe:5:16
   │
 5 │         return foo()
-  │                ^^^ attributes hash: 1664590513608378371
+  │                ^^^ attributes hash: 6696068954755293271
   │
-  = Pure {
-        func_name: "foo",
-    }
+  = Pure(
+        FunctionId(
+            1,
+        ),
+    )
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
@@ -266,20 +266,24 @@ note:
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                ^^^ attributes hash: 1664590513608378371
+   │                ^^^ attributes hash: 6251600114237252411
    │
-   = Pure {
-         func_name: "foo",
-     }
+   = Pure(
+         FunctionId(
+             0,
+         ),
+     )
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:26
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                          ^^^ attributes hash: 3933618496970144567
+   │                          ^^^ attributes hash: 6696068954755293271
    │
-   = Pure {
-         func_name: "cem",
-     }
+   = Pure(
+         FunctionId(
+             1,
+         ),
+     )
 
 

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -1464,11 +1464,11 @@ note:
    ┌─ features/structs.fe:83:16
    │
 83 │         return keccak256(house.abi_encode())
-   │                ^^^^^^^^^ attributes hash: 11888120106960716956
+   │                ^^^^^^^^^ attributes hash: 3985281278010092305
    │
-   = BuiltinFunction {
-         func: Keccak256,
-     }
+   = BuiltinFunction(
+         Keccak256,
+     )
 
 note: 
    ┌─ features/structs.fe:83:26

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -825,11 +825,13 @@ note:
    ┌─ stress/tuple_stress.fe:43:9
    │
 43 │         emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^ attributes hash: 4428583522641384060
+   │         ^^^^^^^^^^^^^ attributes hash: 12310327282992125219
    │
-   = Pure {
-         func_name: "emit_my_event",
-     }
+   = Pure(
+         FunctionId(
+             5,
+         ),
+     )
 
 note: 
    ┌─ stress/tuple_stress.fe:46:16

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -5879,21 +5879,25 @@ note:
     ┌─ demos/uniswap.fe:144:36
     │
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                    ^^^^ attributes hash: 11539501539171308117
+    │                                    ^^^^ attributes hash: 3607074860458368047
     │
-    = Pure {
-          func_name: "sqrt",
-      }
+    = Pure(
+          FunctionId(
+              23,
+          ),
+      )
 
 note: 
     ┌─ demos/uniswap.fe:145:41
     │
 145 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                         ^^^^ attributes hash: 11539501539171308117
+    │                                         ^^^^ attributes hash: 3607074860458368047
     │
-    = Pure {
-          func_name: "sqrt",
-      }
+    = Pure(
+          FunctionId(
+              23,
+          ),
+      )
 
 note: 
     ┌─ demos/uniswap.fe:151:25
@@ -5977,11 +5981,13 @@ note:
     ┌─ demos/uniswap.fe:171:25
     │
 171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^ attributes hash: 11539501539171308117
+    │                         ^^^^ attributes hash: 3607074860458368047
     │
-    = Pure {
-          func_name: "sqrt",
-      }
+    = Pure(
+          FunctionId(
+              23,
+          ),
+      )
 
 note: 
     ┌─ demos/uniswap.fe:172:13
@@ -6013,11 +6019,13 @@ note:
     ┌─ demos/uniswap.fe:174:25
     │
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^ attributes hash: 2385741873862807477
+    │                         ^^^ attributes hash: 1164657736943769014
     │
-    = Pure {
-          func_name: "min",
-      }
+    = Pure(
+          FunctionId(
+              24,
+          ),
+      )
 
 note: 
     ┌─ demos/uniswap.fe:178:9
@@ -6433,11 +6441,11 @@ note:
     ┌─ demos/uniswap.fe:319:26
     │
 319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                          ^^^^^^^^^ attributes hash: 11888120106960716956
+    │                          ^^^^^^^^^ attributes hash: 3985281278010092305
     │
-    = BuiltinFunction {
-          func: Keccak256,
-      }
+    = BuiltinFunction(
+          Keccak256,
+      )
 
 note: 
     ┌─ demos/uniswap.fe:319:36

--- a/crates/analyzer/tests/snapshots/errors__abi_encode_u256.snap
+++ b/crates/analyzer/tests/snapshots/errors__abi_encode_u256.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: value of type u256 does not support `abi_encode()`
+error: value of type `u256` does not support `abi_encode()`
   ┌─ compile_errors/abi_encode_u256.fe:3:9
   │
 3 │         42.abi_encode()

--- a/crates/analyzer/tests/snapshots/errors__array_constructor_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__array_constructor_call.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: cannot find value `u8` in this scope
+error: `u8` is a built-in type name, and can't be used as an expression
   ┌─ [snippet]:3:3
   │
 3 │   u8[3]([1, 2, 3])
-  │   ^^ undefined
+  │   ^^ `u8` is used here as a value
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_to_mut_fn_without_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_to_mut_fn_without_self.snap
@@ -3,12 +3,15 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: `baz` must be called using `self`
+error: `baz` must be called via `self`
   ┌─ compile_errors/call_to_mut_fn_without_self.fe:3:9
   │
 3 │         baz()
-  │         ^^^ function takes self
+  │         ^^^ `baz` is called here as a standalone function
+4 │ 
+5 │     fn baz(self):
+  │        ^^^ `baz` is defined here as a function that takes `self`
   │
-  = Suggestion: try `self.baz(...)` instead of `baz(...)`
+  = Suggestion: use `self.baz(...)` instead of `baz(...)`
 
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_contract_in_module.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_contract_in_module.snap
@@ -4,18 +4,12 @@ expression: "error_string(&path, &src)"
 
 ---
 error: duplicate type name
-  ┌─ compile_errors/duplicate_contract_in_module.fe:1:1
-  │    
-1 │ ╭   contract Foo:
-2 │ │   
-3 │ │       pub fn bar():
-4 │ │           pass
-  │ ╰──────────────^ `Foo` first defined here
-5 │     
-6 │   ╭ contract Foo:
-7 │   │ 
-8 │   │     pub fn bar():
-9 │   │         pass
-  │   ╰────────────' `Foo` redefined here
+  ┌─ compile_errors/duplicate_contract_in_module.fe:1:10
+  │
+1 │ contract Foo:
+  │          ^^^ `Foo` first defined here
+  ·
+6 │ contract Foo:
+  │          --- `Foo` redefined here
 
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_struct_in_module.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_struct_in_module.snap
@@ -4,14 +4,12 @@ expression: "error_string(&path, &src)"
 
 ---
 error: duplicate type name
-  ┌─ compile_errors/duplicate_struct_in_module.fe:1:1
-  │    
-1 │ ╭   struct MyStruct:
-2 │ │       foo: u8
-  │ ╰─────────────^ `MyStruct` first defined here
-3 │     
-4 │   ╭ struct MyStruct:
-5 │   │     foo: u8
-  │   ╰───────────' `MyStruct` redefined here
+  ┌─ compile_errors/duplicate_struct_in_module.fe:1:8
+  │
+1 │ struct MyStruct:
+  │        ^^^^^^^^ `MyStruct` first defined here
+  ·
+4 │ struct MyStruct:
+  │        -------- `MyStruct` redefined here
 
 

--- a/crates/analyzer/tests/snapshots/errors__duplicate_typedef_in_module.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_typedef_in_module.snap
@@ -4,12 +4,21 @@ expression: "error_string(&path, &src)"
 
 ---
 error: duplicate type name
-  ┌─ compile_errors/duplicate_typedef_in_module.fe:2:1
+  ┌─ compile_errors/duplicate_typedef_in_module.fe:2:6
   │
 2 │ type bar = u8
-  │ ^^^^^^^^^^^^^ `bar` first defined here
+  │      ^^^ `bar` first defined here
 3 │ 
 4 │ type bar = u8
-  │ ------------- `bar` redefined here
+  │      --- `bar` redefined here
+
+error: function name `bar` conflicts with previously defined type
+  ┌─ compile_errors/duplicate_typedef_in_module.fe:2:6
+  │
+2 │ type bar = u8
+  │      ^^^ `bar` first defined here
+  ·
+8 │     pub fn bar():
+  │            --- `bar` redefined here
 
 

--- a/crates/analyzer/tests/snapshots/errors__emit_type_name.snap
+++ b/crates/analyzer/tests/snapshots/errors__emit_type_name.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `emit` expects an event
+  ┌─ [snippet]:3:8
+  │
+3 │   emit u8()
+  │        ^^ `u8` is a type name; expected an event
+
+

--- a/crates/analyzer/tests/snapshots/errors__emit_variable.snap
+++ b/crates/analyzer/tests/snapshots/errors__emit_variable.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: `emit` expects an event
+  ┌─ [snippet]:4:8
+  │
+4 │   emit x()
+  │        ^ `x` is a variable name; expected an event
+
+

--- a/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg.snap
@@ -7,8 +7,6 @@ error: `u256` type is not generic
   ┌─ [snippet]:3:7
   │
 3 │   u256<1>(10)
-  │       ^^^ unexpected type argument list
-  │
-  = Hint: use `u256`
+  │       ^^^ unexpected generic argument list
 
 

--- a/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_constructor_generic_arg_list.snap
@@ -7,8 +7,6 @@ error: `u256` type is not generic
   ┌─ [snippet]:3:7
   │
 3 │   u256<>(10)
-  │       ^^ unexpected type argument list
-  │
-  = Hint: use `u256`
+  │       ^^ unexpected generic argument list
 
 

--- a/crates/analyzer/tests/snapshots/errors__int_type_generic_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_generic_arg.snap
@@ -7,8 +7,6 @@ error: `u256` type is not generic
   ┌─ [snippet]:3:14
   │
 3 │   let x: u256<10>
-  │              ^^^^ unexpected type argument list
-  │
-  = Hint: use `u256`
+  │              ^^^^ unexpected generic argument list
 
 

--- a/crates/analyzer/tests/snapshots/errors__int_type_generic_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__int_type_generic_arg_list.snap
@@ -7,8 +7,6 @@ error: `u256` type is not generic
   ┌─ [snippet]:3:14
   │
 3 │   let x: u256<>
-  │              ^^ unexpected type argument list
-  │
-  = Hint: use `u256`
+  │              ^^ unexpected generic argument list
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_int_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_int_type_arg.snap
@@ -7,6 +7,6 @@ error: `Map` value must be a type
   ┌─ [snippet]:3:23
   │
 3 │   let x: Map<address, 100>
-  │                       ^^^ this should be a type name
+  │                       ^^^ expected a type name
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_int_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_int_type_args.snap
@@ -7,6 +7,6 @@ error: `Map` key must be a type
   ┌─ [snippet]:3:14
   │
 3 │   let x: Map<10, 20>
-  │              ^^ this should be a type name
+  │              ^^ expected a type name
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_map_key_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_map_key_type.snap
@@ -7,6 +7,6 @@ error: `Map` key must be a primitive type
   ┌─ [snippet]:3:14
   │
 3 │   let x: Map<Map<u8, u8>, address>
-  │              ^^^^^^^^^^^ this can't be used as a Map key
+  │              ^^^^^^^^^^^ this has type `Map<u8, u8>`; expected a primitive type
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_no_type_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_no_type_arg_list.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `Map` type requires key and value type arguments
+error: missing generic arguments for type `Map`
   ┌─ [snippet]:3:10
   │
 3 │   let x: Map
-  │          ^^^
+  │          ^^^ expected 2 generic arguments
   │
-  = Example: Map<address, u256>
+  = Example: `Map<u64, String<32>>`
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_no_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_no_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `Map` expects 2 arguments, but 0 were provided
+error: `Map` expects 2 generic arguments, but 0 were provided
   ┌─ [snippet]:3:10
   │
 3 │   let x: Map<>
   │          ^^^-- supplied 0 arguments
   │          │   
-  │          expects 2 arguments
+  │          expects 2 generic arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_one_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_one_type_arg.snap
@@ -3,18 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `Map` expects 2 arguments, but 1 was provided
+error: `Map` expects 2 generic arguments, but 1 was provided
   ┌─ [snippet]:3:10
   │
 3 │   let x: Map<y>
-  │          ^^^ - supplied 1 argument
+  │          ^^^ - supplied 1 generic argument
   │          │    
-  │          expects 2 arguments
-
-error: undefined type
-  ┌─ [snippet]:3:14
-  │
-3 │   let x: Map<y>
-  │              ^ this type name has not been defined
+  │          expects 2 generic arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__map_three_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_three_type_args.snap
@@ -3,18 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `Map` expects 2 arguments, but 3 were provided
+error: `Map` expects 2 generic arguments, but 3 were provided
   ┌─ [snippet]:3:10
   │
 3 │   let x: Map<u8, u8, u8>
-  │          ^^^ --  --  -- supplied 3 arguments
+  │          ^^^ --  --  -- supplied 3 generic arguments
   │          │            
-  │          expects 2 arguments
-
-error: invalid variable type
-  ┌─ [snippet]:3:10
-  │
-3 │   let x: Map<u8, u8, u8>
-  │          ^^^^^^^^^^^^^^^ `Map` type can only be used as a contract field
+  │          expects 2 generic arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__module_const_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__module_const_call.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `FOO` is not callable
+  ┌─ compile_errors/module_const_call.fe:5:5
+  │
+5 │     FOO()
+  │     ^^^ `FOO` is a constant of type `u8`, and can't be used as a function
+
+

--- a/crates/analyzer/tests/snapshots/errors__module_const_unknown_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__module_const_unknown_type.snap
@@ -7,6 +7,6 @@ error: undefined type
   ┌─ compile_errors/module_const_unknown_type.fe:1:12
   │
 1 │ const FOO: Bar = 1
-  │            ^^^ this type name has not been defined
+  │            ^^^ `Bar` has not been defined
 
 

--- a/crates/analyzer/tests/snapshots/errors__not_callable.snap
+++ b/crates/analyzer/tests/snapshots/errors__not_callable.snap
@@ -4,9 +4,29 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `u256` type is not callable
-  ┌─ compile_errors/not_callable.fe:4:9
+  ┌─ compile_errors/not_callable.fe:7:5
   │
-4 │         5()
-  │         ^ this has type `u256`
+7 │     5()
+  │     ^ this has type `u256`
+
+error: `MyEvent` is not callable
+   ┌─ compile_errors/not_callable.fe:10:5
+   │
+10 │     MyEvent(x=10)
+   │     ^^^^^^^ `MyEvent` is an event, and can't be constructed in this context
+   │
+   = Hint: to emit an event, use `emit MyEvent(..)`
+
+error: `block` is not callable
+   ┌─ compile_errors/not_callable.fe:13:5
+   │
+13 │     block()
+   │     ^^^^^ `block` is a built-in object, and can't be used as a function
+
+error: `self` is not callable
+   ┌─ compile_errors/not_callable.fe:16:5
+   │
+16 │     self()
+   │     ^^^^ `self` is a built-in object, and can't be used as a function
 
 

--- a/crates/analyzer/tests/snapshots/errors__return_type_undefined.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_type_undefined.snap
@@ -7,6 +7,6 @@ error: undefined type
   ┌─ compile_errors/return_type_undefined.fe:2:17
   │
 2 │   pub fn f() -> Foo:
-  │                 ^^^ this type name has not been defined
+  │                 ^^^ `Foo` has not been defined
 
 

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_function.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_function.snap
@@ -3,25 +3,25 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: function name conflicts with built-in function
+error: function name `keccak256` conflicts with built-in function
   ┌─ compile_errors/shadow_builtin_function.fe:2:10
   │
 2 │   pub fn keccak256(bytes: u8[4]) -> u8[4]:
   │          ^^^^^^^^^ `keccak256` is a built-in function
 
-error: function name conflicts with built-in type
+error: function name `u256` conflicts with built-in type
   ┌─ compile_errors/shadow_builtin_function.fe:5:10
   │
 5 │   pub fn u256(x: u8) -> u256:
   │          ^^^^ `u256` is a built-in type
 
-error: function name conflicts with built-in type
+error: function name `bool` conflicts with built-in type
   ┌─ compile_errors/shadow_builtin_function.fe:8:10
   │
 8 │   pub fn bool(x: u8) -> bool:
   │          ^^^^ `bool` is a built-in type
 
-error: function name conflicts with built-in object
+error: function name `self` conflicts with built-in object
    ┌─ compile_errors/shadow_builtin_function.fe:11:10
    │
 11 │   pub fn self() -> bool:

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_type.snap
@@ -57,4 +57,16 @@ error: type name conflicts with built-in object
 10 │ type self = u8
    │      ^^^^ `self` is a built-in object
 
+error: function parameter name `u8` conflicts with built-in type
+   ┌─ compile_errors/shadow_builtin_type.fe:13:8
+   │
+13 │   fn f(u8: u256):
+   │        ^^ `u8` is a built-in type
+
+error: function parameter name `keccak256` conflicts with built-in function
+   ┌─ compile_errors/shadow_builtin_type.fe:16:8
+   │
+16 │   fn g(keccak256: u8):
+   │        ^^^^^^^^^ `keccak256` is a built-in function
+
 

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_arg_list.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `String` type requires a max size argument
+error: missing generic argument for type `String`
   ┌─ [snippet]:3:3
   │
 3 │   String()
-  │   ^^^^^^
+  │   ^^^^^^ expected 1 generic argument
   │
-  = Example: String<100>
+  = Example: `String<32>`
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_no_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:9
+error: `String` expects 1 generic argument, but 0 were provided
+  ┌─ [snippet]:3:3
   │
 3 │   String<>()
-  │         ^^ expected an integer
-  │
-  = Example: String<100>
+  │   ^^^^^^-- supplied 0 arguments
+  │   │      
+  │   expects 1 generic argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_non_int_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_non_int_type_arg.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:9
+error: `String` max size must be an integer
+  ┌─ [snippet]:3:10
   │
 3 │   String<foo>()
-  │         ^^^^^ expected an integer
-  │
-  = Example: String<100>
+  │          ^^^ expected an integer
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_two_int_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_two_int_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:9
+error: `String` expects 1 generic argument, but 2 were provided
+  ┌─ [snippet]:3:3
   │
 3 │   String<1, 2>()
-  │         ^^^^^^ expected an integer
-  │
-  = Example: String<100>
+  │   ^^^^^^ -  - supplied 2 generic arguments
+  │   │          
+  │   expects 1 generic argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_constructor_two_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_constructor_two_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:9
+error: `String` expects 1 generic argument, but 2 were provided
+  ┌─ [snippet]:3:3
   │
 3 │   String<1, u8>()
-  │         ^^^^^^^ expected an integer
-  │
-  = Example: String<100>
+  │   ^^^^^^ -  -- supplied 2 generic arguments
+  │   │          
+  │   expects 1 generic argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_no_type_arg_list.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_no_type_arg_list.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `String` type requires a max size argument
+error: missing generic argument for type `String`
   ┌─ [snippet]:3:10
   │
 3 │   let x: String
-  │          ^^^^^^
+  │          ^^^^^^ expected 1 generic argument
   │
-  = Example: String<100>
+  = Example: `String<32>`
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_no_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_no_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:16
+error: `String` expects 1 generic argument, but 0 were provided
+  ┌─ [snippet]:3:10
   │
 3 │   let x: String<>
-  │                ^^ expected an integer
-  │
-  = Example: String<100>
+  │          ^^^^^^-- supplied 0 arguments
+  │          │      
+  │          expects 1 generic argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_non_int_type_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_non_int_type_arg.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:16
+error: `String` max size must be an integer
+  ┌─ [snippet]:3:17
   │
 3 │   let x: String<u8>
-  │                ^^^^ expected an integer
-  │
-  = Example: String<100>
+  │                 ^^ expected an integer
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_two_int_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_two_int_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:16
+error: `String` expects 1 generic argument, but 2 were provided
+  ┌─ [snippet]:3:10
   │
 3 │   let x: String<1, 2>
-  │                ^^^^^^ expected an integer
-  │
-  = Example: String<100>
+  │          ^^^^^^ -  - supplied 2 generic arguments
+  │          │          
+  │          expects 1 generic argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__string_two_type_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__string_two_type_args.snap
@@ -3,12 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: invalid `String` type argument
-  ┌─ [snippet]:3:16
+error: `String` expects 1 generic argument, but 2 were provided
+  ┌─ [snippet]:3:10
   │
 3 │   let x: String<1, u8>
-  │                ^^^^^^^ expected an integer
-  │
-  = Example: String<100>
+  │          ^^^^^^ -  -- supplied 2 generic arguments
+  │          │          
+  │          expects 1 generic argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__undefined_generic_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_generic_type.snap
@@ -7,6 +7,6 @@ error: undefined type
   ┌─ [snippet]:3:10
   │
 3 │   let x: foobar<u256> = 10
-  │          ^^^^^^ this type name has not been defined
+  │          ^^^^^^ `foobar` has not been defined
 
 

--- a/crates/analyzer/tests/snapshots/errors__undefined_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_type.snap
@@ -7,6 +7,6 @@ error: undefined type
   ┌─ [snippet]:3:10
   │
 3 │   let x: foobar = 10
-  │          ^^^^^^ this type name has not been defined
+  │          ^^^^^^ `foobar` has not been defined
 
 

--- a/crates/analyzer/tests/snapshots/errors__undefined_type_param.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_type_param.snap
@@ -7,12 +7,12 @@ error: undefined type
   ┌─ compile_errors/undefined_type_param.fe:4:8
   │
 4 │     x: MysteryType
-  │        ^^^^^^^^^^^ this type name has not been defined
+  │        ^^^^^^^^^^^ `MysteryType` has not been defined
 
 error: undefined type
   ┌─ compile_errors/undefined_type_param.fe:8:19
   │
 8 │     pub fn a(val: DoesntExist):
-  │                   ^^^^^^^^^^^ this type name has not been defined
+  │                   ^^^^^^^^^^^ `DoesntExist` has not been defined
 
 

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -82,6 +82,7 @@ pub struct Struct {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub enum TypeDesc {
     Unit,
+    // TODO: change `Base { base: String }` to `Name(String)`
     Base {
         base: String,
     },
@@ -353,6 +354,13 @@ impl Node<FunctionArg> {
         match &self.kind {
             FunctionArg::Regular(arg) => &arg.name.kind,
             FunctionArg::Zelf => "self",
+        }
+    }
+
+    pub fn name_span(&self) -> Span {
+        match &self.kind {
+            FunctionArg::Regular(arg) => arg.name.span,
+            FunctionArg::Zelf => self.span,
         }
     }
 }

--- a/crates/test-files/fixtures/compile_errors/module_const_call.fe
+++ b/crates/test-files/fixtures/compile_errors/module_const_call.fe
@@ -1,0 +1,5 @@
+const FOO: u8 = 1
+
+contract C:
+  fn f():
+    FOO()

--- a/crates/test-files/fixtures/compile_errors/not_callable.fe
+++ b/crates/test-files/fixtures/compile_errors/not_callable.fe
@@ -1,4 +1,16 @@
-contract Foo:
 
-    pub fn bar():
-        5()
+contract Foo:
+  event MyEvent:
+    x: u8
+
+  fn call_int():
+    5()
+
+  fn call_event():
+    MyEvent(x=10)
+
+  fn call_block():
+    block()
+
+  fn call_self(self):
+    self()

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
@@ -8,3 +8,10 @@ type block = u8
 type msg = u8
 type chain = u8
 type self = u8
+
+contract C:
+  fn f(u8: u256):
+    pass
+
+  fn g(keccak256: u8):
+    pass

--- a/crates/yulgen/src/names/mod.rs
+++ b/crates/yulgen/src/names/mod.rs
@@ -7,14 +7,13 @@ pub mod abi;
 
 /// Generate a function name to perform checked addition
 pub fn checked_add(size: &Integer) -> yul::Identifier {
-    let size: &str = size.into();
-    identifier! {(format!("checked_add_{}", size.to_lowercase()))}
+    identifier! {(format!("checked_add_{}", size.as_ref().to_lowercase()))}
 }
 
 /// Generate a function name to perform checked division
 pub fn checked_div(size: &Integer) -> yul::Identifier {
     let size: &str = if size.is_signed() {
-        size.into()
+        size.as_ref()
     } else {
         "unsigned"
     };
@@ -33,20 +32,18 @@ pub fn checked_mod(size: &Integer) -> yul::Identifier {
 
 /// Generate a function name to perform checked exponentiation
 pub fn checked_exp(size: &Integer) -> yul::Identifier {
-    let size: &str = size.into();
-    identifier! {(format!("checked_exp_{}", size.to_lowercase()))}
+    identifier! {(format!("checked_exp_{}", size.as_ref().to_lowercase()))}
 }
 
 /// Generate a function name to perform checked multiplication
 pub fn checked_mul(size: &Integer) -> yul::Identifier {
-    let size: &str = size.into();
-    identifier! {(format!("checked_mul_{}", size.to_lowercase()))}
+    identifier! {(format!("checked_mul_{}", size.as_ref().to_lowercase()))}
 }
 
 /// Generate a function name to perform checked subtraction
 pub fn checked_sub(size: &Integer) -> yul::Identifier {
     let size: &str = if size.is_signed() {
-        size.into()
+        size.as_ref()
     } else {
         "unsigned"
     };
@@ -55,8 +52,7 @@ pub fn checked_sub(size: &Integer) -> yul::Identifier {
 
 /// Generate a function name to adjust the size of the integer
 pub fn adjust_numeric_size(size: &Integer) -> yul::Identifier {
-    let size: &str = size.into();
-    identifier! {(format!("adjust_numeric_{}", size.to_lowercase()))}
+    identifier! {(format!("adjust_numeric_{}", size.as_ref().to_lowercase()))}
 }
 
 /// Generate a safe function name for a user defined function

--- a/newsfragments/555.internal.md
+++ b/newsfragments/555.internal.md
@@ -1,0 +1,3 @@
+In the analysis stage, all name resolution (of variable names, function names,
+type names, etc used in code) now happens via a single `resolve_name` pathway,
+so we can catch more cases of name collisions and log more helpful error messages.


### PR DESCRIPTION
This consolidates all named things into a `NamedThing` hierarchy, and name resolution into a single `resolve_name` chain (block -> fn -> contract -> module), along with some related refactoring. This is mostly groundwork for the module system, and moves us in the direction of representing built-ins as declarative structures that are analyzed using general-purpose code that will work for things defined in fe (when the language is sufficiently powerful).

Notably, checking of generic type parameters for the built-in generic types String and Map is now handled in a general-purpose `apply_generic_type_args` function which will work for generic types defined in fe, rather than special-case code.

Note that I've postponed the module-level fn definition support functionality for now. I'll do that in a separate PR.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
