### PR TITLE
Ensure expressions in list expressions are lowered

### DIFF
--- a/crates/lowering/src/mappers/expressions.rs
+++ b/crates/lowering/src/mappers/expressions.rs
@@ -183,7 +183,7 @@ fn expr_list(context: &mut FnContext, exp: Node<fe::Expr>) -> fe::Expr {
                 .map(|list_val| {
                     fe::CallArg {
                         label: None,
-                        value: list_val,
+                        value: expr(context, list_val),
                     }
                     .into_node()
                 })

--- a/crates/lowering/tests/snapshots/lowering__module_const.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_const.snap
@@ -3,16 +3,47 @@ source: crates/lowering/tests/lowering.rs
 expression: lowered_code
 
 ---
+struct $tuple_u256_u256_:
+    item0: u256
+    item1: u256
+
+struct Bar:
+    val: u256
+
 contract Foo:
-    pub fn bar() -> u256:
-        if true:
-            return 3 * 10
-        else true:
-            return 10
-
-
-    pub fn baz() -> u256:
-        return 3 * 3
+    table: Map<u256, u256>
 
     pub fn return_unit() -> ():
         return ()
+
+    pub fn usage(self) -> u256:
+        let my_calc: u256 = 3 * 10
+        let my_other_calc: u256 = 3 * 3
+        let my_array: u256[2] = list_expr_array_u256_2(3, 10)
+        let my_tuple: $tuple_u256_u256_ = $tuple_u256_u256_(item0=3, item1=10)
+        let my_bar: Bar = Bar(val=3)
+        while 3 > 4:
+            pass
+
+        for x in list_expr_array_u256_2(3, 10):
+            pass
+
+        self.table[10] = 3
+        if 3 == 10:
+            pass
+        else:
+            if 10 == 10:
+                return 3 * 10
+            else:
+                if true:
+                    revert Bar(val=THREE)
+
+
+
+        return self.table[3]
+
+    fn list_expr_array_u256_2(val0: u256, val1: u256) -> u256[2]:
+        let generated_array: u256[2]
+        generated_array[0] = val0
+        generated_array[1] = val1
+        return generated_array

--- a/crates/lowering/tests/snapshots/lowering__return_unit.snap
+++ b/crates/lowering/tests/snapshots/lowering__return_unit.snap
@@ -27,10 +27,10 @@ contract Foo:
     pub fn if_elif_else() -> ():
         if true:
             return ()
-        else true:
+        else:
             if false:
                 return ()
-            else false:
+            else:
                 pass
 
 

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -629,7 +629,7 @@ impl fmt::Display for FuncStmt {
                 writeln!(f, "if {}:", test.kind)?;
                 writeln!(indented(f), "{}", node_line_joined(body))?;
                 if !or_else.is_empty() {
-                    writeln!(f, "else {}:", test.kind)?;
+                    writeln!(f, "else:")?;
                     writeln!(indented(f), "{}", node_line_joined(or_else))
                 } else {
                     Ok(())

--- a/crates/test-files/fixtures/lowering/module_const.fe
+++ b/crates/test-files/fixtures/lowering/module_const.fe
@@ -3,16 +3,38 @@ const TEN: u256 = 10
 const IS_ADMIN: bool = true
 const UNIT: () = ()
 
+struct Bar:
+  val: u256
+
 contract Foo:
 
-  pub fn bar() -> u256:
-    if IS_ADMIN:
-        return THREE * TEN
-    else:
-        return TEN
-
-  pub fn baz() -> u256:
-    return THREE * 3
+  table: Map<u256, u256>
 
   pub fn return_unit():
     return UNIT
+
+  pub fn usage(self) ->  u256:
+
+    let my_calc: u256 = THREE * TEN
+    let my_other_calc: u256 = THREE * 3
+
+    let my_array: u256[2] = [THREE, TEN]
+    let my_tuple: (u256, u256) = (THREE, TEN)
+    let my_bar: Bar = Bar(val=THREE)
+
+    while THREE > 4:
+        pass
+
+    for x in [THREE, TEN]:
+        pass
+
+    self.table[TEN] = THREE
+
+    if THREE == TEN:
+        pass
+    elif TEN == 10:
+        return THREE * TEN
+    elif IS_ADMIN:
+        revert Bar(val=THREE)
+
+    return self.table[THREE]


### PR DESCRIPTION
### What was wrong?

We missed to lower expressions inside list expressions.

### How was it fixed?

Call to `expr`

I didn't create a release notes entry for this because I don't think that in previous releases there was a way for an user to hit this bug. But they can hit it now with the `const` support.