### PR TITLE
Expanded release guide to include website & docs

### DIFF
--- a/docs/src/development/release.md
+++ b/docs/src/development/release.md
@@ -42,3 +42,17 @@ After the tests were adjusted run `make push-tag` to create the tag and push it 
 ### Manually edit the release on GitHub
 
 Running the previous command will push a new tag to Github and cause CI to create a [release](https://github.com/ethereum/fe/releases) with the Fe binaries attached. We may want to edit the release afterwards to put in some verbiage about the release.
+
+## Updating Docs & Website
+
+A release of a new Fe compiler should usually go hand in hand with updating the website and documentation. For one, the front page of [fe-lang.org](https://fe-lang.org) links to the download of the compiler but won't automatically pick up the latest release without a fresh deployment. Furthermore, if code examples and other docs needed to be updated along with compiler changes, these updates are also only reflected online when the site gets redeployed. This is especially problematic since our docs do currently not have a version switcher to view documentation for different compiler versions ([See GitHub issue #543](https://github.com/ethereum/fe/issues/543)).
+
+### Preview the sites locally
+
+Run `make serve-website` and visit http://0.0.0.0:8000 to preview it locally. Ensure the front page displays the correct compiler version for download and that the docs render correctly.
+
+### Deploy website & docs
+
+**Prerequisite**: Make sure the central repository is configured as `upstream`, **not** `origin`.
+
+Run `make deploy-website` and validate that [fe-lang.org](https://fe-lang.org) renders the updated sites (Can take up to a few minutes).


### PR DESCRIPTION
### What was wrong?

Our release guide did not mention that we need to update the website after each release.

### How was it fixed?

:writing_hand: 
