### PR TITLE
Allow functions to be defined outside of contracts

### DIFF
--- a/crates/abi/src/builder.rs
+++ b/crates/abi/src/builder.rs
@@ -131,16 +131,20 @@ mod tests {
 
     #[test]
     fn build_contract_abi() {
-        let contract = "\
-            \ncontract Foo:\
-            \n  event Food:\
-            \n    idx barge: u256
-            \n  pub fn __init__(x: address):\
-            \n    pass\
-            \n  fn baz(x: address) -> u256:\
-            \n    revert\
-            \n  pub fn bar(x: u256) -> u256[10]:\
-            \n    revert";
+        let contract = r#"
+pub fn add(x: u256, y: u256) -> u256:
+  return x + y
+
+contract Foo:
+  event Food:
+    idx barge: u256
+  pub fn __init__(x: address):
+    pass
+  fn baz(x: address) -> u256:
+    add(10, 20)
+    revert
+  pub fn bar(x: u256) -> u256[10]:
+    revert"#;
 
         let module = parse_code_chunk(parse_module, contract)
             .expect("unable to build module AST")

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -21,7 +21,7 @@ pub fn contract_all_functions(db: &dyn AnalyzerDb, contract: ContractId) -> Rc<V
                 ast::ContractStmt::Function(node) => {
                     Some(db.intern_function(Rc::new(items::Function {
                         ast: node.clone(),
-                        contract,
+                        contract: Some(contract),
                         module,
                     })))
                 }

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -3,8 +3,8 @@ use crate::context::{Analysis, AnalyzerContext};
 use crate::db::AnalyzerDb;
 use crate::errors::{self, TypeError};
 use crate::namespace::items::{
-    Contract, ContractId, Item, ModuleConstant, ModuleConstantId, ModuleId, Struct, StructId,
-    TypeAlias, TypeDef,
+    Contract, ContractId, Function, Item, ModuleConstant, ModuleConstantId, ModuleId, Struct,
+    StructId, TypeAlias, TypeDef,
 };
 use crate::namespace::scopes::ItemScope;
 use crate::namespace::types::{self, Type};
@@ -75,6 +75,13 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> 
                     module,
                 }),
             ))),
+            ast::ModuleStmt::Function(node) => {
+                Some(Item::Function(db.intern_function(Rc::new(Function {
+                    ast: node.clone(),
+                    contract: None,
+                    module,
+                }))))
+            }
             ast::ModuleStmt::Pragma(_) => None,
             ast::ModuleStmt::Use(_) => todo!(),
         })

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -85,6 +85,7 @@ test_analysis! { multi_param, "features/multi_param.fe"}
 test_analysis! { nested_map, "features/nested_map.fe"}
 test_analysis! { numeric_sizes, "features/numeric_sizes.fe"}
 test_analysis! { ownable, "features/ownable.fe"}
+test_analysis! { pure_fn_standalone, "features/pure_fn_standalone.fe"}
 test_analysis! { return_addition_i256, "features/return_addition_i256.fe"}
 test_analysis! { return_addition_u128, "features/return_addition_u128.fe"}
 test_analysis! { return_addition_u256, "features/return_addition_u256.fe"}

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -256,3 +256,4 @@ test_file! { call_to_mut_fn_without_self }
 test_file! { call_to_pure_fn_on_self }
 test_file! { missing_self }
 test_file! { self_not_first }
+test_file! { self_in_standalone_fn }

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -1,0 +1,311 @@
+---
+source: crates/analyzer/tests/analysis.rs
+expression: "build_snapshot(\"features/pure_fn_standalone.fe\", &src, module, &db)"
+
+---
+note: 
+  ┌─ features/pure_fn_standalone.fe:6:5
+  │
+6 │     cool_users: Map<address, bool>
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, bool>
+
+note: 
+  ┌─ features/pure_fn_standalone.fe:7:5
+  │
+7 │     points: Map<address, u256>
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:9:5
+   │  
+ 9 │ ╭     fn add_points(self, user: address, val: u256):
+10 │ │         if self.cool_users[user]:
+11 │ │             self.points[user] += add_bonus(val)
+12 │ │         else:
+13 │ │             self.points[user] += val
+   │ ╰────────────────────────────────────^ attributes hash: 316895463975841295
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "user",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "val",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:15:5
+   │  
+15 │ ╭     pub fn bar(self, x: u256) -> u256:
+16 │ │         let a: address = address(x)
+17 │ │         self.add_points(a, 100)
+18 │ │         self.cool_users[a] = true
+19 │ │         self.add_points(a, 100)
+20 │ │         return self.points[a]
+   │ ╰─────────────────────────────^ attributes hash: 14124651018748084078
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "x",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:10:12
+   │
+10 │         if self.cool_users[user]:
+   │            ^^^^^^^^^^^^^^^ Map<address, bool>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:10:28
+   │
+10 │         if self.cool_users[user]:
+   │                            ^^^^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:10:12
+   │
+10 │         if self.cool_users[user]:
+   │            ^^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:13
+   │
+11 │             self.points[user] += add_bonus(val)
+   │             ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:25
+   │
+11 │             self.points[user] += add_bonus(val)
+   │                         ^^^^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:13
+   │
+11 │             self.points[user] += add_bonus(val)
+   │             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:44
+   │
+11 │             self.points[user] += add_bonus(val)
+   │                                            ^^^ u256: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:34
+   │
+11 │             self.points[user] += add_bonus(val)
+   │                                  ^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:13:13
+   │
+13 │             self.points[user] += val
+   │             ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:13:25
+   │
+13 │             self.points[user] += val
+   │                         ^^^^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:13:13
+   │
+13 │             self.points[user] += val
+   │             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:13:34
+   │
+13 │             self.points[user] += val
+   │                                  ^^^ u256: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:16:34
+   │
+16 │         let a: address = address(x)
+   │                                  ^ u256: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:16:26
+   │
+16 │         let a: address = address(x)
+   │                          ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:17:25
+   │
+17 │         self.add_points(a, 100)
+   │                         ^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:17:28
+   │
+17 │         self.add_points(a, 100)
+   │                            ^^^ u256: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:17:9
+   │
+17 │         self.add_points(a, 100)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:18:9
+   │
+18 │         self.cool_users[a] = true
+   │         ^^^^^^^^^^^^^^^ Map<address, bool>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:18:25
+   │
+18 │         self.cool_users[a] = true
+   │                         ^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:18:9
+   │
+18 │         self.cool_users[a] = true
+   │         ^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:18:30
+   │
+18 │         self.cool_users[a] = true
+   │                              ^^^^ bool: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:19:25
+   │
+19 │         self.add_points(a, 100)
+   │                         ^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:19:28
+   │
+19 │         self.add_points(a, 100)
+   │                            ^^^ u256: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:19:9
+   │
+19 │         self.add_points(a, 100)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:20:16
+   │
+20 │         return self.points[a]
+   │                ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:20:28
+   │
+20 │         return self.points[a]
+   │                            ^ address: Value => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:20:16
+   │
+20 │         return self.points[a]
+   │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:16:16
+   │
+16 │         let a: address = address(x)
+   │                ^^^^^^^ address
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:34
+   │
+11 │             self.points[user] += add_bonus(val)
+   │                                  ^^^^^^^^^ attributes hash: 6251600114237252411
+   │
+   = Pure(
+         FunctionId(
+             0,
+         ),
+     )
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:16:26
+   │
+16 │         let a: address = address(x)
+   │                          ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
+         ),
+     }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:17:9
+   │
+17 │         self.add_points(a, 100)
+   │         ^^^^^^^^^^^^^^^ attributes hash: 8626870049799486243
+   │
+   = SelfAttribute {
+         func_name: "add_points",
+         self_span: Span {
+             start: 400,
+             end: 404,
+         },
+     }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:19:9
+   │
+19 │         self.add_points(a, 100)
+   │         ^^^^^^^^^^^^^^^ attributes hash: 13248801714086080881
+   │
+   = SelfAttribute {
+         func_name: "add_points",
+         self_span: Span {
+             start: 466,
+             end: 470,
+         },
+     }
+
+

--- a/crates/analyzer/tests/snapshots/errors__self_in_standalone_fn.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_in_standalone_fn.snap
@@ -1,0 +1,27 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `self` can only be used in contract functions
+  ┌─ compile_errors/self_in_standalone_fn.fe:1:12
+  │
+1 │ fn pure_fn(self):
+  │            ^^^^ not allowed in functions defined outside of a contract
+
+error: `self` can only be used in contract functions
+  ┌─ compile_errors/self_in_standalone_fn.fe:2:5
+  │
+2 │     self.mut_fn()
+  │     ^^^^ not allowed in functions defined outside of a contract
+
+error: `pure_fn` expects 0 arguments, but 1 was provided
+  ┌─ compile_errors/self_in_standalone_fn.fe:1:4
+  │
+1 │ fn pure_fn(self):
+  │    ^^^^^^^ expects 0 arguments
+  ·
+7 │         pure_fn(self)
+  │                 ---- supplied 1 argument
+
+

--- a/crates/analyzer/tests/snapshots/errors__self_not_first.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_not_first.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: self is not the first parameter
+error: `self` is not the first parameter
   ┌─ compile_errors/self_not_first.fe:2:28
   │
 2 │     pub fn bar(my_num: u8, self):
-  │                            ^^^^ self may only be used as the first parameter
+  │                            ^^^^ `self` may only be used as the first parameter
 
 

--- a/crates/lowering/src/mappers/contracts.rs
+++ b/crates/lowering/src/mappers/contracts.rs
@@ -1,69 +1,61 @@
-use crate::context::{ContractContext, ModuleContext};
+use crate::context::ModuleContext;
 use crate::mappers::{functions, types};
-use crate::names;
 use crate::utils::ZeroSpanNode;
 use fe_analyzer::namespace::items::{ContractFieldId, ContractId, EventId};
-use fe_analyzer::namespace::types::{Array, FixedSize};
 use fe_parser::ast;
-use fe_parser::ast::RegularFunctionArg;
 use fe_parser::node::Node;
 
 /// Lowers a contract definition.
-pub fn contract_def(module: &mut ModuleContext, contract: ContractId) -> Node<ast::Contract> {
-    let mut context = ContractContext::new(module);
+pub fn contract_def(context: &mut ModuleContext, contract: ContractId) -> Node<ast::Contract> {
+    let db = context.db;
     let fields = contract
-        .all_fields(context.db())
+        .all_fields(db)
         .iter()
-        .map(|field| contract_field(&mut context, *field))
+        .map(|field| contract_field(context, *field))
         .collect();
 
     let events = contract
-        .all_events(context.db())
+        .all_events(db)
         .iter()
-        .map(|event| ast::ContractStmt::Event(event_def(&mut context, *event)))
-        .collect();
+        .map(|event| ast::ContractStmt::Event(event_def(context, *event)))
+        .collect::<Vec<_>>();
+
     let functions = contract
-        .all_functions(context.db())
+        .all_functions(db)
         .iter()
-        .map(|function| ast::ContractStmt::Function(functions::func_def(&mut context, *function)))
+        .map(|function| ast::ContractStmt::Function(functions::func_def(context, *function)))
         .collect();
 
-    let func_defs_from_list_expr = context
-        .list_expressions
-        .iter()
-        .map(|expr| ast::ContractStmt::Function(list_expr_to_fn_def(expr).into_node()))
-        .collect::<Vec<ast::ContractStmt>>();
-
-    let node = &contract.data(context.db()).ast;
+    let node = &contract.data(context.db).ast;
     Node::new(
         ast::Contract {
             name: node.kind.name.clone(),
             fields,
-            body: [events, functions, func_defs_from_list_expr].concat(),
+            body: [events, functions].concat(),
         },
         node.span,
     )
 }
 
-fn contract_field(context: &mut ContractContext, field: ContractFieldId) -> Node<ast::Field> {
-    let node = &field.data(context.db()).ast;
-    let typ = field.typ(context.db()).expect("contract field type error");
+fn contract_field(context: &mut ModuleContext, field: ContractFieldId) -> Node<ast::Field> {
+    let node = &field.data(context.db).ast;
+    let typ = field.typ(context.db).expect("contract field type error");
     Node::new(
         ast::Field {
             is_pub: node.kind.is_pub,
             is_const: node.kind.is_const,
             name: node.kind.name.clone(),
-            typ: types::type_desc(&mut context.module, node.kind.typ.clone(), &typ),
+            typ: types::type_desc(context, node.kind.typ.clone(), &typ),
             value: node.kind.value.clone(),
         },
         node.span,
     )
 }
 
-fn event_def(context: &mut ContractContext, event: EventId) -> Node<ast::Event> {
-    let ast_fields = &event.data(context.db()).ast.kind.fields;
+fn event_def(context: &mut ModuleContext, event: EventId) -> Node<ast::Event> {
+    let ast_fields = &event.data(context.db).ast.kind.fields;
     let fields = event
-        .typ(context.db())
+        .typ(context.db)
         .fields
         .iter()
         .zip(ast_fields.iter())
@@ -72,7 +64,7 @@ fn event_def(context: &mut ContractContext, event: EventId) -> Node<ast::Event> 
                 is_idx: field.is_indexed,
                 name: field.name.clone().into_node(),
                 typ: types::type_desc(
-                    context.module,
+                    context,
                     node.kind.typ.clone(),
                     &field
                         .typ
@@ -86,7 +78,7 @@ fn event_def(context: &mut ContractContext, event: EventId) -> Node<ast::Event> 
         })
         .collect();
 
-    let node = &event.data(context.db()).ast;
+    let node = &event.data(context.db).ast;
     Node::new(
         ast::Event {
             name: node.kind.name.clone(),
@@ -94,59 +86,4 @@ fn event_def(context: &mut ContractContext, event: EventId) -> Node<ast::Event> 
         },
         node.span,
     )
-}
-
-fn list_expr_to_fn_def(array: &Array) -> ast::Function {
-    // Built the AST nodes for the function arguments
-    let args = (0..array.size)
-        .map(|index| {
-            ast::FunctionArg::Regular(RegularFunctionArg {
-                name: format!("val{}", index).into_node(),
-                typ: names::fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
-            })
-            .into_node()
-        })
-        .collect::<Vec<_>>();
-
-    // Build the AST node for the array declaration
-    let var_decl_name = "generated_array";
-    let var_decl = ast::FuncStmt::VarDecl {
-        target: ast::VarDeclTarget::Name(var_decl_name.to_string()).into_node(),
-        typ: names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node(),
-        value: None,
-    }
-    .into_node();
-
-    // Build the AST nodes for the individual assignments of array slots
-    let assignments = (0..array.size)
-        .map(|index| {
-            ast::FuncStmt::Assign {
-                target: ast::Expr::Subscript {
-                    value: ast::Expr::Name(var_decl_name.to_string()).into_boxed_node(),
-                    index: ast::Expr::Num(index.to_string()).into_boxed_node(),
-                }
-                .into_node(),
-                value: ast::Expr::Name(format!("val{}", index)).into_node(),
-            }
-            .into_node()
-        })
-        .collect::<Vec<_>>();
-
-    // Build the AST node for the return statement
-    let return_stmt = ast::FuncStmt::Return {
-        value: Some(ast::Expr::Name(var_decl_name.to_string()).into_node()),
-    }
-    .into_node();
-
-    let return_type =
-        Some(names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node());
-
-    // Put it all together in one AST node that holds the entire function definition
-    ast::Function {
-        is_pub: false,
-        name: names::list_expr_generator_fn_name(array).into_node(),
-        args,
-        return_type,
-        body: [vec![var_decl], assignments, vec![return_stmt]].concat(),
-    }
 }

--- a/crates/lowering/src/mappers/expressions.rs
+++ b/crates/lowering/src/mappers/expressions.rs
@@ -156,7 +156,7 @@ fn expr_tuple(context: &mut FnContext, exp: Node<fe::Expr>) -> fe::Expr {
             .collect(),
         exp.span,
     );
-    context.contract.module.add_tuple(typ);
+    context.module.tuples.insert(typ);
 
     // create type constructor call for the lowered tuple
     fe::Expr::Call {
@@ -174,7 +174,7 @@ fn expr_list(context: &mut FnContext, exp: Node<fe::Expr>) -> fe::Expr {
     if let Type::Array(array) = &attributes.typ {
         let array = array.clone();
         let fn_name = list_expr_generator_fn_name(&array);
-        context.contract.list_expressions.insert(array);
+        context.module.list_expressions.insert(array);
 
         if let fe::Expr::List { elts } = exp.kind {
             let args = elts

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -1,16 +1,16 @@
 use crate::context::ModuleContext;
-use crate::mappers::{contracts, types};
+use crate::mappers::{contracts, functions, types};
 use crate::names;
 use crate::utils::ZeroSpanNode;
 use fe_analyzer::namespace::items::{Item, ModuleId, TypeDef};
-use fe_analyzer::namespace::types::{Base, FixedSize, Tuple};
+use fe_analyzer::namespace::types::{Array, Base, FixedSize, Tuple};
 use fe_analyzer::AnalyzerDb;
 use fe_parser::ast;
 use fe_parser::node::Node;
 
 /// Lowers a module.
 pub fn module(db: &dyn AnalyzerDb, module: ModuleId) -> ast::Module {
-    let mut context = ModuleContext::new(db);
+    let mut context = ModuleContext::new(db, module);
 
     let mut lowered_body = module
         .data(db)
@@ -48,9 +48,13 @@ pub fn module(db: &dyn AnalyzerDb, module: ModuleId) -> ast::Module {
             ))),
             TypeDef::Primitive(_) => unreachable!(),
         },
+        Item::Function(id) => Some(ast::ModuleStmt::Function(functions::func_def(
+            &mut context,
+            *id,
+        ))),
+
         Item::GenericType(_) => todo!("generic types can't be defined in fe yet"),
         Item::Event(_) => todo!("events can't be defined at the module level yet"),
-        Item::Function(_) => todo!("functions can't be defined at the module level yet"),
         Item::BuiltinFunction(_) | Item::Object(_) => unreachable!("special built-in stuff"),
 
         // All name expressions referring to constants are handled at the time of lowering,
@@ -59,13 +63,24 @@ pub fn module(db: &dyn AnalyzerDb, module: ModuleId) -> ast::Module {
     }));
 
     let struct_defs_from_tuples = context
-        .into_tuples()
+        .tuples
         .iter()
         .map(|typ| ast::ModuleStmt::Struct(build_tuple_struct(typ).into_node()))
         .collect::<Vec<ast::ModuleStmt>>();
 
+    let func_defs_from_list_expr = context
+        .list_expressions
+        .iter()
+        .map(|expr| ast::ModuleStmt::Function(list_expr_to_fn_def(expr).into_node()))
+        .collect::<Vec<_>>();
+
     ast::Module {
-        body: [struct_defs_from_tuples, lowered_body].concat(),
+        body: [
+            struct_defs_from_tuples,
+            func_defs_from_list_expr,
+            lowered_body,
+        ]
+        .concat(),
     }
 }
 
@@ -118,5 +133,60 @@ fn build_type_desc(typ: &FixedSize) -> ast::TypeDesc {
         FixedSize::Struct(strukt) => ast::TypeDesc::Base {
             base: strukt.name.clone(),
         },
+    }
+}
+
+fn list_expr_to_fn_def(array: &Array) -> ast::Function {
+    // Built the AST nodes for the function arguments
+    let args = (0..array.size)
+        .map(|index| {
+            ast::FunctionArg::Regular(ast::RegularFunctionArg {
+                name: format!("val{}", index).into_node(),
+                typ: names::fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
+            })
+            .into_node()
+        })
+        .collect::<Vec<_>>();
+
+    // Build the AST node for the array declaration
+    let var_decl_name = "generated_array";
+    let var_decl = ast::FuncStmt::VarDecl {
+        target: ast::VarDeclTarget::Name(var_decl_name.to_string()).into_node(),
+        typ: names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node(),
+        value: None,
+    }
+    .into_node();
+
+    // Build the AST nodes for the individual assignments of array slots
+    let assignments = (0..array.size)
+        .map(|index| {
+            ast::FuncStmt::Assign {
+                target: ast::Expr::Subscript {
+                    value: ast::Expr::Name(var_decl_name.to_string()).into_boxed_node(),
+                    index: ast::Expr::Num(index.to_string()).into_boxed_node(),
+                }
+                .into_node(),
+                value: ast::Expr::Name(format!("val{}", index)).into_node(),
+            }
+            .into_node()
+        })
+        .collect::<Vec<_>>();
+
+    // Build the AST node for the return statement
+    let return_stmt = ast::FuncStmt::Return {
+        value: Some(ast::Expr::Name(var_decl_name.to_string()).into_node()),
+    }
+    .into_node();
+
+    let return_type =
+        Some(names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node());
+
+    // Put it all together in one AST node that holds the entire function definition
+    ast::Function {
+        is_pub: false,
+        name: names::list_expr_generator_fn_name(array).into_node(),
+        args,
+        return_type,
+        body: [vec![var_decl], assignments, vec![return_stmt]].concat(),
     }
 }

--- a/crates/lowering/src/mappers/types.rs
+++ b/crates/lowering/src/mappers/types.rs
@@ -14,7 +14,7 @@ pub fn type_desc(context: &mut ModuleContext, desc: Node<TypeDesc>, typ: &Type) 
             for (item_desc, item_type) in items.into_iter().zip(typ.items.iter()) {
                 type_desc(context, item_desc, &item_type.clone().into());
             }
-            context.add_tuple(typ.clone());
+            context.tuples.insert(typ.clone());
             Node::new(
                 TypeDesc::Base {
                     base: names::tuple_struct_name(typ),

--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -68,5 +68,6 @@ test_file! { map_tuple, "lowering/map_tuple.fe" }
 test_file! { type_alias_tuple, "lowering/type_alias_tuple.fe" }
 test_file! { tuple_destruct, "lowering/tuple_destruct.fe" }
 test_file! { module_const, "lowering/module_const.fe" }
+test_file! { module_fn, "lowering/module_fn.fe" }
 // TODO: the analyzer rejects lowered nested tuples.
 // test_file!(array_tuple, "lowering/array_tuple.fe");

--- a/crates/lowering/tests/snapshots/lowering__list_expressions.snap
+++ b/crates/lowering/tests/snapshots/lowering__list_expressions.snap
@@ -3,14 +3,14 @@ source: crates/lowering/tests/lowering.rs
 expression: lowered_code
 
 ---
+fn list_expr_array_u256_3(val0: u256, val1: u256, val2: u256) -> u256[3]:
+    let generated_array: u256[3]
+    generated_array[0] = val0
+    generated_array[1] = val1
+    generated_array[2] = val2
+    return generated_array
+
 contract Foo:
     pub fn foo() -> ():
         let x: u256[3] = list_expr_array_u256_3(10, 20, 30)
         return ()
-
-    fn list_expr_array_u256_3(val0: u256, val1: u256, val2: u256) -> u256[3]:
-        let generated_array: u256[3]
-        generated_array[0] = val0
-        generated_array[1] = val1
-        generated_array[2] = val2
-        return generated_array

--- a/crates/lowering/tests/snapshots/lowering__module_fn.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_fn.snap
@@ -1,0 +1,34 @@
+---
+source: crates/lowering/tests/lowering.rs
+expression: lowered_code
+
+---
+struct $tuple_u256_u8_:
+    item0: u256
+    item1: u8
+
+struct $tuple_address_tuple_u256_u8__:
+    item0: address
+    item1: $tuple_u256_u8_
+
+fn list_expr_array_u8_3(val0: u8, val1: u8, val2: u8) -> u8[3]:
+    let generated_array: u8[3]
+    generated_array[0] = val0
+    generated_array[1] = val1
+    generated_array[2] = val2
+    return generated_array
+
+fn return_tuple() -> $tuple_address_tuple_u256_u8__:
+    return $tuple_address_tuple_u256_u8__(item0=address(0), item1=$tuple_u256_u8_(item0=10, item1=20))
+
+fn return_array() -> u8[3]:
+    return list_expr_array_u8_3(1, 2, 3)
+
+contract Foo:
+    pub fn bar(self) -> u256:
+        let tuple: $tuple_address_tuple_u256_u8__ = return_tuple()
+        return tuple.item1.item0
+
+    pub fn sum_things() -> u8:
+        let x: u8[3] = return_array()
+        return x[0] + x[1] + x[2]

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -20,6 +20,7 @@ pub enum ModuleStmt {
     Contract(Node<Contract>),
     Constant(Node<ConstantDecl>),
     Struct(Node<Struct>),
+    Function(Node<Function>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -380,6 +381,7 @@ impl Spanned for ModuleStmt {
             ModuleStmt::Contract(inner) => inner.span,
             ModuleStmt::Constant(inner) => inner.span,
             ModuleStmt::Struct(inner) => inner.span,
+            ModuleStmt::Function(inner) => inner.span,
         }
     }
 }
@@ -408,6 +410,7 @@ impl fmt::Display for ModuleStmt {
             ModuleStmt::Contract(node) => write!(f, "{}", node.kind),
             ModuleStmt::Constant(node) => write!(f, "{}", node.kind),
             ModuleStmt::Struct(node) => write!(f, "{}", node.kind),
+            ModuleStmt::Function(node) => write!(f, "{}", node.kind),
         }
     }
 }

--- a/crates/parser/src/grammar/Fe.grammar
+++ b/crates/parser/src/grammar/Fe.grammar
@@ -1,6 +1,6 @@
 file_input: NEWLINE ENDMARKER | module_stmt+ ENDMARKER
 
-module_stmt: import_stmt | type_def | contract_def
+module_stmt: import_stmt | type_def | contract_def | func_def
 
 ########################### path ######################################
 
@@ -63,9 +63,6 @@ func_qual: 'pub'
 func_stmt:  compound_stmt | simple_stmt
 simple_stmt: small_stmt (';' small_stmt)* [';'] NEWLINE
 
-# NOTE: `vardecl_stmt`, `assign_stmt`, and `augassign_stmt` MUST precede
-# `exprs`.  Otherwise, the parser will get stuck.  However, they must follow
-# all others.  Otherwise, reserved words will match a simple NAME.
 small_stmt: return_stmt | assert_stmt | emit_stmt | pass_stmt | break_stmt |
             continue_stmt | revert_stmt | vardecl_stmt | assign_stmt | augassign_stmt |
             exprs

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -183,6 +183,12 @@ use foo::bar::{
 
 type X = Map<u8, u16>
 
+pub fn double(x: u8) -> u8:
+    return x * 2
+
+fn secret() -> u8:
+    return 0xBEEF
+
 contract A:
     pub const x: u256 = 10
 

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_stmts), module::parse_module,\n           r#\"\npragma 0.5.0\n\nuse foo::bar::{\n    bing as bong,\n    food::*\n}\n\ntype X = Map<u8, u16>\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
+expression: "ast_string(stringify!(module_stmts), module::parse_module,\n           r#\"\npragma 0.5.0\n\nuse foo::bar::{\n    bing as bong,\n    food::*\n}\n\ntype X = Map<u8, u16>\n\npub fn double(x: u8) -> u8:\n    return x * 2\n\nfn secret() -> u8:\n    return 0xBEEF\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
 
 ---
 Node(
@@ -179,13 +179,146 @@ Node(
           end: 85,
         ),
       )),
+      Function(Node(
+        kind: Function(
+          is_pub: true,
+          name: Node(
+            kind: "double",
+            span: Span(
+              start: 94,
+              end: 100,
+            ),
+          ),
+          args: [
+            Node(
+              kind: Regular(RegularFunctionArg(
+                name: Node(
+                  kind: "x",
+                  span: Span(
+                    start: 101,
+                    end: 102,
+                  ),
+                ),
+                typ: Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 104,
+                    end: 106,
+                  ),
+                ),
+              )),
+              span: Span(
+                start: 101,
+                end: 106,
+              ),
+            ),
+          ],
+          return_type: Some(Node(
+            kind: Base(
+              base: "u8",
+            ),
+            span: Span(
+              start: 111,
+              end: 113,
+            ),
+          )),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: BinOperation(
+                    left: Node(
+                      kind: Name("x"),
+                      span: Span(
+                        start: 126,
+                        end: 127,
+                      ),
+                    ),
+                    op: Node(
+                      kind: Mult,
+                      span: Span(
+                        start: 128,
+                        end: 129,
+                      ),
+                    ),
+                    right: Node(
+                      kind: Num("2"),
+                      span: Span(
+                        start: 130,
+                        end: 131,
+                      ),
+                    ),
+                  ),
+                  span: Span(
+                    start: 126,
+                    end: 131,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 119,
+                end: 131,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 87,
+          end: 131,
+        ),
+      )),
+      Function(Node(
+        kind: Function(
+          is_pub: false,
+          name: Node(
+            kind: "secret",
+            span: Span(
+              start: 136,
+              end: 142,
+            ),
+          ),
+          args: [],
+          return_type: Some(Node(
+            kind: Base(
+              base: "u8",
+            ),
+            span: Span(
+              start: 148,
+              end: 150,
+            ),
+          )),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: Num("0xBEEF"),
+                  span: Span(
+                    start: 163,
+                    end: 169,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 156,
+                end: 169,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 133,
+          end: 169,
+        ),
+      )),
       Contract(Node(
         kind: Contract(
           name: Node(
             kind: "A",
             span: Span(
-              start: 96,
-              end: 97,
+              start: 180,
+              end: 181,
             ),
           ),
           fields: [
@@ -196,8 +329,8 @@ Node(
                 name: Node(
                   kind: "x",
                   span: Span(
-                    start: 113,
-                    end: 114,
+                    start: 197,
+                    end: 198,
                   ),
                 ),
                 typ: Node(
@@ -205,29 +338,29 @@ Node(
                     base: "u256",
                   ),
                   span: Span(
-                    start: 116,
-                    end: 120,
+                    start: 200,
+                    end: 204,
                   ),
                 ),
                 value: Some(Node(
                   kind: Num("10"),
                   span: Span(
-                    start: 123,
-                    end: 125,
+                    start: 207,
+                    end: 209,
                   ),
                 )),
               ),
               span: Span(
-                start: 103,
-                end: 120,
+                start: 187,
+                end: 204,
               ),
             ),
           ],
           body: [],
         ),
         span: Span(
-          start: 87,
-          end: 120,
+          start: 171,
+          end: 204,
         ),
       )),
       Contract(Node(
@@ -235,8 +368,8 @@ Node(
           name: Node(
             kind: "B",
             span: Span(
-              start: 136,
-              end: 137,
+              start: 220,
+              end: 221,
             ),
           ),
           fields: [
@@ -247,8 +380,8 @@ Node(
                 name: Node(
                   kind: "x",
                   span: Span(
-                    start: 147,
-                    end: 148,
+                    start: 231,
+                    end: 232,
                   ),
                 ),
                 typ: Node(
@@ -256,29 +389,29 @@ Node(
                     base: "X",
                   ),
                   span: Span(
-                    start: 150,
-                    end: 151,
+                    start: 234,
+                    end: 235,
                   ),
                 ),
                 value: None,
               ),
               span: Span(
-                start: 143,
-                end: 151,
+                start: 227,
+                end: 235,
               ),
             ),
           ],
           body: [],
         ),
         span: Span(
-          start: 127,
-          end: 151,
+          start: 211,
+          end: 235,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 151,
+    end: 235,
   ),
 )

--- a/crates/test-files/fixtures/compile_errors/self_in_standalone_fn.fe
+++ b/crates/test-files/fixtures/compile_errors/self_in_standalone_fn.fe
@@ -1,0 +1,7 @@
+fn pure_fn(self):
+    self.mut_fn()
+
+contract Foo:
+
+    fn foo(self):
+        pure_fn(self)

--- a/crates/test-files/fixtures/features/pure_fn_standalone.fe
+++ b/crates/test-files/fixtures/features/pure_fn_standalone.fe
@@ -1,0 +1,20 @@
+
+fn add_bonus(x: u256) -> u256:
+    return x + 10
+
+contract Foo:
+    cool_users: Map<address, bool>
+    points: Map<address, u256>
+
+    fn add_points(self, user: address, val: u256):
+        if self.cool_users[user]:
+            self.points[user] += add_bonus(val)
+        else:
+            self.points[user] += val
+
+    pub fn bar(self, x: u256) -> u256:
+        let a: address = address(x)
+        self.add_points(a, 100)
+        self.cool_users[a] = true
+        self.add_points(a, 100)
+        return self.points[a]

--- a/crates/test-files/fixtures/lowering/module_fn.fe
+++ b/crates/test-files/fixtures/lowering/module_fn.fe
@@ -1,0 +1,14 @@
+fn return_tuple() -> (address, (u256, u8)):
+  return (address(0), (10, 20))
+
+fn return_array() -> u8[3]:
+  return [1, 2, 3]
+
+contract Foo:
+    pub fn bar(self) -> u256:
+        let tuple: (address, (u256, u8)) = return_tuple()
+        return tuple.item1.item0
+
+    pub fn sum_things() -> u8:
+        let x: u8[3] = return_array()
+        return x[0] + x[1] + x[2]

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -163,6 +163,7 @@ fn test_assert() {
     case("return_sum_list_expression_2.fe", &[], uint_token(210)),
     case("pure_fn.fe", &[uint_token(42), uint_token(26)], uint_token(68)),
     case("pure_fn_internal_call.fe", &[uint_token(42), uint_token(26)], uint_token(68)),
+    case("pure_fn_standalone.fe", &[uint_token(5)], uint_token(210)),
     // unary invert
     case("return_invert_i256.fe", &[int_token(1)], int_token(-2)),
     case("return_invert_i128.fe", &[int_token(1)], int_token(-2)),

--- a/crates/yulgen/src/mappers/contracts.rs
+++ b/crates/yulgen/src/mappers/contracts.rs
@@ -2,7 +2,7 @@ use crate::constructor;
 use crate::context::ContractContext;
 use crate::mappers::functions;
 use crate::runtime;
-use fe_analyzer::namespace::items::ContractId;
+use fe_analyzer::namespace::items::{ContractId, Item};
 use fe_analyzer::AnalyzerDb;
 use fe_common::utils::keccak;
 use std::collections::HashMap;
@@ -28,9 +28,15 @@ pub fn contract_def(
         )
     });
 
+    // All module fns are added to each contract, for now.
+    let module = contract.module(db);
     let user_functions = contract
         .functions(db)
         .values()
+        .chain(module.items(db).values().filter_map(|item| match item {
+            Item::Function(fid) => Some(fid),
+            _ => None,
+        }))
         .map(|func| functions::func_def(db, &mut context, *func))
         .collect::<Vec<_>>();
 

--- a/newsfragments/566.feature.md
+++ b/newsfragments/566.feature.md
@@ -1,0 +1,12 @@
+Functions can no be defined outside of contracts. Example:
+
+```
+fn add_bonus(x: u256) -> u256:
+    return x + 10
+
+contract PointTracker:
+    points: Map<address, u256>
+
+    pub fn add_points(self, user: address, val: u256):
+        self.points[user] += add_bonus(val)
+```


### PR DESCRIPTION
### What was wrong?

Utility functions couldn't be defined at the module level, they had to be inside of contracts.

### How was it fixed?

Nothing too complicated here. Note that every module-level fn will be compiled into every contract (in yul) for now (but a `pub` module-level fn doesn't become a public contract function). Someday soon I hope to change the yulgen to only include things that are used.

I didn't update the spec. I figured module functions should be discussed in the section on modules that doesn't exist yet, and also I just didn't really feel like updating it :shrug:

The grammar file contains a small lie; `self` isn't allowed in module function parameter lists. Feeling lazy, I guess.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
