### PR TITLE
Struct functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "rstest",
  "salsa",
  "semver 1.0.0",
+ "smallvec",
  "strum",
  "vec1",
  "wasm-bindgen-test",

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -19,6 +19,7 @@ salsa = "0.16.1"
 parking_lot_core = { version = "=0.8.0" } # used by salsa; version pinned for wasm compatibility
 indexmap = "1.6.2"
 if_chain = "1.0.1"
+smallvec = { version = "1.6.1", features = ["union"] }
 
 [dev-dependencies]
 insta = "1.7.1"

--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -1,6 +1,6 @@
 use strum::{AsRefStr, EnumIter, EnumString};
 
-#[derive(Debug, PartialEq, EnumString)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumString, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ValueMethod {
     Clone,
@@ -10,29 +10,36 @@ pub enum ValueMethod {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, EnumString, AsRefStr, Hash, EnumIter)]
 #[strum(serialize_all = "snake_case")]
-pub enum GlobalMethod {
+pub enum GlobalFunction {
     Keccak256,
     SendValue,
     Balance,
     BalanceOf,
 }
 
-#[derive(Debug, PartialEq, EnumString, AsRefStr)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ContractTypeMethod {
     Create,
     Create2,
 }
 
+impl ContractTypeMethod {
+    pub fn arg_count(&self) -> usize {
+        match self {
+            ContractTypeMethod::Create => 1,
+            ContractTypeMethod::Create2 => 2,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, EnumString, EnumIter, AsRefStr)]
 #[strum(serialize_all = "lowercase")]
-pub enum Object {
+pub enum GlobalObject {
     Block,
     Chain,
     Msg,
     Tx,
-    #[strum(serialize = "self")]
-    Self_,
 }
 
 #[derive(Debug, PartialEq, EnumString)]
@@ -67,6 +74,6 @@ pub enum TxField {
 
 #[derive(Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "snake_case")]
-pub enum SelfField {
+pub enum ContractSelfField {
     Address,
 }

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -73,10 +73,6 @@ pub trait AnalyzerDb {
     fn contract_function_map(&self, id: ContractId) -> Analysis<Rc<IndexMap<String, FunctionId>>>;
     #[salsa::invoke(queries::contracts::contract_public_function_map)]
     fn contract_public_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
-    #[salsa::invoke(queries::contracts::contract_pure_function_map)]
-    fn contract_pure_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
-    #[salsa::invoke(queries::contracts::contract_self_function_map)]
-    fn contract_self_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
     #[salsa::invoke(queries::contracts::contract_init_function)]
     fn contract_init_function(&self, id: ContractId) -> Analysis<Option<FunctionId>>;
 
@@ -114,6 +110,10 @@ pub trait AnalyzerDb {
         &self,
         field: StructFieldId,
     ) -> Analysis<Result<types::FixedSize, TypeError>>;
+    #[salsa::invoke(queries::structs::struct_all_functions)]
+    fn struct_all_functions(&self, id: StructId) -> Rc<Vec<FunctionId>>;
+    #[salsa::invoke(queries::structs::struct_function_map)]
+    fn struct_function_map(&self, id: StructId) -> Analysis<Rc<IndexMap<String, FunctionId>>>;
 
     // Event
     #[salsa::invoke(queries::events::event_type)]

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -32,10 +32,12 @@ fn std_prelude_items() -> IndexMap<String, Item> {
         types::GenericType::iter().map(|typ| (typ.name().to_string(), Item::GenericType(typ))),
     );
     items.extend(
-        builtins::GlobalMethod::iter()
+        builtins::GlobalFunction::iter()
             .map(|fun| (fun.as_ref().to_string(), Item::BuiltinFunction(fun))),
     );
-    items.extend(builtins::Object::iter().map(|obj| (obj.as_ref().to_string(), Item::Object(obj))));
+    items.extend(
+        builtins::GlobalObject::iter().map(|obj| (obj.as_ref().to_string(), Item::Object(obj))),
+    );
     items
 }
 
@@ -78,8 +80,8 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> 
             ast::ModuleStmt::Function(node) => {
                 Some(Item::Function(db.intern_function(Rc::new(Function {
                     ast: node.clone(),
-                    contract: None,
                     module,
+                    parent: None,
                 }))))
             }
             ast::ModuleStmt::Pragma(_) => None,

--- a/crates/analyzer/src/operations.rs
+++ b/crates/analyzer/src/operations.rs
@@ -14,6 +14,7 @@ pub fn index(value: Type, index: Type) -> Result<Type, IndexingError> {
         Type::Tuple(_) => Err(IndexingError::NotSubscriptable),
         Type::String(_) => Err(IndexingError::NotSubscriptable),
         Type::Contract(_) => Err(IndexingError::NotSubscriptable),
+        Type::SelfContract(_) => Err(IndexingError::NotSubscriptable),
         Type::Struct(_) => Err(IndexingError::NotSubscriptable),
     }
 }

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -1,6 +1,5 @@
-use fe_analyzer::context;
 use fe_analyzer::namespace::items::{self, Item, TypeDef};
-use fe_analyzer::namespace::types::{Event, FixedSize, FunctionSignature, Type};
+use fe_analyzer::namespace::types::{Event, FixedSize};
 use fe_analyzer::{AnalyzerDb, Db};
 use fe_common::diagnostics::{diagnostics_string, print_diagnostics, Diagnostic, Label, Severity};
 use fe_common::files::FileStore;
@@ -8,6 +7,7 @@ use fe_parser::node::NodeId;
 use fe_parser::node::Span;
 use indexmap::IndexMap;
 use insta::assert_snapshot;
+use smallvec::SmallVec;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -46,10 +46,10 @@ macro_rules! test_analysis {
                 //  for larger diffs. I recommend commenting out all tests but one.
                 fe_common::assert_snapshot_wasm!(
                     concat!("snapshots/analysis__", stringify!($name), ".snap"),
-                    build_snapshot(files, module, &db)
+                    build_snapshot(&files, module, &db)
                 );
             } else {
-                assert_snapshot!(build_snapshot(files, module, &db));
+                assert_snapshot!(build_snapshot(&files, module, &db));
             }
         }
     };
@@ -162,128 +162,155 @@ test_analysis! { data_copying_stress, "stress/data_copying_stress.fe"}
 test_analysis! { tuple_stress, "stress/tuple_stress.fe"}
 test_analysis! { type_aliases, "features/type_aliases.fe"}
 
-fn build_snapshot(file_store: FileStore, module: items::ModuleId, db: &dyn AnalyzerDb) -> String {
-    // contract and struct types aren't worth printing
-    let type_aliases = module
+fn build_snapshot(file_store: &FileStore, module: items::ModuleId, db: &dyn AnalyzerDb) -> String {
+    let diagnostics = module
         .all_items(db)
         .iter()
-        .filter_map(|def| match def {
-            Item::Type(TypeDef::Alias(alias)) => {
-                Some((alias.data(db).ast.span, alias.typ(db).unwrap()))
-            }
-            _ => None,
-        })
-        .collect::<Vec<(Span, Type)>>();
-
-    let struct_fields: Vec<(Span, Type)> = module
-        .all_structs(db)
-        .iter()
-        .map(|struc| {
-            struc
-                .all_fields(db)
-                .iter()
-                .map(|field| (field.data(db).ast.span, field.typ(db).unwrap().into()))
-                .collect::<Vec<_>>()
-        })
-        .flatten()
-        .collect();
-
-    let contract_ids = module.all_contracts(db);
-    let contract_fields: Vec<(Span, Type)> = contract_ids
-        .iter()
-        .map(|contract| {
-            contract
-                .all_fields(db)
-                .iter()
-                .map(|field| (field.data(db).ast.span, field.typ(db).unwrap()))
-                .collect::<Vec<_>>()
-        })
-        .flatten()
-        .collect();
-    let event_fields = contract_ids
-        .iter()
-        .map(|contract| {
-            contract
-                .all_events(db)
-                .iter()
-                .map(|event| {
-                    // Event field spans are a bit of a hassle right now
-                    event
-                        .data(db)
-                        .ast
-                        .kind
-                        .fields
+        .map(|item| match item {
+            Item::Type(TypeDef::Alias(alias)) => vec![build_display_diagnostic(
+                alias.data(db).ast.span,
+                &alias.typ(db).unwrap(),
+            )],
+            Item::Type(TypeDef::Struct(struct_)) => [label_in_non_overlapping_groups(
+                &struct_
+                    .all_fields(db)
+                    .iter()
+                    .map(|field| (field.data(db).ast.span, field.typ(db).unwrap()))
+                    .collect::<Vec<_>>(),
+            )]
+            .concat(),
+            Item::Type(TypeDef::Contract(contract)) => [
+                label_in_non_overlapping_groups(
+                    &contract
+                        .all_fields(db)
                         .iter()
-                        .map(|node| node.span)
-                        .zip(
-                            event
-                                .typ(db)
-                                .fields
-                                .iter()
-                                .map(|field| field.typ.clone().unwrap()),
-                        )
-                        .collect::<Vec<(Span, FixedSize)>>()
-                })
-                .flatten()
-                .collect::<Vec<(Span, FixedSize)>>()
-        })
-        .flatten()
-        .collect::<Vec<(Span, FixedSize)>>();
+                        .map(|field| (field.data(db).ast.span, field.typ(db).unwrap()))
+                        .collect::<Vec<_>>(),
+                ),
+                contract
+                    .events(db)
+                    .values()
+                    .map(|id| event_diagnostics(*id, db))
+                    .flatten()
+                    .collect(),
+                contract
+                    .functions(db)
+                    .values()
+                    .map(|id| function_diagnostics(*id, db))
+                    .flatten()
+                    .collect(),
+            ]
+            .concat(),
 
-    let all_function_ids: Vec<items::FunctionId> = contract_ids
-        .iter()
-        .map(|contract| contract.all_functions(db).as_ref().clone())
-        .flatten()
-        .collect();
+            Item::Function(id) => function_diagnostics(*id, db),
+            Item::Constant(id) => vec![build_display_diagnostic(id.span(db), &id.typ(db).unwrap())],
 
-    let function_sigs = all_function_ids
-        .iter()
-        .map(|fun| (fun.data(db).ast.span, fun.signature(db)))
-        .collect::<Vec<(Span, Rc<FunctionSignature>)>>();
+            // Events can't be defined at the module level yet.
+            Item::Event(_) => vec![],
 
-    let all_function_bodies: Vec<Rc<context::FunctionBody>> =
-        all_function_ids.iter().map(|func| func.body(db)).collect();
-
-    let expressions = all_function_bodies
-        .iter()
-        .map(|body| lookup_spans(&body.expressions, &body.spans))
-        .flatten()
-        .collect::<Vec<_>>();
-    let emits = all_function_bodies
-        .iter()
-        .map(|body| {
-            lookup_spans(&body.emits, &body.spans)
-                .into_iter()
-                .map(|(span, eventid)| (span, eventid.typ(db)))
-                .collect::<Vec<(Span, Rc<Event>)>>()
+            // Built-in stuff
+            Item::Type(TypeDef::Primitive(_))
+            | Item::GenericType(_)
+            | Item::BuiltinFunction(_)
+            | Item::Object(_) => vec![],
         })
         .flatten()
         .collect::<Vec<_>>();
-    let declarations = all_function_bodies
-        .iter()
-        .map(|body| lookup_spans(&body.var_decl_types, &body.spans))
-        .flatten()
-        .collect::<Vec<_>>();
-    let calls = all_function_bodies
-        .iter()
-        .map(|body| lookup_spans(&body.calls, &body.spans))
-        .flatten()
-        .collect::<Vec<_>>();
-
-    let diagnostics = [
-        build_display_diagnostics(&type_aliases),
-        build_display_diagnostics(&struct_fields),
-        build_display_diagnostics(&contract_fields),
-        build_display_diagnostics(&event_fields),
-        build_debug_diagnostics(&function_sigs),
-        build_display_diagnostics(&expressions),
-        build_debug_diagnostics(&emits),
-        build_display_diagnostics(&declarations),
-        build_debug_diagnostics(&calls),
-    ]
-    .concat();
 
     diagnostics_string(&diagnostics, &file_store)
+}
+
+fn new_diagnostic(labels: Vec<Label>) -> Diagnostic {
+    Diagnostic {
+        severity: Severity::Note,
+        message: String::new(),
+        labels: labels.to_vec(),
+        notes: vec![],
+    }
+}
+
+fn label_in_non_overlapping_groups(spans: &[(Span, impl Display)]) -> Vec<Diagnostic> {
+    // Accumulate labels in a vec until we reach a span that overlaps
+    // the labeled range, then emit a Diagnostic with the accumulated labels
+    // and begin again. This assumes that all spans are within the same file.
+    let file_id = if let Some((span, _)) = spans.first() {
+        span.file_id
+    } else {
+        return vec![];
+    };
+
+    spans
+        .iter()
+        .enumerate()
+        .scan(
+            (Span::zero(file_id), vec![]),
+            |(labeled, labels), (idx, (span, attr))| {
+                let mut diags = SmallVec::<[Diagnostic; 2]>::new();
+
+                let overlaps = span.start < labeled.end && span.end > labeled.start;
+
+                // If the current span overlaps with the union of the current set of labels,
+                // emit a diagnostic, and clear the set of labels.
+                if overlaps {
+                    diags.push(new_diagnostic(labels.to_vec()));
+                    labels.clear();
+                    *labeled = *span;
+                }
+                labels.push(Label::primary(*span, format!("{}", attr)));
+                *labeled += *span;
+
+                // If this is the last thing to label, emit a diagnostic.
+                if idx == spans.len() - 1 {
+                    diags.push(new_diagnostic(labels.to_vec()));
+                }
+                Some(diags)
+            },
+        )
+        .flatten()
+        .collect()
+}
+
+fn function_diagnostics(fun: items::FunctionId, db: &dyn AnalyzerDb) -> Vec<Diagnostic> {
+    let body = fun.body(db);
+    [
+        // signature
+        build_debug_diagnostics(&[(fun.data(db).ast.span, &fun.signature(db))]),
+        // declarations
+        label_in_non_overlapping_groups(&lookup_spans(&body.var_decl_types, &body.spans)),
+        // expressions
+        label_in_non_overlapping_groups(&lookup_spans(&body.expressions, &body.spans)),
+        // emits
+        build_debug_diagnostics(
+            &lookup_spans(&body.emits, &body.spans)
+                .into_iter()
+                .map(|(span, eventid)| (span, eventid.typ(db)))
+                .collect::<Vec<(Span, Rc<Event>)>>(),
+        ),
+        // calls
+        build_debug_diagnostics(&lookup_spans(&body.calls, &body.spans)),
+    ]
+    .concat()
+}
+
+fn event_diagnostics(event: items::EventId, db: &dyn AnalyzerDb) -> Vec<Diagnostic> {
+    // Event field spans are a bit of a hassle right now
+    label_in_non_overlapping_groups(
+        &event
+            .data(db)
+            .ast
+            .kind
+            .fields
+            .iter()
+            .map(|node| node.span)
+            .zip(
+                event
+                    .typ(db)
+                    .fields
+                    .iter()
+                    .map(|field| field.typ.clone().unwrap()),
+            )
+            .collect::<Vec<(Span, FixedSize)>>(),
+    )
 }
 
 fn lookup_spans<T: Clone>(
@@ -314,15 +341,7 @@ fn build_debug_diagnostic<T: Debug>(span: Span, attributes: &T) -> Diagnostic {
     }
 }
 
-fn build_display_diagnostics<T: Display>(spanned_attributes: &[(Span, T)]) -> Vec<Diagnostic> {
-    spanned_attributes
-        .iter()
-        .map(|(span, attributes)| build_display_diagnostic(*span, attributes))
-        .collect::<Vec<_>>()
-}
-
 fn build_display_diagnostic<T: Display>(span: Span, attributes: &T) -> Diagnostic {
-    // Hash the attributes and label the span with it.
     let label = Label::primary(span, format!("{}", attributes));
     Diagnostic {
         severity: Severity::Note,

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -156,9 +156,9 @@ test_stmt! { pow_with_signed_exponent, "let base: i128\nlet xp: i128\nbase ** ex
 test_stmt! { pow_with_wrong_capacity, "let base: i128\nlet exp: u256\nbase ** exp" }
 test_stmt! { shadow_builtin_type_with_var, "let u8: u8 = 10" }
 test_stmt! { shadow_builtin_fn_with_var, "let keccak256: u8 = 10" }
-test_stmt! { shadow_builtin_object_with_var, "let self: u8 = 10" }
 test_file! { shadow_builtin_type }
 test_file! { shadow_builtin_function }
+test_file! { self_misuse }
 test_stmt! { string_capacity_mismatch, "String<3>(\"too long\")" }
 test_stmt! { string_non_int_type_arg, "let x: String<u8>" }
 test_stmt! { string_no_type_arg_list, "let x: String" }

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -52,10 +52,12 @@ note:
    │  
 23 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 5>):
 24 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 8230149271433625082
+   │ ╰────────────────────────────────^ attributes hash: 9394631703967802524
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_addrs",
@@ -80,19 +82,27 @@ note:
    ┌─ stress/abi_encoding_stress.fe:24:9
    │
 24 │         self.my_addrs = my_addrs
-   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 5>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:24:9
+   │
+24 │         self.my_addrs = my_addrs
+   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 5>: Memory
    │         │                
-   │         Array<address, 5>: Storage { nonce: Some(0) } => None
+   │         Array<address, 5>: Storage { nonce: Some(0) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:26:5
    │  
 26 │ ╭     pub fn get_my_addrs(self) -> Array<address, 5>:
 27 │ │         return self.my_addrs.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 14938423529265024589
+   │ ╰─────────────────────────────────────^ attributes hash: 4079318501250934113
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Array(
@@ -108,31 +118,37 @@ note:
    ┌─ stress/abi_encoding_stress.fe:27:16
    │
 27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:27:16
    │
 27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Some(Memory)
+   │                ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:27:16
    │
 27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Memory
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:27:16
    │
-   = ValueAttribute
+27 │         return self.my_addrs.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:29:5
    │  
 29 │ ╭     pub fn set_my_u128(self, my_u128: u128):
 30 │ │         self.my_u128 = my_u128
-   │ ╰──────────────────────────────^ attributes hash: 9586494768459567014
+   │ ╰──────────────────────────────^ attributes hash: 9980408974823709141
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_u128",
@@ -156,19 +172,27 @@ note:
    ┌─ stress/abi_encoding_stress.fe:30:9
    │
 30 │         self.my_u128 = my_u128
-   │         ^^^^^^^^^^^^   ^^^^^^^ u128: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:30:9
+   │
+30 │         self.my_u128 = my_u128
+   │         ^^^^^^^^^^^^   ^^^^^^^ u128: Value
    │         │               
-   │         u128: Storage { nonce: Some(1) } => None
+   │         u128: Storage { nonce: Some(1) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:32:5
    │  
 32 │ ╭     pub fn get_my_u128(self) -> u128:
 33 │ │         return self.my_u128
-   │ ╰───────────────────────────^ attributes hash: 1703680575433883116
+   │ ╰───────────────────────────^ attributes hash: 2605238939391421698
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -183,17 +207,25 @@ note:
    ┌─ stress/abi_encoding_stress.fe:33:16
    │
 33 │         return self.my_u128
-   │                ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Some(Value)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:33:16
+   │
+33 │         return self.my_u128
+   │                ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:35:5
    │  
 35 │ ╭     pub fn set_my_string(self, my_string: String<10>):
 36 │ │         self.my_string = my_string
-   │ ╰──────────────────────────────────^ attributes hash: 12755746761294548533
+   │ ╰──────────────────────────────────^ attributes hash: 801613487093993571
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_string",
@@ -217,19 +249,27 @@ note:
    ┌─ stress/abi_encoding_stress.fe:36:9
    │
 36 │         self.my_string = my_string
-   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<10>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:36:9
+   │
+36 │         self.my_string = my_string
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<10>: Memory
    │         │                 
-   │         String<10>: Storage { nonce: Some(2) } => None
+   │         String<10>: Storage { nonce: Some(2) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:38:5
    │  
 38 │ ╭     pub fn get_my_string(self) -> String<10>:
 39 │ │         return self.my_string.to_mem()
-   │ ╰──────────────────────────────────────^ attributes hash: 7751556256223364605
+   │ ╰──────────────────────────────────────^ attributes hash: 8319003966728987416
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              String(
@@ -244,31 +284,37 @@ note:
    ┌─ stress/abi_encoding_stress.fe:39:16
    │
 39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:39:16
    │
 39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Some(Memory)
+   │                ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:39:16
    │
 39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Memory
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:39:16
    │
-   = ValueAttribute
+39 │         return self.my_string.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:41:5
    │  
 41 │ ╭     pub fn set_my_u16s(self, my_u16s: Array<u16, 255>):
 42 │ │         self.my_u16s = my_u16s
-   │ ╰──────────────────────────────^ attributes hash: 15627129425342656114
+   │ ╰──────────────────────────────^ attributes hash: 6348795826864150593
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_u16s",
@@ -295,19 +341,27 @@ note:
    ┌─ stress/abi_encoding_stress.fe:42:9
    │
 42 │         self.my_u16s = my_u16s
-   │         ^^^^^^^^^^^^   ^^^^^^^ Array<u16, 255>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:42:9
+   │
+42 │         self.my_u16s = my_u16s
+   │         ^^^^^^^^^^^^   ^^^^^^^ Array<u16, 255>: Memory
    │         │               
-   │         Array<u16, 255>: Storage { nonce: Some(3) } => None
+   │         Array<u16, 255>: Storage { nonce: Some(3) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:44:5
    │  
 44 │ ╭     pub fn get_my_u16s(self) -> Array<u16, 255>:
 45 │ │         return self.my_u16s.to_mem()
-   │ ╰────────────────────────────────────^ attributes hash: 1712184078290376685
+   │ ╰────────────────────────────────────^ attributes hash: 1359438709249232878
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Array(
@@ -325,31 +379,37 @@ note:
    ┌─ stress/abi_encoding_stress.fe:45:16
    │
 45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:45:16
    │
 45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Some(Memory)
+   │                ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:45:16
    │
 45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Memory
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:45:16
    │
-   = ValueAttribute
+45 │         return self.my_u16s.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:47:5
    │  
 47 │ ╭     pub fn set_my_bool(self, my_bool: bool):
 48 │ │         self.my_bool = my_bool
-   │ ╰──────────────────────────────^ attributes hash: 6416448266362982339
+   │ ╰──────────────────────────────^ attributes hash: 14055988620028862174
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_bool",
@@ -371,19 +431,27 @@ note:
    ┌─ stress/abi_encoding_stress.fe:48:9
    │
 48 │         self.my_bool = my_bool
-   │         ^^^^^^^^^^^^   ^^^^^^^ bool: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:48:9
+   │
+48 │         self.my_bool = my_bool
+   │         ^^^^^^^^^^^^   ^^^^^^^ bool: Value
    │         │               
-   │         bool: Storage { nonce: Some(4) } => None
+   │         bool: Storage { nonce: Some(4) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:50:5
    │  
 50 │ ╭     pub fn get_my_bool(self) -> bool:
 51 │ │         return self.my_bool
-   │ ╰───────────────────────────^ attributes hash: 4761504089579832229
+   │ ╰───────────────────────────^ attributes hash: 10897195883816692453
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -396,17 +464,25 @@ note:
    ┌─ stress/abi_encoding_stress.fe:51:16
    │
 51 │         return self.my_bool
-   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Some(Value)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:51:16
+   │
+51 │         return self.my_bool
+   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:53:5
    │  
 53 │ ╭     pub fn set_my_bytes(self, my_bytes: Array<u8, 100>):
 54 │ │         self.my_bytes = my_bytes
-   │ ╰────────────────────────────────^ attributes hash: 5447714587686147158
+   │ ╰────────────────────────────────^ attributes hash: 232105020008464236
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_bytes",
@@ -433,19 +509,27 @@ note:
    ┌─ stress/abi_encoding_stress.fe:54:9
    │
 54 │         self.my_bytes = my_bytes
-   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<u8, 100>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:54:9
+   │
+54 │         self.my_bytes = my_bytes
+   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<u8, 100>: Memory
    │         │                
-   │         Array<u8, 100>: Storage { nonce: Some(5) } => None
+   │         Array<u8, 100>: Storage { nonce: Some(5) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:56:5
    │  
 56 │ ╭     pub fn get_my_bytes(self) -> Array<u8, 100>:
 57 │ │         return self.my_bytes.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 11897278640933106358
+   │ ╰─────────────────────────────────────^ attributes hash: 1384022860599926390
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Array(
@@ -463,21 +547,25 @@ note:
    ┌─ stress/abi_encoding_stress.fe:57:16
    │
 57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:57:16
    │
 57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Some(Memory)
+   │                ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) }
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:57:16
    │
 57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:57:16
    │
-   = ValueAttribute
+57 │         return self.my_bytes.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:59:5
@@ -511,25 +599,25 @@ note:
    ┌─ stress/abi_encoding_stress.fe:61:20
    │
 61 │             my_num=42,
-   │                    ^^ u256: Value => None
+   │                    ^^ u256: Value
 62 │             my_num2=u8(26),
-   │                        ^^ u8: Value => None
+   │                        ^^ u8: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:62:21
    │
 62 │             my_num2=u8(26),
-   │                     ^^^^^^ u8: Value => None
+   │                     ^^^^^^ u8: Value
 63 │             my_bool=true,
-   │                     ^^^^ bool: Value => None
+   │                     ^^^^ bool: Value
 64 │             my_addr=address(123456)
-   │                             ^^^^^^ u256: Value => None
+   │                             ^^^^^^ u256: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:64:21
    │
 64 │             my_addr=address(123456)
-   │                     ^^^^^^^^^^^^^^^ address: Value => None
+   │                     ^^^^^^^^^^^^^^^ address: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:60:16
@@ -541,51 +629,22 @@ note:
 63 │ │             my_bool=true,
 64 │ │             my_addr=address(123456)
 65 │ │         )
-   │ ╰─────────^ MyStruct: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:60:16
-   │
-60 │         return MyStruct(
-   │                ^^^^^^^^ attributes hash: 9455737928596384977
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "MyStruct",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 4,
-             },
-         ),
-     }
+   │ ╰─────────^ MyStruct: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:62:21
    │
 62 │             my_num2=u8(26),
-   │                     ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+   │                     ^^ TypeConstructor(Base(Numeric(U8)))
+63 │             my_bool=true,
+64 │             my_addr=address(123456)
+   │                     ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:64:21
+   ┌─ stress/abi_encoding_stress.fe:60:16
    │
-64 │             my_addr=address(123456)
-   │                     ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+60 │         return MyStruct(
+   │                ^^^^^^^^ TypeConstructor(Struct(Struct { name: "MyStruct", id: StructId(0), field_count: 4 }))
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:67:5
@@ -633,85 +692,68 @@ note:
    ┌─ stress/abi_encoding_stress.fe:68:9
    │
 68 │         my_struct.my_num = 12341234
-   │         ^^^^^^^^^ MyStruct: Memory => None
+   │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:68:9
    │
 68 │         my_struct.my_num = 12341234
-   │         ^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
    │         │                   
-   │         u256: Memory => None
+   │         u256: Memory
 69 │         my_struct.my_num2 = u8(42)
-   │         ^^^^^^^^^ MyStruct: Memory => None
+   │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:69:9
    │
 69 │         my_struct.my_num2 = u8(42)
-   │         ^^^^^^^^^^^^^^^^^      ^^ u8: Value => None
+   │         ^^^^^^^^^^^^^^^^^      ^^ u8: Value
    │         │                       
-   │         u8: Memory => None
+   │         u8: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:69:29
    │
 69 │         my_struct.my_num2 = u8(42)
-   │                             ^^^^^^ u8: Value => None
+   │                             ^^^^^^ u8: Value
 70 │         my_struct.my_bool = false
-   │         ^^^^^^^^^ MyStruct: Memory => None
+   │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:70:9
    │
 70 │         my_struct.my_bool = false
-   │         ^^^^^^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         ^^^^^^^^^^^^^^^^^   ^^^^^ bool: Value
    │         │                    
-   │         bool: Memory => None
+   │         bool: Memory
 71 │         my_struct.my_addr = address(9999)
-   │         ^^^^^^^^^ MyStruct: Memory => None
+   │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:71:9
    │
 71 │         my_struct.my_addr = address(9999)
-   │         ^^^^^^^^^^^^^^^^^           ^^^^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^^           ^^^^ u256: Value
    │         │                            
-   │         address: Memory => None
+   │         address: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:71:29
    │
 71 │         my_struct.my_addr = address(9999)
-   │                             ^^^^^^^^^^^^^ address: Value => None
+   │                             ^^^^^^^^^^^^^ address: Value
 72 │         return my_struct
-   │                ^^^^^^^^^ MyStruct: Memory => None
+   │                ^^^^^^^^^ MyStruct: Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:69:29
    │
 69 │         my_struct.my_num2 = u8(42)
-   │                             ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:71:29
-   │
+   │                             ^^ TypeConstructor(Base(Numeric(U8)))
+70 │         my_struct.my_bool = false
 71 │         my_struct.my_addr = address(9999)
-   │                             ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                             ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:74:5
@@ -723,10 +765,12 @@ note:
    · │
 81 │ │             my_bytes=self.my_bytes.to_mem()
 82 │ │         )
-   │ ╰─────────^ attributes hash: 4369441865732737140
+   │ ╰─────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -739,41 +783,77 @@ note:
    ┌─ stress/abi_encoding_stress.fe:76:22
    │
 76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => None
+   │                      ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:76:22
    │
 76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Some(Memory)
+   │                      ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:76:22
+   │
+76 │             my_addrs=self.my_addrs.to_mem(),
+   │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Memory
 77 │             my_u128=self.my_u128,
-   │                     ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Some(Value)
+   │                     ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:77:21
+   │
+77 │             my_u128=self.my_u128,
+   │                     ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Value
 78 │             my_string=self.my_string.to_mem(),
-   │                       ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => None
+   │                       ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:78:23
    │
 78 │             my_string=self.my_string.to_mem(),
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Some(Memory)
+   │                       ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:78:23
+   │
+78 │             my_string=self.my_string.to_mem(),
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Memory
 79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => None
+   │                     ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:79:21
    │
 79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Some(Memory)
+   │                     ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:79:21
+   │
+79 │             my_u16s=self.my_u16s.to_mem(),
+   │                     ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Memory
 80 │             my_bool=self.my_bool,
-   │                     ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Some(Value)
+   │                     ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:80:21
+   │
+80 │             my_bool=self.my_bool,
+   │                     ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Value
 81 │             my_bytes=self.my_bytes.to_mem()
-   │                      ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => None
+   │                      ^^^^ Foo: Value
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:81:22
    │
 81 │             my_bytes=self.my_bytes.to_mem()
-   │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Some(Memory)
+   │                      ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:81:22
+   │
+81 │             my_bytes=self.my_bytes.to_mem()
+   │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:75:9
@@ -868,32 +948,14 @@ note:
    ┌─ stress/abi_encoding_stress.fe:76:22
    │
 76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:78:23
-   │
+   │                      ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
+77 │             my_u128=self.my_u128,
 78 │             my_string=self.my_string.to_mem(),
-   │                       ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:79:21
-   │
+   │                       ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:81:22
-   │
+   │                     ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
+80 │             my_bool=self.my_bool,
 81 │             my_bytes=self.my_bytes.to_mem()
-   │                      ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                      ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"stress/abi_encoding_stress.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -8,58 +8,26 @@ note:
   │
 2 │     my_num: u256
   │     ^^^^^^^^^^^^ u256
-
-note: 
-  ┌─ stress/abi_encoding_stress.fe:3:5
-  │
 3 │     my_num2: u8
   │     ^^^^^^^^^^^ u8
-
-note: 
-  ┌─ stress/abi_encoding_stress.fe:4:5
-  │
 4 │     my_bool: bool
   │     ^^^^^^^^^^^^^ bool
-
-note: 
-  ┌─ stress/abi_encoding_stress.fe:5:5
-  │
 5 │     my_addr: address
   │     ^^^^^^^^^^^^^^^^ address
 
 note: 
-  ┌─ stress/abi_encoding_stress.fe:8:5
-  │
-8 │     my_addrs: Array<address, 5>
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
-
-note: 
-  ┌─ stress/abi_encoding_stress.fe:9:5
-  │
-9 │     my_u128: u128
-  │     ^^^^^^^^^^^^^ u128
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:10:5
+   ┌─ stress/abi_encoding_stress.fe:8:5
    │
+ 8 │     my_addrs: Array<address, 5>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
+ 9 │     my_u128: u128
+   │     ^^^^^^^^^^^^^ u128
 10 │     my_string: String<10>
    │     ^^^^^^^^^^^^^^^^^^^^^ String<10>
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:11:5
-   │
 11 │     my_u16s: Array<u16, 255>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:12:5
-   │
 12 │     my_bool: bool
    │     ^^^^^^^^^^^^^ bool
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:13:5
-   │
 13 │     my_bytes: Array<u8, 100>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>
 
@@ -68,34 +36,14 @@ note:
    │
 16 │         my_addrs: Array<address, 5>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:17:9
-   │
 17 │         my_u128: u128
    │         ^^^^^^^^^^^^^ u128
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:18:9
-   │
 18 │         my_string: String<10>
    │         ^^^^^^^^^^^^^^^^^^^^^ String<10>
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:19:9
-   │
 19 │         my_u16s: Array<u16, 255>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:20:9
-   │
 20 │         my_bool: bool
    │         ^^^^^^^^^^^^^ bool
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:21:9
-   │
 21 │         my_bytes: Array<u8, 100>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>
 
@@ -129,6 +77,14 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:24:9
+   │
+24 │         self.my_addrs = my_addrs
+   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 5>: Memory => None
+   │         │                
+   │         Array<address, 5>: Storage { nonce: Some(0) } => None
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:26:5
    │  
 26 │ ╭     pub fn get_my_addrs(self) -> Array<address, 5>:
@@ -147,6 +103,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:27:16
+   │
+27 │         return self.my_addrs.to_mem()
+   │                ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:27:16
+   │
+27 │         return self.my_addrs.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Some(Memory)
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:27:16
+   │
+27 │         return self.my_addrs.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:29:5
@@ -177,6 +153,14 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:30:9
+   │
+30 │         self.my_u128 = my_u128
+   │         ^^^^^^^^^^^^   ^^^^^^^ u128: Value => None
+   │         │               
+   │         u128: Storage { nonce: Some(1) } => None
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:32:5
    │  
 32 │ ╭     pub fn get_my_u128(self) -> u128:
@@ -194,6 +178,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:33:16
+   │
+33 │         return self.my_u128
+   │                ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Some(Value)
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:35:5
@@ -224,6 +214,14 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:36:9
+   │
+36 │         self.my_string = my_string
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<10>: Memory => None
+   │         │                 
+   │         String<10>: Storage { nonce: Some(2) } => None
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:38:5
    │  
 38 │ ╭     pub fn get_my_string(self) -> String<10>:
@@ -241,6 +239,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:39:16
+   │
+39 │         return self.my_string.to_mem()
+   │                ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:39:16
+   │
+39 │         return self.my_string.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Some(Memory)
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:39:16
+   │
+39 │         return self.my_string.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:41:5
@@ -274,6 +292,14 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:42:9
+   │
+42 │         self.my_u16s = my_u16s
+   │         ^^^^^^^^^^^^   ^^^^^^^ Array<u16, 255>: Memory => None
+   │         │               
+   │         Array<u16, 255>: Storage { nonce: Some(3) } => None
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:44:5
    │  
 44 │ ╭     pub fn get_my_u16s(self) -> Array<u16, 255>:
@@ -294,6 +320,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:45:16
+   │
+45 │         return self.my_u16s.to_mem()
+   │                ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:45:16
+   │
+45 │         return self.my_u16s.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Some(Memory)
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:45:16
+   │
+45 │         return self.my_u16s.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:47:5
@@ -322,6 +368,14 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:48:9
+   │
+48 │         self.my_bool = my_bool
+   │         ^^^^^^^^^^^^   ^^^^^^^ bool: Value => None
+   │         │               
+   │         bool: Storage { nonce: Some(4) } => None
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:50:5
    │  
 50 │ ╭     pub fn get_my_bool(self) -> bool:
@@ -337,6 +391,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:51:16
+   │
+51 │         return self.my_bool
+   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Some(Value)
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:53:5
@@ -370,6 +430,14 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:54:9
+   │
+54 │         self.my_bytes = my_bytes
+   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<u8, 100>: Memory => None
+   │         │                
+   │         Array<u8, 100>: Storage { nonce: Some(5) } => None
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:56:5
    │  
 56 │ ╭     pub fn get_my_bytes(self) -> Array<u8, 100>:
@@ -390,6 +458,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:57:16
+   │
+57 │         return self.my_bytes.to_mem()
+   │                ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:57:16
+   │
+57 │         return self.my_bytes.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Some(Memory)
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:57:16
+   │
+57 │         return self.my_bytes.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:59:5
@@ -416,6 +504,86 @@ note:
                      field_count: 4,
                  },
              ),
+         ),
+     }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:61:20
+   │
+61 │             my_num=42,
+   │                    ^^ u256: Value => None
+62 │             my_num2=u8(26),
+   │                        ^^ u8: Value => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:62:21
+   │
+62 │             my_num2=u8(26),
+   │                     ^^^^^^ u8: Value => None
+63 │             my_bool=true,
+   │                     ^^^^ bool: Value => None
+64 │             my_addr=address(123456)
+   │                             ^^^^^^ u256: Value => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:64:21
+   │
+64 │             my_addr=address(123456)
+   │                     ^^^^^^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:60:16
+   │  
+60 │           return MyStruct(
+   │ ╭────────────────^
+61 │ │             my_num=42,
+62 │ │             my_num2=u8(26),
+63 │ │             my_bool=true,
+64 │ │             my_addr=address(123456)
+65 │ │         )
+   │ ╰─────────^ MyStruct: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:60:16
+   │
+60 │         return MyStruct(
+   │                ^^^^^^^^ attributes hash: 9455737928596384977
+   │
+   = TypeConstructor {
+         typ: Struct(
+             Struct {
+                 name: "MyStruct",
+                 id: StructId(
+                     0,
+                 ),
+                 field_count: 4,
+             },
+         ),
+     }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:62:21
+   │
+62 │             my_num2=u8(26),
+   │                     ^^ attributes hash: 4311289215688173045
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U8,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:64:21
+   │
+64 │             my_addr=address(123456)
+   │                     ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
          ),
      }
 
@@ -462,6 +630,90 @@ note:
      }
 
 note: 
+   ┌─ stress/abi_encoding_stress.fe:68:9
+   │
+68 │         my_struct.my_num = 12341234
+   │         ^^^^^^^^^ MyStruct: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:68:9
+   │
+68 │         my_struct.my_num = 12341234
+   │         ^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+   │         │                   
+   │         u256: Memory => None
+69 │         my_struct.my_num2 = u8(42)
+   │         ^^^^^^^^^ MyStruct: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:69:9
+   │
+69 │         my_struct.my_num2 = u8(42)
+   │         ^^^^^^^^^^^^^^^^^      ^^ u8: Value => None
+   │         │                       
+   │         u8: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:69:29
+   │
+69 │         my_struct.my_num2 = u8(42)
+   │                             ^^^^^^ u8: Value => None
+70 │         my_struct.my_bool = false
+   │         ^^^^^^^^^ MyStruct: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:70:9
+   │
+70 │         my_struct.my_bool = false
+   │         ^^^^^^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         │                    
+   │         bool: Memory => None
+71 │         my_struct.my_addr = address(9999)
+   │         ^^^^^^^^^ MyStruct: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:71:9
+   │
+71 │         my_struct.my_addr = address(9999)
+   │         ^^^^^^^^^^^^^^^^^           ^^^^ u256: Value => None
+   │         │                            
+   │         address: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:71:29
+   │
+71 │         my_struct.my_addr = address(9999)
+   │                             ^^^^^^^^^^^^^ address: Value => None
+72 │         return my_struct
+   │                ^^^^^^^^^ MyStruct: Memory => None
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:69:29
+   │
+69 │         my_struct.my_num2 = u8(42)
+   │                             ^^ attributes hash: 4311289215688173045
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U8,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ stress/abi_encoding_stress.fe:71:29
+   │
+71 │         my_struct.my_addr = address(9999)
+   │                             ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
+         ),
+     }
+
+note: 
    ┌─ stress/abi_encoding_stress.fe:74:5
    │  
 74 │ ╭     pub fn emit_my_event(self):
@@ -484,276 +736,6 @@ note:
      }
 
 note: 
-   ┌─ stress/abi_encoding_stress.fe:24:9
-   │
-24 │         self.my_addrs = my_addrs
-   │         ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:24:25
-   │
-24 │         self.my_addrs = my_addrs
-   │                         ^^^^^^^^ Array<address, 5>: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:27:16
-   │
-27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:27:16
-   │
-27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:30:9
-   │
-30 │         self.my_u128 = my_u128
-   │         ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:30:24
-   │
-30 │         self.my_u128 = my_u128
-   │                        ^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:33:16
-   │
-33 │         return self.my_u128
-   │                ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Some(Value)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:36:9
-   │
-36 │         self.my_string = my_string
-   │         ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:36:26
-   │
-36 │         self.my_string = my_string
-   │                          ^^^^^^^^^ String<10>: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:39:16
-   │
-39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:39:16
-   │
-39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:42:9
-   │
-42 │         self.my_u16s = my_u16s
-   │         ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:42:24
-   │
-42 │         self.my_u16s = my_u16s
-   │                        ^^^^^^^ Array<u16, 255>: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:45:16
-   │
-45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:45:16
-   │
-45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:48:9
-   │
-48 │         self.my_bool = my_bool
-   │         ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:48:24
-   │
-48 │         self.my_bool = my_bool
-   │                        ^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:51:16
-   │
-51 │         return self.my_bool
-   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:54:9
-   │
-54 │         self.my_bytes = my_bytes
-   │         ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:54:25
-   │
-54 │         self.my_bytes = my_bytes
-   │                         ^^^^^^^^ Array<u8, 100>: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:57:16
-   │
-57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:57:16
-   │
-57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:61:20
-   │
-61 │             my_num=42,
-   │                    ^^ u256: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:62:24
-   │
-62 │             my_num2=u8(26),
-   │                        ^^ u8: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:62:21
-   │
-62 │             my_num2=u8(26),
-   │                     ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:63:21
-   │
-63 │             my_bool=true,
-   │                     ^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:64:29
-   │
-64 │             my_addr=address(123456)
-   │                             ^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:64:21
-   │
-64 │             my_addr=address(123456)
-   │                     ^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:60:16
-   │  
-60 │           return MyStruct(
-   │ ╭────────────────^
-61 │ │             my_num=42,
-62 │ │             my_num2=u8(26),
-63 │ │             my_bool=true,
-64 │ │             my_addr=address(123456)
-65 │ │         )
-   │ ╰─────────^ MyStruct: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:68:9
-   │
-68 │         my_struct.my_num = 12341234
-   │         ^^^^^^^^^ MyStruct: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:68:9
-   │
-68 │         my_struct.my_num = 12341234
-   │         ^^^^^^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:68:28
-   │
-68 │         my_struct.my_num = 12341234
-   │                            ^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:69:9
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │         ^^^^^^^^^ MyStruct: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:69:9
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │         ^^^^^^^^^^^^^^^^^ u8: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:69:32
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │                                ^^ u8: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:69:29
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │                             ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:70:9
-   │
-70 │         my_struct.my_bool = false
-   │         ^^^^^^^^^ MyStruct: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:70:9
-   │
-70 │         my_struct.my_bool = false
-   │         ^^^^^^^^^^^^^^^^^ bool: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:70:29
-   │
-70 │         my_struct.my_bool = false
-   │                             ^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:71:9
-   │
-71 │         my_struct.my_addr = address(9999)
-   │         ^^^^^^^^^ MyStruct: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:71:9
-   │
-71 │         my_struct.my_addr = address(9999)
-   │         ^^^^^^^^^^^^^^^^^ address: Memory => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:71:37
-   │
-71 │         my_struct.my_addr = address(9999)
-   │                                     ^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:71:29
-   │
-71 │         my_struct.my_addr = address(9999)
-   │                             ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:72:16
-   │
-72 │         return my_struct
-   │                ^^^^^^^^^ MyStruct: Memory => None
-
-note: 
    ┌─ stress/abi_encoding_stress.fe:76:22
    │
 76 │             my_addrs=self.my_addrs.to_mem(),
@@ -764,16 +746,8 @@ note:
    │
 76 │             my_addrs=self.my_addrs.to_mem(),
    │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:77:21
-   │
 77 │             my_u128=self.my_u128,
    │                     ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Some(Value)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:78:23
-   │
 78 │             my_string=self.my_string.to_mem(),
    │                       ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => None
 
@@ -782,10 +756,6 @@ note:
    │
 78 │             my_string=self.my_string.to_mem(),
    │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:79:21
-   │
 79 │             my_u16s=self.my_u16s.to_mem(),
    │                     ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => None
 
@@ -794,16 +764,8 @@ note:
    │
 79 │             my_u16s=self.my_u16s.to_mem(),
    │                     ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Some(Memory)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:80:21
-   │
 80 │             my_bool=self.my_bool,
    │                     ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:81:22
-   │
 81 │             my_bytes=self.my_bytes.to_mem()
    │                      ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => None
 
@@ -900,108 +862,6 @@ note:
                  is_indexed: false,
              },
          ],
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:27:16
-   │
-27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:39:16
-   │
-39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:45:16
-   │
-45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:57:16
-   │
-57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:60:16
-   │
-60 │         return MyStruct(
-   │                ^^^^^^^^ attributes hash: 9455737928596384977
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "MyStruct",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 4,
-             },
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:62:21
-   │
-62 │             my_num2=u8(26),
-   │                     ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:64:21
-   │
-64 │             my_addr=address(123456)
-   │                     ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:69:29
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │                             ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/abi_encoding_stress.fe:71:29
-   │
-71 │         my_struct.my_addr = address(9999)
-   │                             ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
      }
 
 note: 

--- a/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: address) -> Array<u8, 10>:
 5 │ │         return self.bar[key].to_mem()
-  │ ╰─────────────────────────────────────^ attributes hash: 8899857923785283493
+  │ ╰─────────────────────────────────────^ attributes hash: 17131555945527520636
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -44,39 +46,45 @@ note:
   ┌─ features/address_bytes10_map.fe:5:16
   │
 5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^ ^^^ address: Value => None
+  │                ^^^^ Foo: Value
+
+note: 
+  ┌─ features/address_bytes10_map.fe:5:16
+  │
+5 │         return self.bar[key].to_mem()
+  │                ^^^^^^^^ ^^^ address: Value
   │                │         
-  │                Map<address, Array<u8, 10>>: Storage { nonce: Some(0) } => None
+  │                Map<address, Array<u8, 10>>: Storage { nonce: Some(0) }
 
 note: 
   ┌─ features/address_bytes10_map.fe:5:16
   │
 5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => None
+  │                ^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None }
 
 note: 
   ┌─ features/address_bytes10_map.fe:5:16
   │
 5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => Some(Memory)
+  │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => Memory
 
 note: 
   ┌─ features/address_bytes10_map.fe:5:16
   │
 5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-  │
-  = ValueAttribute
+  │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
   ┌─ features/address_bytes10_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: address, value: Array<u8, 10>):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 8250642936007969286
+  │ ╰─────────────────────────────^ attributes hash: 427041985524849514
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -111,16 +119,22 @@ note:
   ┌─ features/address_bytes10_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ address: Value => None
-  │         │         
-  │         Map<address, Array<u8, 10>>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/address_bytes10_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ Array<u8, 10>: Memory => None
+  │         ^^^^^^^^ ^^^ address: Value
+  │         │         
+  │         Map<address, Array<u8, 10>>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/address_bytes10_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ Array<u8, 10>: Memory
   │         │                
-  │         Array<u8, 10>: Storage { nonce: None } => None
+  │         Array<u8, 10>: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/address_bytes10_map.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -39,6 +39,34 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/address_bytes10_map.fe:5:16
+  │
+5 │         return self.bar[key].to_mem()
+  │                ^^^^^^^^ ^^^ address: Value => None
+  │                │         
+  │                Map<address, Array<u8, 10>>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/address_bytes10_map.fe:5:16
+  │
+5 │         return self.bar[key].to_mem()
+  │                ^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => None
+
+note: 
+  ┌─ features/address_bytes10_map.fe:5:16
+  │
+5 │         return self.bar[key].to_mem()
+  │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => Some(Memory)
+
+note: 
+  ┌─ features/address_bytes10_map.fe:5:16
+  │
+5 │         return self.bar[key].to_mem()
+  │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+  │
+  = ValueAttribute
 
 note: 
   ┌─ features/address_bytes10_map.fe:7:5
@@ -80,59 +108,19 @@ note:
     }
 
 note: 
-  ┌─ features/address_bytes10_map.fe:5:16
+  ┌─ features/address_bytes10_map.fe:8:9
   │
-5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^ Map<address, Array<u8, 10>>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:5:25
-  │
-5 │         return self.bar[key].to_mem()
-  │                         ^^^ address: Value => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:5:16
-  │
-5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:5:16
-  │
-5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => Some(Memory)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ address: Value => None
+  │         │         
+  │         Map<address, Array<u8, 10>>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/address_bytes10_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<address, Array<u8, 10>>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ address: Value => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ Array<u8, 10>: Memory => None
-
-note: 
-  ┌─ features/address_bytes10_map.fe:5:16
-  │
-5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-  │
-  = ValueAttribute
+  │         ^^^^^^^^^^^^^   ^^^^^ Array<u8, 10>: Memory => None
+  │         │                
+  │         Array<u8, 10>: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__assert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__assert.snap
@@ -43,15 +43,15 @@ note:
   ┌─ features/assert.fe:6:16
   │
 6 │         assert baz > 5
-  │                ^^^   ^ u256: Value => None
+  │                ^^^   ^ u256: Value
   │                │      
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/assert.fe:6:16
   │
 6 │         assert baz > 5
-  │                ^^^^^^^ bool: Value => None
+  │                ^^^^^^^ bool: Value
 
 note: 
   ┌─ features/assert.fe:8:5
@@ -85,17 +85,17 @@ note:
   ┌─ features/assert.fe:9:16
   │
 9 │         assert baz > 5, "Must be greater than five"
-  │                ^^^   ^ u256: Value => None
+  │                ^^^   ^ u256: Value
   │                │      
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/assert.fe:9:16
   │
 9 │         assert baz > 5, "Must be greater than five"
-  │                ^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<25>: Memory => None
+  │                ^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<25>: Memory
   │                │         
-  │                bool: Value => None
+  │                bool: Value
 
 note: 
    ┌─ features/assert.fe:11:5
@@ -139,17 +139,17 @@ note:
    ┌─ features/assert.fe:12:16
    │
 12 │         assert baz > 5, reason
-   │                ^^^   ^ u256: Value => None
+   │                ^^^   ^ u256: Value
    │                │      
-   │                u256: Value => None
+   │                u256: Value
 
 note: 
    ┌─ features/assert.fe:12:16
    │
 12 │         assert baz > 5, reason
-   │                ^^^^^^^  ^^^^^^ String<1000>: Memory => None
+   │                ^^^^^^^  ^^^^^^ String<1000>: Memory
    │                │         
-   │                bool: Value => None
+   │                bool: Value
 
 note: 
    ┌─ features/assert.fe:14:5
@@ -157,10 +157,12 @@ note:
 14 │ ╭     pub fn assert_sto_bool(self):
 15 │ │         self.my_bool = false
 16 │ │         assert self.my_bool
-   │ ╰───────────────────────────^ attributes hash: 4369441865732737140
+   │ ╰───────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -173,11 +175,23 @@ note:
    ┌─ features/assert.fe:15:9
    │
 15 │         self.my_bool = false
-   │         ^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/assert.fe:15:9
+   │
+15 │         self.my_bool = false
+   │         ^^^^^^^^^^^^   ^^^^^ bool: Value
    │         │               
-   │         bool: Storage { nonce: Some(0) } => None
+   │         bool: Storage { nonce: Some(0) }
 16 │         assert self.my_bool
-   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/assert.fe:16:16
+   │
+16 │         assert self.my_bool
+   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ features/assert.fe:18:5
@@ -185,10 +199,12 @@ note:
 18 │ ╭     pub fn assert_sto_string_msg(self):
 19 │ │         self.my_string = "hello"
 20 │ │         assert false, self.my_string.to_mem()
-   │ ╰─────────────────────────────────────────────^ attributes hash: 4369441865732737140
+   │ ╰─────────────────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -201,26 +217,36 @@ note:
    ┌─ features/assert.fe:19:9
    │
 19 │         self.my_string = "hello"
-   │         ^^^^^^^^^^^^^^   ^^^^^^^ String<5>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/assert.fe:19:9
+   │
+19 │         self.my_string = "hello"
+   │         ^^^^^^^^^^^^^^   ^^^^^^^ String<5>: Memory
    │         │                 
-   │         String<5>: Storage { nonce: Some(1) } => None
+   │         String<5>: Storage { nonce: Some(1) }
 20 │         assert false, self.my_string.to_mem()
-   │                ^^^^^  ^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => None
+   │                ^^^^^  ^^^^ Foo: Value
    │                │       
-   │                bool: Value => None
+   │                bool: Value
 
 note: 
    ┌─ features/assert.fe:20:23
    │
 20 │         assert false, self.my_string.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => Some(Memory)
+   │                       ^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ features/assert.fe:20:23
    │
 20 │         assert false, self.my_string.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => Memory
+
+note: 
+   ┌─ features/assert.fe:20:23
    │
-   = ValueAttribute
+20 │         assert false, self.my_string.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__assert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__assert.snap
@@ -8,10 +8,6 @@ note:
   │
 2 │     my_bool: bool
   │     ^^^^^^^^^^^^^ bool
-
-note: 
-  ┌─ features/assert.fe:3:5
-  │
 3 │     my_string: String<5>
   │     ^^^^^^^^^^^^^^^^^^^^ String<5>
 
@@ -44,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/assert.fe:6:16
+  │
+6 │         assert baz > 5
+  │                ^^^   ^ u256: Value => None
+  │                │      
+  │                u256: Value => None
+
+note: 
+  ┌─ features/assert.fe:6:16
+  │
+6 │         assert baz > 5
+  │                ^^^^^^^ bool: Value => None
+
+note: 
   ┌─ features/assert.fe:8:5
   │  
 8 │ ╭     pub fn revert_with_static_string(baz: u256):
@@ -70,6 +80,22 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/assert.fe:9:16
+  │
+9 │         assert baz > 5, "Must be greater than five"
+  │                ^^^   ^ u256: Value => None
+  │                │      
+  │                u256: Value => None
+
+note: 
+  ┌─ features/assert.fe:9:16
+  │
+9 │         assert baz > 5, "Must be greater than five"
+  │                ^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<25>: Memory => None
+  │                │         
+  │                bool: Value => None
 
 note: 
    ┌─ features/assert.fe:11:5
@@ -110,6 +136,22 @@ note:
      }
 
 note: 
+   ┌─ features/assert.fe:12:16
+   │
+12 │         assert baz > 5, reason
+   │                ^^^   ^ u256: Value => None
+   │                │      
+   │                u256: Value => None
+
+note: 
+   ┌─ features/assert.fe:12:16
+   │
+12 │         assert baz > 5, reason
+   │                ^^^^^^^  ^^^^^^ String<1000>: Memory => None
+   │                │         
+   │                bool: Value => None
+
+note: 
    ┌─ features/assert.fe:14:5
    │  
 14 │ ╭     pub fn assert_sto_bool(self):
@@ -126,6 +168,16 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/assert.fe:15:9
+   │
+15 │         self.my_bool = false
+   │         ^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         │               
+   │         bool: Storage { nonce: Some(0) } => None
+16 │         assert self.my_bool
+   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/assert.fe:18:5
@@ -146,112 +198,16 @@ note:
      }
 
 note: 
-  ┌─ features/assert.fe:6:16
-  │
-6 │         assert baz > 5
-  │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/assert.fe:6:22
-  │
-6 │         assert baz > 5
-  │                      ^ u256: Value => None
-
-note: 
-  ┌─ features/assert.fe:6:16
-  │
-6 │         assert baz > 5
-  │                ^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/assert.fe:9:16
-  │
-9 │         assert baz > 5, "Must be greater than five"
-  │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/assert.fe:9:22
-  │
-9 │         assert baz > 5, "Must be greater than five"
-  │                      ^ u256: Value => None
-
-note: 
-  ┌─ features/assert.fe:9:16
-  │
-9 │         assert baz > 5, "Must be greater than five"
-  │                ^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/assert.fe:9:25
-  │
-9 │         assert baz > 5, "Must be greater than five"
-  │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<25>: Memory => None
-
-note: 
-   ┌─ features/assert.fe:12:16
-   │
-12 │         assert baz > 5, reason
-   │                ^^^ u256: Value => None
-
-note: 
-   ┌─ features/assert.fe:12:22
-   │
-12 │         assert baz > 5, reason
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ features/assert.fe:12:16
-   │
-12 │         assert baz > 5, reason
-   │                ^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/assert.fe:12:25
-   │
-12 │         assert baz > 5, reason
-   │                         ^^^^^^ String<1000>: Memory => None
-
-note: 
-   ┌─ features/assert.fe:15:9
-   │
-15 │         self.my_bool = false
-   │         ^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/assert.fe:15:24
-   │
-15 │         self.my_bool = false
-   │                        ^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/assert.fe:16:16
-   │
-16 │         assert self.my_bool
-   │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
    ┌─ features/assert.fe:19:9
    │
 19 │         self.my_string = "hello"
-   │         ^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/assert.fe:19:26
-   │
-19 │         self.my_string = "hello"
-   │                          ^^^^^^^ String<5>: Memory => None
-
-note: 
-   ┌─ features/assert.fe:20:16
-   │
+   │         ^^^^^^^^^^^^^^   ^^^^^^^ String<5>: Memory => None
+   │         │                 
+   │         String<5>: Storage { nonce: Some(1) } => None
 20 │         assert false, self.my_string.to_mem()
-   │                ^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/assert.fe:20:23
-   │
-20 │         assert false, self.my_string.to_mem()
-   │                       ^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => None
+   │                ^^^^^  ^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => None
+   │                │       
+   │                bool: Value => None
 
 note: 
    ┌─ features/assert.fe:20:23

--- a/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
@@ -1,0 +1,195 @@
+---
+source: crates/analyzer/tests/analysis.rs
+expression: "build_snapshot(\"features/associated_fns.fe\", &src, module, &db)"
+
+---
+note: 
+  ┌─ features/associated_fns.fe:3:3
+  │  
+3 │ ╭   pub fn square(x: u256) -> u256:
+4 │ │     return x * x
+  │ ╰────────────────^ attributes hash: 10491700091878076414
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [
+            FunctionParam {
+                name: "x",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U256,
+                        ),
+                    ),
+                ),
+            },
+        ],
+        return_type: Ok(
+            Base(
+                Numeric(
+                    U256,
+                ),
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/associated_fns.fe:4:12
+  │
+4 │     return x * x
+  │            ^   ^ u256: Value
+  │            │    
+  │            u256: Value
+
+note: 
+  ┌─ features/associated_fns.fe:4:12
+  │
+4 │     return x * x
+  │            ^^^^^ u256: Value
+
+note: 
+  ┌─ features/associated_fns.fe:7:3
+  │
+7 │   x: u256
+  │   ^^^^^^^ u256
+
+note: 
+  ┌─ features/associated_fns.fe:8:3
+  │  
+8 │ ╭   pub fn new(x: u256) -> MyStruct:
+9 │ │     return MyStruct(x)
+  │ ╰──────────────────────^ attributes hash: 12320534675640633934
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [
+            FunctionParam {
+                name: "x",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U256,
+                        ),
+                    ),
+                ),
+            },
+        ],
+        return_type: Ok(
+            Struct(
+                Struct {
+                    name: "MyStruct",
+                    id: StructId(
+                        1,
+                    ),
+                    field_count: 1,
+                },
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/associated_fns.fe:9:21
+  │
+9 │     return MyStruct(x)
+  │                     ^ u256: Value
+
+note: 
+  ┌─ features/associated_fns.fe:9:12
+  │
+9 │     return MyStruct(x)
+  │            ^^^^^^^^^^^ MyStruct: Memory
+
+note: 
+  ┌─ features/associated_fns.fe:9:12
+  │
+9 │     return MyStruct(x)
+  │            ^^^^^^^^ TypeConstructor(Struct(Struct { name: "MyStruct", id: StructId(1), field_count: 1 }))
+
+note: 
+   ┌─ features/associated_fns.fe:12:3
+   │
+12 │   my_struct: MyStruct
+   │   ^^^^^^^^^^^^^^^^^^^ MyStruct
+
+note: 
+   ┌─ features/associated_fns.fe:14:3
+   │  
+14 │ ╭   pub fn bar(self, val: u256) -> u256:
+15 │ │     self.my_struct = MyStruct.new(val)
+16 │ │     return Lib.square(self.my_struct.x)
+   │ ╰───────────────────────────────────────^ attributes hash: 18287971674339323054
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [
+             FunctionParam {
+                 name: "val",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/associated_fns.fe:15:5
+   │
+15 │     self.my_struct = MyStruct.new(val)
+   │     ^^^^ Foo: Value
+
+note: 
+   ┌─ features/associated_fns.fe:15:5
+   │
+15 │     self.my_struct = MyStruct.new(val)
+   │     ^^^^^^^^^^^^^^                ^^^ u256: Value
+   │     │                              
+   │     MyStruct: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/associated_fns.fe:15:22
+   │
+15 │     self.my_struct = MyStruct.new(val)
+   │                      ^^^^^^^^^^^^^^^^^ MyStruct: Memory
+16 │     return Lib.square(self.my_struct.x)
+   │                       ^^^^ Foo: Value
+
+note: 
+   ┌─ features/associated_fns.fe:16:23
+   │
+16 │     return Lib.square(self.my_struct.x)
+   │                       ^^^^^^^^^^^^^^ MyStruct: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/associated_fns.fe:16:23
+   │
+16 │     return Lib.square(self.my_struct.x)
+   │                       ^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/associated_fns.fe:16:12
+   │
+16 │     return Lib.square(self.my_struct.x)
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+   ┌─ features/associated_fns.fe:15:22
+   │
+15 │     self.my_struct = MyStruct.new(val)
+   │                      ^^^^^^^^^^^^ AssociatedFunction { class: Struct(StructId(1)), function: FunctionId(1) }
+16 │     return Lib.square(self.my_struct.x)
+   │            ^^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(0) }
+
+

--- a/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
+++ b/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/aug_assign.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -51,6 +51,16 @@ note:
     }
 
 note: 
+  ┌─ features/aug_assign.fe:5:9
+  │
+5 │         a += b
+  │         ^    ^ u256: Value => None
+  │         │     
+  │         u256: Value => None
+6 │         return a
+  │                ^ u256: Value => None
+
+note: 
    ┌─ features/aug_assign.fe:8:5
    │  
  8 │ ╭     pub fn sub(a: u256, b: u256) -> u256:
@@ -90,6 +100,16 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/aug_assign.fe:9:9
+   │
+ 9 │         a -= b
+   │         ^    ^ u256: Value => None
+   │         │     
+   │         u256: Value => None
+10 │         return a
+   │                ^ u256: Value => None
 
 note: 
    ┌─ features/aug_assign.fe:12:5
@@ -133,6 +153,16 @@ note:
      }
 
 note: 
+   ┌─ features/aug_assign.fe:13:9
+   │
+13 │         a *= b
+   │         ^    ^ u256: Value => None
+   │         │     
+   │         u256: Value => None
+14 │         return a
+   │                ^ u256: Value => None
+
+note: 
    ┌─ features/aug_assign.fe:16:5
    │  
 16 │ ╭     pub fn div(a: u256, b: u256) -> u256:
@@ -172,6 +202,16 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/aug_assign.fe:17:9
+   │
+17 │         a /= b
+   │         ^    ^ u256: Value => None
+   │         │     
+   │         u256: Value => None
+18 │         return a
+   │                ^ u256: Value => None
 
 note: 
    ┌─ features/aug_assign.fe:20:5
@@ -215,6 +255,16 @@ note:
      }
 
 note: 
+   ┌─ features/aug_assign.fe:21:9
+   │
+21 │         a %= b
+   │         ^    ^ u256: Value => None
+   │         │     
+   │         u256: Value => None
+22 │         return a
+   │                ^ u256: Value => None
+
+note: 
    ┌─ features/aug_assign.fe:24:5
    │  
 24 │ ╭     pub fn pow(a: u256, b: u256) -> u256:
@@ -254,6 +304,16 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/aug_assign.fe:25:9
+   │
+25 │         a **= b
+   │         ^     ^ u256: Value => None
+   │         │      
+   │         u256: Value => None
+26 │         return a
+   │                ^ u256: Value => None
 
 note: 
    ┌─ features/aug_assign.fe:28:5
@@ -297,6 +357,16 @@ note:
      }
 
 note: 
+   ┌─ features/aug_assign.fe:29:9
+   │
+29 │         a <<= b
+   │         ^     ^ u8: Value => None
+   │         │      
+   │         u8: Value => None
+30 │         return a
+   │                ^ u8: Value => None
+
+note: 
    ┌─ features/aug_assign.fe:32:5
    │  
 32 │ ╭     pub fn rshift(a: u8, b: u8) -> u8:
@@ -336,6 +406,16 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/aug_assign.fe:33:9
+   │
+33 │         a >>= b
+   │         ^     ^ u8: Value => None
+   │         │      
+   │         u8: Value => None
+34 │         return a
+   │                ^ u8: Value => None
 
 note: 
    ┌─ features/aug_assign.fe:36:5
@@ -379,6 +459,16 @@ note:
      }
 
 note: 
+   ┌─ features/aug_assign.fe:37:9
+   │
+37 │         a |= b
+   │         ^    ^ u8: Value => None
+   │         │     
+   │         u8: Value => None
+38 │         return a
+   │                ^ u8: Value => None
+
+note: 
    ┌─ features/aug_assign.fe:40:5
    │  
 40 │ ╭     pub fn bit_xor(a: u8, b: u8) -> u8:
@@ -418,6 +508,16 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/aug_assign.fe:41:9
+   │
+41 │         a ^= b
+   │         ^    ^ u8: Value => None
+   │         │     
+   │         u8: Value => None
+42 │         return a
+   │                ^ u8: Value => None
 
 note: 
    ┌─ features/aug_assign.fe:44:5
@@ -461,6 +561,16 @@ note:
      }
 
 note: 
+   ┌─ features/aug_assign.fe:45:9
+   │
+45 │         a &= b
+   │         ^    ^ u8: Value => None
+   │         │     
+   │         u8: Value => None
+46 │         return a
+   │                ^ u8: Value => None
+
+note: 
    ┌─ features/aug_assign.fe:48:5
    │  
 48 │ ╭     pub fn add_from_sto(self, a: u256, b: u256) -> u256:
@@ -501,6 +611,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/aug_assign.fe:49:9
+   │
+49 │         self.my_num = a
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Storage { nonce: Some(0) } => None
+50 │         self.my_num += b
+   │         ^^^^^^^^^^^    ^ u256: Value => None
+   │         │               
+   │         u256: Storage { nonce: Some(0) } => None
+51 │         return self.my_num
+   │                ^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/aug_assign.fe:53:5
@@ -546,303 +670,47 @@ note:
      }
 
 note: 
-  ┌─ features/aug_assign.fe:5:9
-  │
-5 │         a += b
-  │         ^ u256: Value => None
-
-note: 
-  ┌─ features/aug_assign.fe:5:14
-  │
-5 │         a += b
-  │              ^ u256: Value => None
-
-note: 
-  ┌─ features/aug_assign.fe:6:16
-  │
-6 │         return a
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/aug_assign.fe:9:9
-  │
-9 │         a -= b
-  │         ^ u256: Value => None
-
-note: 
-  ┌─ features/aug_assign.fe:9:14
-  │
-9 │         a -= b
-  │              ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:10:16
+   ┌─ features/aug_assign.fe:54:23
    │
-10 │         return a
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:13:9
-   │
-13 │         a *= b
-   │         ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:13:14
-   │
-13 │         a *= b
-   │              ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:14:16
-   │
-14 │         return a
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:17:9
-   │
-17 │         a /= b
-   │         ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:17:14
-   │
-17 │         a /= b
-   │              ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:18:16
-   │
-18 │         return a
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:21:9
-   │
-21 │         a %= b
-   │         ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:21:14
-   │
-21 │         a %= b
-   │              ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:22:16
-   │
-22 │         return a
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:25:9
-   │
-25 │         a **= b
-   │         ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:25:15
-   │
-25 │         a **= b
-   │               ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:26:16
-   │
-26 │         return a
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:29:9
-   │
-29 │         a <<= b
-   │         ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:29:15
-   │
-29 │         a <<= b
-   │               ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:30:16
-   │
-30 │         return a
-   │                ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:33:9
-   │
-33 │         a >>= b
-   │         ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:33:15
-   │
-33 │         a >>= b
-   │               ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:34:16
-   │
-34 │         return a
-   │                ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:37:9
-   │
-37 │         a |= b
-   │         ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:37:14
-   │
-37 │         a |= b
-   │              ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:38:16
-   │
-38 │         return a
-   │                ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:41:9
-   │
-41 │         a ^= b
-   │         ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:41:14
-   │
-41 │         a ^= b
-   │              ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:42:16
-   │
-42 │         return a
-   │                ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:45:9
-   │
-45 │         a &= b
-   │         ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:45:14
-   │
-45 │         a &= b
-   │              ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:46:16
-   │
-46 │         return a
-   │                ^ u8: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:49:9
-   │
-49 │         self.my_num = a
-   │         ^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/aug_assign.fe:49:23
-   │
-49 │         self.my_num = a
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:50:9
-   │
-50 │         self.my_num += b
-   │         ^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/aug_assign.fe:50:24
-   │
-50 │         self.my_num += b
-   │                        ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:51:16
-   │
-51 │         return self.my_num
-   │                ^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+54 │         let my_array: Array<u256, 10>
+   │                       ^^^^^^^^^^^^^^^ Array<u256, 10>
 
 note: 
    ┌─ features/aug_assign.fe:55:9
    │
 55 │         my_array[7] = a
-   │         ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ features/aug_assign.fe:55:18
-   │
-55 │         my_array[7] = a
-   │                  ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 10>: Memory => None
 
 note: 
    ┌─ features/aug_assign.fe:55:9
    │
 55 │         my_array[7] = a
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/aug_assign.fe:55:23
-   │
-55 │         my_array[7] = a
-   │                       ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+56 │         my_array[7] += b
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 10>: Memory => None
 
 note: 
    ┌─ features/aug_assign.fe:56:9
    │
 56 │         my_array[7] += b
-   │         ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ features/aug_assign.fe:56:18
-   │
-56 │         my_array[7] += b
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:56:9
-   │
-56 │         my_array[7] += b
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/aug_assign.fe:56:24
-   │
-56 │         my_array[7] += b
-   │                        ^ u256: Value => None
-
-note: 
-   ┌─ features/aug_assign.fe:57:16
-   │
+   │         ^^^^^^^^^^^    ^ u256: Value => None
+   │         │               
+   │         u256: Memory => None
 57 │         return my_array[7]
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ features/aug_assign.fe:57:25
-   │
-57 │         return my_array[7]
-   │                         ^ u256: Value => None
+   │                ^^^^^^^^ ^ u256: Value => None
+   │                │         
+   │                Array<u256, 10>: Memory => None
 
 note: 
    ┌─ features/aug_assign.fe:57:16
    │
 57 │         return my_array[7]
    │                ^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/aug_assign.fe:54:23
-   │
-54 │         let my_array: Array<u256, 10>
-   │                       ^^^^^^^^^^^^^^^ Array<u256, 10>
 
 

--- a/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
+++ b/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
@@ -54,11 +54,11 @@ note:
   ┌─ features/aug_assign.fe:5:9
   │
 5 │         a += b
-  │         ^    ^ u256: Value => None
+  │         ^    ^ u256: Value
   │         │     
-  │         u256: Value => None
+  │         u256: Value
 6 │         return a
-  │                ^ u256: Value => None
+  │                ^ u256: Value
 
 note: 
    ┌─ features/aug_assign.fe:8:5
@@ -105,11 +105,11 @@ note:
    ┌─ features/aug_assign.fe:9:9
    │
  9 │         a -= b
-   │         ^    ^ u256: Value => None
+   │         ^    ^ u256: Value
    │         │     
-   │         u256: Value => None
+   │         u256: Value
 10 │         return a
-   │                ^ u256: Value => None
+   │                ^ u256: Value
 
 note: 
    ┌─ features/aug_assign.fe:12:5
@@ -156,11 +156,11 @@ note:
    ┌─ features/aug_assign.fe:13:9
    │
 13 │         a *= b
-   │         ^    ^ u256: Value => None
+   │         ^    ^ u256: Value
    │         │     
-   │         u256: Value => None
+   │         u256: Value
 14 │         return a
-   │                ^ u256: Value => None
+   │                ^ u256: Value
 
 note: 
    ┌─ features/aug_assign.fe:16:5
@@ -207,11 +207,11 @@ note:
    ┌─ features/aug_assign.fe:17:9
    │
 17 │         a /= b
-   │         ^    ^ u256: Value => None
+   │         ^    ^ u256: Value
    │         │     
-   │         u256: Value => None
+   │         u256: Value
 18 │         return a
-   │                ^ u256: Value => None
+   │                ^ u256: Value
 
 note: 
    ┌─ features/aug_assign.fe:20:5
@@ -258,11 +258,11 @@ note:
    ┌─ features/aug_assign.fe:21:9
    │
 21 │         a %= b
-   │         ^    ^ u256: Value => None
+   │         ^    ^ u256: Value
    │         │     
-   │         u256: Value => None
+   │         u256: Value
 22 │         return a
-   │                ^ u256: Value => None
+   │                ^ u256: Value
 
 note: 
    ┌─ features/aug_assign.fe:24:5
@@ -309,11 +309,11 @@ note:
    ┌─ features/aug_assign.fe:25:9
    │
 25 │         a **= b
-   │         ^     ^ u256: Value => None
+   │         ^     ^ u256: Value
    │         │      
-   │         u256: Value => None
+   │         u256: Value
 26 │         return a
-   │                ^ u256: Value => None
+   │                ^ u256: Value
 
 note: 
    ┌─ features/aug_assign.fe:28:5
@@ -360,11 +360,11 @@ note:
    ┌─ features/aug_assign.fe:29:9
    │
 29 │         a <<= b
-   │         ^     ^ u8: Value => None
+   │         ^     ^ u8: Value
    │         │      
-   │         u8: Value => None
+   │         u8: Value
 30 │         return a
-   │                ^ u8: Value => None
+   │                ^ u8: Value
 
 note: 
    ┌─ features/aug_assign.fe:32:5
@@ -411,11 +411,11 @@ note:
    ┌─ features/aug_assign.fe:33:9
    │
 33 │         a >>= b
-   │         ^     ^ u8: Value => None
+   │         ^     ^ u8: Value
    │         │      
-   │         u8: Value => None
+   │         u8: Value
 34 │         return a
-   │                ^ u8: Value => None
+   │                ^ u8: Value
 
 note: 
    ┌─ features/aug_assign.fe:36:5
@@ -462,11 +462,11 @@ note:
    ┌─ features/aug_assign.fe:37:9
    │
 37 │         a |= b
-   │         ^    ^ u8: Value => None
+   │         ^    ^ u8: Value
    │         │     
-   │         u8: Value => None
+   │         u8: Value
 38 │         return a
-   │                ^ u8: Value => None
+   │                ^ u8: Value
 
 note: 
    ┌─ features/aug_assign.fe:40:5
@@ -513,11 +513,11 @@ note:
    ┌─ features/aug_assign.fe:41:9
    │
 41 │         a ^= b
-   │         ^    ^ u8: Value => None
+   │         ^    ^ u8: Value
    │         │     
-   │         u8: Value => None
+   │         u8: Value
 42 │         return a
-   │                ^ u8: Value => None
+   │                ^ u8: Value
 
 note: 
    ┌─ features/aug_assign.fe:44:5
@@ -564,11 +564,11 @@ note:
    ┌─ features/aug_assign.fe:45:9
    │
 45 │         a &= b
-   │         ^    ^ u8: Value => None
+   │         ^    ^ u8: Value
    │         │     
-   │         u8: Value => None
+   │         u8: Value
 46 │         return a
-   │                ^ u8: Value => None
+   │                ^ u8: Value
 
 note: 
    ┌─ features/aug_assign.fe:48:5
@@ -577,10 +577,12 @@ note:
 49 │ │         self.my_num = a
 50 │ │         self.my_num += b
 51 │ │         return self.my_num
-   │ ╰──────────────────────────^ attributes hash: 2855001974628647253
+   │ ╰──────────────────────────^ attributes hash: 12434239357523874673
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "a",
@@ -616,15 +618,33 @@ note:
    ┌─ features/aug_assign.fe:49:9
    │
 49 │         self.my_num = a
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/aug_assign.fe:49:9
+   │
+49 │         self.my_num = a
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: Some(0) }
 50 │         self.my_num += b
-   │         ^^^^^^^^^^^    ^ u256: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/aug_assign.fe:50:9
+   │
+50 │         self.my_num += b
+   │         ^^^^^^^^^^^    ^ u256: Value
    │         │               
-   │         u256: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: Some(0) }
 51 │         return self.my_num
-   │                ^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/aug_assign.fe:51:16
+   │
+51 │         return self.my_num
+   │                ^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ features/aug_assign.fe:53:5
@@ -679,38 +699,38 @@ note:
    ┌─ features/aug_assign.fe:55:9
    │
 55 │         my_array[7] = a
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 10>: Memory => None
+   │         Array<u256, 10>: Memory
 
 note: 
    ┌─ features/aug_assign.fe:55:9
    │
 55 │         my_array[7] = a
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
 56 │         my_array[7] += b
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 10>: Memory => None
+   │         Array<u256, 10>: Memory
 
 note: 
    ┌─ features/aug_assign.fe:56:9
    │
 56 │         my_array[7] += b
-   │         ^^^^^^^^^^^    ^ u256: Value => None
+   │         ^^^^^^^^^^^    ^ u256: Value
    │         │               
-   │         u256: Memory => None
+   │         u256: Memory
 57 │         return my_array[7]
-   │                ^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^ ^ u256: Value
    │                │         
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ features/aug_assign.fe:57:16
    │
 57 │         return my_array[7]
-   │                ^^^^^^^^^^^ u256: Memory => Some(Value)
+   │                ^^^^^^^^^^^ u256: Memory => Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__balances.snap
+++ b/crates/analyzer/tests/snapshots/analysis__balances.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/balances.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -21,6 +21,22 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/balances.fe:3:16
+  │
+3 │         return balance()
+  │                ^^^^^^^^^ u256: Value => None
+
+note: 
+  ┌─ features/balances.fe:3:16
+  │
+3 │         return balance()
+  │                ^^^^^^^ attributes hash: 16310782615237733127
+  │
+  = BuiltinFunction(
+        Balance,
+    )
 
 note: 
   ┌─ features/balances.fe:5:5
@@ -51,12 +67,6 @@ note:
     }
 
 note: 
-  ┌─ features/balances.fe:3:16
-  │
-3 │         return balance()
-  │                ^^^^^^^^^ u256: Value => None
-
-note: 
   ┌─ features/balances.fe:6:27
   │
 6 │         return balance_of(someone)
@@ -67,16 +77,6 @@ note:
   │
 6 │         return balance_of(someone)
   │                ^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/balances.fe:3:16
-  │
-3 │         return balance()
-  │                ^^^^^^^ attributes hash: 16310782615237733127
-  │
-  = BuiltinFunction(
-        Balance,
-    )
 
 note: 
   ┌─ features/balances.fe:6:16

--- a/crates/analyzer/tests/snapshots/analysis__balances.snap
+++ b/crates/analyzer/tests/snapshots/analysis__balances.snap
@@ -8,10 +8,12 @@ note:
   │  
 2 │ ╭     pub fn my_balance(self) -> u256:
 3 │ │         return balance()
-  │ ╰────────────────────────^ attributes hash: 16482263331346774611
+  │ ╰────────────────────────^ attributes hash: 2875164910451995213
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -26,27 +28,25 @@ note:
   ┌─ features/balances.fe:3:16
   │
 3 │         return balance()
-  │                ^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/balances.fe:3:16
   │
 3 │         return balance()
-  │                ^^^^^^^ attributes hash: 16310782615237733127
-  │
-  = BuiltinFunction(
-        Balance,
-    )
+  │                ^^^^^^^ BuiltinFunction(Balance)
 
 note: 
   ┌─ features/balances.fe:5:5
   │  
 5 │ ╭     pub fn other_balance(self, someone: address) -> u256:
 6 │ │         return balance_of(someone)
-  │ ╰──────────────────────────────────^ attributes hash: 2478257718014019887
+  │ ╰──────────────────────────────────^ attributes hash: 4973462877553265717
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "someone",
@@ -70,22 +70,18 @@ note:
   ┌─ features/balances.fe:6:27
   │
 6 │         return balance_of(someone)
-  │                           ^^^^^^^ address: Value => None
+  │                           ^^^^^^^ address: Value
 
 note: 
   ┌─ features/balances.fe:6:16
   │
 6 │         return balance_of(someone)
-  │                ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/balances.fe:6:16
   │
 6 │         return balance_of(someone)
-  │                ^^^^^^^^^^ attributes hash: 17653883527447570056
-  │
-  = BuiltinFunction(
-        BalanceOf,
-    )
+  │                ^^^^^^^^^^ BuiltinFunction(BalanceOf)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
@@ -54,14 +54,14 @@ note:
   ┌─ features/base_tuple.fe:3:17
   │
 3 │         return (my_num, my_bool)
-  │                 ^^^^^^  ^^^^^^^ bool: Value => None
+  │                 ^^^^^^  ^^^^^^^ bool: Value
   │                 │        
-  │                 u256: Value => None
+  │                 u256: Value
 
 note: 
   ┌─ features/base_tuple.fe:3:16
   │
 3 │         return (my_num, my_bool)
-  │                ^^^^^^^^^^^^^^^^^ (u256, bool): Memory => None
+  │                ^^^^^^^^^^^^^^^^^ (u256, bool): Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
@@ -54,13 +54,9 @@ note:
   ┌─ features/base_tuple.fe:3:17
   │
 3 │         return (my_num, my_bool)
-  │                 ^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/base_tuple.fe:3:25
-  │
-3 │         return (my_num, my_bool)
-  │                         ^^^^^^^ bool: Value => None
+  │                 ^^^^^^  ^^^^^^^ bool: Value => None
+  │                 │        
+  │                 u256: Value => None
 
 note: 
   ┌─ features/base_tuple.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     fn assign(self, val: u256):
 5 │ │         self.baz[0] = val
-  │ ╰─────────────────────────^ attributes hash: 254453825868610726
+  │ ╰─────────────────────────^ attributes hash: 7431471554531340963
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "val",
@@ -41,17 +43,23 @@ note:
   ┌─ features/call_statement_with_args.fe:5:9
   │
 5 │         self.baz[0] = val
-  │         ^^^^^^^^ ^ u256: Value => None
-  │         │         
-  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/call_statement_with_args.fe:5:9
   │
 5 │         self.baz[0] = val
-  │         ^^^^^^^^^^^   ^^^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/call_statement_with_args.fe:5:9
+  │
+5 │         self.baz[0] = val
+  │         ^^^^^^^^^^^   ^^^ u256: Value
   │         │              
-  │         u256: Storage { nonce: None } => None
+  │         u256: Storage { nonce: None }
 
 note: 
   ┌─ features/call_statement_with_args.fe:7:5
@@ -59,10 +67,12 @@ note:
 7 │ ╭     pub fn bar(self) -> u256:
 8 │ │         self.assign(100)
 9 │ │         return self.baz[0]
-  │ ╰──────────────────────────^ attributes hash: 16482263331346774611
+  │ ╰──────────────────────────^ attributes hash: 2875164910451995213
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -74,36 +84,39 @@ note:
     }
 
 note: 
-  ┌─ features/call_statement_with_args.fe:8:21
+  ┌─ features/call_statement_with_args.fe:8:9
   │
 8 │         self.assign(100)
-  │                     ^^^ u256: Value => None
+  │         ^^^^        ^^^ u256: Value
+  │         │            
+  │         Foo: Value
 
 note: 
   ┌─ features/call_statement_with_args.fe:8:9
   │
 8 │         self.assign(100)
-  │         ^^^^^^^^^^^^^^^^ (): Value => None
+  │         ^^^^^^^^^^^^^^^^ (): Value
 9 │         return self.baz[0]
-  │                ^^^^^^^^ ^ u256: Value => None
-  │                │         
-  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/call_statement_with_args.fe:9:16
   │
 9 │         return self.baz[0]
-  │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^ u256: Value
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/call_statement_with_args.fe:9:16
+  │
+9 │         return self.baz[0]
+  │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/call_statement_with_args.fe:8:9
   │
 8 │         self.assign(100)
-  │         ^^^^^^^^^^^ attributes hash: 8522453005002335674
-  │
-  = SelfAttribute {
-        func_name: "assign",
-        self_span: 137..141,
-    }
+  │         ^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
@@ -38,6 +38,22 @@ note:
     }
 
 note: 
+  ┌─ features/call_statement_with_args.fe:5:9
+  │
+5 │         self.baz[0] = val
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/call_statement_with_args.fe:5:9
+  │
+5 │         self.baz[0] = val
+  │         ^^^^^^^^^^^   ^^^ u256: Value => None
+  │         │              
+  │         u256: Storage { nonce: None } => None
+
+note: 
   ┌─ features/call_statement_with_args.fe:7:5
   │  
 7 │ ╭     pub fn bar(self) -> u256:
@@ -58,30 +74,6 @@ note:
     }
 
 note: 
-  ┌─ features/call_statement_with_args.fe:5:9
-  │
-5 │         self.baz[0] = val
-  │         ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/call_statement_with_args.fe:5:18
-  │
-5 │         self.baz[0] = val
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/call_statement_with_args.fe:5:9
-  │
-5 │         self.baz[0] = val
-  │         ^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/call_statement_with_args.fe:5:23
-  │
-5 │         self.baz[0] = val
-  │                       ^^^ u256: Value => None
-
-note: 
   ┌─ features/call_statement_with_args.fe:8:21
   │
 8 │         self.assign(100)
@@ -92,18 +84,10 @@ note:
   │
 8 │         self.assign(100)
   │         ^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-  ┌─ features/call_statement_with_args.fe:9:16
-  │
 9 │         return self.baz[0]
-  │                ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/call_statement_with_args.fe:9:25
-  │
-9 │         return self.baz[0]
-  │                         ^ u256: Value => None
+  │                ^^^^^^^^ ^ u256: Value => None
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/call_statement_with_args.fe:9:16

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
@@ -41,6 +41,24 @@ note:
     }
 
 note: 
+  ┌─ features/call_statement_with_args_2.fe:5:9
+  │
+5 │         self.baz[0] = val
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/call_statement_with_args_2.fe:5:9
+  │
+5 │         self.baz[0] = val
+  │         ^^^^^^^^^^^   ^^^ u256: Value => None
+  │         │              
+  │         u256: Storage { nonce: None } => None
+6 │         return val
+  │                ^^^ u256: Value => None
+
+note: 
    ┌─ features/call_statement_with_args_2.fe:8:5
    │  
  8 │ ╭     pub fn bar(self) -> u256:
@@ -61,58 +79,20 @@ note:
      }
 
 note: 
-  ┌─ features/call_statement_with_args_2.fe:5:9
-  │
-5 │         self.baz[0] = val
-  │         ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/call_statement_with_args_2.fe:5:18
-  │
-5 │         self.baz[0] = val
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/call_statement_with_args_2.fe:5:9
-  │
-5 │         self.baz[0] = val
-  │         ^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/call_statement_with_args_2.fe:5:23
-  │
-5 │         self.baz[0] = val
-  │                       ^^^ u256: Value => None
-
-note: 
-  ┌─ features/call_statement_with_args_2.fe:6:16
-  │
-6 │         return val
-  │                ^^^ u256: Value => None
-
-note: 
   ┌─ features/call_statement_with_args_2.fe:9:21
   │
 9 │         self.assign(100)
   │                     ^^^ u256: Value => None
 
 note: 
-  ┌─ features/call_statement_with_args_2.fe:9:9
-  │
-9 │         self.assign(100)
-  │         ^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/call_statement_with_args_2.fe:10:16
+   ┌─ features/call_statement_with_args_2.fe:9:9
    │
+ 9 │         self.assign(100)
+   │         ^^^^^^^^^^^^^^^^ u256: Value => None
 10 │         return self.baz[0]
-   │                ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/call_statement_with_args_2.fe:10:25
-   │
-10 │         return self.baz[0]
-   │                         ^ u256: Value => None
+   │                ^^^^^^^^ ^ u256: Value => None
+   │                │         
+   │                Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/call_statement_with_args_2.fe:10:16

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -15,10 +15,12 @@ note:
 4 │ ╭     fn assign(self, val: u256) -> u256:
 5 │ │         self.baz[0] = val
 6 │ │         return val
-  │ ╰──────────────────^ attributes hash: 13803375927344563415
+  │ ╰──────────────────^ attributes hash: 18287971674339323054
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "val",
@@ -44,19 +46,25 @@ note:
   ┌─ features/call_statement_with_args_2.fe:5:9
   │
 5 │         self.baz[0] = val
-  │         ^^^^^^^^ ^ u256: Value => None
-  │         │         
-  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/call_statement_with_args_2.fe:5:9
   │
 5 │         self.baz[0] = val
-  │         ^^^^^^^^^^^   ^^^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/call_statement_with_args_2.fe:5:9
+  │
+5 │         self.baz[0] = val
+  │         ^^^^^^^^^^^   ^^^ u256: Value
   │         │              
-  │         u256: Storage { nonce: None } => None
+  │         u256: Storage { nonce: None }
 6 │         return val
-  │                ^^^ u256: Value => None
+  │                ^^^ u256: Value
 
 note: 
    ┌─ features/call_statement_with_args_2.fe:8:5
@@ -64,10 +72,12 @@ note:
  8 │ ╭     pub fn bar(self) -> u256:
  9 │ │         self.assign(100)
 10 │ │         return self.baz[0]
-   │ ╰──────────────────────────^ attributes hash: 16482263331346774611
+   │ ╰──────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -79,36 +89,39 @@ note:
      }
 
 note: 
-  ┌─ features/call_statement_with_args_2.fe:9:21
+  ┌─ features/call_statement_with_args_2.fe:9:9
   │
 9 │         self.assign(100)
-  │                     ^^^ u256: Value => None
+  │         ^^^^        ^^^ u256: Value
+  │         │            
+  │         Foo: Value
 
 note: 
    ┌─ features/call_statement_with_args_2.fe:9:9
    │
  9 │         self.assign(100)
-   │         ^^^^^^^^^^^^^^^^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^ u256: Value
 10 │         return self.baz[0]
-   │                ^^^^^^^^ ^ u256: Value => None
-   │                │         
-   │                Map<u256, u256>: Storage { nonce: Some(0) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/call_statement_with_args_2.fe:10:16
    │
 10 │         return self.baz[0]
-   │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+   │                ^^^^^^^^ ^ u256: Value
+   │                │         
+   │                Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/call_statement_with_args_2.fe:10:16
+   │
+10 │         return self.baz[0]
+   │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/call_statement_with_args_2.fe:9:9
   │
 9 │         self.assign(100)
-  │         ^^^^^^^^^^^ attributes hash: 2997557065728909304
-  │
-  = SelfAttribute {
-        func_name: "assign",
-        self_span: 164..168,
-    }
+  │         ^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     fn assign(self):
 5 │ │         self.baz[0] = 100
-  │ ╰─────────────────────────^ attributes hash: 4369441865732737140
+  │ ╰─────────────────────────^ attributes hash: 17603814563784536273
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -30,17 +32,23 @@ note:
   ┌─ features/call_statement_without_args.fe:5:9
   │
 5 │         self.baz[0] = 100
-  │         ^^^^^^^^ ^ u256: Value => None
-  │         │         
-  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/call_statement_without_args.fe:5:9
   │
 5 │         self.baz[0] = 100
-  │         ^^^^^^^^^^^   ^^^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/call_statement_without_args.fe:5:9
+  │
+5 │         self.baz[0] = 100
+  │         ^^^^^^^^^^^   ^^^ u256: Value
   │         │              
-  │         u256: Storage { nonce: None } => None
+  │         u256: Storage { nonce: None }
 
 note: 
   ┌─ features/call_statement_without_args.fe:7:5
@@ -48,10 +56,12 @@ note:
 7 │ ╭     pub fn bar(self) -> u256:
 8 │ │         self.assign()
 9 │ │         return self.baz[0]
-  │ ╰──────────────────────────^ attributes hash: 16482263331346774611
+  │ ╰──────────────────────────^ attributes hash: 2875164910451995213
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -66,27 +76,34 @@ note:
   ┌─ features/call_statement_without_args.fe:8:9
   │
 8 │         self.assign()
-  │         ^^^^^^^^^^^^^ (): Value => None
-9 │         return self.baz[0]
-  │                ^^^^^^^^ ^ u256: Value => None
-  │                │         
-  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/call_statement_without_args.fe:9:16
-  │
-9 │         return self.baz[0]
-  │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/call_statement_without_args.fe:8:9
   │
 8 │         self.assign()
-  │         ^^^^^^^^^^^ attributes hash: 1845414425399096131
+  │         ^^^^^^^^^^^^^ (): Value
+9 │         return self.baz[0]
+  │                ^^^^ Foo: Value
+
+note: 
+  ┌─ features/call_statement_without_args.fe:9:16
   │
-  = SelfAttribute {
-        func_name: "assign",
-        self_span: 126..130,
-    }
+9 │         return self.baz[0]
+  │                ^^^^^^^^ ^ u256: Value
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/call_statement_without_args.fe:9:16
+  │
+9 │         return self.baz[0]
+  │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
+
+note: 
+  ┌─ features/call_statement_without_args.fe:8:9
+  │
+8 │         self.assign()
+  │         ^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
@@ -27,6 +27,22 @@ note:
     }
 
 note: 
+  ┌─ features/call_statement_without_args.fe:5:9
+  │
+5 │         self.baz[0] = 100
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/call_statement_without_args.fe:5:9
+  │
+5 │         self.baz[0] = 100
+  │         ^^^^^^^^^^^   ^^^ u256: Value => None
+  │         │              
+  │         u256: Storage { nonce: None } => None
+
+note: 
   ┌─ features/call_statement_without_args.fe:7:5
   │  
 7 │ ╭     pub fn bar(self) -> u256:
@@ -47,46 +63,14 @@ note:
     }
 
 note: 
-  ┌─ features/call_statement_without_args.fe:5:9
-  │
-5 │         self.baz[0] = 100
-  │         ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/call_statement_without_args.fe:5:18
-  │
-5 │         self.baz[0] = 100
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/call_statement_without_args.fe:5:9
-  │
-5 │         self.baz[0] = 100
-  │         ^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/call_statement_without_args.fe:5:23
-  │
-5 │         self.baz[0] = 100
-  │                       ^^^ u256: Value => None
-
-note: 
   ┌─ features/call_statement_without_args.fe:8:9
   │
 8 │         self.assign()
   │         ^^^^^^^^^^^^^ (): Value => None
-
-note: 
-  ┌─ features/call_statement_without_args.fe:9:16
-  │
 9 │         return self.baz[0]
-  │                ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/call_statement_without_args.fe:9:25
-  │
-9 │         return self.baz[0]
-  │                         ^ u256: Value => None
+  │                ^^^^^^^^ ^ u256: Value => None
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/call_statement_without_args.fe:9:16

--- a/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
+++ b/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
@@ -44,6 +44,20 @@ note:
     }
 
 note: 
+  ┌─ features/checked_arithmetic.fe:4:16
+  │
+4 │         return left + right
+  │                ^^^^   ^^^^^ u256: Value => None
+  │                │       
+  │                u256: Value => None
+
+note: 
+  ┌─ features/checked_arithmetic.fe:4:16
+  │
+4 │         return left + right
+  │                ^^^^^^^^^^^^ u256: Value => None
+
+note: 
   ┌─ features/checked_arithmetic.fe:6:5
   │  
 6 │ ╭     pub fn add_u128(left: u128, right: u128) -> u128:
@@ -82,6 +96,20 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/checked_arithmetic.fe:7:16
+  │
+7 │         return left + right
+  │                ^^^^   ^^^^^ u128: Value => None
+  │                │       
+  │                u128: Value => None
+
+note: 
+  ┌─ features/checked_arithmetic.fe:7:16
+  │
+7 │         return left + right
+  │                ^^^^^^^^^^^^ u128: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:9:5
@@ -124,6 +152,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:10:16
+   │
+10 │         return left + right
+   │                ^^^^   ^^^^^ u64: Value => None
+   │                │       
+   │                u64: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:10:16
+   │
+10 │         return left + right
+   │                ^^^^^^^^^^^^ u64: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:12:5
    │  
 12 │ ╭     pub fn add_u32(left: u32, right: u32) -> u32:
@@ -162,6 +204,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:13:16
+   │
+13 │         return left + right
+   │                ^^^^   ^^^^^ u32: Value => None
+   │                │       
+   │                u32: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:13:16
+   │
+13 │         return left + right
+   │                ^^^^^^^^^^^^ u32: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:15:5
@@ -204,6 +260,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:16:16
+   │
+16 │         return left + right
+   │                ^^^^   ^^^^^ u16: Value => None
+   │                │       
+   │                u16: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:16:16
+   │
+16 │         return left + right
+   │                ^^^^^^^^^^^^ u16: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:18:5
    │  
 18 │ ╭     pub fn add_u8(left: u8, right: u8) -> u8:
@@ -242,6 +312,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:19:16
+   │
+19 │         return left + right
+   │                ^^^^   ^^^^^ u8: Value => None
+   │                │       
+   │                u8: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:19:16
+   │
+19 │         return left + right
+   │                ^^^^^^^^^^^^ u8: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:21:5
@@ -284,6 +368,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:22:16
+   │
+22 │         return left + right
+   │                ^^^^   ^^^^^ i256: Value => None
+   │                │       
+   │                i256: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:22:16
+   │
+22 │         return left + right
+   │                ^^^^^^^^^^^^ i256: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:24:5
    │  
 24 │ ╭     pub fn add_i128(left: i128, right: i128) -> i128:
@@ -322,6 +420,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:25:16
+   │
+25 │         return left + right
+   │                ^^^^   ^^^^^ i128: Value => None
+   │                │       
+   │                i128: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:25:16
+   │
+25 │         return left + right
+   │                ^^^^^^^^^^^^ i128: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:27:5
@@ -364,6 +476,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:28:16
+   │
+28 │         return left + right
+   │                ^^^^   ^^^^^ i64: Value => None
+   │                │       
+   │                i64: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:28:16
+   │
+28 │         return left + right
+   │                ^^^^^^^^^^^^ i64: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:30:5
    │  
 30 │ ╭     pub fn add_i32(left: i32, right: i32) -> i32:
@@ -402,6 +528,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:31:16
+   │
+31 │         return left + right
+   │                ^^^^   ^^^^^ i32: Value => None
+   │                │       
+   │                i32: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:31:16
+   │
+31 │         return left + right
+   │                ^^^^^^^^^^^^ i32: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:33:5
@@ -444,6 +584,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:34:16
+   │
+34 │         return left + right
+   │                ^^^^   ^^^^^ i16: Value => None
+   │                │       
+   │                i16: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:34:16
+   │
+34 │         return left + right
+   │                ^^^^^^^^^^^^ i16: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:36:5
    │  
 36 │ ╭     pub fn add_i8(left: i8, right: i8) -> i8:
@@ -482,6 +636,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:37:16
+   │
+37 │         return left + right
+   │                ^^^^   ^^^^^ i8: Value => None
+   │                │       
+   │                i8: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:37:16
+   │
+37 │         return left + right
+   │                ^^^^^^^^^^^^ i8: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:39:5
@@ -524,6 +692,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:40:16
+   │
+40 │         return left - right
+   │                ^^^^   ^^^^^ u256: Value => None
+   │                │       
+   │                u256: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:40:16
+   │
+40 │         return left - right
+   │                ^^^^^^^^^^^^ u256: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:42:5
    │  
 42 │ ╭     pub fn sub_u128(left: u128, right: u128) -> u128:
@@ -562,6 +744,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:43:16
+   │
+43 │         return left - right
+   │                ^^^^   ^^^^^ u128: Value => None
+   │                │       
+   │                u128: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:43:16
+   │
+43 │         return left - right
+   │                ^^^^^^^^^^^^ u128: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:45:5
@@ -604,6 +800,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:46:16
+   │
+46 │         return left - right
+   │                ^^^^   ^^^^^ u64: Value => None
+   │                │       
+   │                u64: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:46:16
+   │
+46 │         return left - right
+   │                ^^^^^^^^^^^^ u64: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:48:5
    │  
 48 │ ╭     pub fn sub_u32(left: u32, right: u32) -> u32:
@@ -642,6 +852,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:49:16
+   │
+49 │         return left - right
+   │                ^^^^   ^^^^^ u32: Value => None
+   │                │       
+   │                u32: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:49:16
+   │
+49 │         return left - right
+   │                ^^^^^^^^^^^^ u32: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:51:5
@@ -684,6 +908,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:52:16
+   │
+52 │         return left - right
+   │                ^^^^   ^^^^^ u16: Value => None
+   │                │       
+   │                u16: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:52:16
+   │
+52 │         return left - right
+   │                ^^^^^^^^^^^^ u16: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:54:5
    │  
 54 │ ╭     pub fn sub_u8(left: u8, right: u8) -> u8:
@@ -722,6 +960,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:55:16
+   │
+55 │         return left - right
+   │                ^^^^   ^^^^^ u8: Value => None
+   │                │       
+   │                u8: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:55:16
+   │
+55 │         return left - right
+   │                ^^^^^^^^^^^^ u8: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:57:5
@@ -764,6 +1016,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:58:16
+   │
+58 │         return left - right
+   │                ^^^^   ^^^^^ i256: Value => None
+   │                │       
+   │                i256: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:58:16
+   │
+58 │         return left - right
+   │                ^^^^^^^^^^^^ i256: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:60:5
    │  
 60 │ ╭     pub fn sub_i128(left: i128, right: i128) -> i128:
@@ -802,6 +1068,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:61:16
+   │
+61 │         return left - right
+   │                ^^^^   ^^^^^ i128: Value => None
+   │                │       
+   │                i128: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:61:16
+   │
+61 │         return left - right
+   │                ^^^^^^^^^^^^ i128: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:63:5
@@ -844,6 +1124,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:64:16
+   │
+64 │         return left - right
+   │                ^^^^   ^^^^^ i64: Value => None
+   │                │       
+   │                i64: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:64:16
+   │
+64 │         return left - right
+   │                ^^^^^^^^^^^^ i64: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:66:5
    │  
 66 │ ╭     pub fn sub_i32(left: i32, right: i32) -> i32:
@@ -882,6 +1176,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:67:16
+   │
+67 │         return left - right
+   │                ^^^^   ^^^^^ i32: Value => None
+   │                │       
+   │                i32: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:67:16
+   │
+67 │         return left - right
+   │                ^^^^^^^^^^^^ i32: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:69:5
@@ -924,6 +1232,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:70:16
+   │
+70 │         return left - right
+   │                ^^^^   ^^^^^ i16: Value => None
+   │                │       
+   │                i16: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:70:16
+   │
+70 │         return left - right
+   │                ^^^^^^^^^^^^ i16: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:72:5
    │  
 72 │ ╭     pub fn sub_i8(left: i8, right: i8) -> i8:
@@ -962,6 +1284,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:73:16
+   │
+73 │         return left - right
+   │                ^^^^   ^^^^^ i8: Value => None
+   │                │       
+   │                i8: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:73:16
+   │
+73 │         return left - right
+   │                ^^^^^^^^^^^^ i8: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:75:5
@@ -1004,6 +1340,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:76:16
+   │
+76 │         return left / right
+   │                ^^^^   ^^^^^ u256: Value => None
+   │                │       
+   │                u256: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:76:16
+   │
+76 │         return left / right
+   │                ^^^^^^^^^^^^ u256: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:78:5
    │  
 78 │ ╭     pub fn div_u128(left: u128, right: u128) -> u128:
@@ -1042,6 +1392,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:79:16
+   │
+79 │         return left / right
+   │                ^^^^   ^^^^^ u128: Value => None
+   │                │       
+   │                u128: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:79:16
+   │
+79 │         return left / right
+   │                ^^^^^^^^^^^^ u128: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:81:5
@@ -1084,6 +1448,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:82:16
+   │
+82 │         return left / right
+   │                ^^^^   ^^^^^ u64: Value => None
+   │                │       
+   │                u64: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:82:16
+   │
+82 │         return left / right
+   │                ^^^^^^^^^^^^ u64: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:84:5
    │  
 84 │ ╭     pub fn div_u32(left: u32, right: u32) -> u32:
@@ -1122,6 +1500,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:85:16
+   │
+85 │         return left / right
+   │                ^^^^   ^^^^^ u32: Value => None
+   │                │       
+   │                u32: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:85:16
+   │
+85 │         return left / right
+   │                ^^^^^^^^^^^^ u32: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:87:5
@@ -1164,6 +1556,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:88:16
+   │
+88 │         return left / right
+   │                ^^^^   ^^^^^ u16: Value => None
+   │                │       
+   │                u16: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:88:16
+   │
+88 │         return left / right
+   │                ^^^^^^^^^^^^ u16: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:90:5
    │  
 90 │ ╭     pub fn div_u8(left: u8, right: u8) -> u8:
@@ -1202,6 +1608,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:91:16
+   │
+91 │         return left / right
+   │                ^^^^   ^^^^^ u8: Value => None
+   │                │       
+   │                u8: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:91:16
+   │
+91 │         return left / right
+   │                ^^^^^^^^^^^^ u8: Value => None
 
 note: 
    ┌─ features/checked_arithmetic.fe:93:5
@@ -1244,6 +1664,20 @@ note:
      }
 
 note: 
+   ┌─ features/checked_arithmetic.fe:94:16
+   │
+94 │         return left / right
+   │                ^^^^   ^^^^^ i256: Value => None
+   │                │       
+   │                i256: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:94:16
+   │
+94 │         return left / right
+   │                ^^^^^^^^^^^^ i256: Value => None
+
+note: 
    ┌─ features/checked_arithmetic.fe:96:5
    │  
 96 │ ╭     pub fn div_i128(left: i128, right: i128) -> i128:
@@ -1282,6 +1716,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/checked_arithmetic.fe:97:16
+   │
+97 │         return left / right
+   │                ^^^^   ^^^^^ i128: Value => None
+   │                │       
+   │                i128: Value => None
+
+note: 
+   ┌─ features/checked_arithmetic.fe:97:16
+   │
+97 │         return left / right
+   │                ^^^^^^^^^^^^ i128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:99:5
@@ -1324,6 +1772,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:100:16
+    │
+100 │         return left / right
+    │                ^^^^   ^^^^^ i64: Value => None
+    │                │       
+    │                i64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:100:16
+    │
+100 │         return left / right
+    │                ^^^^^^^^^^^^ i64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:102:5
     │  
 102 │ ╭     pub fn div_i32(left: i32, right: i32) -> i32:
@@ -1362,6 +1824,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:103:16
+    │
+103 │         return left / right
+    │                ^^^^   ^^^^^ i32: Value => None
+    │                │       
+    │                i32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:103:16
+    │
+103 │         return left / right
+    │                ^^^^^^^^^^^^ i32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:105:5
@@ -1404,6 +1880,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:106:16
+    │
+106 │         return left / right
+    │                ^^^^   ^^^^^ i16: Value => None
+    │                │       
+    │                i16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:106:16
+    │
+106 │         return left / right
+    │                ^^^^^^^^^^^^ i16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:108:5
     │  
 108 │ ╭     pub fn div_i8(left: i8, right: i8) -> i8:
@@ -1442,6 +1932,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:109:16
+    │
+109 │         return left / right
+    │                ^^^^   ^^^^^ i8: Value => None
+    │                │       
+    │                i8: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:109:16
+    │
+109 │         return left / right
+    │                ^^^^^^^^^^^^ i8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:111:5
@@ -1484,6 +1988,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:112:16
+    │
+112 │         return left * right
+    │                ^^^^   ^^^^^ u256: Value => None
+    │                │       
+    │                u256: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:112:16
+    │
+112 │         return left * right
+    │                ^^^^^^^^^^^^ u256: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:114:5
     │  
 114 │ ╭     pub fn mul_u128(left: u128, right: u128) -> u128:
@@ -1522,6 +2040,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:115:16
+    │
+115 │         return left * right
+    │                ^^^^   ^^^^^ u128: Value => None
+    │                │       
+    │                u128: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:115:16
+    │
+115 │         return left * right
+    │                ^^^^^^^^^^^^ u128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:117:5
@@ -1564,6 +2096,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:118:16
+    │
+118 │         return left * right
+    │                ^^^^   ^^^^^ u64: Value => None
+    │                │       
+    │                u64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:118:16
+    │
+118 │         return left * right
+    │                ^^^^^^^^^^^^ u64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:120:5
     │  
 120 │ ╭     pub fn mul_u32(left: u32, right: u32) -> u32:
@@ -1602,6 +2148,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:121:16
+    │
+121 │         return left * right
+    │                ^^^^   ^^^^^ u32: Value => None
+    │                │       
+    │                u32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:121:16
+    │
+121 │         return left * right
+    │                ^^^^^^^^^^^^ u32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:123:5
@@ -1644,6 +2204,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:124:16
+    │
+124 │         return left * right
+    │                ^^^^   ^^^^^ u16: Value => None
+    │                │       
+    │                u16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:124:16
+    │
+124 │         return left * right
+    │                ^^^^^^^^^^^^ u16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:126:5
     │  
 126 │ ╭     pub fn mul_u8(left: u8, right: u8) -> u8:
@@ -1682,6 +2256,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:127:16
+    │
+127 │         return left * right
+    │                ^^^^   ^^^^^ u8: Value => None
+    │                │       
+    │                u8: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:127:16
+    │
+127 │         return left * right
+    │                ^^^^^^^^^^^^ u8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:129:5
@@ -1724,6 +2312,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:130:16
+    │
+130 │         return left * right
+    │                ^^^^   ^^^^^ i256: Value => None
+    │                │       
+    │                i256: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:130:16
+    │
+130 │         return left * right
+    │                ^^^^^^^^^^^^ i256: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:132:5
     │  
 132 │ ╭     pub fn mul_i128(left: i128, right: i128) -> i128:
@@ -1762,6 +2364,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:133:16
+    │
+133 │         return left * right
+    │                ^^^^   ^^^^^ i128: Value => None
+    │                │       
+    │                i128: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:133:16
+    │
+133 │         return left * right
+    │                ^^^^^^^^^^^^ i128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:135:5
@@ -1804,6 +2420,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:136:16
+    │
+136 │         return left * right
+    │                ^^^^   ^^^^^ i64: Value => None
+    │                │       
+    │                i64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:136:16
+    │
+136 │         return left * right
+    │                ^^^^^^^^^^^^ i64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:138:5
     │  
 138 │ ╭     pub fn mul_i32(left: i32, right: i32) -> i32:
@@ -1842,6 +2472,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:139:16
+    │
+139 │         return left * right
+    │                ^^^^   ^^^^^ i32: Value => None
+    │                │       
+    │                i32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:139:16
+    │
+139 │         return left * right
+    │                ^^^^^^^^^^^^ i32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:141:5
@@ -1884,6 +2528,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:142:16
+    │
+142 │         return left * right
+    │                ^^^^   ^^^^^ i16: Value => None
+    │                │       
+    │                i16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:142:16
+    │
+142 │         return left * right
+    │                ^^^^^^^^^^^^ i16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:144:5
     │  
 144 │ ╭     pub fn mul_i8(left: i8, right: i8) -> i8:
@@ -1922,6 +2580,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:145:16
+    │
+145 │         return left * right
+    │                ^^^^   ^^^^^ i8: Value => None
+    │                │       
+    │                i8: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:145:16
+    │
+145 │         return left * right
+    │                ^^^^^^^^^^^^ i8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:147:5
@@ -1964,6 +2636,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:148:16
+    │
+148 │         return left % right
+    │                ^^^^   ^^^^^ u256: Value => None
+    │                │       
+    │                u256: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:148:16
+    │
+148 │         return left % right
+    │                ^^^^^^^^^^^^ u256: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:150:5
     │  
 150 │ ╭     pub fn mod_u128(left: u128, right: u128) -> u128:
@@ -2002,6 +2688,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:151:16
+    │
+151 │         return left % right
+    │                ^^^^   ^^^^^ u128: Value => None
+    │                │       
+    │                u128: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:151:16
+    │
+151 │         return left % right
+    │                ^^^^^^^^^^^^ u128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:153:5
@@ -2044,6 +2744,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:154:16
+    │
+154 │         return left % right
+    │                ^^^^   ^^^^^ u64: Value => None
+    │                │       
+    │                u64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:154:16
+    │
+154 │         return left % right
+    │                ^^^^^^^^^^^^ u64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:156:5
     │  
 156 │ ╭     pub fn mod_u32(left: u32, right: u32) -> u32:
@@ -2082,6 +2796,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:157:16
+    │
+157 │         return left % right
+    │                ^^^^   ^^^^^ u32: Value => None
+    │                │       
+    │                u32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:157:16
+    │
+157 │         return left % right
+    │                ^^^^^^^^^^^^ u32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:159:5
@@ -2124,6 +2852,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:160:16
+    │
+160 │         return left % right
+    │                ^^^^   ^^^^^ u16: Value => None
+    │                │       
+    │                u16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:160:16
+    │
+160 │         return left % right
+    │                ^^^^^^^^^^^^ u16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:162:5
     │  
 162 │ ╭     pub fn mod_u8(left: u8, right: u8) -> u8:
@@ -2162,6 +2904,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:163:16
+    │
+163 │         return left % right
+    │                ^^^^   ^^^^^ u8: Value => None
+    │                │       
+    │                u8: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:163:16
+    │
+163 │         return left % right
+    │                ^^^^^^^^^^^^ u8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:165:5
@@ -2204,6 +2960,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:166:16
+    │
+166 │         return left % right
+    │                ^^^^   ^^^^^ i256: Value => None
+    │                │       
+    │                i256: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:166:16
+    │
+166 │         return left % right
+    │                ^^^^^^^^^^^^ i256: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:168:5
     │  
 168 │ ╭     pub fn mod_i128(left: i128, right: i128) -> i128:
@@ -2242,6 +3012,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:169:16
+    │
+169 │         return left % right
+    │                ^^^^   ^^^^^ i128: Value => None
+    │                │       
+    │                i128: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:169:16
+    │
+169 │         return left % right
+    │                ^^^^^^^^^^^^ i128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:171:5
@@ -2284,6 +3068,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:172:16
+    │
+172 │         return left % right
+    │                ^^^^   ^^^^^ i64: Value => None
+    │                │       
+    │                i64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:172:16
+    │
+172 │         return left % right
+    │                ^^^^^^^^^^^^ i64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:174:5
     │  
 174 │ ╭     pub fn mod_i32(left: i32, right: i32) -> i32:
@@ -2322,6 +3120,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:175:16
+    │
+175 │         return left % right
+    │                ^^^^   ^^^^^ i32: Value => None
+    │                │       
+    │                i32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:175:16
+    │
+175 │         return left % right
+    │                ^^^^^^^^^^^^ i32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:177:5
@@ -2364,6 +3176,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:178:16
+    │
+178 │         return left % right
+    │                ^^^^   ^^^^^ i16: Value => None
+    │                │       
+    │                i16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:178:16
+    │
+178 │         return left % right
+    │                ^^^^^^^^^^^^ i16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:180:5
     │  
 180 │ ╭     pub fn mod_i8(left: i8, right: i8) -> i8:
@@ -2402,6 +3228,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:181:16
+    │
+181 │         return left % right
+    │                ^^^^   ^^^^^ i8: Value => None
+    │                │       
+    │                i8: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:181:16
+    │
+181 │         return left % right
+    │                ^^^^^^^^^^^^ i8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:183:5
@@ -2444,6 +3284,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:184:16
+    │
+184 │         return left ** right
+    │                ^^^^    ^^^^^ u256: Value => None
+    │                │        
+    │                u256: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:184:16
+    │
+184 │         return left ** right
+    │                ^^^^^^^^^^^^^ u256: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:186:5
     │  
 186 │ ╭     pub fn pow_u128(left: u128, right: u128) -> u128:
@@ -2482,6 +3336,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:187:16
+    │
+187 │         return left ** right
+    │                ^^^^    ^^^^^ u128: Value => None
+    │                │        
+    │                u128: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:187:16
+    │
+187 │         return left ** right
+    │                ^^^^^^^^^^^^^ u128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:189:5
@@ -2524,6 +3392,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:190:16
+    │
+190 │         return left ** right
+    │                ^^^^    ^^^^^ u64: Value => None
+    │                │        
+    │                u64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:190:16
+    │
+190 │         return left ** right
+    │                ^^^^^^^^^^^^^ u64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:192:5
     │  
 192 │ ╭     pub fn pow_u32(left: u32, right: u32) -> u32:
@@ -2562,6 +3444,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:193:16
+    │
+193 │         return left ** right
+    │                ^^^^    ^^^^^ u32: Value => None
+    │                │        
+    │                u32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:193:16
+    │
+193 │         return left ** right
+    │                ^^^^^^^^^^^^^ u32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:195:5
@@ -2604,6 +3500,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:196:16
+    │
+196 │         return left ** right
+    │                ^^^^    ^^^^^ u16: Value => None
+    │                │        
+    │                u16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:196:16
+    │
+196 │         return left ** right
+    │                ^^^^^^^^^^^^^ u16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:198:5
     │  
 198 │ ╭     pub fn pow_u8(left: u8, right: u8) -> u8:
@@ -2642,6 +3552,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:199:16
+    │
+199 │         return left ** right
+    │                ^^^^    ^^^^^ u8: Value => None
+    │                │        
+    │                u8: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:199:16
+    │
+199 │         return left ** right
+    │                ^^^^^^^^^^^^^ u8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:201:5
@@ -2684,6 +3608,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:202:16
+    │
+202 │         return left ** right
+    │                ^^^^    ^^^^^ u256: Value => None
+    │                │        
+    │                i256: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:202:16
+    │
+202 │         return left ** right
+    │                ^^^^^^^^^^^^^ i256: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:204:5
     │  
 204 │ ╭     pub fn pow_i128(left: i128, right: u128) -> i128:
@@ -2722,6 +3660,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:205:16
+    │
+205 │         return left ** right
+    │                ^^^^    ^^^^^ u128: Value => None
+    │                │        
+    │                i128: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:205:16
+    │
+205 │         return left ** right
+    │                ^^^^^^^^^^^^^ i128: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:207:5
@@ -2764,6 +3716,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:208:16
+    │
+208 │         return left ** right
+    │                ^^^^    ^^^^^ u64: Value => None
+    │                │        
+    │                i64: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:208:16
+    │
+208 │         return left ** right
+    │                ^^^^^^^^^^^^^ i64: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:210:5
     │  
 210 │ ╭     pub fn pow_i32(left: i32, right: u32) -> i32:
@@ -2802,6 +3768,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ features/checked_arithmetic.fe:211:16
+    │
+211 │         return left ** right
+    │                ^^^^    ^^^^^ u32: Value => None
+    │                │        
+    │                i32: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:211:16
+    │
+211 │         return left ** right
+    │                ^^^^^^^^^^^^^ i32: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:213:5
@@ -2844,6 +3824,20 @@ note:
       }
 
 note: 
+    ┌─ features/checked_arithmetic.fe:214:16
+    │
+214 │         return left ** right
+    │                ^^^^    ^^^^^ u16: Value => None
+    │                │        
+    │                i16: Value => None
+
+note: 
+    ┌─ features/checked_arithmetic.fe:214:16
+    │
+214 │         return left ** right
+    │                ^^^^^^^^^^^^^ i16: Value => None
+
+note: 
     ┌─ features/checked_arithmetic.fe:216:5
     │  
 216 │ ╭     pub fn pow_i8(left: i8, right: u8) -> i8:
@@ -2884,1294 +3878,12 @@ note:
       }
 
 note: 
-  ┌─ features/checked_arithmetic.fe:4:16
-  │
-4 │         return left + right
-  │                ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/checked_arithmetic.fe:4:23
-  │
-4 │         return left + right
-  │                       ^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/checked_arithmetic.fe:4:16
-  │
-4 │         return left + right
-  │                ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/checked_arithmetic.fe:7:16
-  │
-7 │         return left + right
-  │                ^^^^ u128: Value => None
-
-note: 
-  ┌─ features/checked_arithmetic.fe:7:23
-  │
-7 │         return left + right
-  │                       ^^^^^ u128: Value => None
-
-note: 
-  ┌─ features/checked_arithmetic.fe:7:16
-  │
-7 │         return left + right
-  │                ^^^^^^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:10:16
-   │
-10 │         return left + right
-   │                ^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:10:23
-   │
-10 │         return left + right
-   │                       ^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:10:16
-   │
-10 │         return left + right
-   │                ^^^^^^^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:13:16
-   │
-13 │         return left + right
-   │                ^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:13:23
-   │
-13 │         return left + right
-   │                       ^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:13:16
-   │
-13 │         return left + right
-   │                ^^^^^^^^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:16:16
-   │
-16 │         return left + right
-   │                ^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:16:23
-   │
-16 │         return left + right
-   │                       ^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:16:16
-   │
-16 │         return left + right
-   │                ^^^^^^^^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:19:16
-   │
-19 │         return left + right
-   │                ^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:19:23
-   │
-19 │         return left + right
-   │                       ^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:19:16
-   │
-19 │         return left + right
-   │                ^^^^^^^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:22:16
-   │
-22 │         return left + right
-   │                ^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:22:23
-   │
-22 │         return left + right
-   │                       ^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:22:16
-   │
-22 │         return left + right
-   │                ^^^^^^^^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:25:16
-   │
-25 │         return left + right
-   │                ^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:25:23
-   │
-25 │         return left + right
-   │                       ^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:25:16
-   │
-25 │         return left + right
-   │                ^^^^^^^^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:28:16
-   │
-28 │         return left + right
-   │                ^^^^ i64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:28:23
-   │
-28 │         return left + right
-   │                       ^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:28:16
-   │
-28 │         return left + right
-   │                ^^^^^^^^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:31:16
-   │
-31 │         return left + right
-   │                ^^^^ i32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:31:23
-   │
-31 │         return left + right
-   │                       ^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:31:16
-   │
-31 │         return left + right
-   │                ^^^^^^^^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:34:16
-   │
-34 │         return left + right
-   │                ^^^^ i16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:34:23
-   │
-34 │         return left + right
-   │                       ^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:34:16
-   │
-34 │         return left + right
-   │                ^^^^^^^^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:37:16
-   │
-37 │         return left + right
-   │                ^^^^ i8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:37:23
-   │
-37 │         return left + right
-   │                       ^^^^^ i8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:37:16
-   │
-37 │         return left + right
-   │                ^^^^^^^^^^^^ i8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:40:16
-   │
-40 │         return left - right
-   │                ^^^^ u256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:40:23
-   │
-40 │         return left - right
-   │                       ^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:40:16
-   │
-40 │         return left - right
-   │                ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:43:16
-   │
-43 │         return left - right
-   │                ^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:43:23
-   │
-43 │         return left - right
-   │                       ^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:43:16
-   │
-43 │         return left - right
-   │                ^^^^^^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:46:16
-   │
-46 │         return left - right
-   │                ^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:46:23
-   │
-46 │         return left - right
-   │                       ^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:46:16
-   │
-46 │         return left - right
-   │                ^^^^^^^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:49:16
-   │
-49 │         return left - right
-   │                ^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:49:23
-   │
-49 │         return left - right
-   │                       ^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:49:16
-   │
-49 │         return left - right
-   │                ^^^^^^^^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:52:16
-   │
-52 │         return left - right
-   │                ^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:52:23
-   │
-52 │         return left - right
-   │                       ^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:52:16
-   │
-52 │         return left - right
-   │                ^^^^^^^^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:55:16
-   │
-55 │         return left - right
-   │                ^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:55:23
-   │
-55 │         return left - right
-   │                       ^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:55:16
-   │
-55 │         return left - right
-   │                ^^^^^^^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:58:16
-   │
-58 │         return left - right
-   │                ^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:58:23
-   │
-58 │         return left - right
-   │                       ^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:58:16
-   │
-58 │         return left - right
-   │                ^^^^^^^^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:61:16
-   │
-61 │         return left - right
-   │                ^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:61:23
-   │
-61 │         return left - right
-   │                       ^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:61:16
-   │
-61 │         return left - right
-   │                ^^^^^^^^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:64:16
-   │
-64 │         return left - right
-   │                ^^^^ i64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:64:23
-   │
-64 │         return left - right
-   │                       ^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:64:16
-   │
-64 │         return left - right
-   │                ^^^^^^^^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:67:16
-   │
-67 │         return left - right
-   │                ^^^^ i32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:67:23
-   │
-67 │         return left - right
-   │                       ^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:67:16
-   │
-67 │         return left - right
-   │                ^^^^^^^^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:70:16
-   │
-70 │         return left - right
-   │                ^^^^ i16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:70:23
-   │
-70 │         return left - right
-   │                       ^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:70:16
-   │
-70 │         return left - right
-   │                ^^^^^^^^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:73:16
-   │
-73 │         return left - right
-   │                ^^^^ i8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:73:23
-   │
-73 │         return left - right
-   │                       ^^^^^ i8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:73:16
-   │
-73 │         return left - right
-   │                ^^^^^^^^^^^^ i8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:76:16
-   │
-76 │         return left / right
-   │                ^^^^ u256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:76:23
-   │
-76 │         return left / right
-   │                       ^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:76:16
-   │
-76 │         return left / right
-   │                ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:79:16
-   │
-79 │         return left / right
-   │                ^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:79:23
-   │
-79 │         return left / right
-   │                       ^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:79:16
-   │
-79 │         return left / right
-   │                ^^^^^^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:82:16
-   │
-82 │         return left / right
-   │                ^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:82:23
-   │
-82 │         return left / right
-   │                       ^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:82:16
-   │
-82 │         return left / right
-   │                ^^^^^^^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:85:16
-   │
-85 │         return left / right
-   │                ^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:85:23
-   │
-85 │         return left / right
-   │                       ^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:85:16
-   │
-85 │         return left / right
-   │                ^^^^^^^^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:88:16
-   │
-88 │         return left / right
-   │                ^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:88:23
-   │
-88 │         return left / right
-   │                       ^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:88:16
-   │
-88 │         return left / right
-   │                ^^^^^^^^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:91:16
-   │
-91 │         return left / right
-   │                ^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:91:23
-   │
-91 │         return left / right
-   │                       ^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:91:16
-   │
-91 │         return left / right
-   │                ^^^^^^^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:94:16
-   │
-94 │         return left / right
-   │                ^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:94:23
-   │
-94 │         return left / right
-   │                       ^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:94:16
-   │
-94 │         return left / right
-   │                ^^^^^^^^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:97:16
-   │
-97 │         return left / right
-   │                ^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:97:23
-   │
-97 │         return left / right
-   │                       ^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/checked_arithmetic.fe:97:16
-   │
-97 │         return left / right
-   │                ^^^^^^^^^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:100:16
-    │
-100 │         return left / right
-    │                ^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:100:23
-    │
-100 │         return left / right
-    │                       ^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:100:16
-    │
-100 │         return left / right
-    │                ^^^^^^^^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:103:16
-    │
-103 │         return left / right
-    │                ^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:103:23
-    │
-103 │         return left / right
-    │                       ^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:103:16
-    │
-103 │         return left / right
-    │                ^^^^^^^^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:106:16
-    │
-106 │         return left / right
-    │                ^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:106:23
-    │
-106 │         return left / right
-    │                       ^^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:106:16
-    │
-106 │         return left / right
-    │                ^^^^^^^^^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:109:16
-    │
-109 │         return left / right
-    │                ^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:109:23
-    │
-109 │         return left / right
-    │                       ^^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:109:16
-    │
-109 │         return left / right
-    │                ^^^^^^^^^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:112:16
-    │
-112 │         return left * right
-    │                ^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:112:23
-    │
-112 │         return left * right
-    │                       ^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:112:16
-    │
-112 │         return left * right
-    │                ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:115:16
-    │
-115 │         return left * right
-    │                ^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:115:23
-    │
-115 │         return left * right
-    │                       ^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:115:16
-    │
-115 │         return left * right
-    │                ^^^^^^^^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:118:16
-    │
-118 │         return left * right
-    │                ^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:118:23
-    │
-118 │         return left * right
-    │                       ^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:118:16
-    │
-118 │         return left * right
-    │                ^^^^^^^^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:121:16
-    │
-121 │         return left * right
-    │                ^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:121:23
-    │
-121 │         return left * right
-    │                       ^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:121:16
-    │
-121 │         return left * right
-    │                ^^^^^^^^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:124:16
-    │
-124 │         return left * right
-    │                ^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:124:23
-    │
-124 │         return left * right
-    │                       ^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:124:16
-    │
-124 │         return left * right
-    │                ^^^^^^^^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:127:16
-    │
-127 │         return left * right
-    │                ^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:127:23
-    │
-127 │         return left * right
-    │                       ^^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:127:16
-    │
-127 │         return left * right
-    │                ^^^^^^^^^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:130:16
-    │
-130 │         return left * right
-    │                ^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:130:23
-    │
-130 │         return left * right
-    │                       ^^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:130:16
-    │
-130 │         return left * right
-    │                ^^^^^^^^^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:133:16
-    │
-133 │         return left * right
-    │                ^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:133:23
-    │
-133 │         return left * right
-    │                       ^^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:133:16
-    │
-133 │         return left * right
-    │                ^^^^^^^^^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:136:16
-    │
-136 │         return left * right
-    │                ^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:136:23
-    │
-136 │         return left * right
-    │                       ^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:136:16
-    │
-136 │         return left * right
-    │                ^^^^^^^^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:139:16
-    │
-139 │         return left * right
-    │                ^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:139:23
-    │
-139 │         return left * right
-    │                       ^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:139:16
-    │
-139 │         return left * right
-    │                ^^^^^^^^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:142:16
-    │
-142 │         return left * right
-    │                ^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:142:23
-    │
-142 │         return left * right
-    │                       ^^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:142:16
-    │
-142 │         return left * right
-    │                ^^^^^^^^^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:145:16
-    │
-145 │         return left * right
-    │                ^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:145:23
-    │
-145 │         return left * right
-    │                       ^^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:145:16
-    │
-145 │         return left * right
-    │                ^^^^^^^^^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:148:16
-    │
-148 │         return left % right
-    │                ^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:148:23
-    │
-148 │         return left % right
-    │                       ^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:148:16
-    │
-148 │         return left % right
-    │                ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:151:16
-    │
-151 │         return left % right
-    │                ^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:151:23
-    │
-151 │         return left % right
-    │                       ^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:151:16
-    │
-151 │         return left % right
-    │                ^^^^^^^^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:154:16
-    │
-154 │         return left % right
-    │                ^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:154:23
-    │
-154 │         return left % right
-    │                       ^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:154:16
-    │
-154 │         return left % right
-    │                ^^^^^^^^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:157:16
-    │
-157 │         return left % right
-    │                ^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:157:23
-    │
-157 │         return left % right
-    │                       ^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:157:16
-    │
-157 │         return left % right
-    │                ^^^^^^^^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:160:16
-    │
-160 │         return left % right
-    │                ^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:160:23
-    │
-160 │         return left % right
-    │                       ^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:160:16
-    │
-160 │         return left % right
-    │                ^^^^^^^^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:163:16
-    │
-163 │         return left % right
-    │                ^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:163:23
-    │
-163 │         return left % right
-    │                       ^^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:163:16
-    │
-163 │         return left % right
-    │                ^^^^^^^^^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:166:16
-    │
-166 │         return left % right
-    │                ^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:166:23
-    │
-166 │         return left % right
-    │                       ^^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:166:16
-    │
-166 │         return left % right
-    │                ^^^^^^^^^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:169:16
-    │
-169 │         return left % right
-    │                ^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:169:23
-    │
-169 │         return left % right
-    │                       ^^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:169:16
-    │
-169 │         return left % right
-    │                ^^^^^^^^^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:172:16
-    │
-172 │         return left % right
-    │                ^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:172:23
-    │
-172 │         return left % right
-    │                       ^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:172:16
-    │
-172 │         return left % right
-    │                ^^^^^^^^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:175:16
-    │
-175 │         return left % right
-    │                ^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:175:23
-    │
-175 │         return left % right
-    │                       ^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:175:16
-    │
-175 │         return left % right
-    │                ^^^^^^^^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:178:16
-    │
-178 │         return left % right
-    │                ^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:178:23
-    │
-178 │         return left % right
-    │                       ^^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:178:16
-    │
-178 │         return left % right
-    │                ^^^^^^^^^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:181:16
-    │
-181 │         return left % right
-    │                ^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:181:23
-    │
-181 │         return left % right
-    │                       ^^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:181:16
-    │
-181 │         return left % right
-    │                ^^^^^^^^^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:184:16
-    │
-184 │         return left ** right
-    │                ^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:184:24
-    │
-184 │         return left ** right
-    │                        ^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:184:16
-    │
-184 │         return left ** right
-    │                ^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:187:16
-    │
-187 │         return left ** right
-    │                ^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:187:24
-    │
-187 │         return left ** right
-    │                        ^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:187:16
-    │
-187 │         return left ** right
-    │                ^^^^^^^^^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:190:16
-    │
-190 │         return left ** right
-    │                ^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:190:24
-    │
-190 │         return left ** right
-    │                        ^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:190:16
-    │
-190 │         return left ** right
-    │                ^^^^^^^^^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:193:16
-    │
-193 │         return left ** right
-    │                ^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:193:24
-    │
-193 │         return left ** right
-    │                        ^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:193:16
-    │
-193 │         return left ** right
-    │                ^^^^^^^^^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:196:16
-    │
-196 │         return left ** right
-    │                ^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:196:24
-    │
-196 │         return left ** right
-    │                        ^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:196:16
-    │
-196 │         return left ** right
-    │                ^^^^^^^^^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:199:16
-    │
-199 │         return left ** right
-    │                ^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:199:24
-    │
-199 │         return left ** right
-    │                        ^^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:199:16
-    │
-199 │         return left ** right
-    │                ^^^^^^^^^^^^^ u8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:202:16
-    │
-202 │         return left ** right
-    │                ^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:202:24
-    │
-202 │         return left ** right
-    │                        ^^^^^ u256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:202:16
-    │
-202 │         return left ** right
-    │                ^^^^^^^^^^^^^ i256: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:205:16
-    │
-205 │         return left ** right
-    │                ^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:205:24
-    │
-205 │         return left ** right
-    │                        ^^^^^ u128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:205:16
-    │
-205 │         return left ** right
-    │                ^^^^^^^^^^^^^ i128: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:208:16
-    │
-208 │         return left ** right
-    │                ^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:208:24
-    │
-208 │         return left ** right
-    │                        ^^^^^ u64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:208:16
-    │
-208 │         return left ** right
-    │                ^^^^^^^^^^^^^ i64: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:211:16
-    │
-211 │         return left ** right
-    │                ^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:211:24
-    │
-211 │         return left ** right
-    │                        ^^^^^ u32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:211:16
-    │
-211 │         return left ** right
-    │                ^^^^^^^^^^^^^ i32: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:214:16
-    │
-214 │         return left ** right
-    │                ^^^^ i16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:214:24
-    │
-214 │         return left ** right
-    │                        ^^^^^ u16: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:214:16
-    │
-214 │         return left ** right
-    │                ^^^^^^^^^^^^^ i16: Value => None
-
-note: 
     ┌─ features/checked_arithmetic.fe:217:16
     │
 217 │         return left ** right
-    │                ^^^^ i8: Value => None
-
-note: 
-    ┌─ features/checked_arithmetic.fe:217:24
-    │
-217 │         return left ** right
-    │                        ^^^^^ u8: Value => None
+    │                ^^^^    ^^^^^ u8: Value => None
+    │                │        
+    │                i8: Value => None
 
 note: 
     ┌─ features/checked_arithmetic.fe:217:16

--- a/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
+++ b/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
@@ -47,15 +47,15 @@ note:
   ┌─ features/checked_arithmetic.fe:4:16
   │
 4 │         return left + right
-  │                ^^^^   ^^^^^ u256: Value => None
+  │                ^^^^   ^^^^^ u256: Value
   │                │       
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/checked_arithmetic.fe:4:16
   │
 4 │         return left + right
-  │                ^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/checked_arithmetic.fe:6:5
@@ -101,15 +101,15 @@ note:
   ┌─ features/checked_arithmetic.fe:7:16
   │
 7 │         return left + right
-  │                ^^^^   ^^^^^ u128: Value => None
+  │                ^^^^   ^^^^^ u128: Value
   │                │       
-  │                u128: Value => None
+  │                u128: Value
 
 note: 
   ┌─ features/checked_arithmetic.fe:7:16
   │
 7 │         return left + right
-  │                ^^^^^^^^^^^^ u128: Value => None
+  │                ^^^^^^^^^^^^ u128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:9:5
@@ -155,15 +155,15 @@ note:
    ┌─ features/checked_arithmetic.fe:10:16
    │
 10 │         return left + right
-   │                ^^^^   ^^^^^ u64: Value => None
+   │                ^^^^   ^^^^^ u64: Value
    │                │       
-   │                u64: Value => None
+   │                u64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:10:16
    │
 10 │         return left + right
-   │                ^^^^^^^^^^^^ u64: Value => None
+   │                ^^^^^^^^^^^^ u64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:12:5
@@ -209,15 +209,15 @@ note:
    ┌─ features/checked_arithmetic.fe:13:16
    │
 13 │         return left + right
-   │                ^^^^   ^^^^^ u32: Value => None
+   │                ^^^^   ^^^^^ u32: Value
    │                │       
-   │                u32: Value => None
+   │                u32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:13:16
    │
 13 │         return left + right
-   │                ^^^^^^^^^^^^ u32: Value => None
+   │                ^^^^^^^^^^^^ u32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:15:5
@@ -263,15 +263,15 @@ note:
    ┌─ features/checked_arithmetic.fe:16:16
    │
 16 │         return left + right
-   │                ^^^^   ^^^^^ u16: Value => None
+   │                ^^^^   ^^^^^ u16: Value
    │                │       
-   │                u16: Value => None
+   │                u16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:16:16
    │
 16 │         return left + right
-   │                ^^^^^^^^^^^^ u16: Value => None
+   │                ^^^^^^^^^^^^ u16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:18:5
@@ -317,15 +317,15 @@ note:
    ┌─ features/checked_arithmetic.fe:19:16
    │
 19 │         return left + right
-   │                ^^^^   ^^^^^ u8: Value => None
+   │                ^^^^   ^^^^^ u8: Value
    │                │       
-   │                u8: Value => None
+   │                u8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:19:16
    │
 19 │         return left + right
-   │                ^^^^^^^^^^^^ u8: Value => None
+   │                ^^^^^^^^^^^^ u8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:21:5
@@ -371,15 +371,15 @@ note:
    ┌─ features/checked_arithmetic.fe:22:16
    │
 22 │         return left + right
-   │                ^^^^   ^^^^^ i256: Value => None
+   │                ^^^^   ^^^^^ i256: Value
    │                │       
-   │                i256: Value => None
+   │                i256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:22:16
    │
 22 │         return left + right
-   │                ^^^^^^^^^^^^ i256: Value => None
+   │                ^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:24:5
@@ -425,15 +425,15 @@ note:
    ┌─ features/checked_arithmetic.fe:25:16
    │
 25 │         return left + right
-   │                ^^^^   ^^^^^ i128: Value => None
+   │                ^^^^   ^^^^^ i128: Value
    │                │       
-   │                i128: Value => None
+   │                i128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:25:16
    │
 25 │         return left + right
-   │                ^^^^^^^^^^^^ i128: Value => None
+   │                ^^^^^^^^^^^^ i128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:27:5
@@ -479,15 +479,15 @@ note:
    ┌─ features/checked_arithmetic.fe:28:16
    │
 28 │         return left + right
-   │                ^^^^   ^^^^^ i64: Value => None
+   │                ^^^^   ^^^^^ i64: Value
    │                │       
-   │                i64: Value => None
+   │                i64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:28:16
    │
 28 │         return left + right
-   │                ^^^^^^^^^^^^ i64: Value => None
+   │                ^^^^^^^^^^^^ i64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:30:5
@@ -533,15 +533,15 @@ note:
    ┌─ features/checked_arithmetic.fe:31:16
    │
 31 │         return left + right
-   │                ^^^^   ^^^^^ i32: Value => None
+   │                ^^^^   ^^^^^ i32: Value
    │                │       
-   │                i32: Value => None
+   │                i32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:31:16
    │
 31 │         return left + right
-   │                ^^^^^^^^^^^^ i32: Value => None
+   │                ^^^^^^^^^^^^ i32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:33:5
@@ -587,15 +587,15 @@ note:
    ┌─ features/checked_arithmetic.fe:34:16
    │
 34 │         return left + right
-   │                ^^^^   ^^^^^ i16: Value => None
+   │                ^^^^   ^^^^^ i16: Value
    │                │       
-   │                i16: Value => None
+   │                i16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:34:16
    │
 34 │         return left + right
-   │                ^^^^^^^^^^^^ i16: Value => None
+   │                ^^^^^^^^^^^^ i16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:36:5
@@ -641,15 +641,15 @@ note:
    ┌─ features/checked_arithmetic.fe:37:16
    │
 37 │         return left + right
-   │                ^^^^   ^^^^^ i8: Value => None
+   │                ^^^^   ^^^^^ i8: Value
    │                │       
-   │                i8: Value => None
+   │                i8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:37:16
    │
 37 │         return left + right
-   │                ^^^^^^^^^^^^ i8: Value => None
+   │                ^^^^^^^^^^^^ i8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:39:5
@@ -695,15 +695,15 @@ note:
    ┌─ features/checked_arithmetic.fe:40:16
    │
 40 │         return left - right
-   │                ^^^^   ^^^^^ u256: Value => None
+   │                ^^^^   ^^^^^ u256: Value
    │                │       
-   │                u256: Value => None
+   │                u256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:40:16
    │
 40 │         return left - right
-   │                ^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:42:5
@@ -749,15 +749,15 @@ note:
    ┌─ features/checked_arithmetic.fe:43:16
    │
 43 │         return left - right
-   │                ^^^^   ^^^^^ u128: Value => None
+   │                ^^^^   ^^^^^ u128: Value
    │                │       
-   │                u128: Value => None
+   │                u128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:43:16
    │
 43 │         return left - right
-   │                ^^^^^^^^^^^^ u128: Value => None
+   │                ^^^^^^^^^^^^ u128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:45:5
@@ -803,15 +803,15 @@ note:
    ┌─ features/checked_arithmetic.fe:46:16
    │
 46 │         return left - right
-   │                ^^^^   ^^^^^ u64: Value => None
+   │                ^^^^   ^^^^^ u64: Value
    │                │       
-   │                u64: Value => None
+   │                u64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:46:16
    │
 46 │         return left - right
-   │                ^^^^^^^^^^^^ u64: Value => None
+   │                ^^^^^^^^^^^^ u64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:48:5
@@ -857,15 +857,15 @@ note:
    ┌─ features/checked_arithmetic.fe:49:16
    │
 49 │         return left - right
-   │                ^^^^   ^^^^^ u32: Value => None
+   │                ^^^^   ^^^^^ u32: Value
    │                │       
-   │                u32: Value => None
+   │                u32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:49:16
    │
 49 │         return left - right
-   │                ^^^^^^^^^^^^ u32: Value => None
+   │                ^^^^^^^^^^^^ u32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:51:5
@@ -911,15 +911,15 @@ note:
    ┌─ features/checked_arithmetic.fe:52:16
    │
 52 │         return left - right
-   │                ^^^^   ^^^^^ u16: Value => None
+   │                ^^^^   ^^^^^ u16: Value
    │                │       
-   │                u16: Value => None
+   │                u16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:52:16
    │
 52 │         return left - right
-   │                ^^^^^^^^^^^^ u16: Value => None
+   │                ^^^^^^^^^^^^ u16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:54:5
@@ -965,15 +965,15 @@ note:
    ┌─ features/checked_arithmetic.fe:55:16
    │
 55 │         return left - right
-   │                ^^^^   ^^^^^ u8: Value => None
+   │                ^^^^   ^^^^^ u8: Value
    │                │       
-   │                u8: Value => None
+   │                u8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:55:16
    │
 55 │         return left - right
-   │                ^^^^^^^^^^^^ u8: Value => None
+   │                ^^^^^^^^^^^^ u8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:57:5
@@ -1019,15 +1019,15 @@ note:
    ┌─ features/checked_arithmetic.fe:58:16
    │
 58 │         return left - right
-   │                ^^^^   ^^^^^ i256: Value => None
+   │                ^^^^   ^^^^^ i256: Value
    │                │       
-   │                i256: Value => None
+   │                i256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:58:16
    │
 58 │         return left - right
-   │                ^^^^^^^^^^^^ i256: Value => None
+   │                ^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:60:5
@@ -1073,15 +1073,15 @@ note:
    ┌─ features/checked_arithmetic.fe:61:16
    │
 61 │         return left - right
-   │                ^^^^   ^^^^^ i128: Value => None
+   │                ^^^^   ^^^^^ i128: Value
    │                │       
-   │                i128: Value => None
+   │                i128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:61:16
    │
 61 │         return left - right
-   │                ^^^^^^^^^^^^ i128: Value => None
+   │                ^^^^^^^^^^^^ i128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:63:5
@@ -1127,15 +1127,15 @@ note:
    ┌─ features/checked_arithmetic.fe:64:16
    │
 64 │         return left - right
-   │                ^^^^   ^^^^^ i64: Value => None
+   │                ^^^^   ^^^^^ i64: Value
    │                │       
-   │                i64: Value => None
+   │                i64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:64:16
    │
 64 │         return left - right
-   │                ^^^^^^^^^^^^ i64: Value => None
+   │                ^^^^^^^^^^^^ i64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:66:5
@@ -1181,15 +1181,15 @@ note:
    ┌─ features/checked_arithmetic.fe:67:16
    │
 67 │         return left - right
-   │                ^^^^   ^^^^^ i32: Value => None
+   │                ^^^^   ^^^^^ i32: Value
    │                │       
-   │                i32: Value => None
+   │                i32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:67:16
    │
 67 │         return left - right
-   │                ^^^^^^^^^^^^ i32: Value => None
+   │                ^^^^^^^^^^^^ i32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:69:5
@@ -1235,15 +1235,15 @@ note:
    ┌─ features/checked_arithmetic.fe:70:16
    │
 70 │         return left - right
-   │                ^^^^   ^^^^^ i16: Value => None
+   │                ^^^^   ^^^^^ i16: Value
    │                │       
-   │                i16: Value => None
+   │                i16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:70:16
    │
 70 │         return left - right
-   │                ^^^^^^^^^^^^ i16: Value => None
+   │                ^^^^^^^^^^^^ i16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:72:5
@@ -1289,15 +1289,15 @@ note:
    ┌─ features/checked_arithmetic.fe:73:16
    │
 73 │         return left - right
-   │                ^^^^   ^^^^^ i8: Value => None
+   │                ^^^^   ^^^^^ i8: Value
    │                │       
-   │                i8: Value => None
+   │                i8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:73:16
    │
 73 │         return left - right
-   │                ^^^^^^^^^^^^ i8: Value => None
+   │                ^^^^^^^^^^^^ i8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:75:5
@@ -1343,15 +1343,15 @@ note:
    ┌─ features/checked_arithmetic.fe:76:16
    │
 76 │         return left / right
-   │                ^^^^   ^^^^^ u256: Value => None
+   │                ^^^^   ^^^^^ u256: Value
    │                │       
-   │                u256: Value => None
+   │                u256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:76:16
    │
 76 │         return left / right
-   │                ^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:78:5
@@ -1397,15 +1397,15 @@ note:
    ┌─ features/checked_arithmetic.fe:79:16
    │
 79 │         return left / right
-   │                ^^^^   ^^^^^ u128: Value => None
+   │                ^^^^   ^^^^^ u128: Value
    │                │       
-   │                u128: Value => None
+   │                u128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:79:16
    │
 79 │         return left / right
-   │                ^^^^^^^^^^^^ u128: Value => None
+   │                ^^^^^^^^^^^^ u128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:81:5
@@ -1451,15 +1451,15 @@ note:
    ┌─ features/checked_arithmetic.fe:82:16
    │
 82 │         return left / right
-   │                ^^^^   ^^^^^ u64: Value => None
+   │                ^^^^   ^^^^^ u64: Value
    │                │       
-   │                u64: Value => None
+   │                u64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:82:16
    │
 82 │         return left / right
-   │                ^^^^^^^^^^^^ u64: Value => None
+   │                ^^^^^^^^^^^^ u64: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:84:5
@@ -1505,15 +1505,15 @@ note:
    ┌─ features/checked_arithmetic.fe:85:16
    │
 85 │         return left / right
-   │                ^^^^   ^^^^^ u32: Value => None
+   │                ^^^^   ^^^^^ u32: Value
    │                │       
-   │                u32: Value => None
+   │                u32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:85:16
    │
 85 │         return left / right
-   │                ^^^^^^^^^^^^ u32: Value => None
+   │                ^^^^^^^^^^^^ u32: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:87:5
@@ -1559,15 +1559,15 @@ note:
    ┌─ features/checked_arithmetic.fe:88:16
    │
 88 │         return left / right
-   │                ^^^^   ^^^^^ u16: Value => None
+   │                ^^^^   ^^^^^ u16: Value
    │                │       
-   │                u16: Value => None
+   │                u16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:88:16
    │
 88 │         return left / right
-   │                ^^^^^^^^^^^^ u16: Value => None
+   │                ^^^^^^^^^^^^ u16: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:90:5
@@ -1613,15 +1613,15 @@ note:
    ┌─ features/checked_arithmetic.fe:91:16
    │
 91 │         return left / right
-   │                ^^^^   ^^^^^ u8: Value => None
+   │                ^^^^   ^^^^^ u8: Value
    │                │       
-   │                u8: Value => None
+   │                u8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:91:16
    │
 91 │         return left / right
-   │                ^^^^^^^^^^^^ u8: Value => None
+   │                ^^^^^^^^^^^^ u8: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:93:5
@@ -1667,15 +1667,15 @@ note:
    ┌─ features/checked_arithmetic.fe:94:16
    │
 94 │         return left / right
-   │                ^^^^   ^^^^^ i256: Value => None
+   │                ^^^^   ^^^^^ i256: Value
    │                │       
-   │                i256: Value => None
+   │                i256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:94:16
    │
 94 │         return left / right
-   │                ^^^^^^^^^^^^ i256: Value => None
+   │                ^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:96:5
@@ -1721,15 +1721,15 @@ note:
    ┌─ features/checked_arithmetic.fe:97:16
    │
 97 │         return left / right
-   │                ^^^^   ^^^^^ i128: Value => None
+   │                ^^^^   ^^^^^ i128: Value
    │                │       
-   │                i128: Value => None
+   │                i128: Value
 
 note: 
    ┌─ features/checked_arithmetic.fe:97:16
    │
 97 │         return left / right
-   │                ^^^^^^^^^^^^ i128: Value => None
+   │                ^^^^^^^^^^^^ i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:99:5
@@ -1775,15 +1775,15 @@ note:
     ┌─ features/checked_arithmetic.fe:100:16
     │
 100 │         return left / right
-    │                ^^^^   ^^^^^ i64: Value => None
+    │                ^^^^   ^^^^^ i64: Value
     │                │       
-    │                i64: Value => None
+    │                i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:100:16
     │
 100 │         return left / right
-    │                ^^^^^^^^^^^^ i64: Value => None
+    │                ^^^^^^^^^^^^ i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:102:5
@@ -1829,15 +1829,15 @@ note:
     ┌─ features/checked_arithmetic.fe:103:16
     │
 103 │         return left / right
-    │                ^^^^   ^^^^^ i32: Value => None
+    │                ^^^^   ^^^^^ i32: Value
     │                │       
-    │                i32: Value => None
+    │                i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:103:16
     │
 103 │         return left / right
-    │                ^^^^^^^^^^^^ i32: Value => None
+    │                ^^^^^^^^^^^^ i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:105:5
@@ -1883,15 +1883,15 @@ note:
     ┌─ features/checked_arithmetic.fe:106:16
     │
 106 │         return left / right
-    │                ^^^^   ^^^^^ i16: Value => None
+    │                ^^^^   ^^^^^ i16: Value
     │                │       
-    │                i16: Value => None
+    │                i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:106:16
     │
 106 │         return left / right
-    │                ^^^^^^^^^^^^ i16: Value => None
+    │                ^^^^^^^^^^^^ i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:108:5
@@ -1937,15 +1937,15 @@ note:
     ┌─ features/checked_arithmetic.fe:109:16
     │
 109 │         return left / right
-    │                ^^^^   ^^^^^ i8: Value => None
+    │                ^^^^   ^^^^^ i8: Value
     │                │       
-    │                i8: Value => None
+    │                i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:109:16
     │
 109 │         return left / right
-    │                ^^^^^^^^^^^^ i8: Value => None
+    │                ^^^^^^^^^^^^ i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:111:5
@@ -1991,15 +1991,15 @@ note:
     ┌─ features/checked_arithmetic.fe:112:16
     │
 112 │         return left * right
-    │                ^^^^   ^^^^^ u256: Value => None
+    │                ^^^^   ^^^^^ u256: Value
     │                │       
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:112:16
     │
 112 │         return left * right
-    │                ^^^^^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:114:5
@@ -2045,15 +2045,15 @@ note:
     ┌─ features/checked_arithmetic.fe:115:16
     │
 115 │         return left * right
-    │                ^^^^   ^^^^^ u128: Value => None
+    │                ^^^^   ^^^^^ u128: Value
     │                │       
-    │                u128: Value => None
+    │                u128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:115:16
     │
 115 │         return left * right
-    │                ^^^^^^^^^^^^ u128: Value => None
+    │                ^^^^^^^^^^^^ u128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:117:5
@@ -2099,15 +2099,15 @@ note:
     ┌─ features/checked_arithmetic.fe:118:16
     │
 118 │         return left * right
-    │                ^^^^   ^^^^^ u64: Value => None
+    │                ^^^^   ^^^^^ u64: Value
     │                │       
-    │                u64: Value => None
+    │                u64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:118:16
     │
 118 │         return left * right
-    │                ^^^^^^^^^^^^ u64: Value => None
+    │                ^^^^^^^^^^^^ u64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:120:5
@@ -2153,15 +2153,15 @@ note:
     ┌─ features/checked_arithmetic.fe:121:16
     │
 121 │         return left * right
-    │                ^^^^   ^^^^^ u32: Value => None
+    │                ^^^^   ^^^^^ u32: Value
     │                │       
-    │                u32: Value => None
+    │                u32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:121:16
     │
 121 │         return left * right
-    │                ^^^^^^^^^^^^ u32: Value => None
+    │                ^^^^^^^^^^^^ u32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:123:5
@@ -2207,15 +2207,15 @@ note:
     ┌─ features/checked_arithmetic.fe:124:16
     │
 124 │         return left * right
-    │                ^^^^   ^^^^^ u16: Value => None
+    │                ^^^^   ^^^^^ u16: Value
     │                │       
-    │                u16: Value => None
+    │                u16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:124:16
     │
 124 │         return left * right
-    │                ^^^^^^^^^^^^ u16: Value => None
+    │                ^^^^^^^^^^^^ u16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:126:5
@@ -2261,15 +2261,15 @@ note:
     ┌─ features/checked_arithmetic.fe:127:16
     │
 127 │         return left * right
-    │                ^^^^   ^^^^^ u8: Value => None
+    │                ^^^^   ^^^^^ u8: Value
     │                │       
-    │                u8: Value => None
+    │                u8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:127:16
     │
 127 │         return left * right
-    │                ^^^^^^^^^^^^ u8: Value => None
+    │                ^^^^^^^^^^^^ u8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:129:5
@@ -2315,15 +2315,15 @@ note:
     ┌─ features/checked_arithmetic.fe:130:16
     │
 130 │         return left * right
-    │                ^^^^   ^^^^^ i256: Value => None
+    │                ^^^^   ^^^^^ i256: Value
     │                │       
-    │                i256: Value => None
+    │                i256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:130:16
     │
 130 │         return left * right
-    │                ^^^^^^^^^^^^ i256: Value => None
+    │                ^^^^^^^^^^^^ i256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:132:5
@@ -2369,15 +2369,15 @@ note:
     ┌─ features/checked_arithmetic.fe:133:16
     │
 133 │         return left * right
-    │                ^^^^   ^^^^^ i128: Value => None
+    │                ^^^^   ^^^^^ i128: Value
     │                │       
-    │                i128: Value => None
+    │                i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:133:16
     │
 133 │         return left * right
-    │                ^^^^^^^^^^^^ i128: Value => None
+    │                ^^^^^^^^^^^^ i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:135:5
@@ -2423,15 +2423,15 @@ note:
     ┌─ features/checked_arithmetic.fe:136:16
     │
 136 │         return left * right
-    │                ^^^^   ^^^^^ i64: Value => None
+    │                ^^^^   ^^^^^ i64: Value
     │                │       
-    │                i64: Value => None
+    │                i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:136:16
     │
 136 │         return left * right
-    │                ^^^^^^^^^^^^ i64: Value => None
+    │                ^^^^^^^^^^^^ i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:138:5
@@ -2477,15 +2477,15 @@ note:
     ┌─ features/checked_arithmetic.fe:139:16
     │
 139 │         return left * right
-    │                ^^^^   ^^^^^ i32: Value => None
+    │                ^^^^   ^^^^^ i32: Value
     │                │       
-    │                i32: Value => None
+    │                i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:139:16
     │
 139 │         return left * right
-    │                ^^^^^^^^^^^^ i32: Value => None
+    │                ^^^^^^^^^^^^ i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:141:5
@@ -2531,15 +2531,15 @@ note:
     ┌─ features/checked_arithmetic.fe:142:16
     │
 142 │         return left * right
-    │                ^^^^   ^^^^^ i16: Value => None
+    │                ^^^^   ^^^^^ i16: Value
     │                │       
-    │                i16: Value => None
+    │                i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:142:16
     │
 142 │         return left * right
-    │                ^^^^^^^^^^^^ i16: Value => None
+    │                ^^^^^^^^^^^^ i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:144:5
@@ -2585,15 +2585,15 @@ note:
     ┌─ features/checked_arithmetic.fe:145:16
     │
 145 │         return left * right
-    │                ^^^^   ^^^^^ i8: Value => None
+    │                ^^^^   ^^^^^ i8: Value
     │                │       
-    │                i8: Value => None
+    │                i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:145:16
     │
 145 │         return left * right
-    │                ^^^^^^^^^^^^ i8: Value => None
+    │                ^^^^^^^^^^^^ i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:147:5
@@ -2639,15 +2639,15 @@ note:
     ┌─ features/checked_arithmetic.fe:148:16
     │
 148 │         return left % right
-    │                ^^^^   ^^^^^ u256: Value => None
+    │                ^^^^   ^^^^^ u256: Value
     │                │       
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:148:16
     │
 148 │         return left % right
-    │                ^^^^^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:150:5
@@ -2693,15 +2693,15 @@ note:
     ┌─ features/checked_arithmetic.fe:151:16
     │
 151 │         return left % right
-    │                ^^^^   ^^^^^ u128: Value => None
+    │                ^^^^   ^^^^^ u128: Value
     │                │       
-    │                u128: Value => None
+    │                u128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:151:16
     │
 151 │         return left % right
-    │                ^^^^^^^^^^^^ u128: Value => None
+    │                ^^^^^^^^^^^^ u128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:153:5
@@ -2747,15 +2747,15 @@ note:
     ┌─ features/checked_arithmetic.fe:154:16
     │
 154 │         return left % right
-    │                ^^^^   ^^^^^ u64: Value => None
+    │                ^^^^   ^^^^^ u64: Value
     │                │       
-    │                u64: Value => None
+    │                u64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:154:16
     │
 154 │         return left % right
-    │                ^^^^^^^^^^^^ u64: Value => None
+    │                ^^^^^^^^^^^^ u64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:156:5
@@ -2801,15 +2801,15 @@ note:
     ┌─ features/checked_arithmetic.fe:157:16
     │
 157 │         return left % right
-    │                ^^^^   ^^^^^ u32: Value => None
+    │                ^^^^   ^^^^^ u32: Value
     │                │       
-    │                u32: Value => None
+    │                u32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:157:16
     │
 157 │         return left % right
-    │                ^^^^^^^^^^^^ u32: Value => None
+    │                ^^^^^^^^^^^^ u32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:159:5
@@ -2855,15 +2855,15 @@ note:
     ┌─ features/checked_arithmetic.fe:160:16
     │
 160 │         return left % right
-    │                ^^^^   ^^^^^ u16: Value => None
+    │                ^^^^   ^^^^^ u16: Value
     │                │       
-    │                u16: Value => None
+    │                u16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:160:16
     │
 160 │         return left % right
-    │                ^^^^^^^^^^^^ u16: Value => None
+    │                ^^^^^^^^^^^^ u16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:162:5
@@ -2909,15 +2909,15 @@ note:
     ┌─ features/checked_arithmetic.fe:163:16
     │
 163 │         return left % right
-    │                ^^^^   ^^^^^ u8: Value => None
+    │                ^^^^   ^^^^^ u8: Value
     │                │       
-    │                u8: Value => None
+    │                u8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:163:16
     │
 163 │         return left % right
-    │                ^^^^^^^^^^^^ u8: Value => None
+    │                ^^^^^^^^^^^^ u8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:165:5
@@ -2963,15 +2963,15 @@ note:
     ┌─ features/checked_arithmetic.fe:166:16
     │
 166 │         return left % right
-    │                ^^^^   ^^^^^ i256: Value => None
+    │                ^^^^   ^^^^^ i256: Value
     │                │       
-    │                i256: Value => None
+    │                i256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:166:16
     │
 166 │         return left % right
-    │                ^^^^^^^^^^^^ i256: Value => None
+    │                ^^^^^^^^^^^^ i256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:168:5
@@ -3017,15 +3017,15 @@ note:
     ┌─ features/checked_arithmetic.fe:169:16
     │
 169 │         return left % right
-    │                ^^^^   ^^^^^ i128: Value => None
+    │                ^^^^   ^^^^^ i128: Value
     │                │       
-    │                i128: Value => None
+    │                i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:169:16
     │
 169 │         return left % right
-    │                ^^^^^^^^^^^^ i128: Value => None
+    │                ^^^^^^^^^^^^ i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:171:5
@@ -3071,15 +3071,15 @@ note:
     ┌─ features/checked_arithmetic.fe:172:16
     │
 172 │         return left % right
-    │                ^^^^   ^^^^^ i64: Value => None
+    │                ^^^^   ^^^^^ i64: Value
     │                │       
-    │                i64: Value => None
+    │                i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:172:16
     │
 172 │         return left % right
-    │                ^^^^^^^^^^^^ i64: Value => None
+    │                ^^^^^^^^^^^^ i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:174:5
@@ -3125,15 +3125,15 @@ note:
     ┌─ features/checked_arithmetic.fe:175:16
     │
 175 │         return left % right
-    │                ^^^^   ^^^^^ i32: Value => None
+    │                ^^^^   ^^^^^ i32: Value
     │                │       
-    │                i32: Value => None
+    │                i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:175:16
     │
 175 │         return left % right
-    │                ^^^^^^^^^^^^ i32: Value => None
+    │                ^^^^^^^^^^^^ i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:177:5
@@ -3179,15 +3179,15 @@ note:
     ┌─ features/checked_arithmetic.fe:178:16
     │
 178 │         return left % right
-    │                ^^^^   ^^^^^ i16: Value => None
+    │                ^^^^   ^^^^^ i16: Value
     │                │       
-    │                i16: Value => None
+    │                i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:178:16
     │
 178 │         return left % right
-    │                ^^^^^^^^^^^^ i16: Value => None
+    │                ^^^^^^^^^^^^ i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:180:5
@@ -3233,15 +3233,15 @@ note:
     ┌─ features/checked_arithmetic.fe:181:16
     │
 181 │         return left % right
-    │                ^^^^   ^^^^^ i8: Value => None
+    │                ^^^^   ^^^^^ i8: Value
     │                │       
-    │                i8: Value => None
+    │                i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:181:16
     │
 181 │         return left % right
-    │                ^^^^^^^^^^^^ i8: Value => None
+    │                ^^^^^^^^^^^^ i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:183:5
@@ -3287,15 +3287,15 @@ note:
     ┌─ features/checked_arithmetic.fe:184:16
     │
 184 │         return left ** right
-    │                ^^^^    ^^^^^ u256: Value => None
+    │                ^^^^    ^^^^^ u256: Value
     │                │        
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:184:16
     │
 184 │         return left ** right
-    │                ^^^^^^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:186:5
@@ -3341,15 +3341,15 @@ note:
     ┌─ features/checked_arithmetic.fe:187:16
     │
 187 │         return left ** right
-    │                ^^^^    ^^^^^ u128: Value => None
+    │                ^^^^    ^^^^^ u128: Value
     │                │        
-    │                u128: Value => None
+    │                u128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:187:16
     │
 187 │         return left ** right
-    │                ^^^^^^^^^^^^^ u128: Value => None
+    │                ^^^^^^^^^^^^^ u128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:189:5
@@ -3395,15 +3395,15 @@ note:
     ┌─ features/checked_arithmetic.fe:190:16
     │
 190 │         return left ** right
-    │                ^^^^    ^^^^^ u64: Value => None
+    │                ^^^^    ^^^^^ u64: Value
     │                │        
-    │                u64: Value => None
+    │                u64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:190:16
     │
 190 │         return left ** right
-    │                ^^^^^^^^^^^^^ u64: Value => None
+    │                ^^^^^^^^^^^^^ u64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:192:5
@@ -3449,15 +3449,15 @@ note:
     ┌─ features/checked_arithmetic.fe:193:16
     │
 193 │         return left ** right
-    │                ^^^^    ^^^^^ u32: Value => None
+    │                ^^^^    ^^^^^ u32: Value
     │                │        
-    │                u32: Value => None
+    │                u32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:193:16
     │
 193 │         return left ** right
-    │                ^^^^^^^^^^^^^ u32: Value => None
+    │                ^^^^^^^^^^^^^ u32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:195:5
@@ -3503,15 +3503,15 @@ note:
     ┌─ features/checked_arithmetic.fe:196:16
     │
 196 │         return left ** right
-    │                ^^^^    ^^^^^ u16: Value => None
+    │                ^^^^    ^^^^^ u16: Value
     │                │        
-    │                u16: Value => None
+    │                u16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:196:16
     │
 196 │         return left ** right
-    │                ^^^^^^^^^^^^^ u16: Value => None
+    │                ^^^^^^^^^^^^^ u16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:198:5
@@ -3557,15 +3557,15 @@ note:
     ┌─ features/checked_arithmetic.fe:199:16
     │
 199 │         return left ** right
-    │                ^^^^    ^^^^^ u8: Value => None
+    │                ^^^^    ^^^^^ u8: Value
     │                │        
-    │                u8: Value => None
+    │                u8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:199:16
     │
 199 │         return left ** right
-    │                ^^^^^^^^^^^^^ u8: Value => None
+    │                ^^^^^^^^^^^^^ u8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:201:5
@@ -3611,15 +3611,15 @@ note:
     ┌─ features/checked_arithmetic.fe:202:16
     │
 202 │         return left ** right
-    │                ^^^^    ^^^^^ u256: Value => None
+    │                ^^^^    ^^^^^ u256: Value
     │                │        
-    │                i256: Value => None
+    │                i256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:202:16
     │
 202 │         return left ** right
-    │                ^^^^^^^^^^^^^ i256: Value => None
+    │                ^^^^^^^^^^^^^ i256: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:204:5
@@ -3665,15 +3665,15 @@ note:
     ┌─ features/checked_arithmetic.fe:205:16
     │
 205 │         return left ** right
-    │                ^^^^    ^^^^^ u128: Value => None
+    │                ^^^^    ^^^^^ u128: Value
     │                │        
-    │                i128: Value => None
+    │                i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:205:16
     │
 205 │         return left ** right
-    │                ^^^^^^^^^^^^^ i128: Value => None
+    │                ^^^^^^^^^^^^^ i128: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:207:5
@@ -3719,15 +3719,15 @@ note:
     ┌─ features/checked_arithmetic.fe:208:16
     │
 208 │         return left ** right
-    │                ^^^^    ^^^^^ u64: Value => None
+    │                ^^^^    ^^^^^ u64: Value
     │                │        
-    │                i64: Value => None
+    │                i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:208:16
     │
 208 │         return left ** right
-    │                ^^^^^^^^^^^^^ i64: Value => None
+    │                ^^^^^^^^^^^^^ i64: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:210:5
@@ -3773,15 +3773,15 @@ note:
     ┌─ features/checked_arithmetic.fe:211:16
     │
 211 │         return left ** right
-    │                ^^^^    ^^^^^ u32: Value => None
+    │                ^^^^    ^^^^^ u32: Value
     │                │        
-    │                i32: Value => None
+    │                i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:211:16
     │
 211 │         return left ** right
-    │                ^^^^^^^^^^^^^ i32: Value => None
+    │                ^^^^^^^^^^^^^ i32: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:213:5
@@ -3827,15 +3827,15 @@ note:
     ┌─ features/checked_arithmetic.fe:214:16
     │
 214 │         return left ** right
-    │                ^^^^    ^^^^^ u16: Value => None
+    │                ^^^^    ^^^^^ u16: Value
     │                │        
-    │                i16: Value => None
+    │                i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:214:16
     │
 214 │         return left ** right
-    │                ^^^^^^^^^^^^^ i16: Value => None
+    │                ^^^^^^^^^^^^^ i16: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:216:5
@@ -3881,14 +3881,14 @@ note:
     ┌─ features/checked_arithmetic.fe:217:16
     │
 217 │         return left ** right
-    │                ^^^^    ^^^^^ u8: Value => None
+    │                ^^^^    ^^^^^ u8: Value
     │                │        
-    │                i8: Value => None
+    │                i8: Value
 
 note: 
     ┌─ features/checked_arithmetic.fe:217:16
     │
 217 │         return left ** right
-    │                ^^^^^^^^^^^^^ i8: Value => None
+    │                ^^^^^^^^^^^^^ i8: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__constructor.snap
+++ b/crates/analyzer/tests/snapshots/analysis__constructor.snap
@@ -14,10 +14,12 @@ note:
   │  
 7 │ ╭     pub fn read_bar(self) -> u256:
 8 │ │         return self.bar[42]
-  │ ╰───────────────────────────^ attributes hash: 16482263331346774611
+  │ ╰───────────────────────────^ attributes hash: 2875164910451995213
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -32,14 +34,20 @@ note:
   ┌─ features/constructor.fe:8:16
   │
 8 │         return self.bar[42]
-  │                ^^^^^^^^ ^^ u256: Value => None
-  │                │         
-  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/constructor.fe:8:16
   │
 8 │         return self.bar[42]
-  │                ^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^ u256: Value
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/constructor.fe:8:16
+  │
+8 │         return self.bar[42]
+  │                ^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__constructor.snap
+++ b/crates/analyzer/tests/snapshots/analysis__constructor.snap
@@ -10,44 +10,6 @@ note:
   │     ^^^^^^^^^^^^^^^^^^^^ Map<u256, u256>
 
 note: 
-  ┌─ features/constructor.fe:4:5
-  │  
-4 │ ╭     pub fn __init__(self, baz: u256, bing: u256):
-5 │ │         self.bar[42] = baz + bing
-  │ ╰─────────────────────────────────^ attributes hash: 13108393064012885630
-  │  
-  = FunctionSignature {
-        self_decl: Mutable,
-        params: [
-            FunctionParam {
-                name: "baz",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                name: "bing",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
-
-note: 
   ┌─ features/constructor.fe:7:5
   │  
 7 │ ╭     pub fn read_bar(self) -> u256:
@@ -67,52 +29,12 @@ note:
     }
 
 note: 
-  ┌─ features/constructor.fe:5:9
-  │
-5 │         self.bar[42] = baz + bing
-  │         ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/constructor.fe:5:18
-  │
-5 │         self.bar[42] = baz + bing
-  │                  ^^ u256: Value => None
-
-note: 
-  ┌─ features/constructor.fe:5:9
-  │
-5 │         self.bar[42] = baz + bing
-  │         ^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/constructor.fe:5:24
-  │
-5 │         self.bar[42] = baz + bing
-  │                        ^^^ u256: Value => None
-
-note: 
-  ┌─ features/constructor.fe:5:30
-  │
-5 │         self.bar[42] = baz + bing
-  │                              ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/constructor.fe:5:24
-  │
-5 │         self.bar[42] = baz + bing
-  │                        ^^^^^^^^^^ u256: Value => None
-
-note: 
   ┌─ features/constructor.fe:8:16
   │
 8 │         return self.bar[42]
-  │                ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/constructor.fe:8:25
-  │
-8 │         return self.bar[42]
-  │                         ^^ u256: Value => None
+  │                ^^^^^^^^ ^^ u256: Value => None
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/constructor.fe:8:16

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -23,6 +23,12 @@ note:
     }
 
 note: 
+  ┌─ features/create2_contract.fe:3:16
+  │
+3 │         return 42
+  │                ^^ u256: Value => None
+
+note: 
   ┌─ features/create2_contract.fe:6:5
   │  
 6 │ ╭     pub fn create2_foo() -> address:
@@ -42,32 +48,24 @@ note:
     }
 
 note: 
-  ┌─ features/create2_contract.fe:3:16
+  ┌─ features/create2_contract.fe:8:18
   │
-3 │         return 42
-  │                ^^ u256: Value => None
+8 │         let foo: Foo = Foo.create2(0, 52)
+  │                  ^^^ Foo
 
 note: 
   ┌─ features/create2_contract.fe:8:36
   │
 8 │         let foo: Foo = Foo.create2(0, 52)
-  │                                    ^ u256: Value => None
-
-note: 
-  ┌─ features/create2_contract.fe:8:39
-  │
-8 │         let foo: Foo = Foo.create2(0, 52)
-  │                                       ^^ u256: Value => None
+  │                                    ^  ^^ u256: Value => None
+  │                                    │   
+  │                                    u256: Value => None
 
 note: 
   ┌─ features/create2_contract.fe:8:24
   │
 8 │         let foo: Foo = Foo.create2(0, 52)
   │                        ^^^^^^^^^^^^^^^^^^ Foo: Value => None
-
-note: 
-  ┌─ features/create2_contract.fe:9:24
-  │
 9 │         return address(foo)
   │                        ^^^ Foo: Value => None
 
@@ -76,12 +74,6 @@ note:
   │
 9 │         return address(foo)
   │                ^^^^^^^^^^^^ address: Value => None
-
-note: 
-  ┌─ features/create2_contract.fe:8:18
-  │
-8 │         let foo: Foo = Foo.create2(0, 52)
-  │                  ^^^ Foo
 
 note: 
   ┌─ features/create2_contract.fe:8:24

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -26,7 +26,7 @@ note:
   ┌─ features/create2_contract.fe:3:16
   │
 3 │         return 42
-  │                ^^ u256: Value => None
+  │                ^^ u256: Value
 
 note: 
   ┌─ features/create2_contract.fe:6:5
@@ -57,52 +57,30 @@ note:
   ┌─ features/create2_contract.fe:8:36
   │
 8 │         let foo: Foo = Foo.create2(0, 52)
-  │                                    ^  ^^ u256: Value => None
+  │                                    ^  ^^ u256: Value
   │                                    │   
-  │                                    u256: Value => None
+  │                                    u256: Value
 
 note: 
   ┌─ features/create2_contract.fe:8:24
   │
 8 │         let foo: Foo = Foo.create2(0, 52)
-  │                        ^^^^^^^^^^^^^^^^^^ Foo: Value => None
+  │                        ^^^^^^^^^^^^^^^^^^ Foo: Value
 9 │         return address(foo)
-  │                        ^^^ Foo: Value => None
+  │                        ^^^ Foo: Value
 
 note: 
   ┌─ features/create2_contract.fe:9:16
   │
 9 │         return address(foo)
-  │                ^^^^^^^^^^^^ address: Value => None
+  │                ^^^^^^^^^^^^ address: Value
 
 note: 
   ┌─ features/create2_contract.fe:8:24
   │
 8 │         let foo: Foo = Foo.create2(0, 52)
-  │                        ^^^^^^^^^^^ attributes hash: 7674167309652124319
-  │
-  = TypeAttribute {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                id: ContractId(
-                    0,
-                ),
-            },
-        ),
-        func_name: "create2",
-    }
-
-note: 
-  ┌─ features/create2_contract.fe:9:16
-  │
+  │                        ^^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(0), function: Create2 }
 9 │         return address(foo)
-  │                ^^^^^^^ attributes hash: 14203407709342965641
-  │
-  = TypeConstructor {
-        typ: Base(
-            Address,
-        ),
-    }
+  │                ^^^^^^^ TypeConstructor(Base(Address))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -23,6 +23,12 @@ note:
     }
 
 note: 
+  ┌─ features/create_contract.fe:3:16
+  │
+3 │         return 42
+  │                ^^ u256: Value => None
+
+note: 
   ┌─ features/create_contract.fe:6:5
   │  
 6 │ ╭     pub fn create_foo() -> address:
@@ -41,10 +47,10 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract.fe:3:16
+  ┌─ features/create_contract.fe:7:18
   │
-3 │         return 42
-  │                ^^ u256: Value => None
+7 │         let foo: Foo = Foo.create(0)
+  │                  ^^^ Foo
 
 note: 
   ┌─ features/create_contract.fe:7:35
@@ -57,10 +63,6 @@ note:
   │
 7 │         let foo: Foo = Foo.create(0)
   │                        ^^^^^^^^^^^^^ Foo: Value => None
-
-note: 
-  ┌─ features/create_contract.fe:8:24
-  │
 8 │         return address(foo)
   │                        ^^^ Foo: Value => None
 
@@ -69,12 +71,6 @@ note:
   │
 8 │         return address(foo)
   │                ^^^^^^^^^^^^ address: Value => None
-
-note: 
-  ┌─ features/create_contract.fe:7:18
-  │
-7 │         let foo: Foo = Foo.create(0)
-  │                  ^^^ Foo
 
 note: 
   ┌─ features/create_contract.fe:7:24

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -26,7 +26,7 @@ note:
   ┌─ features/create_contract.fe:3:16
   │
 3 │         return 42
-  │                ^^ u256: Value => None
+  │                ^^ u256: Value
 
 note: 
   ┌─ features/create_contract.fe:6:5
@@ -56,50 +56,28 @@ note:
   ┌─ features/create_contract.fe:7:35
   │
 7 │         let foo: Foo = Foo.create(0)
-  │                                   ^ u256: Value => None
+  │                                   ^ u256: Value
 
 note: 
   ┌─ features/create_contract.fe:7:24
   │
 7 │         let foo: Foo = Foo.create(0)
-  │                        ^^^^^^^^^^^^^ Foo: Value => None
+  │                        ^^^^^^^^^^^^^ Foo: Value
 8 │         return address(foo)
-  │                        ^^^ Foo: Value => None
+  │                        ^^^ Foo: Value
 
 note: 
   ┌─ features/create_contract.fe:8:16
   │
 8 │         return address(foo)
-  │                ^^^^^^^^^^^^ address: Value => None
+  │                ^^^^^^^^^^^^ address: Value
 
 note: 
   ┌─ features/create_contract.fe:7:24
   │
 7 │         let foo: Foo = Foo.create(0)
-  │                        ^^^^^^^^^^ attributes hash: 6749875126898824118
-  │
-  = TypeAttribute {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                id: ContractId(
-                    0,
-                ),
-            },
-        ),
-        func_name: "create",
-    }
-
-note: 
-  ┌─ features/create_contract.fe:8:16
-  │
+  │                        ^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(0), function: Create }
 8 │         return address(foo)
-  │                ^^^^^^^ attributes hash: 14203407709342965641
-  │
-  = TypeConstructor {
-        typ: Base(
-            Address,
-        ),
-    }
+  │                ^^^^^^^ TypeConstructor(Base(Address))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
@@ -26,7 +26,7 @@ note:
   ┌─ features/create_contract_from_init.fe:3:16
   │
 3 │         return 42
-  │                ^^ u256: Value => None
+  │                ^^ u256: Value
 
 note: 
   ┌─ features/create_contract_from_init.fe:6:5
@@ -39,10 +39,12 @@ note:
    │  
 11 │ ╭     pub fn get_foo_addr(self) -> address:
 12 │ │         return self.foo_addr
-   │ ╰────────────────────────────^ attributes hash: 17651916811868111914
+   │ ╰────────────────────────────^ attributes hash: 10447292744135180405
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -55,6 +57,12 @@ note:
    ┌─ features/create_contract_from_init.fe:12:16
    │
 12 │         return self.foo_addr
-   │                ^^^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │                ^^^^ FooFactory: Value
+
+note: 
+   ┌─ features/create_contract_from_init.fe:12:16
+   │
+12 │         return self.foo_addr
+   │                ^^^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
@@ -4,12 +4,6 @@ expression: "build_snapshot(\"features/create_contract_from_init.fe\", &src, mod
 
 ---
 note: 
-  ┌─ features/create_contract_from_init.fe:6:5
-  │
-6 │     foo_addr: address
-  │     ^^^^^^^^^^^^^^^^^ address
-
-note: 
   ┌─ features/create_contract_from_init.fe:2:5
   │  
 2 │ ╭     pub fn get_my_num() -> u256:
@@ -29,21 +23,16 @@ note:
     }
 
 note: 
-  ┌─ features/create_contract_from_init.fe:8:5
-  │  
-8 │ ╭     pub fn __init__(self):
-9 │ │         self.foo_addr = address(Foo.create(0))
-  │ ╰──────────────────────────────────────────────^ attributes hash: 4369441865732737140
-  │  
-  = FunctionSignature {
-        self_decl: Mutable,
-        params: [],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  ┌─ features/create_contract_from_init.fe:3:16
+  │
+3 │         return 42
+  │                ^^ u256: Value => None
+
+note: 
+  ┌─ features/create_contract_from_init.fe:6:5
+  │
+6 │     foo_addr: address
+  │     ^^^^^^^^^^^^^^^^^ address
 
 note: 
    ┌─ features/create_contract_from_init.fe:11:5
@@ -63,69 +52,9 @@ note:
      }
 
 note: 
-  ┌─ features/create_contract_from_init.fe:3:16
-  │
-3 │         return 42
-  │                ^^ u256: Value => None
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:9
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │         ^^^^^^^^^^^^^ address: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:44
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                                            ^ u256: Value => None
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:33
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                                 ^^^^^^^^^^^^^ Foo: Value => None
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:25
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                         ^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
    ┌─ features/create_contract_from_init.fe:12:16
    │
 12 │         return self.foo_addr
    │                ^^^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:25
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                         ^^^^^^^ attributes hash: 14203407709342965641
-  │
-  = TypeConstructor {
-        typ: Base(
-            Address,
-        ),
-    }
-
-note: 
-  ┌─ features/create_contract_from_init.fe:9:33
-  │
-9 │         self.foo_addr = address(Foo.create(0))
-  │                                 ^^^^^^^^^^ attributes hash: 6749875126898824118
-  │
-  = TypeAttribute {
-        typ: Contract(
-            Contract {
-                name: "Foo",
-                id: ContractId(
-                    0,
-                ),
-            },
-        ),
-        func_name: "create",
-    }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -40,10 +40,12 @@ note:
    · │
 25 │ │         self.my_u256 = my_u256
 26 │ │         self.my_other_u256 = my_other_u256
-   │ ╰──────────────────────────────────────────^ attributes hash: 17137180982713149068
+   │ ╰──────────────────────────────────────────^ attributes hash: 13337959138492803468
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_string",
@@ -97,21 +99,45 @@ note:
    ┌─ stress/data_copying_stress.fe:23:9
    │
 23 │         self.my_string = my_string
-   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<42>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:23:9
+   │
+23 │         self.my_string = my_string
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<42>: Memory
    │         │                 
-   │         String<42>: Storage { nonce: Some(0) } => None
+   │         String<42>: Storage { nonce: Some(0) }
 24 │         self.my_other_string = my_other_string
-   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ String<42>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:24:9
+   │
+24 │         self.my_other_string = my_other_string
+   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ String<42>: Memory
    │         │                       
-   │         String<42>: Storage { nonce: Some(1) } => None
+   │         String<42>: Storage { nonce: Some(1) }
 25 │         self.my_u256 = my_u256
-   │         ^^^^^^^^^^^^   ^^^^^^^ u256: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:25:9
+   │
+25 │         self.my_u256 = my_u256
+   │         ^^^^^^^^^^^^   ^^^^^^^ u256: Value
    │         │               
-   │         u256: Storage { nonce: Some(2) } => None
+   │         u256: Storage { nonce: Some(2) }
 26 │         self.my_other_u256 = my_other_u256
-   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:26:9
+   │
+26 │         self.my_other_u256 = my_other_u256
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Value
    │         │                     
-   │         u256: Storage { nonce: Some(3) } => None
+   │         u256: Storage { nonce: Some(3) }
 
 note: 
    ┌─ stress/data_copying_stress.fe:28:5
@@ -119,10 +145,12 @@ note:
 28 │ ╭     pub fn set_to_my_other_vals(self):
 29 │ │         self.my_string = self.my_other_string
 30 │ │         self.my_u256 = self.my_other_u256
-   │ ╰─────────────────────────────────────────^ attributes hash: 4369441865732737140
+   │ ╰─────────────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -135,13 +163,37 @@ note:
    ┌─ stress/data_copying_stress.fe:29:9
    │
 29 │         self.my_string = self.my_other_string
-   │         ^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:29:9
+   │
+29 │         self.my_string = self.my_other_string
+   │         ^^^^^^^^^^^^^^   ^^^^ Foo: Value
    │         │                 
-   │         String<42>: Storage { nonce: Some(0) } => None
+   │         String<42>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:29:26
+   │
+29 │         self.my_string = self.my_other_string
+   │                          ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) }
 30 │         self.my_u256 = self.my_other_u256
-   │         ^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:30:9
+   │
+30 │         self.my_u256 = self.my_other_u256
+   │         ^^^^^^^^^^^^   ^^^^ Foo: Value
    │         │               
-   │         u256: Storage { nonce: Some(2) } => None
+   │         u256: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:30:24
+   │
+30 │         self.my_u256 = self.my_other_u256
+   │                        ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) }
 
 note: 
    ┌─ stress/data_copying_stress.fe:32:5
@@ -191,161 +243,161 @@ note:
    ┌─ stress/data_copying_stress.fe:33:45
    │
 33 │         let my_2nd_array: Array<u256, 10> = my_array
-   │                                             ^^^^^^^^ Array<u256, 10>: Memory => None
+   │                                             ^^^^^^^^ Array<u256, 10>: Memory
 34 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
-   │                                             ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
+   │                                             ^^^^^^^^^^^^ Array<u256, 10>: Memory
 35 │ 
 36 │         assert my_array[3] != 5
-   │                ^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^ ^ u256: Value
    │                │         
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:36:16
    │
 36 │         assert my_array[3] != 5
-   │                ^^^^^^^^^^^    ^ u256: Value => None
+   │                ^^^^^^^^^^^    ^ u256: Value
    │                │               
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:36:16
    │
 36 │         assert my_array[3] != 5
-   │                ^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^ bool: Value
 37 │         my_array[3] = 5
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 10>: Memory => None
+   │         Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:37:9
    │
 37 │         my_array[3] = 5
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
 38 │         assert my_array[3] == 5
-   │                ^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^ ^ u256: Value
    │                │         
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:38:16
    │
 38 │         assert my_array[3] == 5
-   │                ^^^^^^^^^^^    ^ u256: Value => None
+   │                ^^^^^^^^^^^    ^ u256: Value
    │                │               
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:38:16
    │
 38 │         assert my_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^ bool: Value
 39 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^^^^^ ^ u256: Value
    │                │             
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:16
    │
 39 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                   
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:39:16
    │
 39 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
 40 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^^^^^ ^ u256: Value
    │                │             
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:40:16
    │
 40 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                   
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:40:16
    │
 40 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
 41 │ 
 42 │         my_3rd_array[3] = 50
-   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
-   │         Array<u256, 10>: Memory => None
+   │         Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:42:9
    │
 42 │         my_3rd_array[3] = 50
-   │         ^^^^^^^^^^^^^^^   ^^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
    │         │                  
-   │         u256: Memory => None
+   │         u256: Memory
 43 │         assert my_array[3] == 50
-   │                ^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^ ^ u256: Value
    │                │         
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:43:16
    │
 43 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^    ^^ u256: Value => None
+   │                ^^^^^^^^^^^    ^^ u256: Value
    │                │               
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:43:16
    │
 43 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^ bool: Value
 44 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^^^^^ ^ u256: Value
    │                │             
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:16
    │
 44 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^    ^^ u256: Value
    │                │                   
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:44:16
    │
 44 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 45 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^^^^^ ^ u256: Value
    │                │             
-   │                Array<u256, 10>: Memory => None
+   │                Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:45:16
    │
 45 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^    ^^ u256: Value
    │                │                   
-   │                u256: Memory => Some(Value)
+   │                u256: Memory => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:45:16
    │
 45 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:47:5
@@ -388,19 +440,19 @@ note:
    ┌─ stress/data_copying_stress.fe:48:9
    │
 48 │         my_array[3] = 5
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 10>: Memory => None
+   │         Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:48:9
    │
 48 │         my_array[3] = 5
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
 49 │         return my_array
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
+   │                ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:51:5
@@ -442,21 +494,19 @@ note:
    ┌─ stress/data_copying_stress.fe:52:16
    │
 52 │         return my_array.clone()
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
+   │                ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:52:16
    │
 52 │         return my_array.clone()
-   │                ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Some(Memory)
+   │                ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:52:16
    │
 52 │         return my_array.clone()
-   │                ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                ^^^^^^^^^^^^^^ BuiltinValueMethod(Clone)
 
 note: 
    ┌─ stress/data_copying_stress.fe:54:5
@@ -499,33 +549,31 @@ note:
    ┌─ stress/data_copying_stress.fe:55:9
    │
 55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^ Array<u256, 10>: Memory => None
+   │         ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:55:9
    │
 55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^ ^ u256: Value
    │         │                 
-   │         Array<u256, 10>: Memory => Some(Memory)
+   │         Array<u256, 10>: Memory => Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:55:9
    │
 55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^   ^ u256: Value
    │         │                      
-   │         u256: Memory => None
+   │         u256: Memory
 56 │         return my_array
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
+   │                ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:55:9
    │
 55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │         ^^^^^^^^^^^^^^ BuiltinValueMethod(Clone)
 
 note: 
    ┌─ stress/data_copying_stress.fe:58:5
@@ -537,10 +585,12 @@ note:
    · │
 65 │ │         my_nums_mem = self.my_nums.to_mem()
 66 │ │         return my_nums_mem
-   │ ╰──────────────────────────^ attributes hash: 1843734974850057968
+   │ ╰──────────────────────────^ attributes hash: 7232749468704655087
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Array(
@@ -564,85 +614,119 @@ note:
    ┌─ stress/data_copying_stress.fe:60:9
    │
 60 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^ ^ u256: Value => None
-   │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:60:9
    │
 60 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^^^^   ^^ u256: Value => None
-   │         │                  
-   │         u256: Storage { nonce: None } => None
-61 │         self.my_nums[1] = 26
-   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:60:9
+   │
+60 │         self.my_nums[0] = 42
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                  
+   │         u256: Storage { nonce: None }
+61 │         self.my_nums[1] = 26
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:61:9
    │
 61 │         self.my_nums[1] = 26
-   │         ^^^^^^^^^^^^^^^   ^^ u256: Value => None
-   │         │                  
-   │         u256: Storage { nonce: None } => None
-62 │         self.my_nums[2] = 0
-   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:61:9
+   │
+61 │         self.my_nums[1] = 26
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                  
+   │         u256: Storage { nonce: None }
+62 │         self.my_nums[2] = 0
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:62:9
    │
 62 │         self.my_nums[2] = 0
-   │         ^^^^^^^^^^^^^^^   ^ u256: Value => None
-   │         │                  
-   │         u256: Storage { nonce: None } => None
-63 │         self.my_nums[3] = 1
-   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:62:9
+   │
+62 │         self.my_nums[2] = 0
+   │         ^^^^^^^^^^^^^^^   ^ u256: Value
+   │         │                  
+   │         u256: Storage { nonce: None }
+63 │         self.my_nums[3] = 1
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:63:9
    │
 63 │         self.my_nums[3] = 1
-   │         ^^^^^^^^^^^^^^^   ^ u256: Value => None
-   │         │                  
-   │         u256: Storage { nonce: None } => None
-64 │         self.my_nums[4] = 255
-   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:63:9
+   │
+63 │         self.my_nums[3] = 1
+   │         ^^^^^^^^^^^^^^^   ^ u256: Value
+   │         │                  
+   │         u256: Storage { nonce: None }
+64 │         self.my_nums[4] = 255
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:64:9
    │
 64 │         self.my_nums[4] = 255
-   │         ^^^^^^^^^^^^^^^   ^^^ u256: Value => None
+   │         ^^^^^^^^^^^^ ^ u256: Value
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:64:9
+   │
+64 │         self.my_nums[4] = 255
+   │         ^^^^^^^^^^^^^^^   ^^^ u256: Value
    │         │                  
-   │         u256: Storage { nonce: None } => None
+   │         u256: Storage { nonce: None }
 65 │         my_nums_mem = self.my_nums.to_mem()
-   │         ^^^^^^^^^^^   ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         ^^^^^^^^^^^   ^^^^ Foo: Value
    │         │              
-   │         Array<u256, 5>: Memory => None
+   │         Array<u256, 5>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:65:23
    │
 65 │         my_nums_mem = self.my_nums.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => Some(Memory)
+   │                       ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:65:23
+   │
+65 │         my_nums_mem = self.my_nums.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => Memory
 66 │         return my_nums_mem
-   │                ^^^^^^^^^^^ Array<u256, 5>: Memory => None
+   │                ^^^^^^^^^^^ Array<u256, 5>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:65:23
    │
 65 │         my_nums_mem = self.my_nums.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                       ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ stress/data_copying_stress.fe:68:5
@@ -652,10 +736,12 @@ note:
 70 │ │             self.my_string.to_mem(),
 71 │ │             self.my_u256.to_mem()
 72 │ │         )
-   │ ╰─────────^ attributes hash: 4369441865732737140
+   │ ╰─────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -668,21 +754,33 @@ note:
    ┌─ stress/data_copying_stress.fe:70:13
    │
 70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
+   │             ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:70:13
    │
 70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => Some(Memory)
+   │             ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:70:13
+   │
+70 │             self.my_string.to_mem(),
+   │             ^^^^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => Memory
 71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
+   │             ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:71:13
    │
 71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+   │             ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:71:13
+   │
+71 │             self.my_u256.to_mem()
+   │             ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:69:9
@@ -691,35 +789,21 @@ note:
 70 │ │             self.my_string.to_mem(),
 71 │ │             self.my_u256.to_mem()
 72 │ │         )
-   │ ╰─────────^ (): Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:69:9
-   │
-69 │         emit_my_event_internal(
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1445082349245844857
-   │
-   = Pure(
-         FunctionId(
-             8,
-         ),
-     )
+   │ ╰─────────^ (): Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:70:13
    │
 70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │             ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
+71 │             self.my_u256.to_mem()
+   │             ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
-   ┌─ stress/data_copying_stress.fe:71:13
+   ┌─ stress/data_copying_stress.fe:69:9
    │
-71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+69 │         emit_my_event_internal(
+   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(8))
 
 note: 
    ┌─ stress/data_copying_stress.fe:74:5
@@ -763,9 +847,9 @@ note:
    ┌─ stress/data_copying_stress.fe:75:32
    │
 75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │                                ^^^^^^^^^^^          ^^^^^^^^^ u256: Value => None
+   │                                ^^^^^^^^^^^          ^^^^^^^^^ u256: Value
    │                                │                     
-   │                                String<42>: Memory => None
+   │                                String<42>: Memory
 
 note: 
    ┌─ stress/data_copying_stress.fe:75:9
@@ -806,10 +890,12 @@ note:
    │  
 77 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>):
 78 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 5533219732473050758
+   │ ╰────────────────────────────────^ attributes hash: 12879711971263255621
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_addrs",
@@ -834,19 +920,27 @@ note:
    ┌─ stress/data_copying_stress.fe:78:9
    │
 78 │         self.my_addrs = my_addrs
-   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 3>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/data_copying_stress.fe:78:9
+   │
+78 │         self.my_addrs = my_addrs
+   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 3>: Memory
    │         │                
-   │         Array<address, 3>: Storage { nonce: Some(5) } => None
+   │         Array<address, 3>: Storage { nonce: Some(5) }
 
 note: 
    ┌─ stress/data_copying_stress.fe:80:5
    │  
 80 │ ╭     pub fn get_my_second_addr(self) -> address:
 81 │ │         return self.my_addrs[1]
-   │ ╰───────────────────────────────^ attributes hash: 17651916811868111914
+   │ ╰───────────────────────────────^ attributes hash: 10447292744135180405
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -859,14 +953,20 @@ note:
    ┌─ stress/data_copying_stress.fe:81:16
    │
 81 │         return self.my_addrs[1]
-   │                ^^^^^^^^^^^^^ ^ u256: Value => None
-   │                │              
-   │                Array<address, 3>: Storage { nonce: Some(5) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/data_copying_stress.fe:81:16
    │
 81 │         return self.my_addrs[1]
-   │                ^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Some(Value)
+   │                ^^^^^^^^^^^^^ ^ u256: Value
+   │                │              
+   │                Array<address, 3>: Storage { nonce: Some(5) }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:81:16
+   │
+81 │         return self.my_addrs[1]
+   │                ^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -1,41 +1,24 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"stress/data_copying_stress.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
-  ┌─ stress/data_copying_stress.fe:2:5
-  │
-2 │     my_string: String<42>
-  │     ^^^^^^^^^^^^^^^^^^^^^ String<42>
-
-note: 
-  ┌─ stress/data_copying_stress.fe:3:5
-  │
-3 │     my_other_string: String<42>
-  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<42>
-
-note: 
-  ┌─ stress/data_copying_stress.fe:5:5
-  │
-5 │     my_u256: u256
-  │     ^^^^^^^^^^^^^ u256
-
-note: 
-  ┌─ stress/data_copying_stress.fe:6:5
-  │
-6 │     my_other_u256: u256
-  │     ^^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-  ┌─ stress/data_copying_stress.fe:8:5
-  │
-8 │     my_nums: Array<u256, 5>
-  │     ^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>
-
-note: 
-   ┌─ stress/data_copying_stress.fe:10:5
+   ┌─ stress/data_copying_stress.fe:2:5
    │
+ 2 │     my_string: String<42>
+   │     ^^^^^^^^^^^^^^^^^^^^^ String<42>
+ 3 │     my_other_string: String<42>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<42>
+ 4 │ 
+ 5 │     my_u256: u256
+   │     ^^^^^^^^^^^^^ u256
+ 6 │     my_other_u256: u256
+   │     ^^^^^^^^^^^^^^^^^^^ u256
+ 7 │ 
+ 8 │     my_nums: Array<u256, 5>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>
+ 9 │ 
 10 │     my_addrs: Array<address, 3>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 3>
 
@@ -44,10 +27,6 @@ note:
    │
 13 │         my_string: String<42>
    │         ^^^^^^^^^^^^^^^^^^^^^ String<42>
-
-note: 
-   ┌─ stress/data_copying_stress.fe:14:9
-   │
 14 │         my_u256: u256
    │         ^^^^^^^^^^^^^ u256
 
@@ -115,6 +94,26 @@ note:
      }
 
 note: 
+   ┌─ stress/data_copying_stress.fe:23:9
+   │
+23 │         self.my_string = my_string
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<42>: Memory => None
+   │         │                 
+   │         String<42>: Storage { nonce: Some(0) } => None
+24 │         self.my_other_string = my_other_string
+   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ String<42>: Memory => None
+   │         │                       
+   │         String<42>: Storage { nonce: Some(1) } => None
+25 │         self.my_u256 = my_u256
+   │         ^^^^^^^^^^^^   ^^^^^^^ u256: Value => None
+   │         │               
+   │         u256: Storage { nonce: Some(2) } => None
+26 │         self.my_other_u256 = my_other_u256
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Value => None
+   │         │                     
+   │         u256: Storage { nonce: Some(3) } => None
+
+note: 
    ┌─ stress/data_copying_stress.fe:28:5
    │  
 28 │ ╭     pub fn set_to_my_other_vals(self):
@@ -131,6 +130,18 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:29:9
+   │
+29 │         self.my_string = self.my_other_string
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
+   │         │                 
+   │         String<42>: Storage { nonce: Some(0) } => None
+30 │         self.my_u256 = self.my_other_u256
+   │         ^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => None
+   │         │               
+   │         u256: Storage { nonce: Some(2) } => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:32:5
@@ -167,6 +178,174 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:33:27
+   │
+33 │         let my_2nd_array: Array<u256, 10> = my_array
+   │                           ^^^^^^^^^^^^^^^ Array<u256, 10>
+34 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
+   │                           ^^^^^^^^^^^^^^^ Array<u256, 10>
+
+note: 
+   ┌─ stress/data_copying_stress.fe:33:45
+   │
+33 │         let my_2nd_array: Array<u256, 10> = my_array
+   │                                             ^^^^^^^^ Array<u256, 10>: Memory => None
+34 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
+   │                                             ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
+35 │ 
+36 │         assert my_array[3] != 5
+   │                ^^^^^^^^ ^ u256: Value => None
+   │                │         
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:36:16
+   │
+36 │         assert my_array[3] != 5
+   │                ^^^^^^^^^^^    ^ u256: Value => None
+   │                │               
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:36:16
+   │
+36 │         assert my_array[3] != 5
+   │                ^^^^^^^^^^^^^^^^ bool: Value => None
+37 │         my_array[3] = 5
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:37:9
+   │
+37 │         my_array[3] = 5
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+38 │         assert my_array[3] == 5
+   │                ^^^^^^^^ ^ u256: Value => None
+   │                │         
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:38:16
+   │
+38 │         assert my_array[3] == 5
+   │                ^^^^^^^^^^^    ^ u256: Value => None
+   │                │               
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:38:16
+   │
+38 │         assert my_array[3] == 5
+   │                ^^^^^^^^^^^^^^^^ bool: Value => None
+39 │         assert my_2nd_array[3] == 5
+   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                │             
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:39:16
+   │
+39 │         assert my_2nd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                   
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:39:16
+   │
+39 │         assert my_2nd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+40 │         assert my_3rd_array[3] == 5
+   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                │             
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:40:16
+   │
+40 │         assert my_3rd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                   
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:40:16
+   │
+40 │         assert my_3rd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+41 │ 
+42 │         my_3rd_array[3] = 50
+   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         │             
+   │         Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:42:9
+   │
+42 │         my_3rd_array[3] = 50
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value => None
+   │         │                  
+   │         u256: Memory => None
+43 │         assert my_array[3] == 50
+   │                ^^^^^^^^ ^ u256: Value => None
+   │                │         
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:43:16
+   │
+43 │         assert my_array[3] == 50
+   │                ^^^^^^^^^^^    ^^ u256: Value => None
+   │                │               
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:43:16
+   │
+43 │         assert my_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^ bool: Value => None
+44 │         assert my_2nd_array[3] == 50
+   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                │             
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:44:16
+   │
+44 │         assert my_2nd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                │                   
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:44:16
+   │
+44 │         assert my_2nd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+45 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^ ^ u256: Value => None
+   │                │             
+   │                Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:45:16
+   │
+45 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                │                   
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:45:16
+   │
+45 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:47:5
@@ -206,6 +385,24 @@ note:
      }
 
 note: 
+   ┌─ stress/data_copying_stress.fe:48:9
+   │
+48 │         my_array[3] = 5
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:48:9
+   │
+48 │         my_array[3] = 5
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+49 │         return my_array
+   │                ^^^^^^^^ Array<u256, 10>: Memory => None
+
+note: 
    ┌─ stress/data_copying_stress.fe:51:5
    │  
 51 │ ╭     pub fn clone_and_return(my_array: Array<u256, 10>) -> Array<u256, 10>:
@@ -240,6 +437,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:52:16
+   │
+52 │         return my_array.clone()
+   │                ^^^^^^^^ Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:52:16
+   │
+52 │         return my_array.clone()
+   │                ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Some(Memory)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:52:16
+   │
+52 │         return my_array.clone()
+   │                ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ stress/data_copying_stress.fe:54:5
@@ -279,6 +496,38 @@ note:
      }
 
 note: 
+   ┌─ stress/data_copying_stress.fe:55:9
+   │
+55 │         my_array.clone()[3] = 5
+   │         ^^^^^^^^ Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:55:9
+   │
+55 │         my_array.clone()[3] = 5
+   │         ^^^^^^^^^^^^^^^^ ^ u256: Value => None
+   │         │                 
+   │         Array<u256, 10>: Memory => Some(Memory)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:55:9
+   │
+55 │         my_array.clone()[3] = 5
+   │         ^^^^^^^^^^^^^^^^^^^   ^ u256: Value => None
+   │         │                      
+   │         u256: Memory => None
+56 │         return my_array
+   │                ^^^^^^^^ Array<u256, 10>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:55:9
+   │
+55 │         my_array.clone()[3] = 5
+   │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
    ┌─ stress/data_copying_stress.fe:58:5
    │  
 58 │ ╭     pub fn assign_my_nums_and_return(self) -> Array<u256, 5>:
@@ -306,6 +555,96 @@ note:
      }
 
 note: 
+   ┌─ stress/data_copying_stress.fe:59:26
+   │
+59 │         let my_nums_mem: Array<u256, 5>
+   │                          ^^^^^^^^^^^^^^ Array<u256, 5>
+
+note: 
+   ┌─ stress/data_copying_stress.fe:60:9
+   │
+60 │         self.my_nums[0] = 42
+   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:60:9
+   │
+60 │         self.my_nums[0] = 42
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value => None
+   │         │                  
+   │         u256: Storage { nonce: None } => None
+61 │         self.my_nums[1] = 26
+   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:61:9
+   │
+61 │         self.my_nums[1] = 26
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value => None
+   │         │                  
+   │         u256: Storage { nonce: None } => None
+62 │         self.my_nums[2] = 0
+   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:62:9
+   │
+62 │         self.my_nums[2] = 0
+   │         ^^^^^^^^^^^^^^^   ^ u256: Value => None
+   │         │                  
+   │         u256: Storage { nonce: None } => None
+63 │         self.my_nums[3] = 1
+   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:63:9
+   │
+63 │         self.my_nums[3] = 1
+   │         ^^^^^^^^^^^^^^^   ^ u256: Value => None
+   │         │                  
+   │         u256: Storage { nonce: None } => None
+64 │         self.my_nums[4] = 255
+   │         ^^^^^^^^^^^^ ^ u256: Value => None
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:64:9
+   │
+64 │         self.my_nums[4] = 255
+   │         ^^^^^^^^^^^^^^^   ^^^ u256: Value => None
+   │         │                  
+   │         u256: Storage { nonce: None } => None
+65 │         my_nums_mem = self.my_nums.to_mem()
+   │         ^^^^^^^^^^^   ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
+   │         │              
+   │         Array<u256, 5>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:65:23
+   │
+65 │         my_nums_mem = self.my_nums.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => Some(Memory)
+66 │         return my_nums_mem
+   │                ^^^^^^^^^^^ Array<u256, 5>: Memory => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:65:23
+   │
+65 │         my_nums_mem = self.my_nums.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
    ┌─ stress/data_copying_stress.fe:68:5
    │  
 68 │ ╭     pub fn emit_my_event(self):
@@ -324,6 +663,63 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:70:13
+   │
+70 │             self.my_string.to_mem(),
+   │             ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:70:13
+   │
+70 │             self.my_string.to_mem(),
+   │             ^^^^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => Some(Memory)
+71 │             self.my_u256.to_mem()
+   │             ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:71:13
+   │
+71 │             self.my_u256.to_mem()
+   │             ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+
+note: 
+   ┌─ stress/data_copying_stress.fe:69:9
+   │  
+69 │ ╭         emit_my_event_internal(
+70 │ │             self.my_string.to_mem(),
+71 │ │             self.my_u256.to_mem()
+72 │ │         )
+   │ ╰─────────^ (): Value => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:69:9
+   │
+69 │         emit_my_event_internal(
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1445082349245844857
+   │
+   = Pure(
+         FunctionId(
+             8,
+         ),
+     )
+
+note: 
+   ┌─ stress/data_copying_stress.fe:70:13
+   │
+70 │             self.my_string.to_mem(),
+   │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
+   ┌─ stress/data_copying_stress.fe:71:13
+   │
+71 │             self.my_u256.to_mem()
+   │             ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ stress/data_copying_stress.fe:74:5
@@ -364,689 +760,12 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:77:5
-   │  
-77 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>):
-78 │ │         self.my_addrs = my_addrs
-   │ ╰────────────────────────────────^ attributes hash: 5533219732473050758
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 3,
-                             inner: Address,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:80:5
-   │  
-80 │ ╭     pub fn get_my_second_addr(self) -> address:
-81 │ │         return self.my_addrs[1]
-   │ ╰───────────────────────────────^ attributes hash: 17651916811868111914
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/data_copying_stress.fe:23:9
-   │
-23 │         self.my_string = my_string
-   │         ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:23:26
-   │
-23 │         self.my_string = my_string
-   │                          ^^^^^^^^^ String<42>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:24:9
-   │
-24 │         self.my_other_string = my_other_string
-   │         ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:24:32
-   │
-24 │         self.my_other_string = my_other_string
-   │                                ^^^^^^^^^^^^^^^ String<42>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:25:9
-   │
-25 │         self.my_u256 = my_u256
-   │         ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:25:24
-   │
-25 │         self.my_u256 = my_u256
-   │                        ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:26:9
-   │
-26 │         self.my_other_u256 = my_other_u256
-   │         ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:26:30
-   │
-26 │         self.my_other_u256 = my_other_u256
-   │                              ^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:29:9
-   │
-29 │         self.my_string = self.my_other_string
-   │         ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:29:26
-   │
-29 │         self.my_string = self.my_other_string
-   │                          ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:30:9
-   │
-30 │         self.my_u256 = self.my_other_u256
-   │         ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:30:24
-   │
-30 │         self.my_u256 = self.my_other_u256
-   │                        ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:33:45
-   │
-33 │         let my_2nd_array: Array<u256, 10> = my_array
-   │                                             ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:34:45
-   │
-34 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
-   │                                             ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:36:16
-   │
-36 │         assert my_array[3] != 5
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:36:25
-   │
-36 │         assert my_array[3] != 5
-   │                         ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:36:16
-   │
-36 │         assert my_array[3] != 5
-   │                ^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:36:31
-   │
-36 │         assert my_array[3] != 5
-   │                               ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:36:16
-   │
-36 │         assert my_array[3] != 5
-   │                ^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:37:9
-   │
-37 │         my_array[3] = 5
-   │         ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:37:18
-   │
-37 │         my_array[3] = 5
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:37:9
-   │
-37 │         my_array[3] = 5
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:37:23
-   │
-37 │         my_array[3] = 5
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_array[3] == 5
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:25
-   │
-38 │         assert my_array[3] == 5
-   │                         ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_array[3] == 5
-   │                ^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:31
-   │
-38 │         assert my_array[3] == 5
-   │                               ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:38:16
-   │
-38 │         assert my_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:16
-   │
-39 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:29
-   │
-39 │         assert my_2nd_array[3] == 5
-   │                             ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:16
-   │
-39 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:35
-   │
-39 │         assert my_2nd_array[3] == 5
-   │                                   ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:39:16
-   │
-39 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:40:16
-   │
-40 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:40:29
-   │
-40 │         assert my_3rd_array[3] == 5
-   │                             ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:40:16
-   │
-40 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:40:35
-   │
-40 │         assert my_3rd_array[3] == 5
-   │                                   ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:40:16
-   │
-40 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:9
-   │
-42 │         my_3rd_array[3] = 50
-   │         ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:22
-   │
-42 │         my_3rd_array[3] = 50
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:9
-   │
-42 │         my_3rd_array[3] = 50
-   │         ^^^^^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:42:27
-   │
-42 │         my_3rd_array[3] = 50
-   │                           ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:16
-   │
-43 │         assert my_array[3] == 50
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:25
-   │
-43 │         assert my_array[3] == 50
-   │                         ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:16
-   │
-43 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:31
-   │
-43 │         assert my_array[3] == 50
-   │                               ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:43:16
-   │
-43 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:16
-   │
-44 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:29
-   │
-44 │         assert my_2nd_array[3] == 50
-   │                             ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:16
-   │
-44 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:35
-   │
-44 │         assert my_2nd_array[3] == 50
-   │                                   ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:44:16
-   │
-44 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:45:16
-   │
-45 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:45:29
-   │
-45 │         assert my_3rd_array[3] == 50
-   │                             ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:45:16
-   │
-45 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:45:35
-   │
-45 │         assert my_3rd_array[3] == 50
-   │                                   ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:45:16
-   │
-45 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:48:9
-   │
-48 │         my_array[3] = 5
-   │         ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:48:18
-   │
-48 │         my_array[3] = 5
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:48:9
-   │
-48 │         my_array[3] = 5
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:48:23
-   │
-48 │         my_array[3] = 5
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:49:16
-   │
-49 │         return my_array
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:52:16
-   │
-52 │         return my_array.clone()
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:52:16
-   │
-52 │         return my_array.clone()
-   │                ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Some(Memory)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:55:9
-   │
-55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:55:9
-   │
-55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Some(Memory)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:55:26
-   │
-55 │         my_array.clone()[3] = 5
-   │                          ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:55:9
-   │
-55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:55:31
-   │
-55 │         my_array.clone()[3] = 5
-   │                               ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:56:16
-   │
-56 │         return my_array
-   │                ^^^^^^^^ Array<u256, 10>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:60:9
-   │
-60 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:60:22
-   │
-60 │         self.my_nums[0] = 42
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:60:9
-   │
-60 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:60:27
-   │
-60 │         self.my_nums[0] = 42
-   │                           ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:61:9
-   │
-61 │         self.my_nums[1] = 26
-   │         ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:61:22
-   │
-61 │         self.my_nums[1] = 26
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:61:9
-   │
-61 │         self.my_nums[1] = 26
-   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:61:27
-   │
-61 │         self.my_nums[1] = 26
-   │                           ^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:62:9
-   │
-62 │         self.my_nums[2] = 0
-   │         ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:62:22
-   │
-62 │         self.my_nums[2] = 0
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:62:9
-   │
-62 │         self.my_nums[2] = 0
-   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:62:27
-   │
-62 │         self.my_nums[2] = 0
-   │                           ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:63:9
-   │
-63 │         self.my_nums[3] = 1
-   │         ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:63:22
-   │
-63 │         self.my_nums[3] = 1
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:63:9
-   │
-63 │         self.my_nums[3] = 1
-   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:63:27
-   │
-63 │         self.my_nums[3] = 1
-   │                           ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:64:9
-   │
-64 │         self.my_nums[4] = 255
-   │         ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:64:22
-   │
-64 │         self.my_nums[4] = 255
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:64:9
-   │
-64 │         self.my_nums[4] = 255
-   │         ^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:64:27
-   │
-64 │         self.my_nums[4] = 255
-   │                           ^^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:65:9
-   │
-65 │         my_nums_mem = self.my_nums.to_mem()
-   │         ^^^^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:65:23
-   │
-65 │         my_nums_mem = self.my_nums.to_mem()
-   │                       ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:65:23
-   │
-65 │         my_nums_mem = self.my_nums.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => Some(Memory)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:66:16
-   │
-66 │         return my_nums_mem
-   │                ^^^^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:70:13
-   │
-70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:70:13
-   │
-70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) } => Some(Memory)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:71:13
-   │
-71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:71:13
-   │
-71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-   ┌─ stress/data_copying_stress.fe:69:9
-   │  
-69 │ ╭         emit_my_event_internal(
-70 │ │             self.my_string.to_mem(),
-71 │ │             self.my_u256.to_mem()
-72 │ │         )
-   │ ╰─────────^ (): Value => None
-
-note: 
    ┌─ stress/data_copying_stress.fe:75:32
    │
 75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │                                ^^^^^^^^^^^ String<42>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:75:53
-   │
-75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │                                                     ^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:78:9
-   │
-78 │         self.my_addrs = my_addrs
-   │         ^^^^^^^^^^^^^ Array<address, 3>: Storage { nonce: Some(5) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:78:25
-   │
-78 │         self.my_addrs = my_addrs
-   │                         ^^^^^^^^ Array<address, 3>: Memory => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:81:16
-   │
-81 │         return self.my_addrs[1]
-   │                ^^^^^^^^^^^^^ Array<address, 3>: Storage { nonce: Some(5) } => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:81:30
-   │
-81 │         return self.my_addrs[1]
-   │                              ^ u256: Value => None
-
-note: 
-   ┌─ stress/data_copying_stress.fe:81:16
-   │
-81 │         return self.my_addrs[1]
-   │                ^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Some(Value)
+   │                                ^^^^^^^^^^^          ^^^^^^^^^ u256: Value => None
+   │                                │                     
+   │                                String<42>: Memory => None
 
 note: 
    ┌─ stress/data_copying_stress.fe:75:9
@@ -1083,73 +802,71 @@ note:
      }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:33:27
-   │
-33 │         let my_2nd_array: Array<u256, 10> = my_array
-   │                           ^^^^^^^^^^^^^^^ Array<u256, 10>
-
-note: 
-   ┌─ stress/data_copying_stress.fe:34:27
-   │
-34 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
-   │                           ^^^^^^^^^^^^^^^ Array<u256, 10>
-
-note: 
-   ┌─ stress/data_copying_stress.fe:59:26
-   │
-59 │         let my_nums_mem: Array<u256, 5>
-   │                          ^^^^^^^^^^^^^^ Array<u256, 5>
-
-note: 
-   ┌─ stress/data_copying_stress.fe:52:16
-   │
-52 │         return my_array.clone()
-   │                ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/data_copying_stress.fe:55:9
-   │
-55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/data_copying_stress.fe:65:23
-   │
-65 │         my_nums_mem = self.my_nums.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/data_copying_stress.fe:69:9
-   │
-69 │         emit_my_event_internal(
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 1445082349245844857
-   │
-   = Pure(
-         FunctionId(
-             8,
+   ┌─ stress/data_copying_stress.fe:77:5
+   │  
+77 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>):
+78 │ │         self.my_addrs = my_addrs
+   │ ╰────────────────────────────────^ attributes hash: 5533219732473050758
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "my_addrs",
+                 typ: Ok(
+                     Array(
+                         Array {
+                             size: 3,
+                             inner: Address,
+                         },
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
          ),
-     )
+     }
 
 note: 
-   ┌─ stress/data_copying_stress.fe:70:13
+   ┌─ stress/data_copying_stress.fe:78:9
    │
-70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+78 │         self.my_addrs = my_addrs
+   │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 3>: Memory => None
+   │         │                
+   │         Array<address, 3>: Storage { nonce: Some(5) } => None
 
 note: 
-   ┌─ stress/data_copying_stress.fe:71:13
+   ┌─ stress/data_copying_stress.fe:80:5
+   │  
+80 │ ╭     pub fn get_my_second_addr(self) -> address:
+81 │ │         return self.my_addrs[1]
+   │ ╰───────────────────────────────^ attributes hash: 17651916811868111914
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Address,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ stress/data_copying_stress.fe:81:16
    │
-71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+81 │         return self.my_addrs[1]
+   │                ^^^^^^^^^^^^^ ^ u256: Value => None
+   │                │              
+   │                Array<address, 3>: Storage { nonce: Some(5) } => None
+
+note: 
+   ┌─ stress/data_copying_stress.fe:81:16
    │
-   = ValueAttribute
+81 │         return self.my_addrs[1]
+   │                ^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Some(Value)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -44,10 +44,12 @@ note:
    │  
 25 │ ╭     pub fn name(self) -> String<100>:
 26 │ │         return self._name.to_mem()
-   │ ╰──────────────────────────────────^ attributes hash: 12632360895853494516
+   │ ╰──────────────────────────────────^ attributes hash: 18230605040615949951
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              String(
@@ -62,31 +64,37 @@ note:
    ┌─ demos/erc20_token.fe:26:16
    │
 26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => None
+   │                ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:26:16
    │
 26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => Some(Memory)
+   │                ^^^^^^^^^^ String<100>: Storage { nonce: Some(3) }
 
 note: 
    ┌─ demos/erc20_token.fe:26:16
    │
 26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => Memory
+
+note: 
+   ┌─ demos/erc20_token.fe:26:16
    │
-   = ValueAttribute
+26 │         return self._name.to_mem()
+   │                ^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ demos/erc20_token.fe:28:5
    │  
 28 │ ╭     pub fn symbol(self) -> String<100>:
 29 │ │         return self._symbol.to_mem()
-   │ ╰────────────────────────────────────^ attributes hash: 12632360895853494516
+   │ ╰────────────────────────────────────^ attributes hash: 18230605040615949951
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              String(
@@ -101,31 +109,37 @@ note:
    ┌─ demos/erc20_token.fe:29:16
    │
 29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => None
+   │                ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:29:16
    │
 29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => Some(Memory)
+   │                ^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) }
 
 note: 
    ┌─ demos/erc20_token.fe:29:16
    │
 29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => Memory
+
+note: 
+   ┌─ demos/erc20_token.fe:29:16
    │
-   = ValueAttribute
+29 │         return self._symbol.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ demos/erc20_token.fe:31:5
    │  
 31 │ ╭     pub fn decimals(self) -> u8:
 32 │ │         return self._decimals
-   │ ╰─────────────────────────────^ attributes hash: 6791549355703693154
+   │ ╰─────────────────────────────^ attributes hash: 7569446044715680860
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -140,17 +154,25 @@ note:
    ┌─ demos/erc20_token.fe:32:16
    │
 32 │         return self._decimals
-   │                ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => Some(Value)
+   │                ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:32:16
+   │
+32 │         return self._decimals
+   │                ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:34:5
    │  
 34 │ ╭     pub fn totalSupply(self) -> u256:
 35 │ │         return self._total_supply
-   │ ╰─────────────────────────────────^ attributes hash: 16482263331346774611
+   │ ╰─────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -165,17 +187,25 @@ note:
    ┌─ demos/erc20_token.fe:35:16
    │
 35 │         return self._total_supply
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+   │                ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:35:16
+   │
+35 │         return self._total_supply
+   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:37:5
    │  
 37 │ ╭     pub fn balanceOf(self, account: address) -> u256:
 38 │ │         return self._balances[account]
-   │ ╰──────────────────────────────────────^ attributes hash: 11484923544867751175
+   │ ╰──────────────────────────────────────^ attributes hash: 993550877953897347
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "account",
@@ -199,15 +229,21 @@ note:
    ┌─ demos/erc20_token.fe:38:16
    │
 38 │         return self._balances[account]
-   │                ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
-   │                │               
-   │                Map<address, u256>: Storage { nonce: Some(0) } => None
+   │                ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:38:16
    │
 38 │         return self._balances[account]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+   │                ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │                │               
+   │                Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:38:16
+   │
+38 │         return self._balances[account]
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:40:5
@@ -215,10 +251,12 @@ note:
 40 │ ╭     pub fn transfer(self, recipient: address, value: u256) -> bool:
 41 │ │         self._transfer(msg.sender, recipient, value)
 42 │ │         return true
-   │ ╰───────────────────^ attributes hash: 1991308505230085281
+   │ ╰───────────────────^ attributes hash: 12728394076690627997
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "recipient",
@@ -247,42 +285,40 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:41:24
+   ┌─ demos/erc20_token.fe:41:9
    │
 41 │         self._transfer(msg.sender, recipient, value)
-   │                        ^^^^^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value => None
-   │                        │           │           
-   │                        │           address: Value => None
-   │                        address: Value => None
+   │         ^^^^           ^^^^^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value
+   │         │              │           │           
+   │         │              │           address: Value
+   │         │              address: Value
+   │         ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:41:9
    │
 41 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 42 │         return true
-   │                ^^^^ bool: Value => None
+   │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/erc20_token.fe:41:9
    │
 41 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 15399895119751945816
-   │
-   = SelfAttribute {
-         func_name: "_transfer",
-         self_span: 1052..1056,
-     }
+   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(12) }
 
 note: 
    ┌─ demos/erc20_token.fe:44:5
    │  
 44 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256:
 45 │ │         return self._allowances[owner][spender]
-   │ ╰───────────────────────────────────────────────^ attributes hash: 9282693738387957668
+   │ ╰───────────────────────────────────────────────^ attributes hash: 8217855766110969592
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "owner",
@@ -314,23 +350,29 @@ note:
    ┌─ demos/erc20_token.fe:45:16
    │
 45 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^ ^^^^^ address: Value => None
+   │                ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:45:16
+   │
+45 │         return self._allowances[owner][spender]
+   │                ^^^^^^^^^^^^^^^^ ^^^^^ address: Value
    │                │                 
-   │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ demos/erc20_token.fe:45:16
    │
 45 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                │                        
-   │                Map<address, u256>: Storage { nonce: None } => None
+   │                Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:45:16
    │
 45 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:47:5
@@ -338,10 +380,12 @@ note:
 47 │ ╭     pub fn approve(self, spender: address, value: u256) -> bool:
 48 │ │         self._approve(msg.sender, spender, value)
 49 │ │         return true
-   │ ╰───────────────────^ attributes hash: 10662679418650794263
+   │ ╰───────────────────^ attributes hash: 844763422390851240
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "spender",
@@ -370,32 +414,28 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:48:23
+   ┌─ demos/erc20_token.fe:48:9
    │
 48 │         self._approve(msg.sender, spender, value)
-   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
-   │                       │           │         
-   │                       │           address: Value => None
-   │                       address: Value => None
+   │         ^^^^          ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value
+   │         │             │           │         
+   │         │             │           address: Value
+   │         │             address: Value
+   │         ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:48:9
    │
 48 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 49 │         return true
-   │                ^^^^ bool: Value => None
+   │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/erc20_token.fe:48:9
    │
 48 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 10047856837296232623
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1310..1314,
-     }
+   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
 
 note: 
    ┌─ demos/erc20_token.fe:51:5
@@ -405,10 +445,12 @@ note:
 53 │ │         self._transfer(sender, recipient, value)
 54 │ │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
 55 │ │         return true
-   │ ╰───────────────────^ attributes hash: 91095815201716281
+   │ ╰───────────────────^ attributes hash: 10460592357103433224
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "sender",
@@ -448,100 +490,101 @@ note:
    ┌─ demos/erc20_token.fe:52:16
    │
 52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+   │                ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:52:16
+   │
+52 │         assert self._allowances[sender][msg.sender] >= value
+   │                ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
    │                │                 
-   │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ demos/erc20_token.fe:52:16
    │
 52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
    │                │                         
-   │                Map<address, u256>: Storage { nonce: None } => None
+   │                Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:52:16
    │
 52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value
    │                │                                        
-   │                u256: Storage { nonce: None } => Some(Value)
+   │                u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:52:16
    │
 52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 53 │         self._transfer(sender, recipient, value)
-   │                        ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value => None
-   │                        │       │           
-   │                        │       address: Value => None
-   │                        address: Value => None
+   │         ^^^^           ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value
+   │         │              │       │           
+   │         │              │       address: Value
+   │         │              address: Value
+   │         ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:53:9
    │
 53 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                       ^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
-   │                       │       │           │                 
-   │                       │       │           Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-   │                       │       address: Value => None
-   │                       address: Value => None
+   │         ^^^^          ^^^^^^  ^^^^^^^^^^  ^^^^ ERC20: Value
+   │         │             │       │            
+   │         │             │       address: Value
+   │         │             address: Value
+   │         ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:54:43
    │
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │                                           ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
+   │                                           │                 
+   │                                           Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ demos/erc20_token.fe:54:43
+   │
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
    │                                           │                         
-   │                                           Map<address, u256>: Storage { nonce: None } => None
+   │                                           Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:54:43
    │
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                           │                                       
-   │                                           u256: Storage { nonce: None } => Some(Value)
+   │                                           u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:54:43
    │
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ demos/erc20_token.fe:54:9
    │
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 55 │         return true
-   │                ^^^^ bool: Value => None
+   │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/erc20_token.fe:53:9
    │
 53 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 13311941709994158162
-   │
-   = SelfAttribute {
-         func_name: "_transfer",
-         self_span: 1531..1535,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:54:9
-   │
+   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(12) }
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^ attributes hash: 5596759839039037729
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1580..1584,
-     }
+   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
 
 note: 
    ┌─ demos/erc20_token.fe:57:5
@@ -549,10 +592,12 @@ note:
 57 │ ╭     pub fn increaseAllowance(self, spender: address, addedValue: u256) -> bool:
 58 │ │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
 59 │ │         return true
-   │ ╰───────────────────^ attributes hash: 950629619328373893
+   │ ╰───────────────────^ attributes hash: 8356619325738060097
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "spender",
@@ -581,55 +626,58 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:58:23
+   ┌─ demos/erc20_token.fe:58:9
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
-   │                       │           │        │                 
-   │                       │           │        Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-   │                       │           address: Value => None
-   │                       address: Value => None
+   │         ^^^^          ^^^^^^^^^^  ^^^^^^^  ^^^^ ERC20: Value
+   │         │             │           │         
+   │         │             │           address: Value
+   │         │             address: Value
+   │         ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:58:44
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                                            ^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
+   │                                            │                 
+   │                                            Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ demos/erc20_token.fe:58:44
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                                            │                             
-   │                                            Map<address, u256>: Storage { nonce: None } => None
+   │                                            Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:58:44
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^ u256: Value => None
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^ u256: Value
    │                                            │                                        
-   │                                            u256: Storage { nonce: None } => Some(Value)
+   │                                            u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:58:44
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ demos/erc20_token.fe:58:9
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 59 │         return true
-   │                ^^^^ bool: Value => None
+   │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/erc20_token.fe:58:9
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 10420458525874606876
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1769..1773,
-     }
+   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
 
 note: 
    ┌─ demos/erc20_token.fe:61:5
@@ -637,10 +685,12 @@ note:
 61 │ ╭     pub fn decreaseAllowance(self, spender: address, subtractedValue: u256) -> bool:
 62 │ │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
 63 │ │         return true
-   │ ╰───────────────────^ attributes hash: 12802591286463221158
+   │ ╰───────────────────^ attributes hash: 5765343984054310012
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "spender",
@@ -669,55 +719,58 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:62:23
+   ┌─ demos/erc20_token.fe:62:9
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
-   │                       │           │        │                 
-   │                       │           │        Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-   │                       │           address: Value => None
-   │                       address: Value => None
+   │         ^^^^          ^^^^^^^^^^  ^^^^^^^  ^^^^ ERC20: Value
+   │         │             │           │         
+   │         │             │           address: Value
+   │         │             address: Value
+   │         ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:62:44
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                                            ^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
+   │                                            │                 
+   │                                            Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ demos/erc20_token.fe:62:44
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                                            │                             
-   │                                            Map<address, u256>: Storage { nonce: None } => None
+   │                                            Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:62:44
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value => None
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value
    │                                            │                                        
-   │                                            u256: Storage { nonce: None } => Some(Value)
+   │                                            u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:62:44
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ demos/erc20_token.fe:62:9
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 63 │         return true
-   │                ^^^^ bool: Value => None
+   │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/erc20_token.fe:62:9
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 1575892034280724253
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1970..1974,
-     }
+   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
 
 note: 
    ┌─ demos/erc20_token.fe:65:5
@@ -729,10 +782,12 @@ note:
 69 │ │         self._balances[sender] = self._balances[sender] - value
 70 │ │         self._balances[recipient] = self._balances[recipient] + value
 71 │ │         emit Transfer(from=sender, to=recipient, value=value)
-   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 923743412527861440
+   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 7042698306793056303
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "sender",
@@ -772,107 +827,133 @@ note:
    ┌─ demos/erc20_token.fe:66:16
    │
 66 │         assert sender != address(0)
-   │                ^^^^^^            ^ u256: Value => None
+   │                ^^^^^^            ^ u256: Value
    │                │                  
-   │                address: Value => None
+   │                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:66:26
    │
 66 │         assert sender != address(0)
-   │                          ^^^^^^^^^^ address: Value => None
+   │                          ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:66:16
    │
 66 │         assert sender != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
 67 │         assert recipient != address(0)
-   │                ^^^^^^^^^            ^ u256: Value => None
+   │                ^^^^^^^^^            ^ u256: Value
    │                │                     
-   │                address: Value => None
+   │                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:67:29
    │
 67 │         assert recipient != address(0)
-   │                             ^^^^^^^^^^ address: Value => None
+   │                             ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:67:16
    │
 67 │         assert recipient != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 68 │         _before_token_transfer(sender, recipient, value)
-   │                                ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value
    │                                │       │           
-   │                                │       address: Value => None
-   │                                address: Value => None
+   │                                │       address: Value
+   │                                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:68:9
    │
 68 │         _before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 69 │         self._balances[sender] = self._balances[sender] - value
-   │         ^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
-   │         │               
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:69:9
    │
 69 │         self._balances[sender] = self._balances[sender] - value
-   │         ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
-   │         │                        │               
-   │         │                        Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:69:34
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │                                  ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
-   │                                  │                         
-   │                                  u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:69:34
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-70 │         self._balances[recipient] = self._balances[recipient] + value
-   │         ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value => None
+   │         ^^^^^^^^^^^^^^ ^^^^^^ address: Value
    │         │               
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:69:9
+   │
+69 │         self._balances[sender] = self._balances[sender] - value
+   │         ^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                         
+   │         u256: Storage { nonce: None }
+
+note: 
+   ┌─ demos/erc20_token.fe:69:34
+   │
+69 │         self._balances[sender] = self._balances[sender] - value
+   │                                  ^^^^^^^^^^^^^^ ^^^^^^ address: Value
+   │                                  │               
+   │                                  Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:69:34
+   │
+69 │         self._balances[sender] = self._balances[sender] - value
+   │                                  ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                                  │                         
+   │                                  u256: Storage { nonce: None } => Value
+
+note: 
+   ┌─ demos/erc20_token.fe:69:34
+   │
+69 │         self._balances[sender] = self._balances[sender] - value
+   │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+70 │         self._balances[recipient] = self._balances[recipient] + value
+   │         ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:70:9
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value => None
-   │         │                           │               
-   │         │                           Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:70:9
+   │
+70 │         self._balances[recipient] = self._balances[recipient] + value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                            
+   │         u256: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:70:37
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                     ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value
+   │                                     │               
+   │                                     Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:70:37
+   │
+70 │         self._balances[recipient] = self._balances[recipient] + value
+   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                     │                            
-   │                                     u256: Storage { nonce: None } => Some(Value)
+   │                                     u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:70:37
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 71 │         emit Transfer(from=sender, to=recipient, value=value)
-   │                            ^^^^^^     ^^^^^^^^^        ^^^^^ u256: Value => None
+   │                            ^^^^^^     ^^^^^^^^^        ^^^^^ u256: Value
    │                            │          │                 
-   │                            │          address: Value => None
-   │                            address: Value => None
+   │                            │          address: Value
+   │                            address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:71:9
@@ -919,37 +1000,11 @@ note:
    ┌─ demos/erc20_token.fe:66:26
    │
 66 │         assert sender != address(0)
-   │                          ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:67:29
-   │
+   │                          ^^^^^^^ TypeConstructor(Base(Address))
 67 │         assert recipient != address(0)
-   │                             ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:68:9
-   │
+   │                             ^^^^^^^ TypeConstructor(Base(Address))
 68 │         _before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
-   │
-   = Pure(
-         FunctionId(
-             17,
-         ),
-     )
+   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
 
 note: 
    ┌─ demos/erc20_token.fe:73:5
@@ -960,10 +1015,12 @@ note:
 76 │ │         self._total_supply = self._total_supply + value
 77 │ │         self._balances[account] = self._balances[account] + value
 78 │ │         emit Transfer(from=address(0), to=account, value=value)
-   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
+   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 2595623246297064609
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "account",
@@ -995,87 +1052,113 @@ note:
    ┌─ demos/erc20_token.fe:74:16
    │
 74 │         assert account != address(0)
-   │                ^^^^^^^            ^ u256: Value => None
+   │                ^^^^^^^            ^ u256: Value
    │                │                   
-   │                address: Value => None
+   │                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:74:27
    │
 74 │         assert account != address(0)
-   │                           ^^^^^^^^^^ address: Value => None
+   │                           ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:74:16
    │
 74 │         assert account != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 75 │         _before_token_transfer(address(0), account, value)
-   │                                        ^ u256: Value => None
+   │                                        ^ u256: Value
 
 note: 
    ┌─ demos/erc20_token.fe:75:32
    │
 75 │         _before_token_transfer(address(0), account, value)
-   │                                ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                                ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value
    │                                │           │         
-   │                                │           address: Value => None
-   │                                address: Value => None
+   │                                │           address: Value
+   │                                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:75:9
    │
 75 │         _before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 76 │         self._total_supply = self._total_supply + value
-   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
-   │         │                    │                     
-   │         │                    u256: Storage { nonce: Some(2) } => Some(Value)
-   │         u256: Storage { nonce: Some(2) } => None
+   │         ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:76:9
+   │
+76 │         self._total_supply = self._total_supply + value
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                     
+   │         u256: Storage { nonce: Some(2) }
 
 note: 
    ┌─ demos/erc20_token.fe:76:30
    │
 76 │         self._total_supply = self._total_supply + value
-   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                              ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                              │                     
+   │                              u256: Storage { nonce: Some(2) } => Value
+
+note: 
+   ┌─ demos/erc20_token.fe:76:30
+   │
+76 │         self._total_supply = self._total_supply + value
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 77 │         self._balances[account] = self._balances[account] + value
-   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
-   │         │               
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:77:9
    │
 77 │         self._balances[account] = self._balances[account] + value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
-   │         │                         │               
-   │         │                         Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:77:9
+   │
+77 │         self._balances[account] = self._balances[account] + value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                          
+   │         u256: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:77:35
    │
 77 │         self._balances[account] = self._balances[account] + value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │                                   │               
+   │                                   Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:77:35
+   │
+77 │         self._balances[account] = self._balances[account] + value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                   │                          
-   │                                   u256: Storage { nonce: None } => Some(Value)
+   │                                   u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:77:35
    │
 77 │         self._balances[account] = self._balances[account] + value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                                    ^ u256: Value => None
+   │                                    ^ u256: Value
 
 note: 
    ┌─ demos/erc20_token.fe:78:28
    │
 78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                            ^^^^^^^^^^     ^^^^^^^        ^^^^^ u256: Value => None
+   │                            ^^^^^^^^^^     ^^^^^^^        ^^^^^ u256: Value
    │                            │              │               
-   │                            │              address: Value => None
-   │                            address: Value => None
+   │                            │              address: Value
+   │                            address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:78:9
@@ -1122,49 +1205,18 @@ note:
    ┌─ demos/erc20_token.fe:74:27
    │
 74 │         assert account != address(0)
-   │                           ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                           ^^^^^^^ TypeConstructor(Base(Address))
+75 │         _before_token_transfer(address(0), account, value)
+   │                                ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/erc20_token.fe:75:9
    │
 75 │         _before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
-   │
-   = Pure(
-         FunctionId(
-             17,
-         ),
-     )
-
-note: 
-   ┌─ demos/erc20_token.fe:75:32
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │                                ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:78:28
-   │
+   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
+   ·
 78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                            ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                            ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/erc20_token.fe:80:5
@@ -1175,10 +1227,12 @@ note:
 83 │ │         self._balances[account] = self._balances[account] - value
 84 │ │         self._total_supply = self._total_supply - value
 85 │ │         emit Transfer(from=account, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 2595623246297064609
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "account",
@@ -1210,89 +1264,115 @@ note:
    ┌─ demos/erc20_token.fe:81:16
    │
 81 │         assert account != address(0)
-   │                ^^^^^^^            ^ u256: Value => None
+   │                ^^^^^^^            ^ u256: Value
    │                │                   
-   │                address: Value => None
+   │                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:81:27
    │
 81 │         assert account != address(0)
-   │                           ^^^^^^^^^^ address: Value => None
+   │                           ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:81:16
    │
 81 │         assert account != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 82 │         _before_token_transfer(account, address(0), value)
-   │                                ^^^^^^^          ^ u256: Value => None
+   │                                ^^^^^^^          ^ u256: Value
    │                                │                 
-   │                                address: Value => None
+   │                                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:82:41
    │
 82 │         _before_token_transfer(account, address(0), value)
-   │                                         ^^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                         ^^^^^^^^^^  ^^^^^ u256: Value
    │                                         │            
-   │                                         address: Value => None
+   │                                         address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:82:9
    │
 82 │         _before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 83 │         self._balances[account] = self._balances[account] - value
-   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
-   │         │               
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ ERC20: Value
 
 note: 
    ┌─ demos/erc20_token.fe:83:9
    │
 83 │         self._balances[account] = self._balances[account] - value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
-   │         │                         │               
-   │         │                         Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:83:9
+   │
+83 │         self._balances[account] = self._balances[account] - value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                          
+   │         u256: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:83:35
    │
 83 │         self._balances[account] = self._balances[account] - value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │                                   │               
+   │                                   Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/erc20_token.fe:83:35
+   │
+83 │         self._balances[account] = self._balances[account] - value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                   │                          
-   │                                   u256: Storage { nonce: None } => Some(Value)
+   │                                   u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/erc20_token.fe:83:35
    │
 83 │         self._balances[account] = self._balances[account] - value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 84 │         self._total_supply = self._total_supply - value
-   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
-   │         │                    │                     
-   │         │                    u256: Storage { nonce: Some(2) } => Some(Value)
-   │         u256: Storage { nonce: Some(2) } => None
+   │         ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:84:9
+   │
+84 │         self._total_supply = self._total_supply - value
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                     
+   │         u256: Storage { nonce: Some(2) }
 
 note: 
    ┌─ demos/erc20_token.fe:84:30
    │
 84 │         self._total_supply = self._total_supply - value
-   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                              ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                              │                     
+   │                              u256: Storage { nonce: Some(2) } => Value
+
+note: 
+   ┌─ demos/erc20_token.fe:84:30
+   │
+84 │         self._total_supply = self._total_supply - value
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 85 │         emit Transfer(from=account, to=address(0), value)
-   │                            ^^^^^^^             ^ u256: Value => None
+   │                            ^^^^^^^             ^ u256: Value
    │                            │                    
-   │                            address: Value => None
+   │                            address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:85:40
    │
 85 │         emit Transfer(from=account, to=address(0), value)
-   │                                        ^^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                        ^^^^^^^^^^  ^^^^^ u256: Value
    │                                        │            
-   │                                        address: Value => None
+   │                                        address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:85:9
@@ -1339,49 +1419,18 @@ note:
    ┌─ demos/erc20_token.fe:81:27
    │
 81 │         assert account != address(0)
-   │                           ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                           ^^^^^^^ TypeConstructor(Base(Address))
+82 │         _before_token_transfer(account, address(0), value)
+   │                                         ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/erc20_token.fe:82:9
    │
 82 │         _before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
-   │
-   = Pure(
-         FunctionId(
-             17,
-         ),
-     )
-
-note: 
-   ┌─ demos/erc20_token.fe:82:41
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │                                         ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:85:40
-   │
+   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
+   ·
 85 │         emit Transfer(from=account, to=address(0), value)
-   │                                        ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                                        ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/erc20_token.fe:87:5
@@ -1391,10 +1440,12 @@ note:
 89 │ │         assert spender != address(0)
 90 │ │         self._allowances[owner][spender] = value
 91 │ │         emit Approval(owner, spender, value)
-   │ ╰────────────────────────────────────────────^ attributes hash: 2670276789438195364
+   │ ╰────────────────────────────────────────────^ attributes hash: 18402794614707408512
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "owner",
@@ -1434,62 +1485,68 @@ note:
    ┌─ demos/erc20_token.fe:88:16
    │
 88 │         assert owner != address(0)
-   │                ^^^^^            ^ u256: Value => None
+   │                ^^^^^            ^ u256: Value
    │                │                 
-   │                address: Value => None
+   │                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:88:25
    │
 88 │         assert owner != address(0)
-   │                         ^^^^^^^^^^ address: Value => None
+   │                         ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:88:16
    │
 88 │         assert owner != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
 89 │         assert spender != address(0)
-   │                ^^^^^^^            ^ u256: Value => None
+   │                ^^^^^^^            ^ u256: Value
    │                │                   
-   │                address: Value => None
+   │                address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:89:27
    │
 89 │         assert spender != address(0)
-   │                           ^^^^^^^^^^ address: Value => None
+   │                           ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:89:16
    │
 89 │         assert spender != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 90 │         self._allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^ ^^^^^ address: Value => None
+   │         ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:90:9
+   │
+90 │         self._allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^^ ^^^^^ address: Value
    │         │                 
-   │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ demos/erc20_token.fe:90:9
    │
 90 │         self._allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │         │                        
-   │         Map<address, u256>: Storage { nonce: None } => None
+   │         Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/erc20_token.fe:90:9
    │
 90 │         self._allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │         │                                   
-   │         u256: Storage { nonce: None } => None
+   │         u256: Storage { nonce: None }
 91 │         emit Approval(owner, spender, value)
-   │                       ^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                       ^^^^^  ^^^^^^^  ^^^^^ u256: Value
    │                       │      │         
-   │                       │      address: Value => None
-   │                       address: Value => None
+   │                       │      address: Value
+   │                       address: Value
 
 note: 
    ┌─ demos/erc20_token.fe:91:9
@@ -1536,35 +1593,21 @@ note:
    ┌─ demos/erc20_token.fe:88:25
    │
 88 │         assert owner != address(0)
-   │                         ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:89:27
-   │
+   │                         ^^^^^^^ TypeConstructor(Base(Address))
 89 │         assert spender != address(0)
-   │                           ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                           ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/erc20_token.fe:93:5
    │  
 93 │ ╭     fn _setup_decimals(self, decimals_: u8):
 94 │ │         self._decimals = decimals_
-   │ ╰──────────────────────────────────^ attributes hash: 9774377157681208112
+   │ ╰──────────────────────────────────^ attributes hash: 9584801749732154005
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "decimals_",
@@ -1588,9 +1631,15 @@ note:
    ┌─ demos/erc20_token.fe:94:9
    │
 94 │         self._decimals = decimals_
-   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ u8: Value => None
+   │         ^^^^ ERC20: Value
+
+note: 
+   ┌─ demos/erc20_token.fe:94:9
+   │
+94 │         self._decimals = decimals_
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ u8: Value
    │         │                 
-   │         u8: Storage { nonce: Some(5) } => None
+   │         u8: Storage { nonce: Some(5) }
 
 note: 
    ┌─ demos/erc20_token.fe:96:5

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -8,34 +8,14 @@ note:
   │
 2 │     _balances: Map<address, u256>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-
-note: 
-  ┌─ demos/erc20_token.fe:3:5
-  │
 3 │     _allowances: Map<address, Map<address, u256>>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>
-
-note: 
-  ┌─ demos/erc20_token.fe:4:5
-  │
 4 │     _total_supply: u256
   │     ^^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-  ┌─ demos/erc20_token.fe:5:5
-  │
 5 │     _name: String<100>
   │     ^^^^^^^^^^^^^^^^^^ String<100>
-
-note: 
-  ┌─ demos/erc20_token.fe:6:5
-  │
 6 │     _symbol: String<100>
   │     ^^^^^^^^^^^^^^^^^^^^ String<100>
-
-note: 
-  ┌─ demos/erc20_token.fe:7:5
-  │
 7 │     _decimals: u8
   │     ^^^^^^^^^^^^^ u8
 
@@ -44,16 +24,8 @@ note:
    │
 10 │         idx owner: address
    │         ^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/erc20_token.fe:11:9
-   │
 11 │         idx spender: address
    │         ^^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/erc20_token.fe:12:9
-   │
 12 │         value: u256
    │         ^^^^^^^^^^^ u256
 
@@ -62,59 +34,10 @@ note:
    │
 15 │         idx from: address
    │         ^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/erc20_token.fe:16:9
-   │
 16 │         idx to: address
    │         ^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/erc20_token.fe:17:9
-   │
 17 │         value: u256
    │         ^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/erc20_token.fe:19:5
-   │  
-19 │ ╭     pub fn __init__(self, name: String<100>, symbol: String<100>):
-20 │ │         self._name = name
-21 │ │         self._symbol = symbol
-22 │ │         self._decimals = u8(18)
-23 │ │         self._mint(msg.sender, 1000000000000000000000000)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 5200858442325067440
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "name",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "symbol",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
 
 note: 
    ┌─ demos/erc20_token.fe:25:5
@@ -136,6 +59,26 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:26:16
+   │
+26 │         return self._name.to_mem()
+   │                ^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:26:16
+   │
+26 │         return self._name.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => Some(Memory)
+
+note: 
+   ┌─ demos/erc20_token.fe:26:16
+   │
+26 │         return self._name.to_mem()
+   │                ^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
    ┌─ demos/erc20_token.fe:28:5
    │  
 28 │ ╭     pub fn symbol(self) -> String<100>:
@@ -153,6 +96,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ demos/erc20_token.fe:29:16
+   │
+29 │         return self._symbol.to_mem()
+   │                ^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:29:16
+   │
+29 │         return self._symbol.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => Some(Memory)
+
+note: 
+   ┌─ demos/erc20_token.fe:29:16
+   │
+29 │         return self._symbol.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ demos/erc20_token.fe:31:5
@@ -174,6 +137,12 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:32:16
+   │
+32 │         return self._decimals
+   │                ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
    ┌─ demos/erc20_token.fe:34:5
    │  
 34 │ ╭     pub fn totalSupply(self) -> u256:
@@ -191,6 +160,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ demos/erc20_token.fe:35:16
+   │
+35 │         return self._total_supply
+   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
 
 note: 
    ┌─ demos/erc20_token.fe:37:5
@@ -219,6 +194,20 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ demos/erc20_token.fe:38:16
+   │
+38 │         return self._balances[account]
+   │                ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                │               
+   │                Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:38:16
+   │
+38 │         return self._balances[account]
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
 
 note: 
    ┌─ demos/erc20_token.fe:40:5
@@ -258,6 +247,34 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:41:24
+   │
+41 │         self._transfer(msg.sender, recipient, value)
+   │                        ^^^^^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value => None
+   │                        │           │           
+   │                        │           address: Value => None
+   │                        address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:41:9
+   │
+41 │         self._transfer(msg.sender, recipient, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+42 │         return true
+   │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:41:9
+   │
+41 │         self._transfer(msg.sender, recipient, value)
+   │         ^^^^^^^^^^^^^^ attributes hash: 15399895119751945816
+   │
+   = SelfAttribute {
+         func_name: "_transfer",
+         self_span: 1052..1056,
+     }
+
+note: 
    ┌─ demos/erc20_token.fe:44:5
    │  
 44 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256:
@@ -294,6 +311,28 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:45:16
+   │
+45 │         return self._allowances[owner][spender]
+   │                ^^^^^^^^^^^^^^^^ ^^^^^ address: Value => None
+   │                │                 
+   │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:45:16
+   │
+45 │         return self._allowances[owner][spender]
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                │                        
+   │                Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:45:16
+   │
+45 │         return self._allowances[owner][spender]
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+
+note: 
    ┌─ demos/erc20_token.fe:47:5
    │  
 47 │ ╭     pub fn approve(self, spender: address, value: u256) -> bool:
@@ -328,6 +367,34 @@ note:
                  Bool,
              ),
          ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:48:23
+   │
+48 │         self._approve(msg.sender, spender, value)
+   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                       │           │         
+   │                       │           address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:48:9
+   │
+48 │         self._approve(msg.sender, spender, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+49 │         return true
+   │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:48:9
+   │
+48 │         self._approve(msg.sender, spender, value)
+   │         ^^^^^^^^^^^^^ attributes hash: 10047856837296232623
+   │
+   = SelfAttribute {
+         func_name: "_approve",
+         self_span: 1310..1314,
      }
 
 note: 
@@ -378,6 +445,105 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:52:16
+   │
+52 │         assert self._allowances[sender][msg.sender] >= value
+   │                ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+   │                │                 
+   │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:52:16
+   │
+52 │         assert self._allowances[sender][msg.sender] >= value
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │                │                         
+   │                Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:52:16
+   │
+52 │         assert self._allowances[sender][msg.sender] >= value
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value => None
+   │                │                                        
+   │                u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/erc20_token.fe:52:16
+   │
+52 │         assert self._allowances[sender][msg.sender] >= value
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+53 │         self._transfer(sender, recipient, value)
+   │                        ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value => None
+   │                        │       │           
+   │                        │       address: Value => None
+   │                        address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:53:9
+   │
+53 │         self._transfer(sender, recipient, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │                       ^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+   │                       │       │           │                 
+   │                       │       │           Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │                       │       address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:54:43
+   │
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │                                           │                         
+   │                                           Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:54:43
+   │
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                           │                                       
+   │                                           u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/erc20_token.fe:54:43
+   │
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:54:9
+   │
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+55 │         return true
+   │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:53:9
+   │
+53 │         self._transfer(sender, recipient, value)
+   │         ^^^^^^^^^^^^^^ attributes hash: 13311941709994158162
+   │
+   = SelfAttribute {
+         func_name: "_transfer",
+         self_span: 1531..1535,
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:54:9
+   │
+54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
+   │         ^^^^^^^^^^^^^ attributes hash: 5596759839039037729
+   │
+   = SelfAttribute {
+         func_name: "_approve",
+         self_span: 1580..1584,
+     }
+
+note: 
    ┌─ demos/erc20_token.fe:57:5
    │  
 57 │ ╭     pub fn increaseAllowance(self, spender: address, addedValue: u256) -> bool:
@@ -415,6 +581,57 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:58:23
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │                       │           │        │                 
+   │                       │           │        Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │                       │           address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:58:44
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                                            │                             
+   │                                            Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:58:44
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^ u256: Value => None
+   │                                            │                                        
+   │                                            u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/erc20_token.fe:58:44
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:58:9
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+59 │         return true
+   │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:58:9
+   │
+58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
+   │         ^^^^^^^^^^^^^ attributes hash: 10420458525874606876
+   │
+   = SelfAttribute {
+         func_name: "_approve",
+         self_span: 1769..1773,
+     }
+
+note: 
    ┌─ demos/erc20_token.fe:61:5
    │  
 61 │ ╭     pub fn decreaseAllowance(self, spender: address, subtractedValue: u256) -> bool:
@@ -449,6 +666,57 @@ note:
                  Bool,
              ),
          ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:62:23
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │                       │           │        │                 
+   │                       │           │        Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │                       │           address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:62:44
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │                                            │                             
+   │                                            Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:62:44
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value => None
+   │                                            │                                        
+   │                                            u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/erc20_token.fe:62:44
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:62:9
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+63 │         return true
+   │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:62:9
+   │
+62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
+   │         ^^^^^^^^^^^^^ attributes hash: 1575892034280724253
+   │
+   = SelfAttribute {
+         func_name: "_approve",
+         self_span: 1970..1974,
      }
 
 note: 
@@ -501,683 +769,12 @@ note:
      }
 
 note: 
-   ┌─ demos/erc20_token.fe:73:5
-   │  
-73 │ ╭     fn _mint(self, account: address, value: u256):
-74 │ │         assert account != address(0)
-75 │ │         _before_token_transfer(address(0), account, value)
-76 │ │         self._total_supply = self._total_supply + value
-77 │ │         self._balances[account] = self._balances[account] + value
-78 │ │         emit Transfer(from=address(0), to=account, value=value)
-   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "account",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:80:5
-   │  
-80 │ ╭     fn _burn(self, account: address, value: u256):
-81 │ │         assert account != address(0)
-82 │ │         _before_token_transfer(account, address(0), value)
-83 │ │         self._balances[account] = self._balances[account] - value
-84 │ │         self._total_supply = self._total_supply - value
-85 │ │         emit Transfer(from=account, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "account",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:87:5
-   │  
-87 │ ╭     fn _approve(self, owner: address, spender: address, value: u256):
-88 │ │         assert owner != address(0)
-89 │ │         assert spender != address(0)
-90 │ │         self._allowances[owner][spender] = value
-91 │ │         emit Approval(owner, spender, value)
-   │ ╰────────────────────────────────────────────^ attributes hash: 2670276789438195364
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "owner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:93:5
-   │  
-93 │ ╭     fn _setup_decimals(self, decimals_: u8):
-94 │ │         self._decimals = decimals_
-   │ ╰──────────────────────────────────^ attributes hash: 9774377157681208112
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "decimals_",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:96:5
-   │  
-96 │ ╭     fn _before_token_transfer(from: address, to: address, value: u256):
-97 │ │         pass
-   │ ╰────────────^ attributes hash: 9175941171634351733
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [
-             FunctionParam {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:20:9
-   │
-20 │         self._name = name
-   │         ^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:20:22
-   │
-20 │         self._name = name
-   │                      ^^^^ String<100>: Memory => None
-
-note: 
-   ┌─ demos/erc20_token.fe:21:9
-   │
-21 │         self._symbol = symbol
-   │         ^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:21:24
-   │
-21 │         self._symbol = symbol
-   │                        ^^^^^^ String<100>: Memory => None
-
-note: 
-   ┌─ demos/erc20_token.fe:22:9
-   │
-22 │         self._decimals = u8(18)
-   │         ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:22:29
-   │
-22 │         self._decimals = u8(18)
-   │                             ^^ u8: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:22:26
-   │
-22 │         self._decimals = u8(18)
-   │                          ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:23:20
-   │
-23 │         self._mint(msg.sender, 1000000000000000000000000)
-   │                    ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:23:32
-   │
-23 │         self._mint(msg.sender, 1000000000000000000000000)
-   │                                ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:23:9
-   │
-23 │         self._mint(msg.sender, 1000000000000000000000000)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:26:16
-   │
-26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:26:16
-   │
-26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => Some(Memory)
-
-note: 
-   ┌─ demos/erc20_token.fe:29:16
-   │
-29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:29:16
-   │
-29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => Some(Memory)
-
-note: 
-   ┌─ demos/erc20_token.fe:32:16
-   │
-32 │         return self._decimals
-   │                ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:35:16
-   │
-35 │         return self._total_supply
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:38:16
-   │
-38 │         return self._balances[account]
-   │                ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:38:31
-   │
-38 │         return self._balances[account]
-   │                               ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:38:16
-   │
-38 │         return self._balances[account]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:41:24
-   │
-41 │         self._transfer(msg.sender, recipient, value)
-   │                        ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:41:36
-   │
-41 │         self._transfer(msg.sender, recipient, value)
-   │                                    ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:41:47
-   │
-41 │         self._transfer(msg.sender, recipient, value)
-   │                                               ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:41:9
-   │
-41 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:42:16
-   │
-42 │         return true
-   │                ^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:45:16
-   │
-45 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:45:33
-   │
-45 │         return self._allowances[owner][spender]
-   │                                 ^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:45:16
-   │
-45 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:45:40
-   │
-45 │         return self._allowances[owner][spender]
-   │                                        ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:45:16
-   │
-45 │         return self._allowances[owner][spender]
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:48:23
-   │
-48 │         self._approve(msg.sender, spender, value)
-   │                       ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:48:35
-   │
-48 │         self._approve(msg.sender, spender, value)
-   │                                   ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:48:44
-   │
-48 │         self._approve(msg.sender, spender, value)
-   │                                            ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:48:9
-   │
-48 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:49:16
-   │
-49 │         return true
-   │                ^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:52:16
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:52:33
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                                 ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:52:16
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:52:41
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                                         ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:52:16
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:52:56
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                                                        ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:52:16
-   │
-52 │         assert self._allowances[sender][msg.sender] >= value
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:53:24
-   │
-53 │         self._transfer(sender, recipient, value)
-   │                        ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:53:32
-   │
-53 │         self._transfer(sender, recipient, value)
-   │                                ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:53:43
-   │
-53 │         self._transfer(sender, recipient, value)
-   │                                           ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:53:9
-   │
-53 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:23
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                       ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:31
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                               ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:43
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:60
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                                            ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:43
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:68
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                                                    ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:43
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:54:82
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                                                                  ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:43
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:54:9
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:55:16
-   │
-55 │         return true
-   │                ^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:23
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                       ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:35
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                   ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:44
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:61
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                                             ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:44
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:73
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                                                         ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:44
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:58:84
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                                                                    ^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:44
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:58:9
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:59:16
-   │
-59 │         return true
-   │                ^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:23
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                       ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:35
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                   ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:44
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:61
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                                             ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:44
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:73
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                                                         ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:44
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:62:84
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                                                                    ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:44
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:62:9
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:63:16
-   │
-63 │         return true
-   │                ^^^^ bool: Value => None
-
-note: 
    ┌─ demos/erc20_token.fe:66:16
    │
 66 │         assert sender != address(0)
-   │                ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:66:34
-   │
-66 │         assert sender != address(0)
-   │                                  ^ u256: Value => None
+   │                ^^^^^^            ^ u256: Value => None
+   │                │                  
+   │                address: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:66:26
@@ -1190,18 +787,10 @@ note:
    │
 66 │         assert sender != address(0)
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:67:16
-   │
 67 │         assert recipient != address(0)
-   │                ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:67:37
-   │
-67 │         assert recipient != address(0)
-   │                                     ^ u256: Value => None
+   │                ^^^^^^^^^            ^ u256: Value => None
+   │                │                     
+   │                address: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:67:29
@@ -1214,558 +803,76 @@ note:
    │
 67 │         assert recipient != address(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:68:32
-   │
 68 │         _before_token_transfer(sender, recipient, value)
-   │                                ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:68:40
-   │
-68 │         _before_token_transfer(sender, recipient, value)
-   │                                        ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:68:51
-   │
-68 │         _before_token_transfer(sender, recipient, value)
-   │                                                   ^^^^^ u256: Value => None
+   │                                ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                │       │           
+   │                                │       address: Value => None
+   │                                address: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:68:9
    │
 68 │         _before_token_transfer(sender, recipient, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+69 │         self._balances[sender] = self._balances[sender] - value
+   │         ^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ demos/erc20_token.fe:69:9
    │
 69 │         self._balances[sender] = self._balances[sender] - value
-   │         ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:69:24
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │                        ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:69:9
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │         ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+   │         │                        │               
+   │         │                        Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
 
 note: 
    ┌─ demos/erc20_token.fe:69:34
    │
 69 │         self._balances[sender] = self._balances[sender] - value
-   │                                  ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:69:49
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │                                                 ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:69:34
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:69:59
-   │
-69 │         self._balances[sender] = self._balances[sender] - value
-   │                                                           ^^^^^ u256: Value => None
+   │                                  ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                  │                         
+   │                                  u256: Storage { nonce: None } => Some(Value)
 
 note: 
    ┌─ demos/erc20_token.fe:69:34
    │
 69 │         self._balances[sender] = self._balances[sender] - value
    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+70 │         self._balances[recipient] = self._balances[recipient] + value
+   │         ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value => None
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ demos/erc20_token.fe:70:9
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
-   │         ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:70:24
-   │
-70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                        ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:70:9
-   │
-70 │         self._balances[recipient] = self._balances[recipient] + value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value => None
+   │         │                           │               
+   │         │                           Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
 
 note: 
    ┌─ demos/erc20_token.fe:70:37
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                                     ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:70:52
-   │
-70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                                                    ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:70:37
-   │
-70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:70:65
-   │
-70 │         self._balances[recipient] = self._balances[recipient] + value
-   │                                                                 ^^^^^ u256: Value => None
+   │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                     │                            
+   │                                     u256: Storage { nonce: None } => Some(Value)
 
 note: 
    ┌─ demos/erc20_token.fe:70:37
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
    │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:71:28
-   │
 71 │         emit Transfer(from=sender, to=recipient, value=value)
-   │                            ^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:71:39
-   │
-71 │         emit Transfer(from=sender, to=recipient, value=value)
-   │                                       ^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:71:56
-   │
-71 │         emit Transfer(from=sender, to=recipient, value=value)
-   │                                                        ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:74:16
-   │
-74 │         assert account != address(0)
-   │                ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:74:35
-   │
-74 │         assert account != address(0)
-   │                                   ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:74:27
-   │
-74 │         assert account != address(0)
-   │                           ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:74:16
-   │
-74 │         assert account != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:75:40
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │                                        ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:75:32
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │                                ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:75:44
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │                                            ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:75:53
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │                                                     ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:75:9
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:76:9
-   │
-76 │         self._total_supply = self._total_supply + value
-   │         ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:76:30
-   │
-76 │         self._total_supply = self._total_supply + value
-   │                              ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:76:51
-   │
-76 │         self._total_supply = self._total_supply + value
-   │                                                   ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:76:30
-   │
-76 │         self._total_supply = self._total_supply + value
-   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:9
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │         ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:24
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │                        ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:9
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:35
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │                                   ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:50
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │                                                  ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:35
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:77:61
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │                                                             ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:77:35
-   │
-77 │         self._balances[account] = self._balances[account] + value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:78:36
-   │
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                                    ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:78:28
-   │
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                            ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:78:43
-   │
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                                           ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:78:58
-   │
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                                                          ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:81:16
-   │
-81 │         assert account != address(0)
-   │                ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:81:35
-   │
-81 │         assert account != address(0)
-   │                                   ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:81:27
-   │
-81 │         assert account != address(0)
-   │                           ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:81:16
-   │
-81 │         assert account != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:82:32
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │                                ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:82:49
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │                                                 ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:82:41
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │                                         ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:82:53
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │                                                     ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:82:9
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:9
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │         ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:24
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │                        ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:9
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:35
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │                                   ^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:50
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │                                                  ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:35
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:83:61
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │                                                             ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:83:35
-   │
-83 │         self._balances[account] = self._balances[account] - value
-   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:84:9
-   │
-84 │         self._total_supply = self._total_supply - value
-   │         ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:84:30
-   │
-84 │         self._total_supply = self._total_supply - value
-   │                              ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-   ┌─ demos/erc20_token.fe:84:51
-   │
-84 │         self._total_supply = self._total_supply - value
-   │                                                   ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:84:30
-   │
-84 │         self._total_supply = self._total_supply - value
-   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:85:28
-   │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                            ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:85:48
-   │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                                                ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:85:40
-   │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                                        ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:85:52
-   │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                                                    ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:88:16
-   │
-88 │         assert owner != address(0)
-   │                ^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:88:33
-   │
-88 │         assert owner != address(0)
-   │                                 ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:88:25
-   │
-88 │         assert owner != address(0)
-   │                         ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:88:16
-   │
-88 │         assert owner != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:89:16
-   │
-89 │         assert spender != address(0)
-   │                ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:89:35
-   │
-89 │         assert spender != address(0)
-   │                                   ^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:89:27
-   │
-89 │         assert spender != address(0)
-   │                           ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:89:16
-   │
-89 │         assert spender != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:90:9
-   │
-90 │         self._allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:90:26
-   │
-90 │         self._allowances[owner][spender] = value
-   │                          ^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:90:9
-   │
-90 │         self._allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:90:33
-   │
-90 │         self._allowances[owner][spender] = value
-   │                                 ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:90:9
-   │
-90 │         self._allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:90:44
-   │
-90 │         self._allowances[owner][spender] = value
-   │                                            ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:91:23
-   │
-91 │         emit Approval(owner, spender, value)
-   │                       ^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:91:30
-   │
-91 │         emit Approval(owner, spender, value)
-   │                              ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:91:39
-   │
-91 │         emit Approval(owner, spender, value)
-   │                                       ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/erc20_token.fe:94:9
-   │
-94 │         self._decimals = decimals_
-   │         ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => None
-
-note: 
-   ┌─ demos/erc20_token.fe:94:26
-   │
-94 │         self._decimals = decimals_
-   │                          ^^^^^^^^^ u8: Value => None
+   │                            ^^^^^^     ^^^^^^^^^        ^^^^^ u256: Value => None
+   │                            │          │                 
+   │                            │          address: Value => None
+   │                            address: Value => None
 
 note: 
    ┌─ demos/erc20_token.fe:71:9
@@ -1809,6 +916,168 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:66:26
+   │
+66 │         assert sender != address(0)
+   │                          ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:67:29
+   │
+67 │         assert recipient != address(0)
+   │                             ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:68:9
+   │
+68 │         _before_token_transfer(sender, recipient, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
+   │
+   = Pure(
+         FunctionId(
+             17,
+         ),
+     )
+
+note: 
+   ┌─ demos/erc20_token.fe:73:5
+   │  
+73 │ ╭     fn _mint(self, account: address, value: u256):
+74 │ │         assert account != address(0)
+75 │ │         _before_token_transfer(address(0), account, value)
+76 │ │         self._total_supply = self._total_supply + value
+77 │ │         self._balances[account] = self._balances[account] + value
+78 │ │         emit Transfer(from=address(0), to=account, value=value)
+   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "account",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:74:16
+   │
+74 │         assert account != address(0)
+   │                ^^^^^^^            ^ u256: Value => None
+   │                │                   
+   │                address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:74:27
+   │
+74 │         assert account != address(0)
+   │                           ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:74:16
+   │
+74 │         assert account != address(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+75 │         _before_token_transfer(address(0), account, value)
+   │                                        ^ u256: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:75:32
+   │
+75 │         _before_token_transfer(address(0), account, value)
+   │                                ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                                │           │         
+   │                                │           address: Value => None
+   │                                address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:75:9
+   │
+75 │         _before_token_transfer(address(0), account, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+76 │         self._total_supply = self._total_supply + value
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         │                    │                     
+   │         │                    u256: Storage { nonce: Some(2) } => Some(Value)
+   │         u256: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:76:30
+   │
+76 │         self._total_supply = self._total_supply + value
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+77 │         self._balances[account] = self._balances[account] + value
+   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:77:9
+   │
+77 │         self._balances[account] = self._balances[account] + value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         │                         │               
+   │         │                         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:77:35
+   │
+77 │         self._balances[account] = self._balances[account] + value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                   │                          
+   │                                   u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/erc20_token.fe:77:35
+   │
+77 │         self._balances[account] = self._balances[account] + value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+78 │         emit Transfer(from=address(0), to=account, value=value)
+   │                                    ^ u256: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:78:28
+   │
+78 │         emit Transfer(from=address(0), to=account, value=value)
+   │                            ^^^^^^^^^^     ^^^^^^^        ^^^^^ u256: Value => None
+   │                            │              │               
+   │                            │              address: Value => None
+   │                            address: Value => None
+
+note: 
    ┌─ demos/erc20_token.fe:78:9
    │
 78 │         emit Transfer(from=address(0), to=account, value=value)
@@ -1848,231 +1117,6 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ demos/erc20_token.fe:85:9
-   │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:91:9
-   │
-91 │         emit Approval(owner, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8893313742751514912
-   │
-   = Event {
-         name: "Approval",
-         fields: [
-             EventField {
-                 name: "owner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:22:26
-   │
-22 │         self._decimals = u8(18)
-   │                          ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:23:9
-   │
-23 │         self._mint(msg.sender, 1000000000000000000000000)
-   │         ^^^^^^^^^^ attributes hash: 3032414134331615192
-   │
-   = SelfAttribute {
-         func_name: "_mint",
-         self_span: 542..546,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:26:16
-   │
-26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ demos/erc20_token.fe:29:16
-   │
-29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ demos/erc20_token.fe:41:9
-   │
-41 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 15399895119751945816
-   │
-   = SelfAttribute {
-         func_name: "_transfer",
-         self_span: 1052..1056,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:48:9
-   │
-48 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 10047856837296232623
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1310..1314,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:53:9
-   │
-53 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 13311941709994158162
-   │
-   = SelfAttribute {
-         func_name: "_transfer",
-         self_span: 1531..1535,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:54:9
-   │
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^ attributes hash: 5596759839039037729
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1580..1584,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:58:9
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 10420458525874606876
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1769..1773,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:62:9
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 1575892034280724253
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 1970..1974,
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:66:26
-   │
-66 │         assert sender != address(0)
-   │                          ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:67:29
-   │
-67 │         assert recipient != address(0)
-   │                             ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/erc20_token.fe:68:9
-   │
-68 │         _before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4288839759476594646
-   │
-   = Pure(
-         FunctionId(
-             17,
-         ),
-     )
 
 note: 
    ┌─ demos/erc20_token.fe:74:27
@@ -2120,6 +1164,175 @@ note:
          typ: Base(
              Address,
          ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:80:5
+   │  
+80 │ ╭     fn _burn(self, account: address, value: u256):
+81 │ │         assert account != address(0)
+82 │ │         _before_token_transfer(account, address(0), value)
+83 │ │         self._balances[account] = self._balances[account] - value
+84 │ │         self._total_supply = self._total_supply - value
+85 │ │         emit Transfer(from=account, to=address(0), value)
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 10909525661003637247
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "account",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:81:16
+   │
+81 │         assert account != address(0)
+   │                ^^^^^^^            ^ u256: Value => None
+   │                │                   
+   │                address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:81:27
+   │
+81 │         assert account != address(0)
+   │                           ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:81:16
+   │
+81 │         assert account != address(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+82 │         _before_token_transfer(account, address(0), value)
+   │                                ^^^^^^^          ^ u256: Value => None
+   │                                │                 
+   │                                address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:82:41
+   │
+82 │         _before_token_transfer(account, address(0), value)
+   │                                         ^^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                         │            
+   │                                         address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:82:9
+   │
+82 │         _before_token_transfer(account, address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+83 │         self._balances[account] = self._balances[account] - value
+   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:83:9
+   │
+83 │         self._balances[account] = self._balances[account] - value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         │                         │               
+   │         │                         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:83:35
+   │
+83 │         self._balances[account] = self._balances[account] - value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                                   │                          
+   │                                   u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/erc20_token.fe:83:35
+   │
+83 │         self._balances[account] = self._balances[account] - value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+84 │         self._total_supply = self._total_supply - value
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         │                    │                     
+   │         │                    u256: Storage { nonce: Some(2) } => Some(Value)
+   │         u256: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:84:30
+   │
+84 │         self._total_supply = self._total_supply - value
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+85 │         emit Transfer(from=account, to=address(0), value)
+   │                            ^^^^^^^             ^ u256: Value => None
+   │                            │                    
+   │                            address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:85:40
+   │
+85 │         emit Transfer(from=account, to=address(0), value)
+   │                                        ^^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                        │            
+   │                                        address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:85:9
+   │
+85 │         emit Transfer(from=account, to=address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+   │
+   = Event {
+         name: "Transfer",
+         fields: [
+             EventField {
+                 name: "from",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "to",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
      }
 
 note: 
@@ -2171,6 +1384,155 @@ note:
      }
 
 note: 
+   ┌─ demos/erc20_token.fe:87:5
+   │  
+87 │ ╭     fn _approve(self, owner: address, spender: address, value: u256):
+88 │ │         assert owner != address(0)
+89 │ │         assert spender != address(0)
+90 │ │         self._allowances[owner][spender] = value
+91 │ │         emit Approval(owner, spender, value)
+   │ ╰────────────────────────────────────────────^ attributes hash: 2670276789438195364
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "owner",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "spender",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:88:16
+   │
+88 │         assert owner != address(0)
+   │                ^^^^^            ^ u256: Value => None
+   │                │                 
+   │                address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:88:25
+   │
+88 │         assert owner != address(0)
+   │                         ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:88:16
+   │
+88 │         assert owner != address(0)
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value => None
+89 │         assert spender != address(0)
+   │                ^^^^^^^            ^ u256: Value => None
+   │                │                   
+   │                address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:89:27
+   │
+89 │         assert spender != address(0)
+   │                           ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:89:16
+   │
+89 │         assert spender != address(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+90 │         self._allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^^ ^^^^^ address: Value => None
+   │         │                 
+   │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:90:9
+   │
+90 │         self._allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         │                        
+   │         Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:90:9
+   │
+90 │         self._allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         │                                   
+   │         u256: Storage { nonce: None } => None
+91 │         emit Approval(owner, spender, value)
+   │                       ^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                       │      │         
+   │                       │      address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/erc20_token.fe:91:9
+   │
+91 │         emit Approval(owner, spender, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8893313742751514912
+   │
+   = Event {
+         name: "Approval",
+         fields: [
+             EventField {
+                 name: "owner",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "spender",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
    ┌─ demos/erc20_token.fe:88:25
    │
 88 │         assert owner != address(0)
@@ -2191,6 +1553,86 @@ note:
    = TypeConstructor {
          typ: Base(
              Address,
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:93:5
+   │  
+93 │ ╭     fn _setup_decimals(self, decimals_: u8):
+94 │ │         self._decimals = decimals_
+   │ ╰──────────────────────────────────^ attributes hash: 9774377157681208112
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "decimals_",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U8,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ demos/erc20_token.fe:94:9
+   │
+94 │         self._decimals = decimals_
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ u8: Value => None
+   │         │                 
+   │         u8: Storage { nonce: Some(5) } => None
+
+note: 
+   ┌─ demos/erc20_token.fe:96:5
+   │  
+96 │ ╭     fn _before_token_transfer(from: address, to: address, value: u256):
+97 │ │         pass
+   │ ╰────────────^ attributes hash: 9175941171634351733
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [
+             FunctionParam {
+                 name: "from",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "to",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
          ),
      }
 

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -58,9 +58,9 @@ note:
    ┌─ features/events.fe:20:24
    │
 20 │         emit Nums(num1=26, num2=42)
-   │                        ^^       ^^ u256: Value => None
+   │                        ^^       ^^ u256: Value
    │                        │         
-   │                        u256: Value => None
+   │                        u256: Value
 
 note: 
    ┌─ features/events.fe:20:9
@@ -126,9 +126,9 @@ note:
    ┌─ features/events.fe:23:24
    │
 23 │         emit Bases(num=26, addr)
-   │                        ^^  ^^^^ address: Value => None
+   │                        ^^  ^^^^ address: Value
    │                        │    
-   │                        u256: Value => None
+   │                        u256: Value
 
 note: 
    ┌─ features/events.fe:23:9
@@ -205,11 +205,11 @@ note:
    ┌─ features/events.fe:26:23
    │
 26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │                       ^^  ^^^^       ^^  ^^^^^^^^ Array<u8, 100>: Memory => None
+   │                       ^^  ^^^^       ^^  ^^^^^^^^ Array<u8, 100>: Memory
    │                       │   │          │    
-   │                       │   │          u256: Value => None
-   │                       │   address: Value => None
-   │                       u256: Value => None
+   │                       │   │          u256: Value
+   │                       │   address: Value
+   │                       u256: Value
 
 note: 
    ┌─ features/events.fe:26:9
@@ -315,31 +315,31 @@ note:
    ┌─ features/events.fe:30:9
    │
 30 │         addrs[0] = addr1
-   │         ^^^^^ ^ u256: Value => None
+   │         ^^^^^ ^ u256: Value
    │         │      
-   │         Array<address, 2>: Memory => None
+   │         Array<address, 2>: Memory
 
 note: 
    ┌─ features/events.fe:30:9
    │
 30 │         addrs[0] = addr1
-   │         ^^^^^^^^   ^^^^^ address: Value => None
+   │         ^^^^^^^^   ^^^^^ address: Value
    │         │           
-   │         address: Memory => None
+   │         address: Memory
 31 │         addrs[1] = addr2
-   │         ^^^^^ ^ u256: Value => None
+   │         ^^^^^ ^ u256: Value
    │         │      
-   │         Array<address, 2>: Memory => None
+   │         Array<address, 2>: Memory
 
 note: 
    ┌─ features/events.fe:31:9
    │
 31 │         addrs[1] = addr2
-   │         ^^^^^^^^   ^^^^^ address: Value => None
+   │         ^^^^^^^^   ^^^^^ address: Value
    │         │           
-   │         address: Memory => None
+   │         address: Memory
 32 │         emit Addresses(addrs)
-   │                        ^^^^^ Array<address, 2>: Memory => None
+   │                        ^^^^^ Array<address, 2>: Memory
 
 note: 
    ┌─ features/events.fe:32:9

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/events.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -8,10 +8,6 @@ note:
   │
 3 │         idx num1: u256
   │         ^^^^^^^^^^^^^^ u256
-
-note: 
-  ┌─ features/events.fe:4:9
-  │
 4 │         num2: u256
   │         ^^^^^^^^^^ u256
 
@@ -20,10 +16,6 @@ note:
   │
 7 │         num: u256
   │         ^^^^^^^^^ u256
-
-note: 
-  ┌─ features/events.fe:8:9
-  │
 8 │         addr: address
   │         ^^^^^^^^^^^^^ address
 
@@ -32,22 +24,10 @@ note:
    │
 11 │         num1: u256
    │         ^^^^^^^^^^ u256
-
-note: 
-   ┌─ features/events.fe:12:9
-   │
 12 │         idx addr: address
    │         ^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ features/events.fe:13:9
-   │
 13 │         num2: u256
    │         ^^^^^^^^^^ u256
-
-note: 
-   ┌─ features/events.fe:14:9
-   │
 14 │         my_bytes: Array<u8, 100>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>
 
@@ -75,6 +55,48 @@ note:
      }
 
 note: 
+   ┌─ features/events.fe:20:24
+   │
+20 │         emit Nums(num1=26, num2=42)
+   │                        ^^       ^^ u256: Value => None
+   │                        │         
+   │                        u256: Value => None
+
+note: 
+   ┌─ features/events.fe:20:9
+   │
+20 │         emit Nums(num1=26, num2=42)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4681095448721924839
+   │
+   = Event {
+         name: "Nums",
+         fields: [
+             EventField {
+                 name: "num1",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "num2",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
    ┌─ features/events.fe:22:5
    │  
 22 │ ╭     pub fn emit_bases(addr: address):
@@ -98,6 +120,46 @@ note:
                  Unit,
              ),
          ),
+     }
+
+note: 
+   ┌─ features/events.fe:23:24
+   │
+23 │         emit Bases(num=26, addr)
+   │                        ^^  ^^^^ address: Value => None
+   │                        │    
+   │                        u256: Value => None
+
+note: 
+   ┌─ features/events.fe:23:9
+   │
+23 │         emit Bases(num=26, addr)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4407350417102602838
+   │
+   = Event {
+         name: "Bases",
+         fields: [
+             EventField {
+                 name: "num",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+             EventField {
+                 name: "addr",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
      }
 
 note: 
@@ -140,209 +202,14 @@ note:
      }
 
 note: 
-   ┌─ features/events.fe:28:5
-   │  
-28 │ ╭     pub fn emit_addresses(addr1: address, addr2: address):
-29 │ │         let addrs: Array<address, 2>
-30 │ │         addrs[0] = addr1
-31 │ │         addrs[1] = addr2
-32 │ │         emit Addresses(addrs)
-   │ ╰─────────────────────────────^ attributes hash: 13018113254659996848
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [
-             FunctionParam {
-                 name: "addr1",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "addr2",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/events.fe:20:24
-   │
-20 │         emit Nums(num1=26, num2=42)
-   │                        ^^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:20:33
-   │
-20 │         emit Nums(num1=26, num2=42)
-   │                                 ^^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:23:24
-   │
-23 │         emit Bases(num=26, addr)
-   │                        ^^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:23:28
-   │
-23 │         emit Bases(num=26, addr)
-   │                            ^^^^ address: Value => None
-
-note: 
    ┌─ features/events.fe:26:23
    │
 26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │                       ^^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:26:27
-   │
-26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │                           ^^^^ address: Value => None
-
-note: 
-   ┌─ features/events.fe:26:38
-   │
-26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │                                      ^^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:26:42
-   │
-26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │                                          ^^^^^^^^ Array<u8, 100>: Memory => None
-
-note: 
-   ┌─ features/events.fe:30:9
-   │
-30 │         addrs[0] = addr1
-   │         ^^^^^ Array<address, 2>: Memory => None
-
-note: 
-   ┌─ features/events.fe:30:15
-   │
-30 │         addrs[0] = addr1
-   │               ^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:30:9
-   │
-30 │         addrs[0] = addr1
-   │         ^^^^^^^^ address: Memory => None
-
-note: 
-   ┌─ features/events.fe:30:20
-   │
-30 │         addrs[0] = addr1
-   │                    ^^^^^ address: Value => None
-
-note: 
-   ┌─ features/events.fe:31:9
-   │
-31 │         addrs[1] = addr2
-   │         ^^^^^ Array<address, 2>: Memory => None
-
-note: 
-   ┌─ features/events.fe:31:15
-   │
-31 │         addrs[1] = addr2
-   │               ^ u256: Value => None
-
-note: 
-   ┌─ features/events.fe:31:9
-   │
-31 │         addrs[1] = addr2
-   │         ^^^^^^^^ address: Memory => None
-
-note: 
-   ┌─ features/events.fe:31:20
-   │
-31 │         addrs[1] = addr2
-   │                    ^^^^^ address: Value => None
-
-note: 
-   ┌─ features/events.fe:32:24
-   │
-32 │         emit Addresses(addrs)
-   │                        ^^^^^ Array<address, 2>: Memory => None
-
-note: 
-   ┌─ features/events.fe:20:9
-   │
-20 │         emit Nums(num1=26, num2=42)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4681095448721924839
-   │
-   = Event {
-         name: "Nums",
-         fields: [
-             EventField {
-                 name: "num1",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "num2",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ features/events.fe:23:9
-   │
-23 │         emit Bases(num=26, addr)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4407350417102602838
-   │
-   = Event {
-         name: "Bases",
-         fields: [
-             EventField {
-                 name: "num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
+   │                       ^^  ^^^^       ^^  ^^^^^^^^ Array<u8, 100>: Memory => None
+   │                       │   │          │    
+   │                       │   │          u256: Value => None
+   │                       │   address: Value => None
+   │                       u256: Value => None
 
 note: 
    ┌─ features/events.fe:26:9
@@ -402,6 +269,79 @@ note:
      }
 
 note: 
+   ┌─ features/events.fe:28:5
+   │  
+28 │ ╭     pub fn emit_addresses(addr1: address, addr2: address):
+29 │ │         let addrs: Array<address, 2>
+30 │ │         addrs[0] = addr1
+31 │ │         addrs[1] = addr2
+32 │ │         emit Addresses(addrs)
+   │ ╰─────────────────────────────^ attributes hash: 13018113254659996848
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [
+             FunctionParam {
+                 name: "addr1",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "addr2",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/events.fe:29:20
+   │
+29 │         let addrs: Array<address, 2>
+   │                    ^^^^^^^^^^^^^^^^^ Array<address, 2>
+
+note: 
+   ┌─ features/events.fe:30:9
+   │
+30 │         addrs[0] = addr1
+   │         ^^^^^ ^ u256: Value => None
+   │         │      
+   │         Array<address, 2>: Memory => None
+
+note: 
+   ┌─ features/events.fe:30:9
+   │
+30 │         addrs[0] = addr1
+   │         ^^^^^^^^   ^^^^^ address: Value => None
+   │         │           
+   │         address: Memory => None
+31 │         addrs[1] = addr2
+   │         ^^^^^ ^ u256: Value => None
+   │         │      
+   │         Array<address, 2>: Memory => None
+
+note: 
+   ┌─ features/events.fe:31:9
+   │
+31 │         addrs[1] = addr2
+   │         ^^^^^^^^   ^^^^^ address: Value => None
+   │         │           
+   │         address: Memory => None
+32 │         emit Addresses(addrs)
+   │                        ^^^^^ Array<address, 2>: Memory => None
+
+note: 
    ┌─ features/events.fe:32:9
    │
 32 │         emit Addresses(addrs)
@@ -424,11 +364,5 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ features/events.fe:29:20
-   │
-29 │         let addrs: Array<address, 2>
-   │                    ^^^^^^^^^^^^^^^^^ Array<address, 2>
 
 

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -66,10 +66,10 @@ note:
   ┌─ features/external_contract.fe:8:22
   │
 8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                      ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory => None
+  │                      ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory
   │                      │       │          
-  │                      │       Array<address, 5>: Memory => None
-  │                      u256: Value => None
+  │                      │       Array<address, 5>: Memory
+  │                      u256: Value
 
 note: 
   ┌─ features/external_contract.fe:8:9
@@ -174,50 +174,50 @@ note:
    ┌─ features/external_contract.fe:12:9
    │
 12 │         my_array[0] = a
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 3>: Memory => None
+   │         Array<u256, 3>: Memory
 
 note: 
    ┌─ features/external_contract.fe:12:9
    │
 12 │         my_array[0] = a
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
 13 │         my_array[1] = a * b
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 3>: Memory => None
+   │         Array<u256, 3>: Memory
 
 note: 
    ┌─ features/external_contract.fe:13:9
    │
 13 │         my_array[1] = a * b
-   │         ^^^^^^^^^^^   ^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^   ^ u256: Value
    │         │             │    
-   │         │             u256: Value => None
-   │         u256: Memory => None
+   │         │             u256: Value
+   │         u256: Memory
 
 note: 
    ┌─ features/external_contract.fe:13:23
    │
 13 │         my_array[1] = a * b
-   │                       ^^^^^ u256: Value => None
+   │                       ^^^^^ u256: Value
 14 │         my_array[2] = b
-   │         ^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
    │         │         
-   │         Array<u256, 3>: Memory => None
+   │         Array<u256, 3>: Memory
 
 note: 
    ┌─ features/external_contract.fe:14:9
    │
 14 │         my_array[2] = b
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
 15 │         return my_array
-   │                ^^^^^^^^ Array<u256, 3>: Memory => None
+   │                ^^^^^^^^ Array<u256, 3>: Memory
 
 note: 
    ┌─ features/external_contract.fe:18:5
@@ -291,50 +291,33 @@ note:
    ┌─ features/external_contract.fe:24:28
    │
 24 │         let foo: Foo = Foo(foo_address)
-   │                            ^^^^^^^^^^^ address: Value => None
+   │                            ^^^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/external_contract.fe:24:24
    │
 24 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^^^^^^ Foo: Value => None
+   │                        ^^^^^^^^^^^^^^^^ Foo: Value
 25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^            ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory => None
+   │         ^^^            ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory
    │         │              │       │          
-   │         │              │       Array<address, 5>: Memory => None
-   │         │              u256: Value => None
-   │         Foo: Value => None
+   │         │              │       Array<address, 5>: Memory
+   │         │              u256: Value
+   │         Foo: Value
 
 note: 
    ┌─ features/external_contract.fe:25:9
    │
 25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
    ┌─ features/external_contract.fe:24:24
    │
 24 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^ attributes hash: 1647454659037951517
-   │
-   = TypeConstructor {
-         typ: Contract(
-             Contract {
-                 name: "Foo",
-                 id: ContractId(
-                     0,
-                 ),
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/external_contract.fe:25:9
-   │
+   │                        ^^^ TypeConstructor(Contract(Contract { name: "Foo", id: ContractId(0) }))
 25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 note: 
    ┌─ features/external_contract.fe:27:5
@@ -402,48 +385,31 @@ note:
    ┌─ features/external_contract.fe:32:28
    │
 32 │         let foo: Foo = Foo(foo_address)
-   │                            ^^^^^^^^^^^ address: Value => None
+   │                            ^^^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/external_contract.fe:32:24
    │
 32 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^^^^^^ Foo: Value => None
+   │                        ^^^^^^^^^^^^^^^^ Foo: Value
 33 │         return foo.build_array(a, b)
-   │                ^^^             ^  ^ u256: Value => None
+   │                ^^^             ^  ^ u256: Value
    │                │               │   
-   │                │               u256: Value => None
-   │                Foo: Value => None
+   │                │               u256: Value
+   │                Foo: Value
 
 note: 
    ┌─ features/external_contract.fe:33:16
    │
 33 │         return foo.build_array(a, b)
-   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 3>: Memory => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 3>: Memory
 
 note: 
    ┌─ features/external_contract.fe:32:24
    │
 32 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^ attributes hash: 1647454659037951517
-   │
-   = TypeConstructor {
-         typ: Contract(
-             Contract {
-                 name: "Foo",
-                 id: ContractId(
-                     0,
-                 ),
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/external_contract.fe:33:16
-   │
+   │                        ^^^ TypeConstructor(Contract(Contract { name: "Foo", id: ContractId(0) }))
 33 │         return foo.build_array(a, b)
-   │                ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/external_contract.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -8,16 +8,8 @@ note:
   │
 3 │         my_num: u256
   │         ^^^^^^^^^^^^ u256
-
-note: 
-  ┌─ features/external_contract.fe:4:9
-  │
 4 │         my_addrs: Array<address, 5>
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
-
-note: 
-  ┌─ features/external_contract.fe:5:9
-  │
 5 │         my_string: String<11>
   │         ^^^^^^^^^^^^^^^^^^^^^ String<11>
 
@@ -71,6 +63,61 @@ note:
     }
 
 note: 
+  ┌─ features/external_contract.fe:8:22
+  │
+8 │         emit MyEvent(my_num, my_addrs, my_string)
+  │                      ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory => None
+  │                      │       │          
+  │                      │       Array<address, 5>: Memory => None
+  │                      u256: Value => None
+
+note: 
+  ┌─ features/external_contract.fe:8:9
+  │
+8 │         emit MyEvent(my_num, my_addrs, my_string)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3872046667435269452
+  │
+  = Event {
+        name: "MyEvent",
+        fields: [
+            EventField {
+                name: "my_num",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U256,
+                        ),
+                    ),
+                ),
+                is_indexed: false,
+            },
+            EventField {
+                name: "my_addrs",
+                typ: Ok(
+                    Array(
+                        Array {
+                            size: 5,
+                            inner: Address,
+                        },
+                    ),
+                ),
+                is_indexed: false,
+            },
+            EventField {
+                name: "my_string",
+                typ: Ok(
+                    String(
+                        FeString {
+                            max_size: 11,
+                        },
+                    ),
+                ),
+                is_indexed: false,
+            },
+        ],
+    }
+
+note: 
    ┌─ features/external_contract.fe:10:5
    │  
 10 │ ╭     pub fn build_array(a: u256, b: u256) -> Array<u256, 3>:
@@ -116,6 +163,61 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/external_contract.fe:11:23
+   │
+11 │         let my_array: Array<u256, 3>
+   │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+
+note: 
+   ┌─ features/external_contract.fe:12:9
+   │
+12 │         my_array[0] = a
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 3>: Memory => None
+
+note: 
+   ┌─ features/external_contract.fe:12:9
+   │
+12 │         my_array[0] = a
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+13 │         my_array[1] = a * b
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 3>: Memory => None
+
+note: 
+   ┌─ features/external_contract.fe:13:9
+   │
+13 │         my_array[1] = a * b
+   │         ^^^^^^^^^^^   ^   ^ u256: Value => None
+   │         │             │    
+   │         │             u256: Value => None
+   │         u256: Memory => None
+
+note: 
+   ┌─ features/external_contract.fe:13:23
+   │
+13 │         my_array[1] = a * b
+   │                       ^^^^^ u256: Value => None
+14 │         my_array[2] = b
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Array<u256, 3>: Memory => None
+
+note: 
+   ┌─ features/external_contract.fe:14:9
+   │
+14 │         my_array[2] = b
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+15 │         return my_array
+   │                ^^^^^^^^ Array<u256, 3>: Memory => None
 
 note: 
    ┌─ features/external_contract.fe:18:5
@@ -180,6 +282,61 @@ note:
      }
 
 note: 
+   ┌─ features/external_contract.fe:24:18
+   │
+24 │         let foo: Foo = Foo(foo_address)
+   │                  ^^^ Foo
+
+note: 
+   ┌─ features/external_contract.fe:24:28
+   │
+24 │         let foo: Foo = Foo(foo_address)
+   │                            ^^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ features/external_contract.fe:24:24
+   │
+24 │         let foo: Foo = Foo(foo_address)
+   │                        ^^^^^^^^^^^^^^^^ Foo: Value => None
+25 │         foo.emit_event(my_num, my_addrs, my_string)
+   │         ^^^            ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory => None
+   │         │              │       │          
+   │         │              │       Array<address, 5>: Memory => None
+   │         │              u256: Value => None
+   │         Foo: Value => None
+
+note: 
+   ┌─ features/external_contract.fe:25:9
+   │
+25 │         foo.emit_event(my_num, my_addrs, my_string)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+
+note: 
+   ┌─ features/external_contract.fe:24:24
+   │
+24 │         let foo: Foo = Foo(foo_address)
+   │                        ^^^ attributes hash: 1647454659037951517
+   │
+   = TypeConstructor {
+         typ: Contract(
+             Contract {
+                 name: "Foo",
+                 id: ContractId(
+                     0,
+                 ),
+             },
+         ),
+     }
+
+note: 
+   ┌─ features/external_contract.fe:25:9
+   │
+25 │         foo.emit_event(my_num, my_addrs, my_string)
+   │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
    ┌─ features/external_contract.fe:27:5
    │  
 27 │ ╭     pub fn call_build_array(
@@ -236,154 +393,10 @@ note:
      }
 
 note: 
-  ┌─ features/external_contract.fe:8:22
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                      ^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/external_contract.fe:8:30
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                              ^^^^^^^^ Array<address, 5>: Memory => None
-
-note: 
-  ┌─ features/external_contract.fe:8:40
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │                                        ^^^^^^^^^ String<11>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:12:9
+   ┌─ features/external_contract.fe:32:18
    │
-12 │         my_array[0] = a
-   │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:12:18
-   │
-12 │         my_array[0] = a
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:12:9
-   │
-12 │         my_array[0] = a
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:12:23
-   │
-12 │         my_array[0] = a
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:13:9
-   │
-13 │         my_array[1] = a * b
-   │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:13:18
-   │
-13 │         my_array[1] = a * b
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:13:9
-   │
-13 │         my_array[1] = a * b
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:13:23
-   │
-13 │         my_array[1] = a * b
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:13:27
-   │
-13 │         my_array[1] = a * b
-   │                           ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:13:23
-   │
-13 │         my_array[1] = a * b
-   │                       ^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:14:9
-   │
-14 │         my_array[2] = b
-   │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:14:18
-   │
-14 │         my_array[2] = b
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:14:9
-   │
-14 │         my_array[2] = b
-   │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:14:23
-   │
-14 │         my_array[2] = b
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:15:16
-   │
-15 │         return my_array
-   │                ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:24:28
-   │
-24 │         let foo: Foo = Foo(foo_address)
-   │                            ^^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:24:24
-   │
-24 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^^^^^^^^^^^^^^ Foo: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:25:9
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^ Foo: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:25:24
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │                        ^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:25:32
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │                                ^^^^^^^^ Array<address, 5>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:25:42
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │                                          ^^^^^^^^^ String<11>: Memory => None
-
-note: 
-   ┌─ features/external_contract.fe:25:9
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+32 │         let foo: Foo = Foo(foo_address)
+   │                  ^^^ Foo
 
 note: 
    ┌─ features/external_contract.fe:32:28
@@ -396,119 +409,17 @@ note:
    │
 32 │         let foo: Foo = Foo(foo_address)
    │                        ^^^^^^^^^^^^^^^^ Foo: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:33:16
-   │
 33 │         return foo.build_array(a, b)
-   │                ^^^ Foo: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:33:32
-   │
-33 │         return foo.build_array(a, b)
-   │                                ^ u256: Value => None
-
-note: 
-   ┌─ features/external_contract.fe:33:35
-   │
-33 │         return foo.build_array(a, b)
-   │                                   ^ u256: Value => None
+   │                ^^^             ^  ^ u256: Value => None
+   │                │               │   
+   │                │               u256: Value => None
+   │                Foo: Value => None
 
 note: 
    ┌─ features/external_contract.fe:33:16
    │
 33 │         return foo.build_array(a, b)
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/external_contract.fe:8:9
-  │
-8 │         emit MyEvent(my_num, my_addrs, my_string)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3872046667435269452
-  │
-  = Event {
-        name: "MyEvent",
-        fields: [
-            EventField {
-                name: "my_num",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-                is_indexed: false,
-            },
-            EventField {
-                name: "my_addrs",
-                typ: Ok(
-                    Array(
-                        Array {
-                            size: 5,
-                            inner: Address,
-                        },
-                    ),
-                ),
-                is_indexed: false,
-            },
-            EventField {
-                name: "my_string",
-                typ: Ok(
-                    String(
-                        FeString {
-                            max_size: 11,
-                        },
-                    ),
-                ),
-                is_indexed: false,
-            },
-        ],
-    }
-
-note: 
-   ┌─ features/external_contract.fe:11:23
-   │
-11 │         let my_array: Array<u256, 3>
-   │                       ^^^^^^^^^^^^^^ Array<u256, 3>
-
-note: 
-   ┌─ features/external_contract.fe:24:18
-   │
-24 │         let foo: Foo = Foo(foo_address)
-   │                  ^^^ Foo
-
-note: 
-   ┌─ features/external_contract.fe:32:18
-   │
-32 │         let foo: Foo = Foo(foo_address)
-   │                  ^^^ Foo
-
-note: 
-   ┌─ features/external_contract.fe:24:24
-   │
-24 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^ attributes hash: 1647454659037951517
-   │
-   = TypeConstructor {
-         typ: Contract(
-             Contract {
-                 name: "Foo",
-                 id: ContractId(
-                     0,
-                 ),
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/external_contract.fe:25:9
-   │
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
 
 note: 
    ┌─ features/external_contract.fe:32:24

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/for_loop_with_break.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -28,147 +28,80 @@ note:
      }
 
 note: 
-  ┌─ features/for_loop_with_break.fe:5:9
+  ┌─ features/for_loop_with_break.fe:4:23
   │
-5 │         my_array[0] = 5
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:5:18
-  │
-5 │         my_array[0] = 5
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:5:9
-  │
-5 │         my_array[0] = 5
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:5:23
-  │
-5 │         my_array[0] = 5
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:6:9
-  │
-6 │         my_array[1] = 10
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:6:18
-  │
-6 │         my_array[1] = 10
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:6:9
-  │
-6 │         my_array[1] = 10
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:6:23
-  │
-6 │         my_array[1] = 10
-  │                       ^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:7:9
-  │
-7 │         my_array[2] = 15
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:7:18
-  │
-7 │         my_array[2] = 15
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:7:9
-  │
-7 │         my_array[2] = 15
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:7:23
-  │
-7 │         my_array[2] = 15
-  │                       ^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:8:25
-  │
+4 │         let my_array: Array<u256, 3>
+  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+  ·
 8 │         let sum: u256 = 0
-  │                         ^ u256: Value => None
+  │                  ^^^^ u256
 
 note: 
-  ┌─ features/for_loop_with_break.fe:9:18
+  ┌─ features/for_loop_with_break.fe:5:9
   │
-9 │         for i in my_array:
-  │                  ^^^^^^^^ Array<u256, 3>: Memory => None
+5 │         my_array[0] = 5
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
 
 note: 
-   ┌─ features/for_loop_with_break.fe:10:13
-   │
-10 │             sum = sum + i
-   │             ^^^ u256: Value => None
+  ┌─ features/for_loop_with_break.fe:5:9
+  │
+5 │         my_array[0] = 5
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+6 │         my_array[1] = 10
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
 
 note: 
-   ┌─ features/for_loop_with_break.fe:10:19
-   │
-10 │             sum = sum + i
-   │                   ^^^ u256: Value => None
+  ┌─ features/for_loop_with_break.fe:6:9
+  │
+6 │         my_array[1] = 10
+  │         ^^^^^^^^^^^   ^^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+7 │         my_array[2] = 15
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
 
 note: 
-   ┌─ features/for_loop_with_break.fe:10:25
+   ┌─ features/for_loop_with_break.fe:7:9
    │
-10 │             sum = sum + i
+ 7 │         my_array[2] = 15
+   │         ^^^^^^^^^^^   ^^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+ 8 │         let sum: u256 = 0
    │                         ^ u256: Value => None
+ 9 │         for i in my_array:
+   │                  ^^^^^^^^ Array<u256, 3>: Memory => None
+10 │             sum = sum + i
+   │             ^^^   ^^^   ^ u256: Value => None
+   │             │     │      
+   │             │     u256: Value => None
+   │             u256: Value => None
 
 note: 
    ┌─ features/for_loop_with_break.fe:10:19
    │
 10 │             sum = sum + i
    │                   ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_break.fe:11:16
-   │
 11 │             if sum == 15:
-   │                ^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_break.fe:11:23
-   │
-11 │             if sum == 15:
-   │                       ^^ u256: Value => None
+   │                ^^^    ^^ u256: Value => None
+   │                │       
+   │                u256: Value => None
 
 note: 
    ┌─ features/for_loop_with_break.fe:11:16
    │
 11 │             if sum == 15:
    │                ^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/for_loop_with_break.fe:13:16
-   │
+12 │                 break
 13 │         return sum
    │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_break.fe:4:23
-  │
-4 │         let my_array: Array<u256, 3>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
-
-note: 
-  ┌─ features/for_loop_with_break.fe:8:18
-  │
-8 │         let sum: u256 = 0
-  │                  ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
@@ -40,68 +40,68 @@ note:
   ┌─ features/for_loop_with_break.fe:5:9
   │
 5 │         my_array[0] = 5
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/for_loop_with_break.fe:5:9
   │
 5 │         my_array[0] = 5
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 6 │         my_array[1] = 10
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/for_loop_with_break.fe:6:9
   │
 6 │         my_array[1] = 10
-  │         ^^^^^^^^^^^   ^^ u256: Value => None
+  │         ^^^^^^^^^^^   ^^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 7 │         my_array[2] = 15
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
    ┌─ features/for_loop_with_break.fe:7:9
    │
  7 │         my_array[2] = 15
-   │         ^^^^^^^^^^^   ^^ u256: Value => None
+   │         ^^^^^^^^^^^   ^^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
  8 │         let sum: u256 = 0
-   │                         ^ u256: Value => None
+   │                         ^ u256: Value
  9 │         for i in my_array:
-   │                  ^^^^^^^^ Array<u256, 3>: Memory => None
+   │                  ^^^^^^^^ Array<u256, 3>: Memory
 10 │             sum = sum + i
-   │             ^^^   ^^^   ^ u256: Value => None
+   │             ^^^   ^^^   ^ u256: Value
    │             │     │      
-   │             │     u256: Value => None
-   │             u256: Value => None
+   │             │     u256: Value
+   │             u256: Value
 
 note: 
    ┌─ features/for_loop_with_break.fe:10:19
    │
 10 │             sum = sum + i
-   │                   ^^^^^^^ u256: Value => None
+   │                   ^^^^^^^ u256: Value
 11 │             if sum == 15:
-   │                ^^^    ^^ u256: Value => None
+   │                ^^^    ^^ u256: Value
    │                │       
-   │                u256: Value => None
+   │                u256: Value
 
 note: 
    ┌─ features/for_loop_with_break.fe:11:16
    │
 11 │             if sum == 15:
-   │                ^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^ bool: Value
 12 │                 break
 13 │         return sum
-   │                ^^^ u256: Value => None
+   │                ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
@@ -40,100 +40,100 @@ note:
   ┌─ features/for_loop_with_continue.fe:5:9
   │
 5 │         my_array[0] = 2
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 5>: Memory => None
+  │         Array<u256, 5>: Memory
 
 note: 
   ┌─ features/for_loop_with_continue.fe:5:9
   │
 5 │         my_array[0] = 2
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 6 │         my_array[1] = 3
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 5>: Memory => None
+  │         Array<u256, 5>: Memory
 
 note: 
   ┌─ features/for_loop_with_continue.fe:6:9
   │
 6 │         my_array[1] = 3
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 7 │         my_array[2] = 5
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 5>: Memory => None
+  │         Array<u256, 5>: Memory
 
 note: 
   ┌─ features/for_loop_with_continue.fe:7:9
   │
 7 │         my_array[2] = 5
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 8 │         my_array[3] = 6
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 5>: Memory => None
+  │         Array<u256, 5>: Memory
 
 note: 
   ┌─ features/for_loop_with_continue.fe:8:9
   │
 8 │         my_array[3] = 6
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 9 │         my_array[4] = 9
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 5>: Memory => None
+  │         Array<u256, 5>: Memory
 
 note: 
    ┌─ features/for_loop_with_continue.fe:9:9
    │
  9 │         my_array[4] = 9
-   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
 10 │         let sum: u256 = 0
-   │                         ^ u256: Value => None
+   │                         ^ u256: Value
 11 │         for i in my_array:
-   │                  ^^^^^^^^ Array<u256, 5>: Memory => None
+   │                  ^^^^^^^^ Array<u256, 5>: Memory
 12 │             if i % 2 == 0:
-   │                ^   ^ u256: Value => None
+   │                ^   ^ u256: Value
    │                │    
-   │                u256: Value => None
+   │                u256: Value
 
 note: 
    ┌─ features/for_loop_with_continue.fe:12:16
    │
 12 │             if i % 2 == 0:
-   │                ^^^^^    ^ u256: Value => None
+   │                ^^^^^    ^ u256: Value
    │                │         
-   │                u256: Value => None
+   │                u256: Value
 
 note: 
    ┌─ features/for_loop_with_continue.fe:12:16
    │
 12 │             if i % 2 == 0:
-   │                ^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^ bool: Value
 13 │                 continue
 14 │             sum = sum + i
-   │             ^^^   ^^^   ^ u256: Value => None
+   │             ^^^   ^^^   ^ u256: Value
    │             │     │      
-   │             │     u256: Value => None
-   │             u256: Value => None
+   │             │     u256: Value
+   │             u256: Value
 
 note: 
    ┌─ features/for_loop_with_continue.fe:14:19
    │
 14 │             sum = sum + i
-   │                   ^^^^^^^ u256: Value => None
+   │                   ^^^^^^^ u256: Value
 15 │         return sum
-   │                ^^^ u256: Value => None
+   │                ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/for_loop_with_continue.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -28,207 +28,112 @@ note:
      }
 
 note: 
-  ┌─ features/for_loop_with_continue.fe:5:9
-  │
-5 │         my_array[0] = 2
-  │         ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:5:18
-  │
-5 │         my_array[0] = 2
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:5:9
-  │
-5 │         my_array[0] = 2
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:5:23
-  │
-5 │         my_array[0] = 2
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:6:9
-  │
-6 │         my_array[1] = 3
-  │         ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:6:18
-  │
-6 │         my_array[1] = 3
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:6:9
-  │
-6 │         my_array[1] = 3
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:6:23
-  │
-6 │         my_array[1] = 3
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:7:9
-  │
-7 │         my_array[2] = 5
-  │         ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:7:18
-  │
-7 │         my_array[2] = 5
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:7:9
-  │
-7 │         my_array[2] = 5
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:7:23
-  │
-7 │         my_array[2] = 5
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:8:9
-  │
-8 │         my_array[3] = 6
-  │         ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:8:18
-  │
-8 │         my_array[3] = 6
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:8:9
-  │
-8 │         my_array[3] = 6
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:8:23
-  │
-8 │         my_array[3] = 6
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:9:9
-  │
-9 │         my_array[4] = 9
-  │         ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:9:18
-  │
-9 │         my_array[4] = 9
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:9:9
-  │
-9 │         my_array[4] = 9
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:9:23
-  │
-9 │         my_array[4] = 9
-  │                       ^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:10:25
+   ┌─ features/for_loop_with_continue.fe:4:23
    │
+ 4 │         let my_array: Array<u256, 5>
+   │                       ^^^^^^^^^^^^^^ Array<u256, 5>
+   ·
+10 │         let sum: u256 = 0
+   │                  ^^^^ u256
+
+note: 
+  ┌─ features/for_loop_with_continue.fe:5:9
+  │
+5 │         my_array[0] = 2
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 5>: Memory => None
+
+note: 
+  ┌─ features/for_loop_with_continue.fe:5:9
+  │
+5 │         my_array[0] = 2
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+6 │         my_array[1] = 3
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 5>: Memory => None
+
+note: 
+  ┌─ features/for_loop_with_continue.fe:6:9
+  │
+6 │         my_array[1] = 3
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+7 │         my_array[2] = 5
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 5>: Memory => None
+
+note: 
+  ┌─ features/for_loop_with_continue.fe:7:9
+  │
+7 │         my_array[2] = 5
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+8 │         my_array[3] = 6
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 5>: Memory => None
+
+note: 
+  ┌─ features/for_loop_with_continue.fe:8:9
+  │
+8 │         my_array[3] = 6
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+9 │         my_array[4] = 9
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 5>: Memory => None
+
+note: 
+   ┌─ features/for_loop_with_continue.fe:9:9
+   │
+ 9 │         my_array[4] = 9
+   │         ^^^^^^^^^^^   ^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
 10 │         let sum: u256 = 0
    │                         ^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:11:18
-   │
 11 │         for i in my_array:
    │                  ^^^^^^^^ Array<u256, 5>: Memory => None
+12 │             if i % 2 == 0:
+   │                ^   ^ u256: Value => None
+   │                │    
+   │                u256: Value => None
 
 note: 
    ┌─ features/for_loop_with_continue.fe:12:16
    │
 12 │             if i % 2 == 0:
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:12:20
-   │
-12 │             if i % 2 == 0:
-   │                    ^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:12:16
-   │
-12 │             if i % 2 == 0:
-   │                ^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:12:25
-   │
-12 │             if i % 2 == 0:
-   │                         ^ u256: Value => None
+   │                ^^^^^    ^ u256: Value => None
+   │                │         
+   │                u256: Value => None
 
 note: 
    ┌─ features/for_loop_with_continue.fe:12:16
    │
 12 │             if i % 2 == 0:
    │                ^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:14:13
-   │
+13 │                 continue
 14 │             sum = sum + i
-   │             ^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:14:19
-   │
-14 │             sum = sum + i
-   │                   ^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:14:25
-   │
-14 │             sum = sum + i
-   │                         ^ u256: Value => None
+   │             ^^^   ^^^   ^ u256: Value => None
+   │             │     │      
+   │             │     u256: Value => None
+   │             u256: Value => None
 
 note: 
    ┌─ features/for_loop_with_continue.fe:14:19
    │
 14 │             sum = sum + i
    │                   ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:15:16
-   │
 15 │         return sum
    │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_continue.fe:4:23
-  │
-4 │         let my_array: Array<u256, 5>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 5>
-
-note: 
-   ┌─ features/for_loop_with_continue.fe:10:18
-   │
-10 │         let sum: u256 = 0
-   │                  ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
@@ -40,57 +40,57 @@ note:
   ┌─ features/for_loop_with_static_array.fe:5:9
   │
 5 │         my_array[0] = 5
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/for_loop_with_static_array.fe:5:9
   │
 5 │         my_array[0] = 5
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 6 │         my_array[1] = 10
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/for_loop_with_static_array.fe:6:9
   │
 6 │         my_array[1] = 10
-  │         ^^^^^^^^^^^   ^^ u256: Value => None
+  │         ^^^^^^^^^^^   ^^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 7 │         my_array[2] = 15
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
    ┌─ features/for_loop_with_static_array.fe:7:9
    │
  7 │         my_array[2] = 15
-   │         ^^^^^^^^^^^   ^^ u256: Value => None
+   │         ^^^^^^^^^^^   ^^ u256: Value
    │         │              
-   │         u256: Memory => None
+   │         u256: Memory
  8 │         let sum: u256 = 0
-   │                         ^ u256: Value => None
+   │                         ^ u256: Value
  9 │         for i in my_array:
-   │                  ^^^^^^^^ Array<u256, 3>: Memory => None
+   │                  ^^^^^^^^ Array<u256, 3>: Memory
 10 │             sum = sum + i
-   │             ^^^   ^^^   ^ u256: Value => None
+   │             ^^^   ^^^   ^ u256: Value
    │             │     │      
-   │             │     u256: Value => None
-   │             u256: Value => None
+   │             │     u256: Value
+   │             u256: Value
 
 note: 
    ┌─ features/for_loop_with_static_array.fe:10:19
    │
 10 │             sum = sum + i
-   │                   ^^^^^^^ u256: Value => None
+   │                   ^^^^^^^ u256: Value
 11 │         return sum
-   │                ^^^ u256: Value => None
+   │                ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/for_loop_with_static_array.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -28,129 +28,69 @@ note:
      }
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:5:9
+  ┌─ features/for_loop_with_static_array.fe:4:23
   │
-5 │         my_array[0] = 5
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:5:18
-  │
-5 │         my_array[0] = 5
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:5:9
-  │
-5 │         my_array[0] = 5
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:5:23
-  │
-5 │         my_array[0] = 5
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:6:9
-  │
-6 │         my_array[1] = 10
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:6:18
-  │
-6 │         my_array[1] = 10
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:6:9
-  │
-6 │         my_array[1] = 10
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:6:23
-  │
-6 │         my_array[1] = 10
-  │                       ^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:7:9
-  │
-7 │         my_array[2] = 15
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:7:18
-  │
-7 │         my_array[2] = 15
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:7:9
-  │
-7 │         my_array[2] = 15
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:7:23
-  │
-7 │         my_array[2] = 15
-  │                       ^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:8:25
-  │
+4 │         let my_array: Array<u256, 3>
+  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+  ·
 8 │         let sum: u256 = 0
-  │                         ^ u256: Value => None
+  │                  ^^^^ u256
 
 note: 
-  ┌─ features/for_loop_with_static_array.fe:9:18
+  ┌─ features/for_loop_with_static_array.fe:5:9
   │
-9 │         for i in my_array:
-  │                  ^^^^^^^^ Array<u256, 3>: Memory => None
+5 │         my_array[0] = 5
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
 
 note: 
-   ┌─ features/for_loop_with_static_array.fe:10:13
-   │
-10 │             sum = sum + i
-   │             ^^^ u256: Value => None
+  ┌─ features/for_loop_with_static_array.fe:5:9
+  │
+5 │         my_array[0] = 5
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+6 │         my_array[1] = 10
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
 
 note: 
-   ┌─ features/for_loop_with_static_array.fe:10:19
-   │
-10 │             sum = sum + i
-   │                   ^^^ u256: Value => None
+  ┌─ features/for_loop_with_static_array.fe:6:9
+  │
+6 │         my_array[1] = 10
+  │         ^^^^^^^^^^^   ^^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+7 │         my_array[2] = 15
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
 
 note: 
-   ┌─ features/for_loop_with_static_array.fe:10:25
+   ┌─ features/for_loop_with_static_array.fe:7:9
    │
-10 │             sum = sum + i
+ 7 │         my_array[2] = 15
+   │         ^^^^^^^^^^^   ^^ u256: Value => None
+   │         │              
+   │         u256: Memory => None
+ 8 │         let sum: u256 = 0
    │                         ^ u256: Value => None
+ 9 │         for i in my_array:
+   │                  ^^^^^^^^ Array<u256, 3>: Memory => None
+10 │             sum = sum + i
+   │             ^^^   ^^^   ^ u256: Value => None
+   │             │     │      
+   │             │     u256: Value => None
+   │             u256: Value => None
 
 note: 
    ┌─ features/for_loop_with_static_array.fe:10:19
    │
 10 │             sum = sum + i
    │                   ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/for_loop_with_static_array.fe:11:16
-   │
 11 │         return sum
    │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:4:23
-  │
-4 │         let my_array: Array<u256, 3>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
-
-note: 
-  ┌─ features/for_loop_with_static_array.fe:8:18
-  │
-8 │         let sum: u256 = 0
-  │                  ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -48,6 +48,48 @@ note:
      }
 
 note: 
+   ┌─ demos/guest_book.fe:13:9
+   │
+13 │         self.messages[msg.sender] = book_msg
+   │         ^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │         │              
+   │         Map<address, String<100>>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/guest_book.fe:13:9
+   │
+13 │         self.messages[msg.sender] = book_msg
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ String<100>: Memory => None
+   │         │                            
+   │         String<100>: Storage { nonce: None } => None
+   ·
+16 │         emit Signed(book_msg=book_msg)
+   │                              ^^^^^^^^ String<100>: Memory => None
+
+note: 
+   ┌─ demos/guest_book.fe:16:9
+   │
+16 │         emit Signed(book_msg=book_msg)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3840771212935086148
+   │
+   = Event {
+         name: "Signed",
+         fields: [
+             EventField {
+                 name: "book_msg",
+                 typ: Ok(
+                     String(
+                         FeString {
+                             max_size: 100,
+                         },
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
    ┌─ demos/guest_book.fe:18:5
    │  
 18 │ ╭     pub fn get_msg(self, addr: address) -> String<100>:
@@ -78,46 +120,12 @@ note:
      }
 
 note: 
-   ┌─ demos/guest_book.fe:13:9
-   │
-13 │         self.messages[msg.sender] = book_msg
-   │         ^^^^^^^^^^^^^ Map<address, String<100>>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/guest_book.fe:13:23
-   │
-13 │         self.messages[msg.sender] = book_msg
-   │                       ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/guest_book.fe:13:9
-   │
-13 │         self.messages[msg.sender] = book_msg
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/guest_book.fe:13:37
-   │
-13 │         self.messages[msg.sender] = book_msg
-   │                                     ^^^^^^^^ String<100>: Memory => None
-
-note: 
-   ┌─ demos/guest_book.fe:16:30
-   │
-16 │         emit Signed(book_msg=book_msg)
-   │                              ^^^^^^^^ String<100>: Memory => None
-
-note: 
    ┌─ demos/guest_book.fe:21:16
    │
 21 │         return self.messages[addr].to_mem()
-   │                ^^^^^^^^^^^^^ Map<address, String<100>>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/guest_book.fe:21:30
-   │
-21 │         return self.messages[addr].to_mem()
-   │                              ^^^^ address: Value => None
+   │                ^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │                │              
+   │                Map<address, String<100>>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ demos/guest_book.fe:21:16
@@ -130,29 +138,6 @@ note:
    │
 21 │         return self.messages[addr].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => Some(Memory)
-
-note: 
-   ┌─ demos/guest_book.fe:16:9
-   │
-16 │         emit Signed(book_msg=book_msg)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3840771212935086148
-   │
-   = Event {
-         name: "Signed",
-         fields: [
-             EventField {
-                 name: "book_msg",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
 
 note: 
    ┌─ demos/guest_book.fe:21:16

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -24,10 +24,12 @@ note:
 14 │ │ 
 15 │ │         # Emit the `Signed` event
 16 │ │         emit Signed(book_msg=book_msg)
-   │ ╰──────────────────────────────────────^ attributes hash: 726352713514806227
+   │ ╰──────────────────────────────────────^ attributes hash: 13094560277149760495
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "book_msg",
@@ -51,20 +53,26 @@ note:
    ┌─ demos/guest_book.fe:13:9
    │
 13 │         self.messages[msg.sender] = book_msg
-   │         ^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
-   │         │              
-   │         Map<address, String<100>>: Storage { nonce: Some(0) } => None
+   │         ^^^^ GuestBook: Value
 
 note: 
    ┌─ demos/guest_book.fe:13:9
    │
 13 │         self.messages[msg.sender] = book_msg
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ String<100>: Memory => None
+   │         ^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
+   │         │              
+   │         Map<address, String<100>>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/guest_book.fe:13:9
+   │
+13 │         self.messages[msg.sender] = book_msg
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ String<100>: Memory
    │         │                            
-   │         String<100>: Storage { nonce: None } => None
+   │         String<100>: Storage { nonce: None }
    ·
 16 │         emit Signed(book_msg=book_msg)
-   │                              ^^^^^^^^ String<100>: Memory => None
+   │                              ^^^^^^^^ String<100>: Memory
 
 note: 
    ┌─ demos/guest_book.fe:16:9
@@ -96,10 +104,12 @@ note:
 19 │ │         # Copying data from storage to memory
 20 │ │         # has to be done explicitly via `to_mem()`
 21 │ │         return self.messages[addr].to_mem()
-   │ ╰───────────────────────────────────────────^ attributes hash: 13118977016650692130
+   │ ╰───────────────────────────────────────────^ attributes hash: 9675466326050585910
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "addr",
@@ -123,28 +133,32 @@ note:
    ┌─ demos/guest_book.fe:21:16
    │
 21 │         return self.messages[addr].to_mem()
-   │                ^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │                ^^^^ GuestBook: Value
+
+note: 
+   ┌─ demos/guest_book.fe:21:16
+   │
+21 │         return self.messages[addr].to_mem()
+   │                ^^^^^^^^^^^^^ ^^^^ address: Value
    │                │              
-   │                Map<address, String<100>>: Storage { nonce: Some(0) } => None
+   │                Map<address, String<100>>: Storage { nonce: Some(0) }
 
 note: 
    ┌─ demos/guest_book.fe:21:16
    │
 21 │         return self.messages[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => None
+   │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None }
 
 note: 
    ┌─ demos/guest_book.fe:21:16
    │
 21 │         return self.messages[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => Some(Memory)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => Memory
 
 note: 
    ┌─ demos/guest_book.fe:21:16
    │
 21 │         return self.messages[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__if_statement.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement.snap
@@ -40,29 +40,18 @@ note:
   ┌─ features/if_statement.fe:4:12
   │
 4 │         if input > 5:
-  │            ^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement.fe:4:20
-  │
-4 │         if input > 5:
-  │                    ^ u256: Value => None
+  │            ^^^^^   ^ u256: Value => None
+  │            │        
+  │            u256: Value => None
 
 note: 
   ┌─ features/if_statement.fe:4:12
   │
 4 │         if input > 5:
   │            ^^^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/if_statement.fe:5:20
-  │
 5 │             return 1
   │                    ^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement.fe:7:20
-  │
+6 │         else:
 7 │             return 0
   │                    ^ u256: Value => None
 

--- a/crates/analyzer/tests/snapshots/analysis__if_statement.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement.snap
@@ -40,19 +40,19 @@ note:
   ┌─ features/if_statement.fe:4:12
   │
 4 │         if input > 5:
-  │            ^^^^^   ^ u256: Value => None
+  │            ^^^^^   ^ u256: Value
   │            │        
-  │            u256: Value => None
+  │            u256: Value
 
 note: 
   ┌─ features/if_statement.fe:4:12
   │
 4 │         if input > 5:
-  │            ^^^^^^^^^ bool: Value => None
+  │            ^^^^^^^^^ bool: Value
 5 │             return 1
-  │                    ^ u256: Value => None
+  │                    ^ u256: Value
 6 │         else:
 7 │             return 0
-  │                    ^ u256: Value => None
+  │                    ^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
@@ -42,35 +42,21 @@ note:
   ┌─ features/if_statement_2.fe:4:12
   │
 4 │         if val > 5:
-  │            ^^^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement_2.fe:4:18
-  │
-4 │         if val > 5:
-  │                  ^ u256: Value => None
+  │            ^^^   ^ u256: Value => None
+  │            │      
+  │            u256: Value => None
 
 note: 
   ┌─ features/if_statement_2.fe:4:12
   │
 4 │         if val > 5:
   │            ^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/if_statement_2.fe:5:20
-  │
 5 │             return 1
   │                    ^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement_2.fe:7:20
-  │
+6 │         else:
 7 │             assert true
   │                    ^^^^ bool: Value => None
-
-note: 
-  ┌─ features/if_statement_2.fe:9:16
-  │
+8 │ 
 9 │         return 0
   │                ^ u256: Value => None
 

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
@@ -42,22 +42,22 @@ note:
   ┌─ features/if_statement_2.fe:4:12
   │
 4 │         if val > 5:
-  │            ^^^   ^ u256: Value => None
+  │            ^^^   ^ u256: Value
   │            │      
-  │            u256: Value => None
+  │            u256: Value
 
 note: 
   ┌─ features/if_statement_2.fe:4:12
   │
 4 │         if val > 5:
-  │            ^^^^^^^ bool: Value => None
+  │            ^^^^^^^ bool: Value
 5 │             return 1
-  │                    ^ u256: Value => None
+  │                    ^ u256: Value
 6 │         else:
 7 │             assert true
-  │                    ^^^^ bool: Value => None
+  │                    ^^^^ bool: Value
 8 │ 
 9 │         return 0
-  │                ^ u256: Value => None
+  │                ^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
@@ -28,45 +28,27 @@ note:
     }
 
 note: 
-  ┌─ features/if_statement_with_block_declaration.fe:4:12
-  │
-4 │         if true:
-  │            ^^^^ bool: Value => None
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:5:27
-  │
-5 │             let y: u256 = 1
-  │                           ^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:6:20
-  │
-6 │             return y
-  │                    ^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:8:27
-  │
-8 │             let y: u256 = 1
-  │                           ^ u256: Value => None
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:9:20
-  │
-9 │             return y
-  │                    ^ u256: Value => None
-
-note: 
   ┌─ features/if_statement_with_block_declaration.fe:5:20
   │
 5 │             let y: u256 = 1
   │                    ^^^^ u256
-
-note: 
-  ┌─ features/if_statement_with_block_declaration.fe:8:20
-  │
+  ·
 8 │             let y: u256 = 1
   │                    ^^^^ u256
+
+note: 
+  ┌─ features/if_statement_with_block_declaration.fe:4:12
+  │
+4 │         if true:
+  │            ^^^^ bool: Value => None
+5 │             let y: u256 = 1
+  │                           ^ u256: Value => None
+6 │             return y
+  │                    ^ u256: Value => None
+7 │         else:
+8 │             let y: u256 = 1
+  │                           ^ u256: Value => None
+9 │             return y
+  │                    ^ u256: Value => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
@@ -40,15 +40,15 @@ note:
   ┌─ features/if_statement_with_block_declaration.fe:4:12
   │
 4 │         if true:
-  │            ^^^^ bool: Value => None
+  │            ^^^^ bool: Value
 5 │             let y: u256 = 1
-  │                           ^ u256: Value => None
+  │                           ^ u256: Value
 6 │             return y
-  │                    ^ u256: Value => None
+  │                    ^ u256: Value
 7 │         else:
 8 │             let y: u256 = 1
-  │                           ^ u256: Value => None
+  │                           ^ u256: Value
 9 │             return y
-  │                    ^ u256: Value => None
+  │                    ^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -40,23 +40,19 @@ note:
   ┌─ features/keccak.fe:4:26
   │
 4 │         return keccak256(val)
-  │                          ^^^ Array<u8, 1>: Memory => None
+  │                          ^^^ Array<u8, 1>: Memory
 
 note: 
   ┌─ features/keccak.fe:4:16
   │
 4 │         return keccak256(val)
-  │                ^^^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/keccak.fe:4:16
   │
 4 │         return keccak256(val)
-  │                ^^^^^^^^^ attributes hash: 3985281278010092305
-  │
-  = BuiltinFunction(
-        Keccak256,
-    )
+  │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 note: 
   ┌─ features/keccak.fe:6:5
@@ -95,23 +91,19 @@ note:
   ┌─ features/keccak.fe:7:26
   │
 7 │         return keccak256(val)
-  │                          ^^^ Array<u8, 3>: Memory => None
+  │                          ^^^ Array<u8, 3>: Memory
 
 note: 
   ┌─ features/keccak.fe:7:16
   │
 7 │         return keccak256(val)
-  │                ^^^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/keccak.fe:7:16
   │
 7 │         return keccak256(val)
-  │                ^^^^^^^^^ attributes hash: 3985281278010092305
-  │
-  = BuiltinFunction(
-        Keccak256,
-    )
+  │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 note: 
    ┌─ features/keccak.fe:9:5
@@ -150,22 +142,18 @@ note:
    ┌─ features/keccak.fe:10:26
    │
 10 │         return keccak256(val)
-   │                          ^^^ Array<u8, 32>: Memory => None
+   │                          ^^^ Array<u8, 32>: Memory
 
 note: 
    ┌─ features/keccak.fe:10:16
    │
 10 │         return keccak256(val)
-   │                ^^^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/keccak.fe:10:16
    │
 10 │         return keccak256(val)
-   │                ^^^^^^^^^ attributes hash: 3985281278010092305
-   │
-   = BuiltinFunction(
-         Keccak256,
-     )
+   │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/keccak.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -37,6 +37,28 @@ note:
     }
 
 note: 
+  ┌─ features/keccak.fe:4:26
+  │
+4 │         return keccak256(val)
+  │                          ^^^ Array<u8, 1>: Memory => None
+
+note: 
+  ┌─ features/keccak.fe:4:16
+  │
+4 │         return keccak256(val)
+  │                ^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+  ┌─ features/keccak.fe:4:16
+  │
+4 │         return keccak256(val)
+  │                ^^^^^^^^^ attributes hash: 3985281278010092305
+  │
+  = BuiltinFunction(
+        Keccak256,
+    )
+
+note: 
   ┌─ features/keccak.fe:6:5
   │  
 6 │ ╭     pub fn return_hash_from_foo(val: Array<u8, 3>) -> u256:
@@ -68,6 +90,28 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/keccak.fe:7:26
+  │
+7 │         return keccak256(val)
+  │                          ^^^ Array<u8, 3>: Memory => None
+
+note: 
+  ┌─ features/keccak.fe:7:16
+  │
+7 │         return keccak256(val)
+  │                ^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+  ┌─ features/keccak.fe:7:16
+  │
+7 │         return keccak256(val)
+  │                ^^^^^^^^^ attributes hash: 3985281278010092305
+  │
+  = BuiltinFunction(
+        Keccak256,
+    )
 
 note: 
    ┌─ features/keccak.fe:9:5
@@ -103,30 +147,6 @@ note:
      }
 
 note: 
-  ┌─ features/keccak.fe:4:26
-  │
-4 │         return keccak256(val)
-  │                          ^^^ Array<u8, 1>: Memory => None
-
-note: 
-  ┌─ features/keccak.fe:4:16
-  │
-4 │         return keccak256(val)
-  │                ^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/keccak.fe:7:26
-  │
-7 │         return keccak256(val)
-  │                          ^^^ Array<u8, 3>: Memory => None
-
-note: 
-  ┌─ features/keccak.fe:7:16
-  │
-7 │         return keccak256(val)
-  │                ^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
    ┌─ features/keccak.fe:10:26
    │
 10 │         return keccak256(val)
@@ -137,26 +157,6 @@ note:
    │
 10 │         return keccak256(val)
    │                ^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/keccak.fe:4:16
-  │
-4 │         return keccak256(val)
-  │                ^^^^^^^^^ attributes hash: 3985281278010092305
-  │
-  = BuiltinFunction(
-        Keccak256,
-    )
-
-note: 
-  ┌─ features/keccak.fe:7:16
-  │
-7 │         return keccak256(val)
-  │                ^^^^^^^^^ attributes hash: 3985281278010092305
-  │
-  = BuiltinFunction(
-        Keccak256,
-    )
 
 note: 
    ┌─ features/keccak.fe:10:16

--- a/crates/analyzer/tests/snapshots/analysis__math.snap
+++ b/crates/analyzer/tests/snapshots/analysis__math.snap
@@ -51,94 +51,94 @@ note:
   ┌─ features/math.fe:6:13
   │
 6 │         if (val > 3):
-  │             ^^^   ^ u256: Value => None
+  │             ^^^   ^ u256: Value
   │             │      
-  │             u256: Value => None
+  │             u256: Value
 
 note: 
   ┌─ features/math.fe:6:12
   │
 6 │         if (val > 3):
-  │            ^^^^^^^^^ bool: Value => None
+  │            ^^^^^^^^^ bool: Value
 7 │             z = val
-  │             ^   ^^^ u256: Value => None
+  │             ^   ^^^ u256: Value
   │             │    
-  │             u256: Value => None
+  │             u256: Value
 8 │             let x: u256 = val / 2 + 1
-  │                           ^^^   ^ u256: Value => None
+  │                           ^^^   ^ u256: Value
   │                           │      
-  │                           u256: Value => None
+  │                           u256: Value
 
 note: 
   ┌─ features/math.fe:8:27
   │
 8 │             let x: u256 = val / 2 + 1
-  │                           ^^^^^^^   ^ u256: Value => None
+  │                           ^^^^^^^   ^ u256: Value
   │                           │          
-  │                           u256: Value => None
+  │                           u256: Value
 
 note: 
   ┌─ features/math.fe:8:27
   │
 8 │             let x: u256 = val / 2 + 1
-  │                           ^^^^^^^^^^^ u256: Value => None
+  │                           ^^^^^^^^^^^ u256: Value
 9 │             while (x < z):
-  │                    ^   ^ u256: Value => None
+  │                    ^   ^ u256: Value
   │                    │    
-  │                    u256: Value => None
+  │                    u256: Value
 
 note: 
    ┌─ features/math.fe:9:19
    │
  9 │             while (x < z):
-   │                   ^^^^^^^ bool: Value => None
+   │                   ^^^^^^^ bool: Value
 10 │                 z = x
-   │                 ^   ^ u256: Value => None
+   │                 ^   ^ u256: Value
    │                 │    
-   │                 u256: Value => None
+   │                 u256: Value
 11 │                 x = (val / x + x) / 2
-   │                 ^    ^^^   ^ u256: Value => None
+   │                 ^    ^^^   ^ u256: Value
    │                 │    │      
-   │                 │    u256: Value => None
-   │                 u256: Value => None
+   │                 │    u256: Value
+   │                 u256: Value
 
 note: 
    ┌─ features/math.fe:11:22
    │
 11 │                 x = (val / x + x) / 2
-   │                      ^^^^^^^   ^ u256: Value => None
+   │                      ^^^^^^^   ^ u256: Value
    │                      │          
-   │                      u256: Value => None
+   │                      u256: Value
 
 note: 
    ┌─ features/math.fe:11:21
    │
 11 │                 x = (val / x + x) / 2
-   │                     ^^^^^^^^^^^^^   ^ u256: Value => None
+   │                     ^^^^^^^^^^^^^   ^ u256: Value
    │                     │                
-   │                     u256: Value => None
+   │                     u256: Value
 
 note: 
    ┌─ features/math.fe:11:21
    │
 11 │                 x = (val / x + x) / 2
-   │                     ^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                     ^^^^^^^^^^^^^^^^^ u256: Value
 12 │         elif (val != 0):
-   │               ^^^    ^ u256: Value => None
+   │               ^^^    ^ u256: Value
    │               │       
-   │               u256: Value => None
+   │               u256: Value
 
 note: 
    ┌─ features/math.fe:12:14
    │
 12 │         elif (val != 0):
-   │              ^^^^^^^^^^ bool: Value => None
+   │              ^^^^^^^^^^ bool: Value
 13 │             z = 1
-   │             ^   ^ u256: Value => None
+   │             ^   ^ u256: Value
    │             │    
-   │             u256: Value => None
+   │             u256: Value
 14 │         return z
-   │                ^ u256: Value => None
+   │                ^ u256: Value
 
 note: 
    ┌─ features/math.fe:16:5
@@ -184,23 +184,23 @@ note:
    ┌─ features/math.fe:17:21
    │
 17 │         return x if x < y else y
-   │                     ^   ^ u256: Value => None
+   │                     ^   ^ u256: Value
    │                     │    
-   │                     u256: Value => None
+   │                     u256: Value
 
 note: 
    ┌─ features/math.fe:17:16
    │
 17 │         return x if x < y else y
-   │                ^    ^^^^^      ^ u256: Value => None
+   │                ^    ^^^^^      ^ u256: Value
    │                │    │           
-   │                │    bool: Value => None
-   │                u256: Value => None
+   │                │    bool: Value
+   │                u256: Value
 
 note: 
    ┌─ features/math.fe:17:16
    │
 17 │         return x if x < y else y
-   │                ^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__math.snap
+++ b/crates/analyzer/tests/snapshots/analysis__math.snap
@@ -39,6 +39,108 @@ note:
      }
 
 note: 
+  ┌─ features/math.fe:5:16
+  │
+5 │         let z: u256
+  │                ^^^^ u256
+  ·
+8 │             let x: u256 = val / 2 + 1
+  │                    ^^^^ u256
+
+note: 
+  ┌─ features/math.fe:6:13
+  │
+6 │         if (val > 3):
+  │             ^^^   ^ u256: Value => None
+  │             │      
+  │             u256: Value => None
+
+note: 
+  ┌─ features/math.fe:6:12
+  │
+6 │         if (val > 3):
+  │            ^^^^^^^^^ bool: Value => None
+7 │             z = val
+  │             ^   ^^^ u256: Value => None
+  │             │    
+  │             u256: Value => None
+8 │             let x: u256 = val / 2 + 1
+  │                           ^^^   ^ u256: Value => None
+  │                           │      
+  │                           u256: Value => None
+
+note: 
+  ┌─ features/math.fe:8:27
+  │
+8 │             let x: u256 = val / 2 + 1
+  │                           ^^^^^^^   ^ u256: Value => None
+  │                           │          
+  │                           u256: Value => None
+
+note: 
+  ┌─ features/math.fe:8:27
+  │
+8 │             let x: u256 = val / 2 + 1
+  │                           ^^^^^^^^^^^ u256: Value => None
+9 │             while (x < z):
+  │                    ^   ^ u256: Value => None
+  │                    │    
+  │                    u256: Value => None
+
+note: 
+   ┌─ features/math.fe:9:19
+   │
+ 9 │             while (x < z):
+   │                   ^^^^^^^ bool: Value => None
+10 │                 z = x
+   │                 ^   ^ u256: Value => None
+   │                 │    
+   │                 u256: Value => None
+11 │                 x = (val / x + x) / 2
+   │                 ^    ^^^   ^ u256: Value => None
+   │                 │    │      
+   │                 │    u256: Value => None
+   │                 u256: Value => None
+
+note: 
+   ┌─ features/math.fe:11:22
+   │
+11 │                 x = (val / x + x) / 2
+   │                      ^^^^^^^   ^ u256: Value => None
+   │                      │          
+   │                      u256: Value => None
+
+note: 
+   ┌─ features/math.fe:11:21
+   │
+11 │                 x = (val / x + x) / 2
+   │                     ^^^^^^^^^^^^^   ^ u256: Value => None
+   │                     │                
+   │                     u256: Value => None
+
+note: 
+   ┌─ features/math.fe:11:21
+   │
+11 │                 x = (val / x + x) / 2
+   │                     ^^^^^^^^^^^^^^^^^ u256: Value => None
+12 │         elif (val != 0):
+   │               ^^^    ^ u256: Value => None
+   │               │       
+   │               u256: Value => None
+
+note: 
+   ┌─ features/math.fe:12:14
+   │
+12 │         elif (val != 0):
+   │              ^^^^^^^^^^ bool: Value => None
+13 │             z = 1
+   │             ^   ^ u256: Value => None
+   │             │    
+   │             u256: Value => None
+14 │         return z
+   │                ^ u256: Value => None
+
+note: 
    ┌─ features/math.fe:16:5
    │  
 16 │ ╭     pub fn min(x: u256, y: u256) -> u256:
@@ -79,225 +181,26 @@ note:
      }
 
 note: 
-  ┌─ features/math.fe:6:13
-  │
-6 │         if (val > 3):
-  │             ^^^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:6:19
-  │
-6 │         if (val > 3):
-  │                   ^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:6:12
-  │
-6 │         if (val > 3):
-  │            ^^^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/math.fe:7:13
-  │
-7 │             z = val
-  │             ^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:7:17
-  │
-7 │             z = val
-  │                 ^^^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:8:27
-  │
-8 │             let x: u256 = val / 2 + 1
-  │                           ^^^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:8:33
-  │
-8 │             let x: u256 = val / 2 + 1
-  │                                 ^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:8:27
-  │
-8 │             let x: u256 = val / 2 + 1
-  │                           ^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:8:37
-  │
-8 │             let x: u256 = val / 2 + 1
-  │                                     ^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:8:27
-  │
-8 │             let x: u256 = val / 2 + 1
-  │                           ^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:9:20
-  │
-9 │             while (x < z):
-  │                    ^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:9:24
-  │
-9 │             while (x < z):
-  │                        ^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:9:19
-  │
-9 │             while (x < z):
-  │                   ^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/math.fe:10:17
-   │
-10 │                 z = x
-   │                 ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:10:21
-   │
-10 │                 z = x
-   │                     ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:17
-   │
-11 │                 x = (val / x + x) / 2
-   │                 ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:22
-   │
-11 │                 x = (val / x + x) / 2
-   │                      ^^^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:28
-   │
-11 │                 x = (val / x + x) / 2
-   │                            ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:22
-   │
-11 │                 x = (val / x + x) / 2
-   │                      ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:32
-   │
-11 │                 x = (val / x + x) / 2
-   │                                ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:21
-   │
-11 │                 x = (val / x + x) / 2
-   │                     ^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:37
-   │
-11 │                 x = (val / x + x) / 2
-   │                                     ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:11:21
-   │
-11 │                 x = (val / x + x) / 2
-   │                     ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:12:15
-   │
-12 │         elif (val != 0):
-   │               ^^^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:12:22
-   │
-12 │         elif (val != 0):
-   │                      ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:12:14
-   │
-12 │         elif (val != 0):
-   │              ^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/math.fe:13:13
-   │
-13 │             z = 1
-   │             ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:13:17
-   │
-13 │             z = 1
-   │                 ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:14:16
-   │
-14 │         return z
-   │                ^ u256: Value => None
-
-note: 
    ┌─ features/math.fe:17:21
    │
 17 │         return x if x < y else y
-   │                     ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:17:25
-   │
-17 │         return x if x < y else y
-   │                         ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:17:21
-   │
-17 │         return x if x < y else y
-   │                     ^^^^^ bool: Value => None
+   │                     ^   ^ u256: Value => None
+   │                     │    
+   │                     u256: Value => None
 
 note: 
    ┌─ features/math.fe:17:16
    │
 17 │         return x if x < y else y
-   │                ^ u256: Value => None
-
-note: 
-   ┌─ features/math.fe:17:32
-   │
-17 │         return x if x < y else y
-   │                                ^ u256: Value => None
+   │                ^    ^^^^^      ^ u256: Value => None
+   │                │    │           
+   │                │    bool: Value => None
+   │                u256: Value => None
 
 note: 
    ┌─ features/math.fe:17:16
    │
 17 │         return x if x < y else y
    │                ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/math.fe:5:16
-  │
-5 │         let z: u256
-  │                ^^^^ u256
-
-note: 
-  ┌─ features/math.fe:8:20
-  │
-8 │             let x: u256 = val / 2 + 1
-  │                    ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/multi_param.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -61,87 +61,51 @@ note:
     }
 
 note: 
-  ┌─ features/multi_param.fe:4:9
-  │
-4 │         my_array[0] = x
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/multi_param.fe:4:18
-  │
-4 │         my_array[0] = x
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/multi_param.fe:4:9
-  │
-4 │         my_array[0] = x
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/multi_param.fe:4:23
-  │
-4 │         my_array[0] = x
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/multi_param.fe:5:9
-  │
-5 │         my_array[1] = y
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/multi_param.fe:5:18
-  │
-5 │         my_array[1] = y
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/multi_param.fe:5:9
-  │
-5 │         my_array[1] = y
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/multi_param.fe:5:23
-  │
-5 │         my_array[1] = y
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/multi_param.fe:6:9
-  │
-6 │         my_array[2] = z
-  │         ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
-  ┌─ features/multi_param.fe:6:18
-  │
-6 │         my_array[2] = z
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/multi_param.fe:6:9
-  │
-6 │         my_array[2] = z
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/multi_param.fe:6:23
-  │
-6 │         my_array[2] = z
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/multi_param.fe:7:16
-  │
-7 │         return my_array
-  │                ^^^^^^^^ Array<u256, 3>: Memory => None
-
-note: 
   ┌─ features/multi_param.fe:3:23
   │
 3 │         let my_array: Array<u256, 3>
   │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+
+note: 
+  ┌─ features/multi_param.fe:4:9
+  │
+4 │         my_array[0] = x
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
+
+note: 
+  ┌─ features/multi_param.fe:4:9
+  │
+4 │         my_array[0] = x
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+5 │         my_array[1] = y
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
+
+note: 
+  ┌─ features/multi_param.fe:5:9
+  │
+5 │         my_array[1] = y
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+6 │         my_array[2] = z
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 3>: Memory => None
+
+note: 
+  ┌─ features/multi_param.fe:6:9
+  │
+6 │         my_array[2] = z
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+7 │         return my_array
+  │                ^^^^^^^^ Array<u256, 3>: Memory => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -70,42 +70,42 @@ note:
   ┌─ features/multi_param.fe:4:9
   │
 4 │         my_array[0] = x
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/multi_param.fe:4:9
   │
 4 │         my_array[0] = x
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 5 │         my_array[1] = y
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/multi_param.fe:5:9
   │
 5 │         my_array[1] = y
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 6 │         my_array[2] = z
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 3>: Memory => None
+  │         Array<u256, 3>: Memory
 
 note: 
   ┌─ features/multi_param.fe:6:9
   │
 6 │         my_array[2] = z
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 7 │         return my_array
-  │                ^^^^^^^^ Array<u256, 3>: Memory => None
+  │                ^^^^^^^^ Array<u256, 3>: Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__nested_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__nested_map.snap
@@ -8,10 +8,6 @@ note:
   │
 2 │     bar: Map<address, Map<address, u256>>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>
-
-note: 
-  ┌─ features/nested_map.fe:3:5
-  │
 3 │     baz: Map<address, Map<u256, bool>>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<u256, bool>>
 
@@ -50,6 +46,28 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/nested_map.fe:6:16
+  │
+6 │         return self.bar[a][b]
+  │                ^^^^^^^^ ^ address: Value => None
+  │                │         
+  │                Map<address, Map<address, u256>>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/nested_map.fe:6:16
+  │
+6 │         return self.bar[a][b]
+  │                ^^^^^^^^^^^ ^ address: Value => None
+  │                │            
+  │                Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+  ┌─ features/nested_map.fe:6:16
+  │
+6 │         return self.bar[a][b]
+  │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
 
 note: 
   ┌─ features/nested_map.fe:8:5
@@ -96,6 +114,30 @@ note:
     }
 
 note: 
+  ┌─ features/nested_map.fe:9:9
+  │
+9 │         self.bar[a][b] = value
+  │         ^^^^^^^^ ^ address: Value => None
+  │         │         
+  │         Map<address, Map<address, u256>>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/nested_map.fe:9:9
+  │
+9 │         self.bar[a][b] = value
+  │         ^^^^^^^^^^^ ^ address: Value => None
+  │         │            
+  │         Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+  ┌─ features/nested_map.fe:9:9
+  │
+9 │         self.bar[a][b] = value
+  │         ^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+  │         │                 
+  │         u256: Storage { nonce: None } => None
+
+note: 
    ┌─ features/nested_map.fe:11:5
    │  
 11 │ ╭     pub fn read_baz(self, a: address, b: u256) -> bool:
@@ -130,6 +172,28 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/nested_map.fe:12:16
+   │
+12 │         return self.baz[a][b]
+   │                ^^^^^^^^ ^ address: Value => None
+   │                │         
+   │                Map<address, Map<u256, bool>>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/nested_map.fe:12:16
+   │
+12 │         return self.baz[a][b]
+   │                ^^^^^^^^^^^ ^ u256: Value => None
+   │                │            
+   │                Map<u256, bool>: Storage { nonce: None } => None
+
+note: 
+   ┌─ features/nested_map.fe:12:16
+   │
+12 │         return self.baz[a][b]
+   │                ^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
 
 note: 
    ┌─ features/nested_map.fe:14:5
@@ -176,135 +240,27 @@ note:
      }
 
 note: 
-  ┌─ features/nested_map.fe:6:16
-  │
-6 │         return self.bar[a][b]
-  │                ^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/nested_map.fe:6:25
-  │
-6 │         return self.bar[a][b]
-  │                         ^ address: Value => None
-
-note: 
-  ┌─ features/nested_map.fe:6:16
-  │
-6 │         return self.bar[a][b]
-  │                ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/nested_map.fe:6:28
-  │
-6 │         return self.bar[a][b]
-  │                            ^ address: Value => None
-
-note: 
-  ┌─ features/nested_map.fe:6:16
-  │
-6 │         return self.bar[a][b]
-  │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-  ┌─ features/nested_map.fe:9:9
-  │
-9 │         self.bar[a][b] = value
-  │         ^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/nested_map.fe:9:18
-  │
-9 │         self.bar[a][b] = value
-  │                  ^ address: Value => None
-
-note: 
-  ┌─ features/nested_map.fe:9:9
-  │
-9 │         self.bar[a][b] = value
-  │         ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/nested_map.fe:9:21
-  │
-9 │         self.bar[a][b] = value
-  │                     ^ address: Value => None
-
-note: 
-  ┌─ features/nested_map.fe:9:9
-  │
-9 │         self.bar[a][b] = value
-  │         ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/nested_map.fe:9:26
-  │
-9 │         self.bar[a][b] = value
-  │                          ^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/nested_map.fe:12:16
+   ┌─ features/nested_map.fe:15:9
    │
-12 │         return self.baz[a][b]
-   │                ^^^^^^^^ Map<address, Map<u256, bool>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/nested_map.fe:12:25
-   │
-12 │         return self.baz[a][b]
-   │                         ^ address: Value => None
-
-note: 
-   ┌─ features/nested_map.fe:12:16
-   │
-12 │         return self.baz[a][b]
-   │                ^^^^^^^^^^^ Map<u256, bool>: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/nested_map.fe:12:28
-   │
-12 │         return self.baz[a][b]
-   │                            ^ u256: Value => None
-
-note: 
-   ┌─ features/nested_map.fe:12:16
-   │
-12 │         return self.baz[a][b]
-   │                ^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
+15 │         self.baz[a][b] = value
+   │         ^^^^^^^^ ^ address: Value => None
+   │         │         
+   │         Map<address, Map<u256, bool>>: Storage { nonce: Some(1) } => None
 
 note: 
    ┌─ features/nested_map.fe:15:9
    │
 15 │         self.baz[a][b] = value
-   │         ^^^^^^^^ Map<address, Map<u256, bool>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/nested_map.fe:15:18
-   │
-15 │         self.baz[a][b] = value
-   │                  ^ address: Value => None
+   │         ^^^^^^^^^^^ ^ u256: Value => None
+   │         │            
+   │         Map<u256, bool>: Storage { nonce: None } => None
 
 note: 
    ┌─ features/nested_map.fe:15:9
    │
 15 │         self.baz[a][b] = value
-   │         ^^^^^^^^^^^ Map<u256, bool>: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/nested_map.fe:15:21
-   │
-15 │         self.baz[a][b] = value
-   │                     ^ u256: Value => None
-
-note: 
-   ┌─ features/nested_map.fe:15:9
-   │
-15 │         self.baz[a][b] = value
-   │         ^^^^^^^^^^^^^^ bool: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/nested_map.fe:15:26
-   │
-15 │         self.baz[a][b] = value
-   │                          ^^^^^ bool: Value => None
+   │         ^^^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         │                 
+   │         bool: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__nested_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__nested_map.snap
@@ -16,10 +16,12 @@ note:
   │  
 5 │ ╭     pub fn read_bar(self, a: address, b: address) -> u256:
 6 │ │         return self.bar[a][b]
-  │ ╰─────────────────────────────^ attributes hash: 10579681573605137522
+  │ ╰─────────────────────────────^ attributes hash: 11552336276528305972
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "a",
@@ -51,33 +53,41 @@ note:
   ┌─ features/nested_map.fe:6:16
   │
 6 │         return self.bar[a][b]
-  │                ^^^^^^^^ ^ address: Value => None
+  │                ^^^^ Foo: Value
+
+note: 
+  ┌─ features/nested_map.fe:6:16
+  │
+6 │         return self.bar[a][b]
+  │                ^^^^^^^^ ^ address: Value
   │                │         
-  │                Map<address, Map<address, u256>>: Storage { nonce: Some(0) } => None
+  │                Map<address, Map<address, u256>>: Storage { nonce: Some(0) }
 
 note: 
   ┌─ features/nested_map.fe:6:16
   │
 6 │         return self.bar[a][b]
-  │                ^^^^^^^^^^^ ^ address: Value => None
+  │                ^^^^^^^^^^^ ^ address: Value
   │                │            
-  │                Map<address, u256>: Storage { nonce: None } => None
+  │                Map<address, u256>: Storage { nonce: None }
 
 note: 
   ┌─ features/nested_map.fe:6:16
   │
 6 │         return self.bar[a][b]
-  │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/nested_map.fe:8:5
   │  
 8 │ ╭     pub fn write_bar(self, a: address, b: address, value: u256):
 9 │ │         self.bar[a][b] = value
-  │ ╰──────────────────────────────^ attributes hash: 6159174104336834167
+  │ ╰──────────────────────────────^ attributes hash: 3270671894149924575
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "a",
@@ -117,35 +127,43 @@ note:
   ┌─ features/nested_map.fe:9:9
   │
 9 │         self.bar[a][b] = value
-  │         ^^^^^^^^ ^ address: Value => None
+  │         ^^^^ Foo: Value
+
+note: 
+  ┌─ features/nested_map.fe:9:9
+  │
+9 │         self.bar[a][b] = value
+  │         ^^^^^^^^ ^ address: Value
   │         │         
-  │         Map<address, Map<address, u256>>: Storage { nonce: Some(0) } => None
+  │         Map<address, Map<address, u256>>: Storage { nonce: Some(0) }
 
 note: 
   ┌─ features/nested_map.fe:9:9
   │
 9 │         self.bar[a][b] = value
-  │         ^^^^^^^^^^^ ^ address: Value => None
+  │         ^^^^^^^^^^^ ^ address: Value
   │         │            
-  │         Map<address, u256>: Storage { nonce: None } => None
+  │         Map<address, u256>: Storage { nonce: None }
 
 note: 
   ┌─ features/nested_map.fe:9:9
   │
 9 │         self.bar[a][b] = value
-  │         ^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+  │         ^^^^^^^^^^^^^^   ^^^^^ u256: Value
   │         │                 
-  │         u256: Storage { nonce: None } => None
+  │         u256: Storage { nonce: None }
 
 note: 
    ┌─ features/nested_map.fe:11:5
    │  
 11 │ ╭     pub fn read_baz(self, a: address, b: u256) -> bool:
 12 │ │         return self.baz[a][b]
-   │ ╰─────────────────────────────^ attributes hash: 4588948300794405674
+   │ ╰─────────────────────────────^ attributes hash: 14681365744320240516
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "a",
@@ -177,33 +195,41 @@ note:
    ┌─ features/nested_map.fe:12:16
    │
 12 │         return self.baz[a][b]
-   │                ^^^^^^^^ ^ address: Value => None
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/nested_map.fe:12:16
+   │
+12 │         return self.baz[a][b]
+   │                ^^^^^^^^ ^ address: Value
    │                │         
-   │                Map<address, Map<u256, bool>>: Storage { nonce: Some(1) } => None
+   │                Map<address, Map<u256, bool>>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ features/nested_map.fe:12:16
    │
 12 │         return self.baz[a][b]
-   │                ^^^^^^^^^^^ ^ u256: Value => None
+   │                ^^^^^^^^^^^ ^ u256: Value
    │                │            
-   │                Map<u256, bool>: Storage { nonce: None } => None
+   │                Map<u256, bool>: Storage { nonce: None }
 
 note: 
    ┌─ features/nested_map.fe:12:16
    │
 12 │         return self.baz[a][b]
-   │                ^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
+   │                ^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Value
 
 note: 
    ┌─ features/nested_map.fe:14:5
    │  
 14 │ ╭     pub fn write_baz(self, a: address, b: u256, value: bool):
 15 │ │         self.baz[a][b] = value
-   │ ╰──────────────────────────────^ attributes hash: 6894542203512356705
+   │ ╰──────────────────────────────^ attributes hash: 15885712977262083842
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "a",
@@ -243,24 +269,30 @@ note:
    ┌─ features/nested_map.fe:15:9
    │
 15 │         self.baz[a][b] = value
-   │         ^^^^^^^^ ^ address: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/nested_map.fe:15:9
+   │
+15 │         self.baz[a][b] = value
+   │         ^^^^^^^^ ^ address: Value
    │         │         
-   │         Map<address, Map<u256, bool>>: Storage { nonce: Some(1) } => None
+   │         Map<address, Map<u256, bool>>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ features/nested_map.fe:15:9
    │
 15 │         self.baz[a][b] = value
-   │         ^^^^^^^^^^^ ^ u256: Value => None
+   │         ^^^^^^^^^^^ ^ u256: Value
    │         │            
-   │         Map<u256, bool>: Storage { nonce: None } => None
+   │         Map<u256, bool>: Storage { nonce: None }
 
 note: 
    ┌─ features/nested_map.fe:15:9
    │
 15 │         self.baz[a][b] = value
-   │         ^^^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         ^^^^^^^^^^^^^^   ^^^^^ bool: Value
    │         │                 
-   │         bool: Storage { nonce: None } => None
+   │         bool: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
@@ -26,27 +26,19 @@ note:
   ┌─ features/numeric_sizes.fe:4:19
   │
 4 │         return u8(0)
-  │                   ^ u8: Value => None
+  │                   ^ u8: Value
 
 note: 
   ┌─ features/numeric_sizes.fe:4:16
   │
 4 │         return u8(0)
-  │                ^^^^^ u8: Value => None
+  │                ^^^^^ u8: Value
 
 note: 
   ┌─ features/numeric_sizes.fe:4:16
   │
 4 │         return u8(0)
-  │                ^^ attributes hash: 4311289215688173045
-  │
-  = TypeConstructor {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-    }
+  │                ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
   ┌─ features/numeric_sizes.fe:6:5
@@ -71,27 +63,19 @@ note:
   ┌─ features/numeric_sizes.fe:7:20
   │
 7 │         return u16(0)
-  │                    ^ u16: Value => None
+  │                    ^ u16: Value
 
 note: 
   ┌─ features/numeric_sizes.fe:7:16
   │
 7 │         return u16(0)
-  │                ^^^^^^ u16: Value => None
+  │                ^^^^^^ u16: Value
 
 note: 
   ┌─ features/numeric_sizes.fe:7:16
   │
 7 │         return u16(0)
-  │                ^^^ attributes hash: 14916054204896698573
-  │
-  = TypeConstructor {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-    }
+  │                ^^^ TypeConstructor(Base(Numeric(U16)))
 
 note: 
    ┌─ features/numeric_sizes.fe:9:5
@@ -116,27 +100,19 @@ note:
    ┌─ features/numeric_sizes.fe:10:20
    │
 10 │         return u32(0)
-   │                    ^ u32: Value => None
+   │                    ^ u32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:10:16
    │
 10 │         return u32(0)
-   │                ^^^^^^ u32: Value => None
+   │                ^^^^^^ u32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:10:16
    │
 10 │         return u32(0)
-   │                ^^^ attributes hash: 14354300448608025539
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(U32)))
 
 note: 
    ┌─ features/numeric_sizes.fe:12:5
@@ -161,27 +137,19 @@ note:
    ┌─ features/numeric_sizes.fe:13:20
    │
 13 │         return u64(0)
-   │                    ^ u64: Value => None
+   │                    ^ u64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:13:16
    │
 13 │         return u64(0)
-   │                ^^^^^^ u64: Value => None
+   │                ^^^^^^ u64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:13:16
    │
 13 │         return u64(0)
-   │                ^^^ attributes hash: 12468012384939114225
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(U64)))
 
 note: 
    ┌─ features/numeric_sizes.fe:15:5
@@ -206,27 +174,19 @@ note:
    ┌─ features/numeric_sizes.fe:16:21
    │
 16 │         return u128(0)
-   │                     ^ u128: Value => None
+   │                     ^ u128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:16:16
    │
 16 │         return u128(0)
-   │                ^^^^^^^ u128: Value => None
+   │                ^^^^^^^ u128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:16:16
    │
 16 │         return u128(0)
-   │                ^^^^ attributes hash: 2454885421097624260
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(U128)))
 
 note: 
    ┌─ features/numeric_sizes.fe:18:5
@@ -251,27 +211,19 @@ note:
    ┌─ features/numeric_sizes.fe:19:21
    │
 19 │         return u256(0)
-   │                     ^ u256: Value => None
+   │                     ^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:19:16
    │
 19 │         return u256(0)
-   │                ^^^^^^^ u256: Value => None
+   │                ^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:19:16
    │
 19 │         return u256(0)
-   │                ^^^^ attributes hash: 2391147244535208323
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(U256)))
 
 note: 
    ┌─ features/numeric_sizes.fe:21:5
@@ -296,33 +248,25 @@ note:
    ┌─ features/numeric_sizes.fe:22:20
    │
 22 │         return i8(-128)
-   │                    ^^^ u256: Value => None
+   │                    ^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:22:19
    │
 22 │         return i8(-128)
-   │                   ^^^^ i8: Value => None
+   │                   ^^^^ i8: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:22:16
    │
 22 │         return i8(-128)
-   │                ^^^^^^^^ i8: Value => None
+   │                ^^^^^^^^ i8: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:22:16
    │
 22 │         return i8(-128)
-   │                ^^ attributes hash: 2086885688824652821
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-     }
+   │                ^^ TypeConstructor(Base(Numeric(I8)))
 
 note: 
    ┌─ features/numeric_sizes.fe:24:5
@@ -347,33 +291,25 @@ note:
    ┌─ features/numeric_sizes.fe:25:21
    │
 25 │         return i16(-32768)
-   │                     ^^^^^ u256: Value => None
+   │                     ^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:25:20
    │
 25 │         return i16(-32768)
-   │                    ^^^^^^ i16: Value => None
+   │                    ^^^^^^ i16: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:25:16
    │
 25 │         return i16(-32768)
-   │                ^^^^^^^^^^^ i16: Value => None
+   │                ^^^^^^^^^^^ i16: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:25:16
    │
 25 │         return i16(-32768)
-   │                ^^^ attributes hash: 1890852259110831876
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(I16)))
 
 note: 
    ┌─ features/numeric_sizes.fe:27:5
@@ -398,33 +334,25 @@ note:
    ┌─ features/numeric_sizes.fe:28:21
    │
 28 │         return i32(-2147483648)
-   │                     ^^^^^^^^^^ u256: Value => None
+   │                     ^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:28:20
    │
 28 │         return i32(-2147483648)
-   │                    ^^^^^^^^^^^ i32: Value => None
+   │                    ^^^^^^^^^^^ i32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:28:16
    │
 28 │         return i32(-2147483648)
-   │                ^^^^^^^^^^^^^^^^ i32: Value => None
+   │                ^^^^^^^^^^^^^^^^ i32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:28:16
    │
 28 │         return i32(-2147483648)
-   │                ^^^ attributes hash: 14092528269543401556
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(I32)))
 
 note: 
    ┌─ features/numeric_sizes.fe:30:5
@@ -449,33 +377,25 @@ note:
    ┌─ features/numeric_sizes.fe:31:21
    │
 31 │         return i64(-9223372036854775808)
-   │                     ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:31:20
    │
 31 │         return i64(-9223372036854775808)
-   │                    ^^^^^^^^^^^^^^^^^^^^ i64: Value => None
+   │                    ^^^^^^^^^^^^^^^^^^^^ i64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:31:16
    │
 31 │         return i64(-9223372036854775808)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:31:16
    │
 31 │         return i64(-9223372036854775808)
-   │                ^^^ attributes hash: 4849552154822743063
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(I64)))
 
 note: 
    ┌─ features/numeric_sizes.fe:33:5
@@ -500,33 +420,25 @@ note:
    ┌─ features/numeric_sizes.fe:34:22
    │
 34 │         return i128(-170141183460469231731687303715884105728)
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:34:21
    │
 34 │         return i128(-170141183460469231731687303715884105728)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:34:16
    │
 34 │         return i128(-170141183460469231731687303715884105728)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:34:16
    │
 34 │         return i128(-170141183460469231731687303715884105728)
-   │                ^^^^ attributes hash: 17259437597606577465
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(I128)))
 
 note: 
    ┌─ features/numeric_sizes.fe:36:5
@@ -551,33 +463,25 @@ note:
    ┌─ features/numeric_sizes.fe:37:22
    │
 37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:37:21
    │
 37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:37:16
    │
 37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:37:16
    │
 37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                ^^^^ attributes hash: 2888144854755155377
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(I256)))
 
 note: 
    ┌─ features/numeric_sizes.fe:39:5
@@ -602,27 +506,19 @@ note:
    ┌─ features/numeric_sizes.fe:40:19
    │
 40 │         return u8(255)
-   │                   ^^^ u8: Value => None
+   │                   ^^^ u8: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:40:16
    │
 40 │         return u8(255)
-   │                ^^^^^^^ u8: Value => None
+   │                ^^^^^^^ u8: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:40:16
    │
 40 │         return u8(255)
-   │                ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+   │                ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
    ┌─ features/numeric_sizes.fe:42:5
@@ -647,27 +543,19 @@ note:
    ┌─ features/numeric_sizes.fe:43:20
    │
 43 │         return u16(65535)
-   │                    ^^^^^ u16: Value => None
+   │                    ^^^^^ u16: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:43:16
    │
 43 │         return u16(65535)
-   │                ^^^^^^^^^^ u16: Value => None
+   │                ^^^^^^^^^^ u16: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:43:16
    │
 43 │         return u16(65535)
-   │                ^^^ attributes hash: 14916054204896698573
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(U16)))
 
 note: 
    ┌─ features/numeric_sizes.fe:45:5
@@ -692,27 +580,19 @@ note:
    ┌─ features/numeric_sizes.fe:46:20
    │
 46 │         return u32(4294967295)
-   │                    ^^^^^^^^^^ u32: Value => None
+   │                    ^^^^^^^^^^ u32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:46:16
    │
 46 │         return u32(4294967295)
-   │                ^^^^^^^^^^^^^^^ u32: Value => None
+   │                ^^^^^^^^^^^^^^^ u32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:46:16
    │
 46 │         return u32(4294967295)
-   │                ^^^ attributes hash: 14354300448608025539
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(U32)))
 
 note: 
    ┌─ features/numeric_sizes.fe:48:5
@@ -737,27 +617,19 @@ note:
    ┌─ features/numeric_sizes.fe:49:20
    │
 49 │         return u64(18446744073709551615)
-   │                    ^^^^^^^^^^^^^^^^^^^^ u64: Value => None
+   │                    ^^^^^^^^^^^^^^^^^^^^ u64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:49:16
    │
 49 │         return u64(18446744073709551615)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u64: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:49:16
    │
 49 │         return u64(18446744073709551615)
-   │                ^^^ attributes hash: 12468012384939114225
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(U64)))
 
 note: 
    ┌─ features/numeric_sizes.fe:51:5
@@ -782,27 +654,19 @@ note:
    ┌─ features/numeric_sizes.fe:52:21
    │
 52 │         return u128(340282366920938463463374607431768211455)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:52:16
    │
 52 │         return u128(340282366920938463463374607431768211455)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:52:16
    │
 52 │         return u128(340282366920938463463374607431768211455)
-   │                ^^^^ attributes hash: 2454885421097624260
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(U128)))
 
 note: 
    ┌─ features/numeric_sizes.fe:54:5
@@ -827,27 +691,19 @@ note:
    ┌─ features/numeric_sizes.fe:55:21
    │
 55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:55:16
    │
 55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:55:16
    │
 55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                ^^^^ attributes hash: 2391147244535208323
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(U256)))
 
 note: 
    ┌─ features/numeric_sizes.fe:57:5
@@ -872,27 +728,19 @@ note:
    ┌─ features/numeric_sizes.fe:58:19
    │
 58 │         return i8(127)
-   │                   ^^^ i8: Value => None
+   │                   ^^^ i8: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:58:16
    │
 58 │         return i8(127)
-   │                ^^^^^^^ i8: Value => None
+   │                ^^^^^^^ i8: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:58:16
    │
 58 │         return i8(127)
-   │                ^^ attributes hash: 2086885688824652821
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-     }
+   │                ^^ TypeConstructor(Base(Numeric(I8)))
 
 note: 
    ┌─ features/numeric_sizes.fe:60:5
@@ -917,27 +765,19 @@ note:
    ┌─ features/numeric_sizes.fe:61:20
    │
 61 │         return i16(32767)
-   │                    ^^^^^ i16: Value => None
+   │                    ^^^^^ i16: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:61:16
    │
 61 │         return i16(32767)
-   │                ^^^^^^^^^^ i16: Value => None
+   │                ^^^^^^^^^^ i16: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:61:16
    │
 61 │         return i16(32767)
-   │                ^^^ attributes hash: 1890852259110831876
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(I16)))
 
 note: 
    ┌─ features/numeric_sizes.fe:63:5
@@ -962,27 +802,19 @@ note:
    ┌─ features/numeric_sizes.fe:64:20
    │
 64 │         return i32(2147483647)
-   │                    ^^^^^^^^^^ i32: Value => None
+   │                    ^^^^^^^^^^ i32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:64:16
    │
 64 │         return i32(2147483647)
-   │                ^^^^^^^^^^^^^^^ i32: Value => None
+   │                ^^^^^^^^^^^^^^^ i32: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:64:16
    │
 64 │         return i32(2147483647)
-   │                ^^^ attributes hash: 14092528269543401556
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(I32)))
 
 note: 
    ┌─ features/numeric_sizes.fe:66:5
@@ -1007,27 +839,19 @@ note:
    ┌─ features/numeric_sizes.fe:67:20
    │
 67 │         return i64(9223372036854775807)
-   │                    ^^^^^^^^^^^^^^^^^^^ i64: Value => None
+   │                    ^^^^^^^^^^^^^^^^^^^ i64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:67:16
    │
 67 │         return i64(9223372036854775807)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:67:16
    │
 67 │         return i64(9223372036854775807)
-   │                ^^^ attributes hash: 4849552154822743063
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-     }
+   │                ^^^ TypeConstructor(Base(Numeric(I64)))
 
 note: 
    ┌─ features/numeric_sizes.fe:69:5
@@ -1052,27 +876,19 @@ note:
    ┌─ features/numeric_sizes.fe:70:21
    │
 70 │         return i128(170141183460469231731687303715884105727)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:70:16
    │
 70 │         return i128(170141183460469231731687303715884105727)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:70:16
    │
 70 │         return i128(170141183460469231731687303715884105727)
-   │                ^^^^ attributes hash: 17259437597606577465
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(I128)))
 
 note: 
    ┌─ features/numeric_sizes.fe:72:5
@@ -1097,26 +913,18 @@ note:
    ┌─ features/numeric_sizes.fe:73:21
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:73:16
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value
 
 note: 
    ┌─ features/numeric_sizes.fe:73:16
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                ^^^^ attributes hash: 2888144854755155377
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-     }
+   │                ^^^^ TypeConstructor(Base(Numeric(I256)))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
@@ -23,6 +23,32 @@ note:
     }
 
 note: 
+  ┌─ features/numeric_sizes.fe:4:19
+  │
+4 │         return u8(0)
+  │                   ^ u8: Value => None
+
+note: 
+  ┌─ features/numeric_sizes.fe:4:16
+  │
+4 │         return u8(0)
+  │                ^^^^^ u8: Value => None
+
+note: 
+  ┌─ features/numeric_sizes.fe:4:16
+  │
+4 │         return u8(0)
+  │                ^^ attributes hash: 4311289215688173045
+  │
+  = TypeConstructor {
+        typ: Base(
+            Numeric(
+                U8,
+            ),
+        ),
+    }
+
+note: 
   ┌─ features/numeric_sizes.fe:6:5
   │  
 6 │ ╭     pub fn get_u16_min() -> u16:
@@ -37,6 +63,32 @@ note:
                 Numeric(
                     U16,
                 ),
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/numeric_sizes.fe:7:20
+  │
+7 │         return u16(0)
+  │                    ^ u16: Value => None
+
+note: 
+  ┌─ features/numeric_sizes.fe:7:16
+  │
+7 │         return u16(0)
+  │                ^^^^^^ u16: Value => None
+
+note: 
+  ┌─ features/numeric_sizes.fe:7:16
+  │
+7 │         return u16(0)
+  │                ^^^ attributes hash: 14916054204896698573
+  │
+  = TypeConstructor {
+        typ: Base(
+            Numeric(
+                U16,
             ),
         ),
     }
@@ -61,6 +113,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:10:20
+   │
+10 │         return u32(0)
+   │                    ^ u32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:10:16
+   │
+10 │         return u32(0)
+   │                ^^^^^^ u32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:10:16
+   │
+10 │         return u32(0)
+   │                ^^^ attributes hash: 14354300448608025539
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U32,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:12:5
    │  
 12 │ ╭     pub fn get_u64_min() -> u64:
@@ -75,6 +153,32 @@ note:
                  Numeric(
                      U64,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:13:20
+   │
+13 │         return u64(0)
+   │                    ^ u64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:13:16
+   │
+13 │         return u64(0)
+   │                ^^^^^^ u64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:13:16
+   │
+13 │         return u64(0)
+   │                ^^^ attributes hash: 12468012384939114225
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U64,
              ),
          ),
      }
@@ -99,6 +203,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:16:21
+   │
+16 │         return u128(0)
+   │                     ^ u128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:16:16
+   │
+16 │         return u128(0)
+   │                ^^^^^^^ u128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:16:16
+   │
+16 │         return u128(0)
+   │                ^^^^ attributes hash: 2454885421097624260
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U128,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:18:5
    │  
 18 │ ╭     pub fn get_u256_min() -> u256:
@@ -113,6 +243,32 @@ note:
                  Numeric(
                      U256,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:19:21
+   │
+19 │         return u256(0)
+   │                     ^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:19:16
+   │
+19 │         return u256(0)
+   │                ^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:19:16
+   │
+19 │         return u256(0)
+   │                ^^^^ attributes hash: 2391147244535208323
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U256,
              ),
          ),
      }
@@ -137,6 +293,38 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:22:20
+   │
+22 │         return i8(-128)
+   │                    ^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:22:19
+   │
+22 │         return i8(-128)
+   │                   ^^^^ i8: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:22:16
+   │
+22 │         return i8(-128)
+   │                ^^^^^^^^ i8: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:22:16
+   │
+22 │         return i8(-128)
+   │                ^^ attributes hash: 2086885688824652821
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I8,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:24:5
    │  
 24 │ ╭     pub fn get_i16_min() -> i16:
@@ -151,6 +339,38 @@ note:
                  Numeric(
                      I16,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:25:21
+   │
+25 │         return i16(-32768)
+   │                     ^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:25:20
+   │
+25 │         return i16(-32768)
+   │                    ^^^^^^ i16: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:25:16
+   │
+25 │         return i16(-32768)
+   │                ^^^^^^^^^^^ i16: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:25:16
+   │
+25 │         return i16(-32768)
+   │                ^^^ attributes hash: 1890852259110831876
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I16,
              ),
          ),
      }
@@ -175,6 +395,38 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:28:21
+   │
+28 │         return i32(-2147483648)
+   │                     ^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:28:20
+   │
+28 │         return i32(-2147483648)
+   │                    ^^^^^^^^^^^ i32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:28:16
+   │
+28 │         return i32(-2147483648)
+   │                ^^^^^^^^^^^^^^^^ i32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:28:16
+   │
+28 │         return i32(-2147483648)
+   │                ^^^ attributes hash: 14092528269543401556
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I32,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:30:5
    │  
 30 │ ╭     pub fn get_i64_min() -> i64:
@@ -189,6 +441,38 @@ note:
                  Numeric(
                      I64,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:31:21
+   │
+31 │         return i64(-9223372036854775808)
+   │                     ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:31:20
+   │
+31 │         return i64(-9223372036854775808)
+   │                    ^^^^^^^^^^^^^^^^^^^^ i64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:31:16
+   │
+31 │         return i64(-9223372036854775808)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:31:16
+   │
+31 │         return i64(-9223372036854775808)
+   │                ^^^ attributes hash: 4849552154822743063
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I64,
              ),
          ),
      }
@@ -213,6 +497,38 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:34:22
+   │
+34 │         return i128(-170141183460469231731687303715884105728)
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:34:21
+   │
+34 │         return i128(-170141183460469231731687303715884105728)
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:34:16
+   │
+34 │         return i128(-170141183460469231731687303715884105728)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:34:16
+   │
+34 │         return i128(-170141183460469231731687303715884105728)
+   │                ^^^^ attributes hash: 17259437597606577465
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I128,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:36:5
    │  
 36 │ ╭     pub fn get_i256_min() -> i256:
@@ -227,6 +543,38 @@ note:
                  Numeric(
                      I256,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:37:22
+   │
+37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
+   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:37:21
+   │
+37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:37:16
+   │
+37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:37:16
+   │
+37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
+   │                ^^^^ attributes hash: 2888144854755155377
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I256,
              ),
          ),
      }
@@ -251,6 +599,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:40:19
+   │
+40 │         return u8(255)
+   │                   ^^^ u8: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:40:16
+   │
+40 │         return u8(255)
+   │                ^^^^^^^ u8: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:40:16
+   │
+40 │         return u8(255)
+   │                ^^ attributes hash: 4311289215688173045
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U8,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:42:5
    │  
 42 │ ╭     pub fn get_u16_max() -> u16:
@@ -265,6 +639,32 @@ note:
                  Numeric(
                      U16,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:43:20
+   │
+43 │         return u16(65535)
+   │                    ^^^^^ u16: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:43:16
+   │
+43 │         return u16(65535)
+   │                ^^^^^^^^^^ u16: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:43:16
+   │
+43 │         return u16(65535)
+   │                ^^^ attributes hash: 14916054204896698573
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U16,
              ),
          ),
      }
@@ -289,6 +689,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:46:20
+   │
+46 │         return u32(4294967295)
+   │                    ^^^^^^^^^^ u32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:46:16
+   │
+46 │         return u32(4294967295)
+   │                ^^^^^^^^^^^^^^^ u32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:46:16
+   │
+46 │         return u32(4294967295)
+   │                ^^^ attributes hash: 14354300448608025539
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U32,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:48:5
    │  
 48 │ ╭     pub fn get_u64_max() -> u64:
@@ -303,6 +729,32 @@ note:
                  Numeric(
                      U64,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:49:20
+   │
+49 │         return u64(18446744073709551615)
+   │                    ^^^^^^^^^^^^^^^^^^^^ u64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:49:16
+   │
+49 │         return u64(18446744073709551615)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:49:16
+   │
+49 │         return u64(18446744073709551615)
+   │                ^^^ attributes hash: 12468012384939114225
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U64,
              ),
          ),
      }
@@ -327,6 +779,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:52:21
+   │
+52 │         return u128(340282366920938463463374607431768211455)
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:52:16
+   │
+52 │         return u128(340282366920938463463374607431768211455)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:52:16
+   │
+52 │         return u128(340282366920938463463374607431768211455)
+   │                ^^^^ attributes hash: 2454885421097624260
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U128,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:54:5
    │  
 54 │ ╭     pub fn get_u256_max() -> u256:
@@ -341,6 +819,32 @@ note:
                  Numeric(
                      U256,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:55:21
+   │
+55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:55:16
+   │
+55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:55:16
+   │
+55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+   │                ^^^^ attributes hash: 2391147244535208323
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U256,
              ),
          ),
      }
@@ -365,6 +869,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:58:19
+   │
+58 │         return i8(127)
+   │                   ^^^ i8: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:58:16
+   │
+58 │         return i8(127)
+   │                ^^^^^^^ i8: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:58:16
+   │
+58 │         return i8(127)
+   │                ^^ attributes hash: 2086885688824652821
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I8,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:60:5
    │  
 60 │ ╭     pub fn get_i16_max() -> i16:
@@ -379,6 +909,32 @@ note:
                  Numeric(
                      I16,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:61:20
+   │
+61 │         return i16(32767)
+   │                    ^^^^^ i16: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:61:16
+   │
+61 │         return i16(32767)
+   │                ^^^^^^^^^^ i16: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:61:16
+   │
+61 │         return i16(32767)
+   │                ^^^ attributes hash: 1890852259110831876
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I16,
              ),
          ),
      }
@@ -403,6 +959,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:64:20
+   │
+64 │         return i32(2147483647)
+   │                    ^^^^^^^^^^ i32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:64:16
+   │
+64 │         return i32(2147483647)
+   │                ^^^^^^^^^^^^^^^ i32: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:64:16
+   │
+64 │         return i32(2147483647)
+   │                ^^^ attributes hash: 14092528269543401556
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I32,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:66:5
    │  
 66 │ ╭     pub fn get_i64_max() -> i64:
@@ -417,6 +999,32 @@ note:
                  Numeric(
                      I64,
                  ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/numeric_sizes.fe:67:20
+   │
+67 │         return i64(9223372036854775807)
+   │                    ^^^^^^^^^^^^^^^^^^^ i64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:67:16
+   │
+67 │         return i64(9223372036854775807)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:67:16
+   │
+67 │         return i64(9223372036854775807)
+   │                ^^^ attributes hash: 4849552154822743063
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I64,
              ),
          ),
      }
@@ -441,6 +1049,32 @@ note:
      }
 
 note: 
+   ┌─ features/numeric_sizes.fe:70:21
+   │
+70 │         return i128(170141183460469231731687303715884105727)
+   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:70:16
+   │
+70 │         return i128(170141183460469231731687303715884105727)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
+
+note: 
+   ┌─ features/numeric_sizes.fe:70:16
+   │
+70 │         return i128(170141183460469231731687303715884105727)
+   │                ^^^^ attributes hash: 17259437597606577465
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I128,
+             ),
+         ),
+     }
+
+note: 
    ┌─ features/numeric_sizes.fe:72:5
    │  
 72 │ ╭     pub fn get_i256_max() -> i256:
@@ -460,318 +1094,6 @@ note:
      }
 
 note: 
-  ┌─ features/numeric_sizes.fe:4:19
-  │
-4 │         return u8(0)
-  │                   ^ u8: Value => None
-
-note: 
-  ┌─ features/numeric_sizes.fe:4:16
-  │
-4 │         return u8(0)
-  │                ^^^^^ u8: Value => None
-
-note: 
-  ┌─ features/numeric_sizes.fe:7:20
-  │
-7 │         return u16(0)
-  │                    ^ u16: Value => None
-
-note: 
-  ┌─ features/numeric_sizes.fe:7:16
-  │
-7 │         return u16(0)
-  │                ^^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:10:20
-   │
-10 │         return u32(0)
-   │                    ^ u32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:10:16
-   │
-10 │         return u32(0)
-   │                ^^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:13:20
-   │
-13 │         return u64(0)
-   │                    ^ u64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:13:16
-   │
-13 │         return u64(0)
-   │                ^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:16:21
-   │
-16 │         return u128(0)
-   │                     ^ u128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:16:16
-   │
-16 │         return u128(0)
-   │                ^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:19:21
-   │
-19 │         return u256(0)
-   │                     ^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:19:16
-   │
-19 │         return u256(0)
-   │                ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:22:20
-   │
-22 │         return i8(-128)
-   │                    ^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:22:19
-   │
-22 │         return i8(-128)
-   │                   ^^^^ i8: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:22:16
-   │
-22 │         return i8(-128)
-   │                ^^^^^^^^ i8: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:25:21
-   │
-25 │         return i16(-32768)
-   │                     ^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:25:20
-   │
-25 │         return i16(-32768)
-   │                    ^^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:25:16
-   │
-25 │         return i16(-32768)
-   │                ^^^^^^^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:28:21
-   │
-28 │         return i32(-2147483648)
-   │                     ^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:28:20
-   │
-28 │         return i32(-2147483648)
-   │                    ^^^^^^^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:28:16
-   │
-28 │         return i32(-2147483648)
-   │                ^^^^^^^^^^^^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:31:21
-   │
-31 │         return i64(-9223372036854775808)
-   │                     ^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:31:20
-   │
-31 │         return i64(-9223372036854775808)
-   │                    ^^^^^^^^^^^^^^^^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:31:16
-   │
-31 │         return i64(-9223372036854775808)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:34:22
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:34:21
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:34:16
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:37:22
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:37:21
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:37:16
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:40:19
-   │
-40 │         return u8(255)
-   │                   ^^^ u8: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:40:16
-   │
-40 │         return u8(255)
-   │                ^^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:43:20
-   │
-43 │         return u16(65535)
-   │                    ^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:43:16
-   │
-43 │         return u16(65535)
-   │                ^^^^^^^^^^ u16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:46:20
-   │
-46 │         return u32(4294967295)
-   │                    ^^^^^^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:46:16
-   │
-46 │         return u32(4294967295)
-   │                ^^^^^^^^^^^^^^^ u32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:49:20
-   │
-49 │         return u64(18446744073709551615)
-   │                    ^^^^^^^^^^^^^^^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:49:16
-   │
-49 │         return u64(18446744073709551615)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:52:21
-   │
-52 │         return u128(340282366920938463463374607431768211455)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:52:16
-   │
-52 │         return u128(340282366920938463463374607431768211455)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:55:21
-   │
-55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:55:16
-   │
-55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:58:19
-   │
-58 │         return i8(127)
-   │                   ^^^ i8: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:58:16
-   │
-58 │         return i8(127)
-   │                ^^^^^^^ i8: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:61:20
-   │
-61 │         return i16(32767)
-   │                    ^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:61:16
-   │
-61 │         return i16(32767)
-   │                ^^^^^^^^^^ i16: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:64:20
-   │
-64 │         return i32(2147483647)
-   │                    ^^^^^^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:64:16
-   │
-64 │         return i32(2147483647)
-   │                ^^^^^^^^^^^^^^^ i32: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:67:20
-   │
-67 │         return i64(9223372036854775807)
-   │                    ^^^^^^^^^^^^^^^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:67:16
-   │
-67 │         return i64(9223372036854775807)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:70:21
-   │
-70 │         return i128(170141183460469231731687303715884105727)
-   │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
-
-note: 
-   ┌─ features/numeric_sizes.fe:70:16
-   │
-70 │         return i128(170141183460469231731687303715884105727)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value => None
-
-note: 
    ┌─ features/numeric_sizes.fe:73:21
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
@@ -782,328 +1104,6 @@ note:
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value => None
-
-note: 
-  ┌─ features/numeric_sizes.fe:4:16
-  │
-4 │         return u8(0)
-  │                ^^ attributes hash: 4311289215688173045
-  │
-  = TypeConstructor {
-        typ: Base(
-            Numeric(
-                U8,
-            ),
-        ),
-    }
-
-note: 
-  ┌─ features/numeric_sizes.fe:7:16
-  │
-7 │         return u16(0)
-  │                ^^^ attributes hash: 14916054204896698573
-  │
-  = TypeConstructor {
-        typ: Base(
-            Numeric(
-                U16,
-            ),
-        ),
-    }
-
-note: 
-   ┌─ features/numeric_sizes.fe:10:16
-   │
-10 │         return u32(0)
-   │                ^^^ attributes hash: 14354300448608025539
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:13:16
-   │
-13 │         return u64(0)
-   │                ^^^ attributes hash: 12468012384939114225
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:16:16
-   │
-16 │         return u128(0)
-   │                ^^^^ attributes hash: 2454885421097624260
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:19:16
-   │
-19 │         return u256(0)
-   │                ^^^^ attributes hash: 2391147244535208323
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:22:16
-   │
-22 │         return i8(-128)
-   │                ^^ attributes hash: 2086885688824652821
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:25:16
-   │
-25 │         return i16(-32768)
-   │                ^^^ attributes hash: 1890852259110831876
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:28:16
-   │
-28 │         return i32(-2147483648)
-   │                ^^^ attributes hash: 14092528269543401556
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:31:16
-   │
-31 │         return i64(-9223372036854775808)
-   │                ^^^ attributes hash: 4849552154822743063
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:34:16
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                ^^^^ attributes hash: 17259437597606577465
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:37:16
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                ^^^^ attributes hash: 2888144854755155377
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I256,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:40:16
-   │
-40 │         return u8(255)
-   │                ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:43:16
-   │
-43 │         return u16(65535)
-   │                ^^^ attributes hash: 14916054204896698573
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U16,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:46:16
-   │
-46 │         return u32(4294967295)
-   │                ^^^ attributes hash: 14354300448608025539
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U32,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:49:16
-   │
-49 │         return u64(18446744073709551615)
-   │                ^^^ attributes hash: 12468012384939114225
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U64,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:52:16
-   │
-52 │         return u128(340282366920938463463374607431768211455)
-   │                ^^^^ attributes hash: 2454885421097624260
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U128,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:55:16
-   │
-55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                ^^^^ attributes hash: 2391147244535208323
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:58:16
-   │
-58 │         return i8(127)
-   │                ^^ attributes hash: 2086885688824652821
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:61:16
-   │
-61 │         return i16(32767)
-   │                ^^^ attributes hash: 1890852259110831876
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I16,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:64:16
-   │
-64 │         return i32(2147483647)
-   │                ^^^ attributes hash: 14092528269543401556
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:67:16
-   │
-67 │         return i64(9223372036854775807)
-   │                ^^^ attributes hash: 4849552154822743063
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I64,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/numeric_sizes.fe:70:16
-   │
-70 │         return i128(170141183460469231731687303715884105727)
-   │                ^^^^ attributes hash: 17259437597606577465
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I128,
-             ),
-         ),
-     }
 
 note: 
    ┌─ features/numeric_sizes.fe:73:16

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -22,10 +22,12 @@ note:
    │  
 11 │ ╭   pub fn owner(self) -> address:
 12 │ │     return self._owner
-   │ ╰──────────────────────^ attributes hash: 17651916811868111914
+   │ ╰──────────────────────^ attributes hash: 10447292744135180405
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -38,7 +40,13 @@ note:
    ┌─ features/ownable.fe:12:12
    │
 12 │     return self._owner
-   │            ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │            ^^^^ Ownable: Value
+
+note: 
+   ┌─ features/ownable.fe:12:12
+   │
+12 │     return self._owner
+   │            ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ features/ownable.fe:14:3
@@ -47,10 +55,12 @@ note:
 15 │ │     assert msg.sender == self._owner
 16 │ │     self._owner = address(0)
 17 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 4369441865732737140
+   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -63,35 +73,47 @@ note:
    ┌─ features/ownable.fe:15:12
    │
 15 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^    ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │            ^^^^^^^^^^    ^^^^ Ownable: Value
    │            │              
-   │            address: Value => None
+   │            address: Value
+
+note: 
+   ┌─ features/ownable.fe:15:26
+   │
+15 │     assert msg.sender == self._owner
+   │                          ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ features/ownable.fe:15:12
    │
 15 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 16 │     self._owner = address(0)
-   │     ^^^^^^^^^^^           ^ u256: Value => None
+   │     ^^^^ Ownable: Value
+
+note: 
+   ┌─ features/ownable.fe:16:5
+   │
+16 │     self._owner = address(0)
+   │     ^^^^^^^^^^^           ^ u256: Value
    │     │                      
-   │     address: Storage { nonce: Some(0) } => None
+   │     address: Storage { nonce: Some(0) }
 
 note: 
    ┌─ features/ownable.fe:16:19
    │
 16 │     self._owner = address(0)
-   │                   ^^^^^^^^^^ address: Value => None
+   │                   ^^^^^^^^^^ address: Value
 17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                             ^^^^^^^^^^                   ^ u256: Value => None
+   │                                             ^^^^^^^^^^                   ^ u256: Value
    │                                             │                             
-   │                                             address: Value => None
+   │                                             address: Value
 
 note: 
    ┌─ features/ownable.fe:17:66
    │
 17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                                                  ^^^^^^^^^^ address: Value => None
+   │                                                                  ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/ownable.fe:17:5
@@ -127,25 +149,9 @@ note:
    ┌─ features/ownable.fe:16:19
    │
 16 │     self._owner = address(0)
-   │                   ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ features/ownable.fe:17:66
-   │
+   │                   ^^^^^^^ TypeConstructor(Base(Address))
 17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                                                  ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                                                                  ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ features/ownable.fe:19:3
@@ -155,10 +161,12 @@ note:
 21 │ │     assert newOwner != address(0)
 22 │ │     self._owner = newOwner
 23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 9053558391660990741
+   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 6773896465733249515
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "newOwner",
@@ -180,39 +188,51 @@ note:
    ┌─ features/ownable.fe:20:12
    │
 20 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^    ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │            ^^^^^^^^^^    ^^^^ Ownable: Value
    │            │              
-   │            address: Value => None
+   │            address: Value
+
+note: 
+   ┌─ features/ownable.fe:20:26
+   │
+20 │     assert msg.sender == self._owner
+   │                          ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ features/ownable.fe:20:12
    │
 20 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 21 │     assert newOwner != address(0)
-   │            ^^^^^^^^            ^ u256: Value => None
+   │            ^^^^^^^^            ^ u256: Value
    │            │                    
-   │            address: Value => None
+   │            address: Value
 
 note: 
    ┌─ features/ownable.fe:21:24
    │
 21 │     assert newOwner != address(0)
-   │                        ^^^^^^^^^^ address: Value => None
+   │                        ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/ownable.fe:21:12
    │
 21 │     assert newOwner != address(0)
-   │            ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │            ^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 22 │     self._owner = newOwner
-   │     ^^^^^^^^^^^   ^^^^^^^^ address: Value => None
+   │     ^^^^ Ownable: Value
+
+note: 
+   ┌─ features/ownable.fe:22:5
+   │
+22 │     self._owner = newOwner
+   │     ^^^^^^^^^^^   ^^^^^^^^ address: Value
    │     │              
-   │     address: Storage { nonce: Some(0) } => None
+   │     address: Storage { nonce: Some(0) }
 23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │                                             ^^^^^^^^^^  ^^^^^^^^ address: Value => None
+   │                                             ^^^^^^^^^^  ^^^^^^^^ address: Value
    │                                             │            
-   │                                             address: Value => None
+   │                                             address: Value
 
 note: 
    ┌─ features/ownable.fe:23:5
@@ -248,12 +268,6 @@ note:
    ┌─ features/ownable.fe:21:24
    │
 21 │     assert newOwner != address(0)
-   │                        ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                        ^^^^^^^ TypeConstructor(Base(Address))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -14,29 +14,8 @@ note:
   │
 5 │     idx previousOwner: address
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-  ┌─ features/ownable.fe:6:5
-  │
 6 │     idx newOwner: address
   │     ^^^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-  ┌─ features/ownable.fe:8:3
-  │  
-8 │ ╭   pub fn __init__(self):
-9 │ │     self._owner = msg.sender
-  │ ╰────────────────────────────^ attributes hash: 4369441865732737140
-  │  
-  = FunctionSignature {
-        self_decl: Mutable,
-        params: [],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
 
 note: 
    ┌─ features/ownable.fe:11:3
@@ -54,6 +33,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/ownable.fe:12:12
+   │
+12 │     return self._owner
+   │            ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/ownable.fe:14:3
@@ -75,99 +60,32 @@ note:
      }
 
 note: 
-   ┌─ features/ownable.fe:19:3
-   │  
-19 │ ╭   pub fn transferOwnership(self, newOwner: address):
-20 │ │     assert msg.sender == self._owner
-21 │ │     assert newOwner != address(0)
-22 │ │     self._owner = newOwner
-23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 9053558391660990741
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [
-             FunctionParam {
-                 name: "newOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-  ┌─ features/ownable.fe:9:5
-  │
-9 │     self._owner = msg.sender
-  │     ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/ownable.fe:9:19
-  │
-9 │     self._owner = msg.sender
-  │                   ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:12:12
-   │
-12 │     return self._owner
-   │            ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
    ┌─ features/ownable.fe:15:12
    │
 15 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:15:26
-   │
-15 │     assert msg.sender == self._owner
-   │                          ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │            ^^^^^^^^^^    ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │            │              
+   │            address: Value => None
 
 note: 
    ┌─ features/ownable.fe:15:12
    │
 15 │     assert msg.sender == self._owner
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/ownable.fe:16:5
-   │
 16 │     self._owner = address(0)
-   │     ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/ownable.fe:16:27
-   │
-16 │     self._owner = address(0)
-   │                           ^ u256: Value => None
+   │     ^^^^^^^^^^^           ^ u256: Value => None
+   │     │                      
+   │     address: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/ownable.fe:16:19
    │
 16 │     self._owner = address(0)
    │                   ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:17:45
-   │
 17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                             ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:17:74
-   │
-17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                                                          ^ u256: Value => None
+   │                                             ^^^^^^^^^^                   ^ u256: Value => None
+   │                                             │                             
+   │                                             address: Value => None
 
 note: 
    ┌─ features/ownable.fe:17:66
@@ -176,106 +94,10 @@ note:
    │                                                                  ^^^^^^^^^^ address: Value => None
 
 note: 
-   ┌─ features/ownable.fe:20:12
-   │
-20 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:20:26
-   │
-20 │     assert msg.sender == self._owner
-   │                          ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/ownable.fe:20:12
-   │
-20 │     assert msg.sender == self._owner
-   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/ownable.fe:21:12
-   │
-21 │     assert newOwner != address(0)
-   │            ^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:21:32
-   │
-21 │     assert newOwner != address(0)
-   │                                ^ u256: Value => None
-
-note: 
-   ┌─ features/ownable.fe:21:24
-   │
-21 │     assert newOwner != address(0)
-   │                        ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:21:12
-   │
-21 │     assert newOwner != address(0)
-   │            ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/ownable.fe:22:5
-   │
-22 │     self._owner = newOwner
-   │     ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/ownable.fe:22:19
-   │
-22 │     self._owner = newOwner
-   │                   ^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:23:45
-   │
-23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │                                             ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/ownable.fe:23:57
-   │
-23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │                                                         ^^^^^^^^ address: Value => None
-
-note: 
    ┌─ features/ownable.fe:17:5
    │
 17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
-   │
-   = Event {
-         name: "OwnershipTransferred",
-         fields: [
-             EventField {
-                 name: "previousOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "newOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-         ],
-     }
-
-note: 
-   ┌─ features/ownable.fe:23:5
-   │
-23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
    │
    = Event {
          name: "OwnershipTransferred",
@@ -323,6 +145,103 @@ note:
          typ: Base(
              Address,
          ),
+     }
+
+note: 
+   ┌─ features/ownable.fe:19:3
+   │  
+19 │ ╭   pub fn transferOwnership(self, newOwner: address):
+20 │ │     assert msg.sender == self._owner
+21 │ │     assert newOwner != address(0)
+22 │ │     self._owner = newOwner
+23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
+   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 9053558391660990741
+   │  
+   = FunctionSignature {
+         self_decl: Mutable,
+         params: [
+             FunctionParam {
+                 name: "newOwner",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/ownable.fe:20:12
+   │
+20 │     assert msg.sender == self._owner
+   │            ^^^^^^^^^^    ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+   │            │              
+   │            address: Value => None
+
+note: 
+   ┌─ features/ownable.fe:20:12
+   │
+20 │     assert msg.sender == self._owner
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+21 │     assert newOwner != address(0)
+   │            ^^^^^^^^            ^ u256: Value => None
+   │            │                    
+   │            address: Value => None
+
+note: 
+   ┌─ features/ownable.fe:21:24
+   │
+21 │     assert newOwner != address(0)
+   │                        ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ features/ownable.fe:21:12
+   │
+21 │     assert newOwner != address(0)
+   │            ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+22 │     self._owner = newOwner
+   │     ^^^^^^^^^^^   ^^^^^^^^ address: Value => None
+   │     │              
+   │     address: Storage { nonce: Some(0) } => None
+23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
+   │                                             ^^^^^^^^^^  ^^^^^^^^ address: Value => None
+   │                                             │            
+   │                                             address: Value => None
+
+note: 
+   ┌─ features/ownable.fe:23:5
+   │
+23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
+   │
+   = Event {
+         name: "OwnershipTransferred",
+         fields: [
+             EventField {
+                 name: "previousOwner",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "newOwner",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+         ],
      }
 
 note: 

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -4,14 +4,54 @@ expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
+  ┌─ features/pure_fn_standalone.fe:2:1
+  │  
+2 │ ╭ fn add_bonus(x: u256) -> u256:
+3 │ │     return x + 10
+  │ ╰─────────────────^ attributes hash: 10491700091878076414
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [
+            FunctionParam {
+                name: "x",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U256,
+                        ),
+                    ),
+                ),
+            },
+        ],
+        return_type: Ok(
+            Base(
+                Numeric(
+                    U256,
+                ),
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/pure_fn_standalone.fe:3:12
+  │
+3 │     return x + 10
+  │            ^   ^^ u256: Value => None
+  │            │    
+  │            u256: Value => None
+
+note: 
+  ┌─ features/pure_fn_standalone.fe:3:12
+  │
+3 │     return x + 10
+  │            ^^^^^^ u256: Value => None
+
+note: 
   ┌─ features/pure_fn_standalone.fe:6:5
   │
 6 │     cool_users: Map<address, bool>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, bool>
-
-note: 
-  ┌─ features/pure_fn_standalone.fe:7:5
-  │
 7 │     points: Map<address, u256>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
 
@@ -55,6 +95,63 @@ note:
      }
 
 note: 
+   ┌─ features/pure_fn_standalone.fe:10:12
+   │
+10 │         if self.cool_users[user]:
+   │            ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │            │                
+   │            Map<address, bool>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:10:12
+   │
+10 │         if self.cool_users[user]:
+   │            ^^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
+11 │             self.points[user] += add_bonus(val)
+   │             ^^^^^^^^^^^ ^^^^ address: Value => None
+   │             │            
+   │             Map<address, u256>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:13
+   │
+11 │             self.points[user] += add_bonus(val)
+   │             ^^^^^^^^^^^^^^^^^              ^^^ u256: Value => None
+   │             │                               
+   │             u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:34
+   │
+11 │             self.points[user] += add_bonus(val)
+   │                                  ^^^^^^^^^^^^^^ u256: Value => None
+12 │         else:
+13 │             self.points[user] += val
+   │             ^^^^^^^^^^^ ^^^^ address: Value => None
+   │             │            
+   │             Map<address, u256>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:13:13
+   │
+13 │             self.points[user] += val
+   │             ^^^^^^^^^^^^^^^^^    ^^^ u256: Value => None
+   │             │                     
+   │             u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:34
+   │
+11 │             self.points[user] += add_bonus(val)
+   │                                  ^^^^^^^^^ attributes hash: 6251600114237252411
+   │
+   = Pure(
+         FunctionId(
+             0,
+         ),
+     )
+
+note: 
    ┌─ features/pure_fn_standalone.fe:15:5
    │  
 15 │ ╭     pub fn bar(self, x: u256) -> u256:
@@ -89,76 +186,10 @@ note:
      }
 
 note: 
-   ┌─ features/pure_fn_standalone.fe:10:12
+   ┌─ features/pure_fn_standalone.fe:16:16
    │
-10 │         if self.cool_users[user]:
-   │            ^^^^^^^^^^^^^^^ Map<address, bool>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:10:28
-   │
-10 │         if self.cool_users[user]:
-   │                            ^^^^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:10:12
-   │
-10 │         if self.cool_users[user]:
-   │            ^^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:11:13
-   │
-11 │             self.points[user] += add_bonus(val)
-   │             ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:11:25
-   │
-11 │             self.points[user] += add_bonus(val)
-   │                         ^^^^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:11:13
-   │
-11 │             self.points[user] += add_bonus(val)
-   │             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:11:44
-   │
-11 │             self.points[user] += add_bonus(val)
-   │                                            ^^^ u256: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:11:34
-   │
-11 │             self.points[user] += add_bonus(val)
-   │                                  ^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:13:13
-   │
-13 │             self.points[user] += val
-   │             ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:13:25
-   │
-13 │             self.points[user] += val
-   │                         ^^^^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:13:13
-   │
-13 │             self.points[user] += val
-   │             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:13:34
-   │
-13 │             self.points[user] += val
-   │                                  ^^^ u256: Value => None
+16 │         let a: address = address(x)
+   │                ^^^^^^^ address
 
 note: 
    ┌─ features/pure_fn_standalone.fe:16:34
@@ -171,102 +202,48 @@ note:
    │
 16 │         let a: address = address(x)
    │                          ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:17:25
-   │
 17 │         self.add_points(a, 100)
-   │                         ^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:17:28
-   │
-17 │         self.add_points(a, 100)
-   │                            ^^^ u256: Value => None
+   │                         ^  ^^^ u256: Value => None
+   │                         │   
+   │                         address: Value => None
 
 note: 
    ┌─ features/pure_fn_standalone.fe:17:9
    │
 17 │         self.add_points(a, 100)
    │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+18 │         self.cool_users[a] = true
+   │         ^^^^^^^^^^^^^^^ ^ address: Value => None
+   │         │                
+   │         Map<address, bool>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/pure_fn_standalone.fe:18:9
    │
 18 │         self.cool_users[a] = true
-   │         ^^^^^^^^^^^^^^^ Map<address, bool>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:18:25
-   │
-18 │         self.cool_users[a] = true
-   │                         ^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:18:9
-   │
-18 │         self.cool_users[a] = true
-   │         ^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:18:30
-   │
-18 │         self.cool_users[a] = true
-   │                              ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:19:25
-   │
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value => None
+   │         │                     
+   │         bool: Storage { nonce: None } => None
 19 │         self.add_points(a, 100)
-   │                         ^ address: Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:19:28
-   │
-19 │         self.add_points(a, 100)
-   │                            ^^^ u256: Value => None
+   │                         ^  ^^^ u256: Value => None
+   │                         │   
+   │                         address: Value => None
 
 note: 
    ┌─ features/pure_fn_standalone.fe:19:9
    │
 19 │         self.add_points(a, 100)
    │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:20:16
-   │
 20 │         return self.points[a]
-   │                ^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:20:28
-   │
-20 │         return self.points[a]
-   │                            ^ address: Value => None
+   │                ^^^^^^^^^^^ ^ address: Value => None
+   │                │            
+   │                Map<address, u256>: Storage { nonce: Some(1) } => None
 
 note: 
    ┌─ features/pure_fn_standalone.fe:20:16
    │
 20 │         return self.points[a]
    │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:16:16
-   │
-16 │         let a: address = address(x)
-   │                ^^^^^^^ address
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:11:34
-   │
-11 │             self.points[user] += add_bonus(val)
-   │                                  ^^^^^^^^^ attributes hash: 6251600114237252411
-   │
-   = Pure(
-         FunctionId(
-             0,
-         ),
-     )
 
 note: 
    ┌─ features/pure_fn_standalone.fe:16:26

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -37,15 +37,15 @@ note:
   ┌─ features/pure_fn_standalone.fe:3:12
   │
 3 │     return x + 10
-  │            ^   ^^ u256: Value => None
+  │            ^   ^^ u256: Value
   │            │    
-  │            u256: Value => None
+  │            u256: Value
 
 note: 
   ┌─ features/pure_fn_standalone.fe:3:12
   │
 3 │     return x + 10
-  │            ^^^^^^ u256: Value => None
+  │            ^^^^^^ u256: Value
 
 note: 
   ┌─ features/pure_fn_standalone.fe:6:5
@@ -63,10 +63,12 @@ note:
 11 │ │             self.points[user] += add_bonus(val)
 12 │ │         else:
 13 │ │             self.points[user] += val
-   │ ╰────────────────────────────────────^ attributes hash: 316895463975841295
+   │ ╰────────────────────────────────────^ attributes hash: 17719730205805698134
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "user",
@@ -98,58 +100,70 @@ note:
    ┌─ features/pure_fn_standalone.fe:10:12
    │
 10 │         if self.cool_users[user]:
-   │            ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
-   │            │                
-   │            Map<address, bool>: Storage { nonce: Some(0) } => None
+   │            ^^^^ Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:10:12
    │
 10 │         if self.cool_users[user]:
-   │            ^^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Some(Value)
+   │            ^^^^^^^^^^^^^^^ ^^^^ address: Value
+   │            │                
+   │            Map<address, bool>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:10:12
+   │
+10 │         if self.cool_users[user]:
+   │            ^^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: None } => Value
 11 │             self.points[user] += add_bonus(val)
-   │             ^^^^^^^^^^^ ^^^^ address: Value => None
-   │             │            
-   │             Map<address, u256>: Storage { nonce: Some(1) } => None
+   │             ^^^^ Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:11:13
    │
 11 │             self.points[user] += add_bonus(val)
-   │             ^^^^^^^^^^^^^^^^^              ^^^ u256: Value => None
+   │             ^^^^^^^^^^^ ^^^^ address: Value
+   │             │            
+   │             Map<address, u256>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:11:13
+   │
+11 │             self.points[user] += add_bonus(val)
+   │             ^^^^^^^^^^^^^^^^^              ^^^ u256: Value
    │             │                               
-   │             u256: Storage { nonce: None } => None
+   │             u256: Storage { nonce: None }
 
 note: 
    ┌─ features/pure_fn_standalone.fe:11:34
    │
 11 │             self.points[user] += add_bonus(val)
-   │                                  ^^^^^^^^^^^^^^ u256: Value => None
+   │                                  ^^^^^^^^^^^^^^ u256: Value
 12 │         else:
 13 │             self.points[user] += val
-   │             ^^^^^^^^^^^ ^^^^ address: Value => None
-   │             │            
-   │             Map<address, u256>: Storage { nonce: Some(1) } => None
+   │             ^^^^ Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:13:13
    │
 13 │             self.points[user] += val
-   │             ^^^^^^^^^^^^^^^^^    ^^^ u256: Value => None
+   │             ^^^^^^^^^^^ ^^^^ address: Value
+   │             │            
+   │             Map<address, u256>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:13:13
+   │
+13 │             self.points[user] += val
+   │             ^^^^^^^^^^^^^^^^^    ^^^ u256: Value
    │             │                     
-   │             u256: Storage { nonce: None } => None
+   │             u256: Storage { nonce: None }
 
 note: 
    ┌─ features/pure_fn_standalone.fe:11:34
    │
 11 │             self.points[user] += add_bonus(val)
-   │                                  ^^^^^^^^^ attributes hash: 6251600114237252411
-   │
-   = Pure(
-         FunctionId(
-             0,
-         ),
-     )
+   │                                  ^^^^^^^^^ Pure(FunctionId(0))
 
 note: 
    ┌─ features/pure_fn_standalone.fe:15:5
@@ -160,10 +174,12 @@ note:
 18 │ │         self.cool_users[a] = true
 19 │ │         self.add_points(a, 100)
 20 │ │         return self.points[a]
-   │ ╰─────────────────────────────^ attributes hash: 14124651018748084078
+   │ ╰─────────────────────────────^ attributes hash: 11582699020310544004
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "x",
@@ -195,88 +211,79 @@ note:
    ┌─ features/pure_fn_standalone.fe:16:34
    │
 16 │         let a: address = address(x)
-   │                                  ^ u256: Value => None
+   │                                  ^ u256: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:16:26
    │
 16 │         let a: address = address(x)
-   │                          ^^^^^^^^^^ address: Value => None
+   │                          ^^^^^^^^^^ address: Value
 17 │         self.add_points(a, 100)
-   │                         ^  ^^^ u256: Value => None
-   │                         │   
-   │                         address: Value => None
+   │         ^^^^            ^  ^^^ u256: Value
+   │         │               │   
+   │         │               address: Value
+   │         Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:17:9
    │
 17 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 18 │         self.cool_users[a] = true
-   │         ^^^^^^^^^^^^^^^ ^ address: Value => None
-   │         │                
-   │         Map<address, bool>: Storage { nonce: Some(0) } => None
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:18:9
    │
 18 │         self.cool_users[a] = true
-   │         ^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value => None
+   │         ^^^^^^^^^^^^^^^ ^ address: Value
+   │         │                
+   │         Map<address, bool>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:18:9
+   │
+18 │         self.cool_users[a] = true
+   │         ^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value
    │         │                     
-   │         bool: Storage { nonce: None } => None
+   │         bool: Storage { nonce: None }
 19 │         self.add_points(a, 100)
-   │                         ^  ^^^ u256: Value => None
-   │                         │   
-   │                         address: Value => None
+   │         ^^^^            ^  ^^^ u256: Value
+   │         │               │   
+   │         │               address: Value
+   │         Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:19:9
    │
 19 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 20 │         return self.points[a]
-   │                ^^^^^^^^^^^ ^ address: Value => None
-   │                │            
-   │                Map<address, u256>: Storage { nonce: Some(1) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:20:16
    │
 20 │         return self.points[a]
-   │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+   │                ^^^^^^^^^^^ ^ address: Value
+   │                │            
+   │                Map<address, u256>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ features/pure_fn_standalone.fe:20:16
+   │
+20 │         return self.points[a]
+   │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ features/pure_fn_standalone.fe:16:26
    │
 16 │         let a: address = address(x)
-   │                          ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:17:9
-   │
+   │                          ^^^^^^^ TypeConstructor(Base(Address))
 17 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^ attributes hash: 5094765954567266946
-   │
-   = SelfAttribute {
-         func_name: "add_points",
-         self_span: 400..404,
-     }
-
-note: 
-   ┌─ features/pure_fn_standalone.fe:19:9
-   │
+   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(1) }
+18 │         self.cool_users[a] = true
 19 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^ attributes hash: 5317772279976617936
-   │
-   = SelfAttribute {
-         func_name: "add_points",
-         self_span: 466..470,
-     }
+   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(1) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_addition_i256.fe:3:16
   │
 3 │         return x + y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_addition_i256.fe:3:16
   │
 3 │         return x + y
-  │                ^^^^^ i256: Value => None
+  │                ^^^^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_addition_i256.fe:3:16
   │
 3 │         return x + y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_addition_i256.fe:3:20
-  │
-3 │         return x + y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_addition_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_addition_u128.fe:3:16
   │
 3 │         return x + y
-  │                ^   ^ u128: Value => None
+  │                ^   ^ u128: Value
   │                │    
-  │                u128: Value => None
+  │                u128: Value
 
 note: 
   ┌─ features/return_addition_u128.fe:3:16
   │
 3 │         return x + y
-  │                ^^^^^ u128: Value => None
+  │                ^^^^^ u128: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_addition_u128.fe:3:16
   │
 3 │         return x + y
-  │                ^ u128: Value => None
-
-note: 
-  ┌─ features/return_addition_u128.fe:3:20
-  │
-3 │         return x + y
-  │                    ^ u128: Value => None
+  │                ^   ^ u128: Value => None
+  │                │    
+  │                u128: Value => None
 
 note: 
   ┌─ features/return_addition_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_addition_u256.fe:3:16
   │
 3 │         return x + y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_addition_u256.fe:3:16
   │
 3 │         return x + y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_addition_u256.fe:3:16
   │
 3 │         return x + y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_addition_u256.fe:3:20
-  │
-3 │         return x + y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_addition_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/return_array.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -39,39 +39,27 @@ note:
     }
 
 note: 
-  ┌─ features/return_array.fe:4:9
-  │
-4 │         my_array[3] = x
-  │         ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
-  ┌─ features/return_array.fe:4:18
-  │
-4 │         my_array[3] = x
-  │                  ^ u256: Value => None
-
-note: 
-  ┌─ features/return_array.fe:4:9
-  │
-4 │         my_array[3] = x
-  │         ^^^^^^^^^^^ u256: Memory => None
-
-note: 
-  ┌─ features/return_array.fe:4:23
-  │
-4 │         my_array[3] = x
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/return_array.fe:5:16
-  │
-5 │         return my_array
-  │                ^^^^^^^^ Array<u256, 5>: Memory => None
-
-note: 
   ┌─ features/return_array.fe:3:23
   │
 3 │         let my_array: Array<u256,5>
   │                       ^^^^^^^^^^^^^ Array<u256, 5>
+
+note: 
+  ┌─ features/return_array.fe:4:9
+  │
+4 │         my_array[3] = x
+  │         ^^^^^^^^ ^ u256: Value => None
+  │         │         
+  │         Array<u256, 5>: Memory => None
+
+note: 
+  ┌─ features/return_array.fe:4:9
+  │
+4 │         my_array[3] = x
+  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         │              
+  │         u256: Memory => None
+5 │         return my_array
+  │                ^^^^^^^^ Array<u256, 5>: Memory => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -48,18 +48,18 @@ note:
   ┌─ features/return_array.fe:4:9
   │
 4 │         my_array[3] = x
-  │         ^^^^^^^^ ^ u256: Value => None
+  │         ^^^^^^^^ ^ u256: Value
   │         │         
-  │         Array<u256, 5>: Memory => None
+  │         Array<u256, 5>: Memory
 
 note: 
   ┌─ features/return_array.fe:4:9
   │
 4 │         my_array[3] = x
-  │         ^^^^^^^^^^^   ^ u256: Value => None
+  │         ^^^^^^^^^^^   ^ u256: Value
   │         │              
-  │         u256: Memory => None
+  │         u256: Memory
 5 │         return my_array
-  │                ^^^^^^^^ Array<u256, 5>: Memory => None
+  │                ^^^^^^^^ Array<u256, 5>: Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwiseand_u128.fe:3:16
   │
 3 │         return x & y
-  │                ^ u128: Value => None
-
-note: 
-  ┌─ features/return_bitwiseand_u128.fe:3:20
-  │
-3 │         return x & y
-  │                    ^ u128: Value => None
+  │                ^   ^ u128: Value => None
+  │                │    
+  │                u128: Value => None
 
 note: 
   ┌─ features/return_bitwiseand_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwiseand_u128.fe:3:16
   │
 3 │         return x & y
-  │                ^   ^ u128: Value => None
+  │                ^   ^ u128: Value
   │                │    
-  │                u128: Value => None
+  │                u128: Value
 
 note: 
   ┌─ features/return_bitwiseand_u128.fe:3:16
   │
 3 │         return x & y
-  │                ^^^^^ u128: Value => None
+  │                ^^^^^ u128: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwiseand_u256.fe:3:16
   │
 3 │         return x & y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_bitwiseand_u256.fe:3:20
-  │
-3 │         return x & y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_bitwiseand_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwiseand_u256.fe:3:16
   │
 3 │         return x & y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_bitwiseand_u256.fe:3:16
   │
 3 │         return x & y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwiseor_u256.fe:3:16
   │
 3 │         return x | y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_bitwiseor_u256.fe:3:20
-  │
-3 │         return x | y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_bitwiseor_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwiseor_u256.fe:3:16
   │
 3 │         return x | y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_bitwiseor_u256.fe:3:16
   │
 3 │         return x | y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwiseshl_u256.fe:3:16
   │
 3 │         return x << y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_bitwiseshl_u256.fe:3:21
-  │
-3 │         return x << y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_bitwiseshl_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwiseshl_u256.fe:3:16
   │
 3 │         return x << y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_bitwiseshl_u256.fe:3:16
   │
 3 │         return x << y
-  │                ^^^^^^ u256: Value => None
+  │                ^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwiseshr_i256.fe:3:16
   │
 3 │         return x >> y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_bitwiseshr_i256.fe:3:16
   │
 3 │         return x >> y
-  │                ^^^^^^ i256: Value => None
+  │                ^^^^^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwiseshr_i256.fe:3:16
   │
 3 │         return x >> y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_bitwiseshr_i256.fe:3:21
-  │
-3 │         return x >> y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_bitwiseshr_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwiseshr_u256.fe:3:16
   │
 3 │         return x >> y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_bitwiseshr_u256.fe:3:16
   │
 3 │         return x >> y
-  │                ^^^^^^ u256: Value => None
+  │                ^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwiseshr_u256.fe:3:16
   │
 3 │         return x >> y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_bitwiseshr_u256.fe:3:21
-  │
-3 │         return x >> y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_bitwiseshr_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_bitwisexor_u256.fe:3:16
   │
 3 │         return x ^ y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_bitwisexor_u256.fe:3:20
-  │
-3 │         return x ^ y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_bitwisexor_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_bitwisexor_u256.fe:3:16
   │
 3 │         return x ^ y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_bitwisexor_u256.fe:3:16
   │
 3 │         return x ^ y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_false.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_false.snap
@@ -24,6 +24,6 @@ note:
   ┌─ features/return_bool_false.fe:3:16
   │
 3 │         return false
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_inverted.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_inverted.snap
@@ -33,12 +33,12 @@ note:
   ┌─ features/return_bool_inverted.fe:3:20
   │
 3 │         return not some_condition
-  │                    ^^^^^^^^^^^^^^ bool: Value => None
+  │                    ^^^^^^^^^^^^^^ bool: Value
 
 note: 
   ┌─ features/return_bool_inverted.fe:3:16
   │
 3 │         return not some_condition
-  │                ^^^^^^^^^^^^^^^^^^ bool: Value => None
+  │                ^^^^^^^^^^^^^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
@@ -41,14 +41,14 @@ note:
   ┌─ features/return_bool_op_and.fe:3:16
   │
 3 │         return x and y
-  │                ^     ^ bool: Value => None
+  │                ^     ^ bool: Value
   │                │      
-  │                bool: Value => None
+  │                bool: Value
 
 note: 
   ┌─ features/return_bool_op_and.fe:3:16
   │
 3 │         return x and y
-  │                ^^^^^^^ bool: Value => None
+  │                ^^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
@@ -41,13 +41,9 @@ note:
   ┌─ features/return_bool_op_and.fe:3:16
   │
 3 │         return x and y
-  │                ^ bool: Value => None
-
-note: 
-  ┌─ features/return_bool_op_and.fe:3:22
-  │
-3 │         return x and y
-  │                      ^ bool: Value => None
+  │                ^     ^ bool: Value => None
+  │                │      
+  │                bool: Value => None
 
 note: 
   ┌─ features/return_bool_op_and.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
@@ -41,13 +41,9 @@ note:
   ┌─ features/return_bool_op_or.fe:3:16
   │
 3 │         return x or y
-  │                ^ bool: Value => None
-
-note: 
-  ┌─ features/return_bool_op_or.fe:3:21
-  │
-3 │         return x or y
-  │                     ^ bool: Value => None
+  │                ^    ^ bool: Value => None
+  │                │     
+  │                bool: Value => None
 
 note: 
   ┌─ features/return_bool_op_or.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
@@ -41,14 +41,14 @@ note:
   ┌─ features/return_bool_op_or.fe:3:16
   │
 3 │         return x or y
-  │                ^    ^ bool: Value => None
+  │                ^    ^ bool: Value
   │                │     
-  │                bool: Value => None
+  │                bool: Value
 
 note: 
   ┌─ features/return_bool_op_or.fe:3:16
   │
 3 │         return x or y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_true.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_true.snap
@@ -24,6 +24,6 @@ note:
   ┌─ features/return_bool_true.fe:3:16
   │
 3 │         return true
-  │                ^^^^ bool: Value => None
+  │                ^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
@@ -21,6 +21,12 @@ note:
     }
 
 note: 
+  ┌─ features/return_builtin_attributes.fe:3:16
+  │
+3 │         return block.coinbase
+  │                ^^^^^^^^^^^^^^ address: Value => None
+
+note: 
   ┌─ features/return_builtin_attributes.fe:5:5
   │  
 5 │ ╭     pub fn difficulty() -> u256:
@@ -38,6 +44,12 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/return_builtin_attributes.fe:6:16
+  │
+6 │         return block.difficulty
+  │                ^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
   ┌─ features/return_builtin_attributes.fe:8:5
@@ -59,6 +71,12 @@ note:
     }
 
 note: 
+  ┌─ features/return_builtin_attributes.fe:9:16
+  │
+9 │         return block.number
+  │                ^^^^^^^^^^^^ u256: Value => None
+
+note: 
    ┌─ features/return_builtin_attributes.fe:11:5
    │  
 11 │ ╭     pub fn timestamp() -> u256:
@@ -76,6 +94,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/return_builtin_attributes.fe:12:16
+   │
+12 │         return block.timestamp
+   │                ^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
    ┌─ features/return_builtin_attributes.fe:14:5
@@ -97,6 +121,12 @@ note:
      }
 
 note: 
+   ┌─ features/return_builtin_attributes.fe:15:16
+   │
+15 │         return chain.id
+   │                ^^^^^^^^ u256: Value => None
+
+note: 
    ┌─ features/return_builtin_attributes.fe:17:5
    │  
 17 │ ╭     pub fn sender() -> address:
@@ -112,6 +142,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/return_builtin_attributes.fe:18:16
+   │
+18 │         return msg.sender
+   │                ^^^^^^^^^^ address: Value => None
 
 note: 
    ┌─ features/return_builtin_attributes.fe:20:5
@@ -133,6 +169,12 @@ note:
      }
 
 note: 
+   ┌─ features/return_builtin_attributes.fe:21:16
+   │
+21 │         return msg.value
+   │                ^^^^^^^^^ u256: Value => None
+
+note: 
    ┌─ features/return_builtin_attributes.fe:23:5
    │  
 23 │ ╭     pub fn origin() -> address:
@@ -148,6 +190,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/return_builtin_attributes.fe:24:16
+   │
+24 │         return tx.origin
+   │                ^^^^^^^^^ address: Value => None
 
 note: 
    ┌─ features/return_builtin_attributes.fe:26:5
@@ -167,54 +215,6 @@ note:
              ),
          ),
      }
-
-note: 
-  ┌─ features/return_builtin_attributes.fe:3:16
-  │
-3 │         return block.coinbase
-  │                ^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-  ┌─ features/return_builtin_attributes.fe:6:16
-  │
-6 │         return block.difficulty
-  │                ^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_builtin_attributes.fe:9:16
-  │
-9 │         return block.number
-  │                ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:12:16
-   │
-12 │         return block.timestamp
-   │                ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:15:16
-   │
-15 │         return chain.id
-   │                ^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:18:16
-   │
-18 │         return msg.sender
-   │                ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:21:16
-   │
-21 │         return msg.value
-   │                ^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/return_builtin_attributes.fe:24:16
-   │
-24 │         return tx.origin
-   │                ^^^^^^^^^ address: Value => None
 
 note: 
    ┌─ features/return_builtin_attributes.fe:27:16

--- a/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
@@ -24,7 +24,7 @@ note:
   ┌─ features/return_builtin_attributes.fe:3:16
   │
 3 │         return block.coinbase
-  │                ^^^^^^^^^^^^^^ address: Value => None
+  │                ^^^^^^^^^^^^^^ address: Value
 
 note: 
   ┌─ features/return_builtin_attributes.fe:5:5
@@ -49,7 +49,7 @@ note:
   ┌─ features/return_builtin_attributes.fe:6:16
   │
 6 │         return block.difficulty
-  │                ^^^^^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/return_builtin_attributes.fe:8:5
@@ -74,7 +74,7 @@ note:
   ┌─ features/return_builtin_attributes.fe:9:16
   │
 9 │         return block.number
-  │                ^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/return_builtin_attributes.fe:11:5
@@ -99,7 +99,7 @@ note:
    ┌─ features/return_builtin_attributes.fe:12:16
    │
 12 │         return block.timestamp
-   │                ^^^^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/return_builtin_attributes.fe:14:5
@@ -124,7 +124,7 @@ note:
    ┌─ features/return_builtin_attributes.fe:15:16
    │
 15 │         return chain.id
-   │                ^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/return_builtin_attributes.fe:17:5
@@ -147,7 +147,7 @@ note:
    ┌─ features/return_builtin_attributes.fe:18:16
    │
 18 │         return msg.sender
-   │                ^^^^^^^^^^ address: Value => None
+   │                ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/return_builtin_attributes.fe:20:5
@@ -172,7 +172,7 @@ note:
    ┌─ features/return_builtin_attributes.fe:21:16
    │
 21 │         return msg.value
-   │                ^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/return_builtin_attributes.fe:23:5
@@ -195,7 +195,7 @@ note:
    ┌─ features/return_builtin_attributes.fe:24:16
    │
 24 │         return tx.origin
-   │                ^^^^^^^^^ address: Value => None
+   │                ^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/return_builtin_attributes.fe:26:5
@@ -220,6 +220,6 @@ note:
    ┌─ features/return_builtin_attributes.fe:27:16
    │
 27 │         return tx.gas_price
-   │                ^^^^^^^^^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_division_i256.fe:3:16
   │
 3 │         return x / y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_division_i256.fe:3:16
   │
 3 │         return x / y
-  │                ^^^^^ i256: Value => None
+  │                ^^^^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_division_i256.fe:3:16
   │
 3 │         return x / y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_division_i256.fe:3:20
-  │
-3 │         return x / y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_division_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_division_u256.fe:3:16
   │
 3 │         return x / y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_division_u256.fe:3:20
-  │
-3 │         return x / y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_division_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_division_u256.fe:3:16
   │
 3 │         return x / y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_division_u256.fe:3:16
   │
 3 │         return x / y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
@@ -38,6 +38,12 @@ note:
     }
 
 note: 
+  ┌─ features/return_unit.fe:7:12
+  │
+7 │     return ()
+  │            ^^ (): Value => None
+
+note: 
    ┌─ features/return_unit.fe:9:3
    │  
  9 │ ╭   pub fn explicit_return_b1() -> ():
@@ -72,6 +78,12 @@ note:
      }
 
 note: 
+   ┌─ features/return_unit.fe:13:12
+   │
+13 │     return ()
+   │            ^^ (): Value => None
+
+note: 
    ┌─ features/return_unit.fe:15:3
    │  
 15 │ ╭   pub fn implicit_a1():
@@ -104,17 +116,5 @@ note:
              ),
          ),
      }
-
-note: 
-  ┌─ features/return_unit.fe:7:12
-  │
-7 │     return ()
-  │            ^^ (): Value => None
-
-note: 
-   ┌─ features/return_unit.fe:13:12
-   │
-13 │     return ()
-   │            ^^ (): Value => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
@@ -41,7 +41,7 @@ note:
   ┌─ features/return_unit.fe:7:12
   │
 7 │     return ()
-  │            ^^ (): Value => None
+  │            ^^ (): Value
 
 note: 
    ┌─ features/return_unit.fe:9:3
@@ -81,7 +81,7 @@ note:
    ┌─ features/return_unit.fe:13:12
    │
 13 │     return ()
-   │            ^^ (): Value => None
+   │            ^^ (): Value
 
 note: 
    ┌─ features/return_unit.fe:15:3

--- a/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_eq_u256.fe:3:16
   │
 3 │         return x == y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_eq_u256.fe:3:21
-  │
-3 │         return x == y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_eq_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_eq_u256.fe:3:16
   │
 3 │         return x == y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_eq_u256.fe:3:16
   │
 3 │         return x == y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_gt_i256.fe:3:16
   │
 3 │         return x > y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_gt_i256.fe:3:16
   │
 3 │         return x > y
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_gt_i256.fe:3:16
   │
 3 │         return x > y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_gt_i256.fe:3:20
-  │
-3 │         return x > y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_gt_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_gt_u256.fe:3:16
   │
 3 │         return x > y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_gt_u256.fe:3:16
   │
 3 │         return x > y
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_gt_u256.fe:3:16
   │
 3 │         return x > y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_gt_u256.fe:3:20
-  │
-3 │         return x > y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_gt_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_gte_i256.fe:3:16
   │
 3 │         return x >= y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_gte_i256.fe:3:21
-  │
-3 │         return x >= y
-  │                     ^ i256: Value => None
+  │                ^    ^ i256: Value => None
+  │                │     
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_gte_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_gte_i256.fe:3:16
   │
 3 │         return x >= y
-  │                ^    ^ i256: Value => None
+  │                ^    ^ i256: Value
   │                │     
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_gte_i256.fe:3:16
   │
 3 │         return x >= y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_gte_u256.fe:3:16
   │
 3 │         return x >= y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_gte_u256.fe:3:21
-  │
-3 │         return x >= y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_gte_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_gte_u256.fe:3:16
   │
 3 │         return x >= y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_gte_u256.fe:3:16
   │
 3 │         return x >= y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
@@ -26,32 +26,24 @@ note:
   ┌─ features/return_i128_cast.fe:3:22
   │
 3 │         return i128(-3)
-  │                      ^ u256: Value => None
+  │                      ^ u256: Value
 
 note: 
   ┌─ features/return_i128_cast.fe:3:21
   │
 3 │         return i128(-3)
-  │                     ^^ i128: Value => None
+  │                     ^^ i128: Value
 
 note: 
   ┌─ features/return_i128_cast.fe:3:16
   │
 3 │         return i128(-3)
-  │                ^^^^^^^^ i128: Value => None
+  │                ^^^^^^^^ i128: Value
 
 note: 
   ┌─ features/return_i128_cast.fe:3:16
   │
 3 │         return i128(-3)
-  │                ^^^^ attributes hash: 17259437597606577465
-  │
-  = TypeConstructor {
-        typ: Base(
-            Numeric(
-                I128,
-            ),
-        ),
-    }
+  │                ^^^^ TypeConstructor(Base(Numeric(I128)))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i256.snap
@@ -26,12 +26,12 @@ note:
   ┌─ features/return_i256.fe:3:17
   │
 3 │         return -3
-  │                 ^ u256: Value => None
+  │                 ^ u256: Value
 
 note: 
   ┌─ features/return_i256.fe:3:16
   │
 3 │         return -3
-  │                ^^ i256: Value => None
+  │                ^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u128.snap
@@ -37,6 +37,6 @@ note:
   ┌─ features/return_identity_u128.fe:3:16
   │
 3 │         return x
-  │                ^ u128: Value => None
+  │                ^ u128: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u16.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u16.snap
@@ -37,6 +37,6 @@ note:
   ┌─ features/return_identity_u16.fe:3:16
   │
 3 │         return x
-  │                ^ u16: Value => None
+  │                ^ u16: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u256.snap
@@ -37,6 +37,6 @@ note:
   ┌─ features/return_identity_u256.fe:3:16
   │
 3 │         return x
-  │                ^ u256: Value => None
+  │                ^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u32.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u32.snap
@@ -37,6 +37,6 @@ note:
   ┌─ features/return_identity_u32.fe:3:16
   │
 3 │         return x
-  │                ^ u32: Value => None
+  │                ^ u32: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u64.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u64.snap
@@ -37,6 +37,6 @@ note:
   ┌─ features/return_identity_u64.fe:3:16
   │
 3 │         return x
-  │                ^ u64: Value => None
+  │                ^ u64: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u8.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u8.snap
@@ -37,6 +37,6 @@ note:
   ┌─ features/return_identity_u8.fe:3:16
   │
 3 │         return x
-  │                ^ u8: Value => None
+  │                ^ u8: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_lt_i256.fe:3:16
   │
 3 │         return x < y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_lt_i256.fe:3:20
-  │
-3 │         return x < y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_lt_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_lt_i256.fe:3:16
   │
 3 │         return x < y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_lt_i256.fe:3:16
   │
 3 │         return x < y
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_lt_u128.fe:3:16
   │
 3 │         return x < y
-  │                ^   ^ u128: Value => None
+  │                ^   ^ u128: Value
   │                │    
-  │                u128: Value => None
+  │                u128: Value
 
 note: 
   ┌─ features/return_lt_u128.fe:3:16
   │
 3 │         return x < y
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_lt_u128.fe:3:16
   │
 3 │         return x < y
-  │                ^ u128: Value => None
-
-note: 
-  ┌─ features/return_lt_u128.fe:3:20
-  │
-3 │         return x < y
-  │                    ^ u128: Value => None
+  │                ^   ^ u128: Value => None
+  │                │    
+  │                u128: Value => None
 
 note: 
   ┌─ features/return_lt_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_lt_u256.fe:3:16
   │
 3 │         return x < y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_lt_u256.fe:3:16
   │
 3 │         return x < y
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_lt_u256.fe:3:16
   │
 3 │         return x < y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_lt_u256.fe:3:20
-  │
-3 │         return x < y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_lt_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_lte_i256.fe:3:16
   │
 3 │         return x <= y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_lte_i256.fe:3:21
-  │
-3 │         return x <= y
-  │                     ^ i256: Value => None
+  │                ^    ^ i256: Value => None
+  │                │     
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_lte_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_lte_i256.fe:3:16
   │
 3 │         return x <= y
-  │                ^    ^ i256: Value => None
+  │                ^    ^ i256: Value
   │                │     
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_lte_i256.fe:3:16
   │
 3 │         return x <= y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_lte_u256.fe:3:16
   │
 3 │         return x <= y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_lte_u256.fe:3:21
-  │
-3 │         return x <= y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_lte_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_lte_u256.fe:3:16
   │
 3 │         return x <= y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_lte_u256.fe:3:16
   │
 3 │         return x <= y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_mod_i256.fe:3:16
   │
 3 │         return x % y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_mod_i256.fe:3:20
-  │
-3 │         return x % y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_mod_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_mod_i256.fe:3:16
   │
 3 │         return x % y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_mod_i256.fe:3:16
   │
 3 │         return x % y
-  │                ^^^^^ i256: Value => None
+  │                ^^^^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_mod_u256.fe:3:16
   │
 3 │         return x % y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_mod_u256.fe:3:16
   │
 3 │         return x % y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_mod_u256.fe:3:16
   │
 3 │         return x % y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_mod_u256.fe:3:20
-  │
-3 │         return x % y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_mod_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
@@ -26,6 +26,6 @@ note:
   ┌─ features/return_msg_sig.fe:3:16
   │
 3 │         return msg.sig
-  │                ^^^^^^^ u256: Value => None
+  │                ^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_multiplication_i256.fe:3:16
   │
 3 │         return x * y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_multiplication_i256.fe:3:16
   │
 3 │         return x * y
-  │                ^^^^^ i256: Value => None
+  │                ^^^^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_multiplication_i256.fe:3:16
   │
 3 │         return x * y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_multiplication_i256.fe:3:20
-  │
-3 │         return x * y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_multiplication_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_multiplication_u256.fe:3:16
   │
 3 │         return x * y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_multiplication_u256.fe:3:20
-  │
-3 │         return x * y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_multiplication_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_multiplication_u256.fe:3:16
   │
 3 │         return x * y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_multiplication_u256.fe:3:16
   │
 3 │         return x * y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
@@ -45,14 +45,14 @@ note:
   ┌─ features/return_noteq_u256.fe:3:16
   │
 3 │         return x != y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_noteq_u256.fe:3:16
   │
 3 │         return x != y
-  │                ^^^^^^ bool: Value => None
+  │                ^^^^^^ bool: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
@@ -45,13 +45,9 @@ note:
   ┌─ features/return_noteq_u256.fe:3:16
   │
 3 │         return x != y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_noteq_u256.fe:3:21
-  │
-3 │         return x != y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_noteq_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_pow_i256.fe:3:16
   │
 3 │         return x ** y
-  │                ^    ^ u8: Value => None
+  │                ^    ^ u8: Value
   │                │     
-  │                i8: Value => None
+  │                i8: Value
 
 note: 
   ┌─ features/return_pow_i256.fe:3:16
   │
 3 │         return x ** y
-  │                ^^^^^^ i8: Value => None
+  │                ^^^^^^ i8: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_pow_i256.fe:3:16
   │
 3 │         return x ** y
-  │                ^ i8: Value => None
-
-note: 
-  ┌─ features/return_pow_i256.fe:3:21
-  │
-3 │         return x ** y
-  │                     ^ u8: Value => None
+  │                ^    ^ u8: Value => None
+  │                │     
+  │                i8: Value => None
 
 note: 
   ┌─ features/return_pow_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_pow_u256.fe:3:16
   │
 3 │         return x ** y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_pow_u256.fe:3:21
-  │
-3 │         return x ** y
-  │                     ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_pow_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_pow_u256.fe:3:16
   │
 3 │         return x ** y
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_pow_u256.fe:3:16
   │
 3 │         return x ** y
-  │                ^^^^^^ u256: Value => None
+  │                ^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_subtraction_i256.fe:3:16
   │
 3 │         return x - y
-  │                ^ i256: Value => None
-
-note: 
-  ┌─ features/return_subtraction_i256.fe:3:20
-  │
-3 │         return x - y
-  │                    ^ i256: Value => None
+  │                ^   ^ i256: Value => None
+  │                │    
+  │                i256: Value => None
 
 note: 
   ┌─ features/return_subtraction_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_subtraction_i256.fe:3:16
   │
 3 │         return x - y
-  │                ^   ^ i256: Value => None
+  │                ^   ^ i256: Value
   │                │    
-  │                i256: Value => None
+  │                i256: Value
 
 note: 
   ┌─ features/return_subtraction_i256.fe:3:16
   │
 3 │         return x - y
-  │                ^^^^^ i256: Value => None
+  │                ^^^^^ i256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
@@ -47,13 +47,9 @@ note:
   ┌─ features/return_subtraction_u256.fe:3:16
   │
 3 │         return x - y
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/return_subtraction_u256.fe:3:20
-  │
-3 │         return x - y
-  │                    ^ u256: Value => None
+  │                ^   ^ u256: Value => None
+  │                │    
+  │                u256: Value => None
 
 note: 
   ┌─ features/return_subtraction_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
@@ -47,14 +47,14 @@ note:
   ┌─ features/return_subtraction_u256.fe:3:16
   │
 3 │         return x - y
-  │                ^   ^ u256: Value => None
+  │                ^   ^ u256: Value
   │                │    
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_subtraction_u256.fe:3:16
   │
 3 │         return x - y
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
@@ -26,26 +26,18 @@ note:
   ┌─ features/return_u128_cast.fe:3:21
   │
 3 │         return u128(42)
-  │                     ^^ u128: Value => None
+  │                     ^^ u128: Value
 
 note: 
   ┌─ features/return_u128_cast.fe:3:16
   │
 3 │         return u128(42)
-  │                ^^^^^^^^ u128: Value => None
+  │                ^^^^^^^^ u128: Value
 
 note: 
   ┌─ features/return_u128_cast.fe:3:16
   │
 3 │         return u128(42)
-  │                ^^^^ attributes hash: 2454885421097624260
-  │
-  = TypeConstructor {
-        typ: Base(
-            Numeric(
-                U128,
-            ),
-        ),
-    }
+  │                ^^^^ TypeConstructor(Base(Numeric(U128)))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256.snap
@@ -26,6 +26,6 @@ note:
   ┌─ features/return_u256.fe:3:16
   │
 3 │         return 42
-  │                ^^ u256: Value => None
+  │                ^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
@@ -8,10 +8,12 @@ note:
   │  
 4 │ ╭     pub fn bar(self) -> u256:
 5 │ │         return foo()
-  │ ╰────────────────────^ attributes hash: 16482263331346774611
+  │ ╰────────────────────^ attributes hash: 2875164910451995213
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -26,19 +28,13 @@ note:
   ┌─ features/return_u256_from_called_fn.fe:5:16
   │
 5 │         return foo()
-  │                ^^^^^ u256: Value => None
+  │                ^^^^^ u256: Value
 
 note: 
   ┌─ features/return_u256_from_called_fn.fe:5:16
   │
 5 │         return foo()
-  │                ^^^ attributes hash: 6696068954755293271
-  │
-  = Pure(
-        FunctionId(
-            1,
-        ),
-    )
+  │                ^^^ Pure(FunctionId(1))
 
 note: 
   ┌─ features/return_u256_from_called_fn.fe:7:5
@@ -63,6 +59,6 @@ note:
   ┌─ features/return_u256_from_called_fn.fe:8:16
   │
 8 │         return 42
-  │                ^^ u256: Value => None
+  │                ^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
@@ -23,6 +23,24 @@ note:
     }
 
 note: 
+  ┌─ features/return_u256_from_called_fn.fe:5:16
+  │
+5 │         return foo()
+  │                ^^^^^ u256: Value => None
+
+note: 
+  ┌─ features/return_u256_from_called_fn.fe:5:16
+  │
+5 │         return foo()
+  │                ^^^ attributes hash: 6696068954755293271
+  │
+  = Pure(
+        FunctionId(
+            1,
+        ),
+    )
+
+note: 
   ┌─ features/return_u256_from_called_fn.fe:7:5
   │  
 7 │ ╭     pub fn foo() -> u256:
@@ -42,27 +60,9 @@ note:
     }
 
 note: 
-  ┌─ features/return_u256_from_called_fn.fe:5:16
-  │
-5 │         return foo()
-  │                ^^^^^ u256: Value => None
-
-note: 
   ┌─ features/return_u256_from_called_fn.fe:8:16
   │
 8 │         return 42
   │                ^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn.fe:5:16
-  │
-5 │         return foo()
-  │                ^^^ attributes hash: 6696068954755293271
-  │
-  = Pure(
-        FunctionId(
-            1,
-        ),
-    )
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
@@ -83,39 +83,39 @@ note:
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
   │
 4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^   ^^^^ u256: Value => None
+  │                ^^^^   ^^^^ u256: Value
   │                │       
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
   │
 4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^   ^^^^ u256: Value => None
+  │                ^^^^^^^^^^^   ^^^^ u256: Value
   │                │              
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
   │
 4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
   │                │                     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
   │
 4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
   │                │                            
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
   │
 4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:6:5
@@ -140,7 +140,7 @@ note:
   ┌─ features/return_u256_from_called_fn_with_args.fe:7:16
   │
 7 │         return 100
-  │                ^^^ u256: Value => None
+  │                ^^^ u256: Value
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:9:5
@@ -148,10 +148,12 @@ note:
  9 │ ╭     pub fn bar(self) -> u256:
 10 │ │         self.baz[0] = 43
 11 │ │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │ ╰─────────────────────────────────────────────────────^ attributes hash: 16482263331346774611
+   │ ╰─────────────────────────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -166,68 +168,69 @@ note:
    ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
    │
 10 │         self.baz[0] = 43
-   │         ^^^^^^^^ ^ u256: Value => None
-   │         │         
-   │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ Foo: Value
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
    │
 10 │         self.baz[0] = 43
-   │         ^^^^^^^^^^^   ^^ u256: Value => None
+   │         ^^^^^^^^ ^ u256: Value
+   │         │         
+   │         Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
+   │
+10 │         self.baz[0] = 43
+   │         ^^^^^^^^^^^   ^^ u256: Value
    │         │              
-   │         u256: Storage { nonce: None } => None
+   │         u256: Storage { nonce: None }
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                    ^  ^  ^^^^^  ^^   ^^ u256: Value => None
+   │                    ^  ^  ^^^^^  ^^   ^^ u256: Value
    │                    │  │  │      │     
-   │                    │  │  │      u256: Value => None
-   │                    │  │  u256: Value => None
-   │                    │  u256: Value => None
-   │                    u256: Value => None
+   │                    │  │  │      u256: Value
+   │                    │  │  u256: Value
+   │                    │  u256: Value
+   │                    u256: Value
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:33
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                 ^^^^^^^  ^^^^^^^^ ^ u256: Value => None
-   │                                 │        │         
-   │                                 │        Map<u256, u256>: Storage { nonce: Some(0) } => None
-   │                                 u256: Value => None
+   │                                 ^^^^^^^  ^^^^ Foo: Value
+   │                                 │         
+   │                                 u256: Value
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:42
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                          ^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+   │                                          ^^^^^^^^ ^ u256: Value
+   │                                          │         
+   │                                          Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:42
+   │
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                                          ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                ^^^ attributes hash: 6251600114237252411
-   │
-   = Pure(
-         FunctionId(
-             0,
-         ),
-     )
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:26
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                          ^^^ attributes hash: 6696068954755293271
+   │                          ^^^ Pure(FunctionId(1))
+
+note: 
+   ┌─ features/return_u256_from_called_fn_with_args.fe:11:16
    │
-   = Pure(
-         FunctionId(
-             1,
-         ),
-     )
+11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
+   │                ^^^ Pure(FunctionId(0))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
@@ -80,6 +80,44 @@ note:
     }
 
 note: 
+  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
+  │
+4 │         return val1 + val2 + val3 + val4 + val5
+  │                ^^^^   ^^^^ u256: Value => None
+  │                │       
+  │                u256: Value => None
+
+note: 
+  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
+  │
+4 │         return val1 + val2 + val3 + val4 + val5
+  │                ^^^^^^^^^^^   ^^^^ u256: Value => None
+  │                │              
+  │                u256: Value => None
+
+note: 
+  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
+  │
+4 │         return val1 + val2 + val3 + val4 + val5
+  │                ^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value => None
+  │                │                     
+  │                u256: Value => None
+
+note: 
+  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
+  │
+4 │         return val1 + val2 + val3 + val4 + val5
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value => None
+  │                │                            
+  │                u256: Value => None
+
+note: 
+  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
+  │
+4 │         return val1 + val2 + val3 + val4 + val5
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
   ┌─ features/return_u256_from_called_fn_with_args.fe:6:5
   │  
 6 │ ╭     pub fn cem() -> u256:
@@ -97,6 +135,12 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ features/return_u256_from_called_fn_with_args.fe:7:16
+  │
+7 │         return 100
+  │                ^^^ u256: Value => None
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:9:5
@@ -119,136 +163,36 @@ note:
      }
 
 note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:23
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                       ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:30
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                              ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:37
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                                     ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:44
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                                            ^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:4:16
-  │
-4 │         return val1 + val2 + val3 + val4 + val5
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/return_u256_from_called_fn_with_args.fe:7:16
-  │
-7 │         return 100
-  │                ^^^ u256: Value => None
+   ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
+   │
+10 │         self.baz[0] = 43
+   │         ^^^^^^^^ ^ u256: Value => None
+   │         │         
+   │         Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
    │
 10 │         self.baz[0] = 43
-   │         ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:10:18
-   │
-10 │         self.baz[0] = 43
-   │                  ^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:10:9
-   │
-10 │         self.baz[0] = 43
-   │         ^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:10:23
-   │
-10 │         self.baz[0] = 43
-   │                       ^^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:20
-   │
+   │         ^^^^^^^^^^^   ^^ u256: Value => None
+   │         │              
+   │         u256: Storage { nonce: None } => None
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                    ^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:23
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                       ^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:26
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                          ^^^^^ u256: Value => None
+   │                    ^  ^  ^^^^^  ^^   ^^ u256: Value => None
+   │                    │  │  │      │     
+   │                    │  │  │      u256: Value => None
+   │                    │  │  u256: Value => None
+   │                    │  u256: Value => None
+   │                    u256: Value => None
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:33
    │
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                 ^^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:38
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                      ^^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:33
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                 ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:42
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                          ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/return_u256_from_called_fn_with_args.fe:11:51
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                                                   ^ u256: Value => None
+   │                                 ^^^^^^^  ^^^^^^^^ ^ u256: Value => None
+   │                                 │        │         
+   │                                 │        Map<u256, u256>: Storage { nonce: Some(0) } => None
+   │                                 u256: Value => None
 
 note: 
    ┌─ features/return_u256_from_called_fn_with_args.fe:11:42

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -65,33 +65,21 @@ note:
    ┌─ features/revert.fe:16:26
    │
 16 │         revert Error(msg=1, val=true)
-   │                          ^      ^^^^ bool: Value => None
+   │                          ^      ^^^^ bool: Value
    │                          │       
-   │                          u256: Value => None
+   │                          u256: Value
 
 note: 
    ┌─ features/revert.fe:16:16
    │
 16 │         revert Error(msg=1, val=true)
-   │                ^^^^^^^^^^^^^^^^^^^^^^ Error: Memory => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^ Error: Memory
 
 note: 
    ┌─ features/revert.fe:16:16
    │
 16 │         revert Error(msg=1, val=true)
-   │                ^^^^^ attributes hash: 4777426826095316337
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "Error",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 2,
-             },
-         ),
-     }
+   │                ^^^^^ TypeConstructor(Struct(Struct { name: "Error", id: StructId(0), field_count: 2 }))
 
 note: 
    ┌─ features/revert.fe:18:5
@@ -114,33 +102,21 @@ note:
    ┌─ features/revert.fe:19:31
    │
 19 │         revert OtherError(msg=1, val=true)
-   │                               ^      ^^^^ bool: Value => None
+   │                               ^      ^^^^ bool: Value
    │                               │       
-   │                               u256: Value => None
+   │                               u256: Value
 
 note: 
    ┌─ features/revert.fe:19:16
    │
 19 │         revert OtherError(msg=1, val=true)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
 
 note: 
    ┌─ features/revert.fe:19:16
    │
 19 │         revert OtherError(msg=1, val=true)
-   │                ^^^^^^^^^^ attributes hash: 5262255621061780991
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "OtherError",
-                 id: StructId(
-                     1,
-                 ),
-                 field_count: 2,
-             },
-         ),
-     }
+   │                ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "OtherError", id: StructId(1), field_count: 2 }))
 
 note: 
    ┌─ features/revert.fe:21:5
@@ -148,10 +124,12 @@ note:
 21 │ ╭     pub fn revert_other_error_from_sto(self):
 22 │ │         self.my_other_error = OtherError(msg=1, val=true)
 23 │ │         revert self.my_other_error.to_mem()
-   │ ╰───────────────────────────────────────────^ attributes hash: 4369441865732737140
+   │ ╰───────────────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -164,49 +142,43 @@ note:
    ┌─ features/revert.fe:22:9
    │
 22 │         self.my_other_error = OtherError(msg=1, val=true)
-   │         ^^^^^^^^^^^^^^^^^^^                  ^      ^^^^ bool: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/revert.fe:22:9
+   │
+22 │         self.my_other_error = OtherError(msg=1, val=true)
+   │         ^^^^^^^^^^^^^^^^^^^                  ^      ^^^^ bool: Value
    │         │                                    │       
-   │         │                                    u256: Value => None
-   │         OtherError: Storage { nonce: Some(0) } => None
+   │         │                                    u256: Value
+   │         OtherError: Storage { nonce: Some(0) }
 
 note: 
    ┌─ features/revert.fe:22:31
    │
 22 │         self.my_other_error = OtherError(msg=1, val=true)
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory => None
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
 23 │         revert self.my_other_error.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/revert.fe:23:16
    │
 23 │         revert self.my_other_error.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => Some(Memory)
+   │                ^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/revert.fe:23:16
+   │
+23 │         revert self.my_other_error.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => Memory
 
 note: 
    ┌─ features/revert.fe:22:31
    │
 22 │         self.my_other_error = OtherError(msg=1, val=true)
-   │                               ^^^^^^^^^^ attributes hash: 5262255621061780991
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "OtherError",
-                 id: StructId(
-                     1,
-                 ),
-                 field_count: 2,
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/revert.fe:23:16
-   │
+   │                               ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "OtherError", id: StructId(1), field_count: 2 }))
 23 │         revert self.my_other_error.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -8,10 +8,6 @@ note:
   │
 2 │     msg: u256
   │     ^^^^^^^^^ u256
-
-note: 
-  ┌─ features/revert.fe:3:5
-  │
 3 │     val: bool
   │     ^^^^^^^^^ bool
 
@@ -20,10 +16,6 @@ note:
   │
 6 │     msg: u256
   │     ^^^^^^^^^ u256
-
-note: 
-  ┌─ features/revert.fe:7:5
-  │
 7 │     val: bool
   │     ^^^^^^^^^ bool
 
@@ -70,6 +62,38 @@ note:
      }
 
 note: 
+   ┌─ features/revert.fe:16:26
+   │
+16 │         revert Error(msg=1, val=true)
+   │                          ^      ^^^^ bool: Value => None
+   │                          │       
+   │                          u256: Value => None
+
+note: 
+   ┌─ features/revert.fe:16:16
+   │
+16 │         revert Error(msg=1, val=true)
+   │                ^^^^^^^^^^^^^^^^^^^^^^ Error: Memory => None
+
+note: 
+   ┌─ features/revert.fe:16:16
+   │
+16 │         revert Error(msg=1, val=true)
+   │                ^^^^^ attributes hash: 4777426826095316337
+   │
+   = TypeConstructor {
+         typ: Struct(
+             Struct {
+                 name: "Error",
+                 id: StructId(
+                     0,
+                 ),
+                 field_count: 2,
+             },
+         ),
+     }
+
+note: 
    ┌─ features/revert.fe:18:5
    │  
 18 │ ╭     pub fn revert_other_error():
@@ -83,6 +107,38 @@ note:
              Base(
                  Unit,
              ),
+         ),
+     }
+
+note: 
+   ┌─ features/revert.fe:19:31
+   │
+19 │         revert OtherError(msg=1, val=true)
+   │                               ^      ^^^^ bool: Value => None
+   │                               │       
+   │                               u256: Value => None
+
+note: 
+   ┌─ features/revert.fe:19:16
+   │
+19 │         revert OtherError(msg=1, val=true)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory => None
+
+note: 
+   ┌─ features/revert.fe:19:16
+   │
+19 │         revert OtherError(msg=1, val=true)
+   │                ^^^^^^^^^^ attributes hash: 5262255621061780991
+   │
+   = TypeConstructor {
+         typ: Struct(
+             Struct {
+                 name: "OtherError",
+                 id: StructId(
+                     1,
+                 ),
+                 field_count: 2,
+             },
          ),
      }
 
@@ -105,68 +161,19 @@ note:
      }
 
 note: 
-   ┌─ features/revert.fe:16:26
-   │
-16 │         revert Error(msg=1, val=true)
-   │                          ^ u256: Value => None
-
-note: 
-   ┌─ features/revert.fe:16:33
-   │
-16 │         revert Error(msg=1, val=true)
-   │                                 ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/revert.fe:16:16
-   │
-16 │         revert Error(msg=1, val=true)
-   │                ^^^^^^^^^^^^^^^^^^^^^^ Error: Memory => None
-
-note: 
-   ┌─ features/revert.fe:19:31
-   │
-19 │         revert OtherError(msg=1, val=true)
-   │                               ^ u256: Value => None
-
-note: 
-   ┌─ features/revert.fe:19:38
-   │
-19 │         revert OtherError(msg=1, val=true)
-   │                                      ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/revert.fe:19:16
-   │
-19 │         revert OtherError(msg=1, val=true)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory => None
-
-note: 
    ┌─ features/revert.fe:22:9
    │
 22 │         self.my_other_error = OtherError(msg=1, val=true)
-   │         ^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/revert.fe:22:46
-   │
-22 │         self.my_other_error = OtherError(msg=1, val=true)
-   │                                              ^ u256: Value => None
-
-note: 
-   ┌─ features/revert.fe:22:53
-   │
-22 │         self.my_other_error = OtherError(msg=1, val=true)
-   │                                                     ^^^^ bool: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^                  ^      ^^^^ bool: Value => None
+   │         │                                    │       
+   │         │                                    u256: Value => None
+   │         OtherError: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/revert.fe:22:31
    │
 22 │         self.my_other_error = OtherError(msg=1, val=true)
    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory => None
-
-note: 
-   ┌─ features/revert.fe:23:16
-   │
 23 │         revert self.my_other_error.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => None
 
@@ -175,42 +182,6 @@ note:
    │
 23 │         revert self.my_other_error.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => Some(Memory)
-
-note: 
-   ┌─ features/revert.fe:16:16
-   │
-16 │         revert Error(msg=1, val=true)
-   │                ^^^^^ attributes hash: 4777426826095316337
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "Error",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 2,
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/revert.fe:19:16
-   │
-19 │         revert OtherError(msg=1, val=true)
-   │                ^^^^^^^^^^ attributes hash: 5262255621061780991
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "OtherError",
-                 id: StructId(
-                     1,
-                 ),
-                 field_count: 2,
-             },
-         ),
-     }
 
 note: 
    ┌─ features/revert.fe:22:31

--- a/crates/analyzer/tests/snapshots/analysis__self_address.snap
+++ b/crates/analyzer/tests/snapshots/analysis__self_address.snap
@@ -8,10 +8,12 @@ note:
   │  
 2 │ ╭     pub fn my_address(self) -> address:
 3 │ │         return self.address
-  │ ╰───────────────────────────^ attributes hash: 17651916811868111914
+  │ ╰───────────────────────────^ attributes hash: 10447292744135180405
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [],
         return_type: Ok(
             Base(
@@ -24,6 +26,12 @@ note:
   ┌─ features/self_address.fe:3:16
   │
 3 │         return self.address
-  │                ^^^^^^^^^^^^ address: Value => None
+  │                ^^^^ Foo: Value
+
+note: 
+  ┌─ features/self_address.fe:3:16
+  │
+3 │         return self.address
+  │                ^^^^^^^^^^^^ address: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__send_value.snap
+++ b/crates/analyzer/tests/snapshots/analysis__send_value.snap
@@ -43,24 +43,20 @@ note:
   ┌─ features/send_value.fe:3:20
   │
 3 │         send_value(to, wei)
-  │                    ^^  ^^^ u256: Value => None
+  │                    ^^  ^^^ u256: Value
   │                    │    
-  │                    address: Value => None
+  │                    address: Value
 
 note: 
   ┌─ features/send_value.fe:3:9
   │
 3 │         send_value(to, wei)
-  │         ^^^^^^^^^^^^^^^^^^^ (): Value => None
+  │         ^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
   ┌─ features/send_value.fe:3:9
   │
 3 │         send_value(to, wei)
-  │         ^^^^^^^^^^ attributes hash: 9660326149299693551
-  │
-  = BuiltinFunction(
-        SendValue,
-    )
+  │         ^^^^^^^^^^ BuiltinFunction(SendValue)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__send_value.snap
+++ b/crates/analyzer/tests/snapshots/analysis__send_value.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/send_value.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -43,13 +43,9 @@ note:
   ┌─ features/send_value.fe:3:20
   │
 3 │         send_value(to, wei)
-  │                    ^^ address: Value => None
-
-note: 
-  ┌─ features/send_value.fe:3:24
-  │
-3 │         send_value(to, wei)
-  │                        ^^^ u256: Value => None
+  │                    ^^  ^^^ u256: Value => None
+  │                    │    
+  │                    address: Value => None
 
 note: 
   ┌─ features/send_value.fe:3:9

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/sized_vals_in_sto.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -8,16 +8,8 @@ note:
   │
 2 │     num: u256
   │     ^^^^^^^^^ u256
-
-note: 
-  ┌─ features/sized_vals_in_sto.fe:3:5
-  │
 3 │     nums: Array<u256, 42>
   │     ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
-
-note: 
-  ┌─ features/sized_vals_in_sto.fe:4:5
-  │
 4 │     str: String<26>
   │     ^^^^^^^^^^^^^^^ String<26>
 
@@ -26,16 +18,8 @@ note:
   │
 7 │         num: u256
   │         ^^^^^^^^^ u256
-
-note: 
-  ┌─ features/sized_vals_in_sto.fe:8:9
-  │
 8 │         nums: Array<u256, 42>
   │         ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
-
-note: 
-  ┌─ features/sized_vals_in_sto.fe:9:9
-  │
 9 │         str: String<26>
   │         ^^^^^^^^^^^^^^^ String<26>
 
@@ -68,6 +52,14 @@ note:
      }
 
 note: 
+   ┌─ features/sized_vals_in_sto.fe:12:9
+   │
+12 │         self.num = x
+   │         ^^^^^^^^   ^ u256: Value => None
+   │         │           
+   │         u256: Storage { nonce: Some(0) } => None
+
+note: 
    ┌─ features/sized_vals_in_sto.fe:14:5
    │  
 14 │ ╭     pub fn read_num(self) -> u256:
@@ -85,6 +77,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:15:16
+   │
+15 │         return self.num
+   │                ^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:17:5
@@ -118,6 +116,14 @@ note:
      }
 
 note: 
+   ┌─ features/sized_vals_in_sto.fe:18:9
+   │
+18 │         self.nums = x
+   │         ^^^^^^^^^   ^ Array<u256, 42>: Memory => None
+   │         │            
+   │         Array<u256, 42>: Storage { nonce: Some(1) } => None
+
+note: 
    ┌─ features/sized_vals_in_sto.fe:20:5
    │  
 20 │ ╭     pub fn read_nums(self) -> Array<u256, 42>:
@@ -138,6 +144,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:21:16
+   │
+21 │         return self.nums.to_mem()
+   │                ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:21:16
+   │
+21 │         return self.nums.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Some(Memory)
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:21:16
+   │
+21 │         return self.nums.to_mem()
+   │                ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:23:5
@@ -168,6 +194,14 @@ note:
      }
 
 note: 
+   ┌─ features/sized_vals_in_sto.fe:24:9
+   │
+24 │         self.str = x
+   │         ^^^^^^^^   ^ String<26>: Memory => None
+   │         │           
+   │         String<26>: Storage { nonce: Some(2) } => None
+
+note: 
    ┌─ features/sized_vals_in_sto.fe:26:5
    │  
 26 │ ╭     pub fn read_str(self) -> String<26>:
@@ -185,6 +219,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:27:16
+   │
+27 │         return self.str.to_mem()
+   │                ^^^^^^^^ String<26>: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:27:16
+   │
+27 │         return self.str.to_mem()
+   │                ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Some(Memory)
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:27:16
+   │
+27 │         return self.str.to_mem()
+   │                ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:29:5
@@ -208,80 +262,10 @@ note:
      }
 
 note: 
-   ┌─ features/sized_vals_in_sto.fe:12:9
-   │
-12 │         self.num = x
-   │         ^^^^^^^^ u256: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:12:20
-   │
-12 │         self.num = x
-   │                    ^ u256: Value => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:15:16
-   │
-15 │         return self.num
-   │                ^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:18:9
-   │
-18 │         self.nums = x
-   │         ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:18:21
-   │
-18 │         self.nums = x
-   │                     ^ Array<u256, 42>: Memory => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:21:16
-   │
-21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:21:16
-   │
-21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Some(Memory)
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:24:9
-   │
-24 │         self.str = x
-   │         ^^^^^^^^ String<26>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:24:20
-   │
-24 │         self.str = x
-   │                    ^ String<26>: Memory => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:27:16
-   │
-27 │         return self.str.to_mem()
-   │                ^^^^^^^^ String<26>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:27:16
-   │
-27 │         return self.str.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Some(Memory)
-
-note: 
    ┌─ features/sized_vals_in_sto.fe:31:17
    │
 31 │             num=self.num,
    │                 ^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:32:18
-   │
 32 │             nums=self.nums.to_mem(),
    │                  ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => None
 
@@ -290,10 +274,6 @@ note:
    │
 32 │             nums=self.nums.to_mem(),
    │                  ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Some(Memory)
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:33:17
-   │
 33 │             str=self.str.to_mem()
    │                 ^^^^^^^^ String<26>: Storage { nonce: Some(2) } => None
 
@@ -354,22 +334,6 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:21:16
-   │
-21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:27:16
-   │
-27 │         return self.str.to_mem()
-   │                ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:32:18

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -28,10 +28,12 @@ note:
    │  
 11 │ ╭     pub fn write_num(self, x: u256):
 12 │ │         self.num = x
-   │ ╰────────────────────^ attributes hash: 1151125091578816070
+   │ ╰────────────────────^ attributes hash: 2697709601428271166
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "x",
@@ -55,19 +57,27 @@ note:
    ┌─ features/sized_vals_in_sto.fe:12:9
    │
 12 │         self.num = x
-   │         ^^^^^^^^   ^ u256: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:12:9
+   │
+12 │         self.num = x
+   │         ^^^^^^^^   ^ u256: Value
    │         │           
-   │         u256: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: Some(0) }
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:14:5
    │  
 14 │ ╭     pub fn read_num(self) -> u256:
 15 │ │         return self.num
-   │ ╰───────────────────────^ attributes hash: 16482263331346774611
+   │ ╰───────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -82,17 +92,25 @@ note:
    ┌─ features/sized_vals_in_sto.fe:15:16
    │
 15 │         return self.num
-   │                ^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:15:16
+   │
+15 │         return self.num
+   │                ^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:17:5
    │  
 17 │ ╭     pub fn write_nums(self, x: Array<u256, 42>):
 18 │ │         self.nums = x
-   │ ╰─────────────────────^ attributes hash: 1325911840329576752
+   │ ╰─────────────────────^ attributes hash: 11400956022302777281
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "x",
@@ -119,19 +137,27 @@ note:
    ┌─ features/sized_vals_in_sto.fe:18:9
    │
 18 │         self.nums = x
-   │         ^^^^^^^^^   ^ Array<u256, 42>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:18:9
+   │
+18 │         self.nums = x
+   │         ^^^^^^^^^   ^ Array<u256, 42>: Memory
    │         │            
-   │         Array<u256, 42>: Storage { nonce: Some(1) } => None
+   │         Array<u256, 42>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:20:5
    │  
 20 │ ╭     pub fn read_nums(self) -> Array<u256, 42>:
 21 │ │         return self.nums.to_mem()
-   │ ╰─────────────────────────────────^ attributes hash: 15090171079052983265
+   │ ╰─────────────────────────────────^ attributes hash: 17841580678646329188
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Array(
@@ -149,31 +175,37 @@ note:
    ┌─ features/sized_vals_in_sto.fe:21:16
    │
 21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:21:16
    │
 21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Some(Memory)
+   │                ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:21:16
    │
 21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Memory
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:21:16
    │
-   = ValueAttribute
+21 │         return self.nums.to_mem()
+   │                ^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:23:5
    │  
 23 │ ╭     pub fn write_str(self, x: String<26>):
 24 │ │         self.str = x
-   │ ╰────────────────────^ attributes hash: 14732302597377039844
+   │ ╰────────────────────^ attributes hash: 14423886445128812604
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "x",
@@ -197,19 +229,27 @@ note:
    ┌─ features/sized_vals_in_sto.fe:24:9
    │
 24 │         self.str = x
-   │         ^^^^^^^^   ^ String<26>: Memory => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:24:9
+   │
+24 │         self.str = x
+   │         ^^^^^^^^   ^ String<26>: Memory
    │         │           
-   │         String<26>: Storage { nonce: Some(2) } => None
+   │         String<26>: Storage { nonce: Some(2) }
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:26:5
    │  
 26 │ ╭     pub fn read_str(self) -> String<26>:
 27 │ │         return self.str.to_mem()
-   │ ╰────────────────────────────────^ attributes hash: 5005215627723595894
+   │ ╰────────────────────────────────^ attributes hash: 17113643796584502543
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              String(
@@ -224,21 +264,25 @@ note:
    ┌─ features/sized_vals_in_sto.fe:27:16
    │
 27 │         return self.str.to_mem()
-   │                ^^^^^^^^ String<26>: Storage { nonce: Some(2) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:27:16
    │
 27 │         return self.str.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Some(Memory)
+   │                ^^^^^^^^ String<26>: Storage { nonce: Some(2) }
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:27:16
    │
 27 │         return self.str.to_mem()
-   │                ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:27:16
    │
-   = ValueAttribute
+27 │         return self.str.to_mem()
+   │                ^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:29:5
@@ -249,10 +293,12 @@ note:
 32 │ │             nums=self.nums.to_mem(),
 33 │ │             str=self.str.to_mem()
 34 │ │         )
-   │ ╰─────────^ attributes hash: 4369441865732737140
+   │ ╰─────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -265,23 +311,41 @@ note:
    ┌─ features/sized_vals_in_sto.fe:31:17
    │
 31 │             num=self.num,
-   │                 ^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+   │                 ^^^^ Foo: Value
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:31:17
+   │
+31 │             num=self.num,
+   │                 ^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 32 │             nums=self.nums.to_mem(),
-   │                  ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => None
+   │                  ^^^^ Foo: Value
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:32:18
    │
 32 │             nums=self.nums.to_mem(),
-   │                  ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Some(Memory)
+   │                  ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:32:18
+   │
+32 │             nums=self.nums.to_mem(),
+   │                  ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Memory
 33 │             str=self.str.to_mem()
-   │                 ^^^^^^^^ String<26>: Storage { nonce: Some(2) } => None
+   │                 ^^^^ Foo: Value
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:33:17
    │
 33 │             str=self.str.to_mem()
-   │                 ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Some(Memory)
+   │                 ^^^^^^^^ String<26>: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ features/sized_vals_in_sto.fe:33:17
+   │
+33 │             str=self.str.to_mem()
+   │                 ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
 
 note: 
    ┌─ features/sized_vals_in_sto.fe:30:9
@@ -339,16 +403,8 @@ note:
    ┌─ features/sized_vals_in_sto.fe:32:18
    │
 32 │             nums=self.nums.to_mem(),
-   │                  ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ features/sized_vals_in_sto.fe:33:17
-   │
+   │                  ^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 33 │             str=self.str.to_mem()
-   │                 ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                 ^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -8,108 +8,18 @@ note:
   │
 3 │         s2: String<26>
   │         ^^^^^^^^^^^^^^ String<26>
-
-note: 
-  ┌─ features/strings.fe:4:9
-  │
 4 │         u: u256
   │         ^^^^^^^ u256
-
-note: 
-  ┌─ features/strings.fe:5:9
-  │
 5 │         s1: String<42>
   │         ^^^^^^^^^^^^^^ String<42>
-
-note: 
-  ┌─ features/strings.fe:6:9
-  │
 6 │         s3: String<100>
   │         ^^^^^^^^^^^^^^^ String<100>
-
-note: 
-  ┌─ features/strings.fe:7:9
-  │
 7 │         a: address
   │         ^^^^^^^^^^ address
-
-note: 
-  ┌─ features/strings.fe:8:9
-  │
 8 │         s4: String<13>
   │         ^^^^^^^^^^^^^^ String<13>
-
-note: 
-  ┌─ features/strings.fe:9:9
-  │
 9 │         s5: String<100>
   │         ^^^^^^^^^^^^^^^ String<100>
-
-note: 
-   ┌─ features/strings.fe:11:5
-   │  
-11 │ ╭     pub fn __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
-12 │ │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │ ╰─────────────────────────────────────────────────────────────────────────────────^ attributes hash: 2002059796134224129
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [
-             FunctionParam {
-                 name: "s1",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 42,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "s2",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 26,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "u",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "s3",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
 
 note: 
    ┌─ features/strings.fe:14:5
@@ -152,6 +62,12 @@ note:
      }
 
 note: 
+   ┌─ features/strings.fe:15:16
+   │
+15 │         return s2
+   │                ^^ String<100>: Memory => None
+
+note: 
    ┌─ features/strings.fe:17:5
    │  
 17 │ ╭     pub fn return_static_string() -> String<43>:
@@ -171,6 +87,12 @@ note:
      }
 
 note: 
+   ┌─ features/strings.fe:18:16
+   │
+18 │         return "The quick brown fox jumps over the lazy dog"
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<43>: Memory => None
+
+note: 
    ┌─ features/strings.fe:20:5
    │  
 20 │ ╭     pub fn return_casted_static_string() -> String<100>:
@@ -186,6 +108,32 @@ note:
                      max_size: 100,
                  },
              ),
+         ),
+     }
+
+note: 
+   ┌─ features/strings.fe:21:28
+   │
+21 │         return String<100>("foo")
+   │                            ^^^^^ String<3>: Memory => None
+
+note: 
+   ┌─ features/strings.fe:21:16
+   │
+21 │         return String<100>("foo")
+   │                ^^^^^^^^^^^^^^^^^^ String<100>: Memory => None
+
+note: 
+   ┌─ features/strings.fe:21:16
+   │
+21 │         return String<100>("foo")
+   │                ^^^^^^ attributes hash: 5923227283421640461
+   │
+   = TypeConstructor {
+         typ: String(
+             FeString {
+                 max_size: 100,
+             },
          ),
      }
 
@@ -210,198 +158,11 @@ note:
      }
 
 note: 
-   ┌─ features/strings.fe:12:22
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                      ^^ String<26>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:12:26
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                          ^ u256: Value => None
-
-note: 
-   ┌─ features/strings.fe:12:29
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                             ^^ String<42>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:12:33
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                                 ^^ String<100>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:12:37
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                                     ^ address: Value => None
-
-note: 
-   ┌─ features/strings.fe:12:43
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                                           ^^^^^^^^^^^^^^^ String<13>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:12:75
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                                                                           ^^^^^ String<3>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:12:63
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                                                               ^^^^^^^^^^^^^^^^^^ String<100>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:15:16
-   │
-15 │         return s2
-   │                ^^ String<100>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:18:16
-   │
-18 │         return "The quick brown fox jumps over the lazy dog"
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<43>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:21:28
-   │
-21 │         return String<100>("foo")
-   │                            ^^^^^ String<3>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:21:16
-   │
-21 │         return String<100>("foo")
-   │                ^^^^^^^^^^^^^^^^^^ String<100>: Memory => None
-
-note: 
    ┌─ features/strings.fe:24:16
    │  
 24 │           return "\n\"'\r\t
    │ ╭────────────────^
 25 │ │         foo\\"
    │ ╰──────────────^ String<18>: Memory => None
-
-note: 
-   ┌─ features/strings.fe:12:9
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8651151160283516495
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "s2",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 26,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "u",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "s1",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 42,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "s3",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "s4",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 13,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "s5",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ features/strings.fe:12:63
-   │
-12 │         emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
-   │                                                               ^^^^^^ attributes hash: 5923227283421640461
-   │
-   = TypeConstructor {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/strings.fe:21:16
-   │
-21 │         return String<100>("foo")
-   │                ^^^^^^ attributes hash: 5923227283421640461
-   │
-   = TypeConstructor {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -65,7 +65,7 @@ note:
    ┌─ features/strings.fe:15:16
    │
 15 │         return s2
-   │                ^^ String<100>: Memory => None
+   │                ^^ String<100>: Memory
 
 note: 
    ┌─ features/strings.fe:17:5
@@ -90,7 +90,7 @@ note:
    ┌─ features/strings.fe:18:16
    │
 18 │         return "The quick brown fox jumps over the lazy dog"
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<43>: Memory => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<43>: Memory
 
 note: 
    ┌─ features/strings.fe:20:5
@@ -115,27 +115,19 @@ note:
    ┌─ features/strings.fe:21:28
    │
 21 │         return String<100>("foo")
-   │                            ^^^^^ String<3>: Memory => None
+   │                            ^^^^^ String<3>: Memory
 
 note: 
    ┌─ features/strings.fe:21:16
    │
 21 │         return String<100>("foo")
-   │                ^^^^^^^^^^^^^^^^^^ String<100>: Memory => None
+   │                ^^^^^^^^^^^^^^^^^^ String<100>: Memory
 
 note: 
    ┌─ features/strings.fe:21:16
    │
 21 │         return String<100>("foo")
-   │                ^^^^^^ attributes hash: 5923227283421640461
-   │
-   = TypeConstructor {
-         typ: String(
-             FeString {
-                 max_size: 100,
-             },
-         ),
-     }
+   │                ^^^^^^ TypeConstructor(String(FeString { max_size: 100 }))
 
 note: 
    ┌─ features/strings.fe:23:5
@@ -163,6 +155,6 @@ note:
 24 │           return "\n\"'\r\t
    │ ╭────────────────^
 25 │ │         foo\\"
-   │ ╰──────────────^ String<18>: Memory => None
+   │ ╰──────────────^ String<18>: Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -1,0 +1,778 @@
+---
+source: crates/analyzer/tests/analysis.rs
+expression: "build_snapshot(&files, module, &db)"
+
+---
+note: 
+  ┌─ features/struct_fns.fe:2:3
+  │
+2 │   x: u64
+  │   ^^^^^^ u64
+3 │   y: u64
+  │   ^^^^^^ u64
+
+note: 
+  ┌─ features/struct_fns.fe:5:3
+  │  
+5 │ ╭   pub fn new(x: u64, y: u64) -> Point:
+6 │ │     return Point(x, y)
+  │ ╰──────────────────────^ attributes hash: 15239695565073513268
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [
+            FunctionParam {
+                name: "x",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U64,
+                        ),
+                    ),
+                ),
+            },
+            FunctionParam {
+                name: "y",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U64,
+                        ),
+                    ),
+                ),
+            },
+        ],
+        return_type: Ok(
+            Struct(
+                Struct {
+                    name: "Point",
+                    id: StructId(
+                        0,
+                    ),
+                    field_count: 2,
+                },
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/struct_fns.fe:6:18
+  │
+6 │     return Point(x, y)
+  │                  ^  ^ u64: Value
+  │                  │   
+  │                  u64: Value
+
+note: 
+  ┌─ features/struct_fns.fe:6:12
+  │
+6 │     return Point(x, y)
+  │            ^^^^^^^^^^^ Point: Memory
+
+note: 
+  ┌─ features/struct_fns.fe:6:12
+  │
+6 │     return Point(x, y)
+  │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+
+note: 
+  ┌─ features/struct_fns.fe:8:3
+  │  
+8 │ ╭   pub fn origin() -> Point:
+9 │ │     return Point(x=0, y=0)
+  │ ╰──────────────────────────^ attributes hash: 1766050550231886475
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [],
+        return_type: Ok(
+            Struct(
+                Struct {
+                    name: "Point",
+                    id: StructId(
+                        0,
+                    ),
+                    field_count: 2,
+                },
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/struct_fns.fe:9:20
+  │
+9 │     return Point(x=0, y=0)
+  │                    ^    ^ u64: Value
+  │                    │     
+  │                    u64: Value
+
+note: 
+  ┌─ features/struct_fns.fe:9:12
+  │
+9 │     return Point(x=0, y=0)
+  │            ^^^^^^^^^^^^^^^ Point: Memory
+
+note: 
+  ┌─ features/struct_fns.fe:9:12
+  │
+9 │     return Point(x=0, y=0)
+  │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+
+note: 
+   ┌─ features/struct_fns.fe:12:3
+   │  
+12 │ ╭   pub fn x(self) -> u64:
+13 │ │     return self.x
+   │ ╰─────────────────^ attributes hash: 10750879109964165534
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U64,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:13:12
+   │
+13 │     return self.x
+   │            ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:13:12
+   │
+13 │     return self.x
+   │            ^^^^^^ u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:15:3
+   │  
+15 │ ╭   pub fn set_x(self, x: u64) -> u64:
+16 │ │     let old: u64 = self.x
+17 │ │     self.x = x
+18 │ │     return old
+   │ ╰──────────────^ attributes hash: 14269972139460780041
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [
+             FunctionParam {
+                 name: "x",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U64,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U64,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:16:14
+   │
+16 │     let old: u64 = self.x
+   │              ^^^ u64
+
+note: 
+   ┌─ features/struct_fns.fe:16:20
+   │
+16 │     let old: u64 = self.x
+   │                    ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:16:20
+   │
+16 │     let old: u64 = self.x
+   │                    ^^^^^^ u64: Memory => Value
+17 │     self.x = x
+   │     ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:17:5
+   │
+17 │     self.x = x
+   │     ^^^^^^   ^ u64: Value
+   │     │         
+   │     u64: Memory
+18 │     return old
+   │            ^^^ u64: Value
+
+note: 
+   ┌─ features/struct_fns.fe:20:3
+   │  
+20 │ ╭   pub fn reflect(self):
+21 │ │     let x: u64 = self.x
+22 │ │     let y: u64 = self.y
+23 │ │     # self.x = self.y panics. see issue #590
+24 │ │     self.x = y
+25 │ │     self.y = x
+   │ ╰──────────────^ attributes hash: 17603814563784536273
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:21:12
+   │
+21 │     let x: u64 = self.x
+   │            ^^^ u64
+22 │     let y: u64 = self.y
+   │            ^^^ u64
+
+note: 
+   ┌─ features/struct_fns.fe:21:18
+   │
+21 │     let x: u64 = self.x
+   │                  ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:21:18
+   │
+21 │     let x: u64 = self.x
+   │                  ^^^^^^ u64: Memory => Value
+22 │     let y: u64 = self.y
+   │                  ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:22:18
+   │
+22 │     let y: u64 = self.y
+   │                  ^^^^^^ u64: Memory => Value
+23 │     # self.x = self.y panics. see issue #590
+24 │     self.x = y
+   │     ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:24:5
+   │
+24 │     self.x = y
+   │     ^^^^^^   ^ u64: Value
+   │     │         
+   │     u64: Memory
+25 │     self.y = x
+   │     ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:25:5
+   │
+25 │     self.y = x
+   │     ^^^^^^   ^ u64: Value
+   │     │         
+   │     u64: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:27:3
+   │  
+27 │ ╭   pub fn translate(self, x: u64, y: u64):
+28 │ │     self.x += x
+29 │ │     self.y += y
+   │ ╰───────────────^ attributes hash: 7098045318883584041
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [
+             FunctionParam {
+                 name: "x",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U64,
+                         ),
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "y",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U64,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:28:5
+   │
+28 │     self.x += x
+   │     ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:28:5
+   │
+28 │     self.x += x
+   │     ^^^^^^    ^ u64: Value
+   │     │          
+   │     u64: Memory
+29 │     self.y += y
+   │     ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:29:5
+   │
+29 │     self.y += y
+   │     ^^^^^^    ^ u64: Value
+   │     │          
+   │     u64: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:31:3
+   │  
+31 │ ╭   pub fn add(self, other: Point) -> Point:
+32 │ │     let x: u64 = self.x + other.x
+33 │ │     let y: u64 = self.y + other.y
+34 │ │     return Point(x, y)
+   │ ╰──────────────────────^ attributes hash: 15351893842694786918
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [
+             FunctionParam {
+                 name: "other",
+                 typ: Ok(
+                     Struct(
+                         Struct {
+                             name: "Point",
+                             id: StructId(
+                                 0,
+                             ),
+                             field_count: 2,
+                         },
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Struct(
+                 Struct {
+                     name: "Point",
+                     id: StructId(
+                         0,
+                     ),
+                     field_count: 2,
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:32:12
+   │
+32 │     let x: u64 = self.x + other.x
+   │            ^^^ u64
+33 │     let y: u64 = self.y + other.y
+   │            ^^^ u64
+
+note: 
+   ┌─ features/struct_fns.fe:32:18
+   │
+32 │     let x: u64 = self.x + other.x
+   │                  ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:32:18
+   │
+32 │     let x: u64 = self.x + other.x
+   │                  ^^^^^^   ^^^^^ Point: Memory
+   │                  │         
+   │                  u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:32:27
+   │
+32 │     let x: u64 = self.x + other.x
+   │                           ^^^^^^^ u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:32:18
+   │
+32 │     let x: u64 = self.x + other.x
+   │                  ^^^^^^^^^^^^^^^^ u64: Value
+33 │     let y: u64 = self.y + other.y
+   │                  ^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:33:18
+   │
+33 │     let y: u64 = self.y + other.y
+   │                  ^^^^^^   ^^^^^ Point: Memory
+   │                  │         
+   │                  u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:33:27
+   │
+33 │     let y: u64 = self.y + other.y
+   │                           ^^^^^^^ u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:33:18
+   │
+33 │     let y: u64 = self.y + other.y
+   │                  ^^^^^^^^^^^^^^^^ u64: Value
+34 │     return Point(x, y)
+   │                  ^  ^ u64: Value
+   │                  │   
+   │                  u64: Value
+
+note: 
+   ┌─ features/struct_fns.fe:34:12
+   │
+34 │     return Point(x, y)
+   │            ^^^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:34:12
+   │
+34 │     return Point(x, y)
+   │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+
+note: 
+   ┌─ features/struct_fns.fe:36:1
+   │  
+36 │ ╭ pub fn do_pointy_things():
+37 │ │   let p1: Point = Point.origin()
+38 │ │   p1.translate(5, 10)
+39 │ │ 
+   · │
+42 │ │ 
+43 │ │   assert p3.x == 6 and p3.y == 12
+   │ ╰─────────────────────────────────^ attributes hash: 15148455653558261645
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:37:11
+   │
+37 │   let p1: Point = Point.origin()
+   │           ^^^^^ Point
+   ·
+40 │   let p2: Point = Point(x=1, y=2)
+   │           ^^^^^ Point
+41 │   let p3: Point = p1.add(p2)
+   │           ^^^^^ Point
+
+note: 
+   ┌─ features/struct_fns.fe:37:19
+   │
+37 │   let p1: Point = Point.origin()
+   │                   ^^^^^^^^^^^^^^ Point: Memory
+38 │   p1.translate(5, 10)
+   │   ^^           ^  ^^ u64: Value
+   │   │            │   
+   │   │            u64: Value
+   │   Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:38:3
+   │
+38 │   p1.translate(5, 10)
+   │   ^^^^^^^^^^^^^^^^^^^ (): Value
+39 │ 
+40 │   let p2: Point = Point(x=1, y=2)
+   │                           ^    ^ u64: Value
+   │                           │     
+   │                           u64: Value
+
+note: 
+   ┌─ features/struct_fns.fe:40:19
+   │
+40 │   let p2: Point = Point(x=1, y=2)
+   │                   ^^^^^^^^^^^^^^^ Point: Memory
+41 │   let p3: Point = p1.add(p2)
+   │                   ^^     ^^ Point: Memory
+   │                   │       
+   │                   Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:41:19
+   │
+41 │   let p3: Point = p1.add(p2)
+   │                   ^^^^^^^^^^ Point: Memory
+42 │ 
+43 │   assert p3.x == 6 and p3.y == 12
+   │          ^^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:43:10
+   │
+43 │   assert p3.x == 6 and p3.y == 12
+   │          ^^^^    ^ u64: Value
+   │          │        
+   │          u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:43:10
+   │
+43 │   assert p3.x == 6 and p3.y == 12
+   │          ^^^^^^^^^     ^^ Point: Memory
+   │          │              
+   │          bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:43:24
+   │
+43 │   assert p3.x == 6 and p3.y == 12
+   │                        ^^^^    ^^ u64: Value
+   │                        │        
+   │                        u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:43:24
+   │
+43 │   assert p3.x == 6 and p3.y == 12
+   │                        ^^^^^^^^^^ bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:43:10
+   │
+43 │   assert p3.x == 6 and p3.y == 12
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:37:19
+   │
+37 │   let p1: Point = Point.origin()
+   │                   ^^^^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(2) }
+38 │   p1.translate(5, 10)
+   │   ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(6) }
+39 │ 
+40 │   let p2: Point = Point(x=1, y=2)
+   │                   ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+41 │   let p3: Point = p1.add(p2)
+   │                   ^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(7) }
+
+note: 
+   ┌─ features/struct_fns.fe:48:3
+   │  
+48 │ ╭   pub fn bar(x: u64, y: u64) -> u64:
+49 │ │     do_pointy_things()
+50 │ │ 
+51 │ │     let p: Point = Point.new(x, y)
+   · │
+55 │ │     assert p.x() == y and p.y == 100
+56 │ │     return p.y
+   │ ╰──────────────^ attributes hash: 11047046466719380007
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [
+             FunctionParam {
+                 name: "x",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U64,
+                         ),
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "y",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U64,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U64,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/struct_fns.fe:51:12
+   │
+51 │     let p: Point = Point.new(x, y)
+   │            ^^^^^ Point
+
+note: 
+   ┌─ features/struct_fns.fe:49:5
+   │
+49 │     do_pointy_things()
+   │     ^^^^^^^^^^^^^^^^^^ (): Value
+50 │ 
+51 │     let p: Point = Point.new(x, y)
+   │                              ^  ^ u64: Value
+   │                              │   
+   │                              u64: Value
+
+note: 
+   ┌─ features/struct_fns.fe:51:20
+   │
+51 │     let p: Point = Point.new(x, y)
+   │                    ^^^^^^^^^^^^^^^ Point: Memory
+52 │     assert p.x == x and p.y == y
+   │            ^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:52:12
+   │
+52 │     assert p.x == x and p.y == y
+   │            ^^^    ^ u64: Value
+   │            │       
+   │            u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:52:12
+   │
+52 │     assert p.x == x and p.y == y
+   │            ^^^^^^^^     ^ Point: Memory
+   │            │             
+   │            bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:52:25
+   │
+52 │     assert p.x == x and p.y == y
+   │                         ^^^    ^ u64: Value
+   │                         │       
+   │                         u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:52:25
+   │
+52 │     assert p.x == x and p.y == y
+   │                         ^^^^^^^^ bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:52:12
+   │
+52 │     assert p.x == x and p.y == y
+   │            ^^^^^^^^^^^^^^^^^^^^^ bool: Value
+53 │     p.set_x(100)
+   │     ^       ^^^ u64: Value
+   │     │        
+   │     Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:53:5
+   │
+53 │     p.set_x(100)
+   │     ^^^^^^^^^^^^ u64: Value
+54 │     p.reflect()
+   │     ^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:54:5
+   │
+54 │     p.reflect()
+   │     ^^^^^^^^^^^ (): Value
+55 │     assert p.x() == y and p.y == 100
+   │            ^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:55:12
+   │
+55 │     assert p.x() == y and p.y == 100
+   │            ^^^^^    ^ u64: Value
+   │            │         
+   │            u64: Value
+
+note: 
+   ┌─ features/struct_fns.fe:55:12
+   │
+55 │     assert p.x() == y and p.y == 100
+   │            ^^^^^^^^^^     ^ Point: Memory
+   │            │               
+   │            bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:55:27
+   │
+55 │     assert p.x() == y and p.y == 100
+   │                           ^^^    ^^^ u64: Value
+   │                           │       
+   │                           u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:55:27
+   │
+55 │     assert p.x() == y and p.y == 100
+   │                           ^^^^^^^^^^ bool: Value
+
+note: 
+   ┌─ features/struct_fns.fe:55:12
+   │
+55 │     assert p.x() == y and p.y == 100
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+56 │     return p.y
+   │            ^ Point: Memory
+
+note: 
+   ┌─ features/struct_fns.fe:56:12
+   │
+56 │     return p.y
+   │            ^^^ u64: Memory => Value
+
+note: 
+   ┌─ features/struct_fns.fe:49:5
+   │
+49 │     do_pointy_things()
+   │     ^^^^^^^^^^^^^^^^ Pure(FunctionId(0))
+50 │ 
+51 │     let p: Point = Point.new(x, y)
+   │                    ^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(1) }
+52 │     assert p.x == x and p.y == y
+53 │     p.set_x(100)
+   │     ^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(4) }
+54 │     p.reflect()
+   │     ^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(5) }
+55 │     assert p.x() == y and p.y == 100
+   │            ^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(3) }
+
+

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -8,22 +8,10 @@ note:
   │
 2 │     price: u256
   │     ^^^^^^^^^^^ u256
-
-note: 
-  ┌─ features/structs.fe:3:5
-  │
 3 │     size: u256
   │     ^^^^^^^^^^ u256
-
-note: 
-  ┌─ features/structs.fe:4:5
-  │
 4 │     rooms: u8
   │     ^^^^^^^^^ u8
-
-note: 
-  ┌─ features/structs.fe:5:5
-  │
 5 │     vacant: bool
   │     ^^^^^^^^^^^^ bool
 
@@ -66,6 +54,14 @@ note:
      }
 
 note: 
+   ┌─ features/structs.fe:11:9
+   │
+11 │         self.my_house = data
+   │         ^^^^^^^^^^^^^   ^^^^ House: Memory => None
+   │         │                
+   │         House: Storage { nonce: Some(0) } => None
+
+note: 
    ┌─ features/structs.fe:13:5
    │  
 13 │ ╭     pub fn get_house(self) -> House:
@@ -87,6 +83,26 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ features/structs.fe:14:16
+   │
+14 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ features/structs.fe:14:16
+   │
+14 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Some(Memory)
+
+note: 
+   ┌─ features/structs.fe:14:16
+   │
+14 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
 
 note: 
    ┌─ features/structs.fe:16:5
@@ -111,125 +127,14 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:50:5
-   │  
-50 │ ╭     pub fn bar() -> u256:
-51 │ │         let building: House = House(
-52 │ │             price=300,
-53 │ │             size=500,
-   · │
-70 │ │         assert building.rooms == u8(10)
-71 │ │         return building.size
-   │ ╰────────────────────────────^ attributes hash: 17979516652885443340
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:73:5
-   │  
-73 │ ╭     pub fn encode_house() -> Array<u8, 128>:
-74 │ │         let house: House = House(
-75 │ │             price=300,
-76 │ │             size=500,
-   · │
-79 │ │         )
-80 │ │         return house.abi_encode()
-   │ ╰─────────────────────────────────^ attributes hash: 6092146250611764360
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 128,
-                     inner: Numeric(
-                         U8,
-                     ),
-                 },
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:82:5
-   │  
-82 │ ╭     pub fn hashed_house() -> u256:
-83 │ │         let house: House = House(
-84 │ │             price=300,
-85 │ │             size=500,
-   · │
-88 │ │         )
-89 │ │         return keccak256(house.abi_encode())
-   │ ╰────────────────────────────────────────────^ attributes hash: 17979516652885443340
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:11:9
-   │
-11 │         self.my_house = data
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:11:25
-   │
-11 │         self.my_house = data
-   │                         ^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:14:16
-   │
-14 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:14:16
-   │
-14 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Some(Memory)
-
-note: 
    ┌─ features/structs.fe:17:9
    │
 17 │         self.my_house = House(
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:18:19
-   │
 18 │             price=1,
    │                   ^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:19:18
-   │
 19 │             size=2,
    │                  ^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:20:22
-   │
 20 │             rooms=u8(5),
    │                      ^ u8: Value => None
 
@@ -238,10 +143,6 @@ note:
    │
 20 │             rooms=u8(5),
    │                   ^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:21:20
-   │
 21 │             vacant=false
    │                    ^^^^^ bool: Value => None
 
@@ -256,34 +157,22 @@ note:
 21 │ │             vacant=false
 22 │ │         )
    │ ╰─────────^ House: Memory => None
+23 │           assert self.my_house.price == 1
+   │                  ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/structs.fe:23:16
    │
 23 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:23:16
-   │
-23 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:23:39
-   │
-23 │         assert self.my_house.price == 1
-   │                                       ^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:23:16
    │
 23 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:24:16
-   │
 24 │         assert self.my_house.size == 2
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -291,23 +180,15 @@ note:
    ┌─ features/structs.fe:24:16
    │
 24 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:24:38
-   │
-24 │         assert self.my_house.size == 2
-   │                                      ^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:24:16
    │
 24 │         assert self.my_house.size == 2
    │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:25:16
-   │
 25 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -315,13 +196,9 @@ note:
    ┌─ features/structs.fe:25:16
    │
 25 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:25:42
-   │
-25 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ u8: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:25:39
@@ -334,10 +211,6 @@ note:
    │
 25 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:26:16
-   │
 26 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -345,23 +218,16 @@ note:
    ┌─ features/structs.fe:26:16
    │
 26 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:26:40
-   │
-26 │         assert self.my_house.vacant == false
-   │                                        ^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:26:16
    │
 26 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:28:9
-   │
+27 │         # We change only the size and check other fields are unchanged
 28 │         self.my_house.size = 50
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -369,17 +235,9 @@ note:
    ┌─ features/structs.fe:28:9
    │
 28 │         self.my_house.size = 50
-   │         ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:28:30
-   │
-28 │         self.my_house.size = 50
-   │                              ^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:29:16
-   │
+   │         ^^^^^^^^^^^^^^^^^^   ^^ u256: Value => None
+   │         │                     
+   │         u256: Storage { nonce: Some(0) } => None
 29 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -387,23 +245,15 @@ note:
    ┌─ features/structs.fe:29:16
    │
 29 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:29:38
-   │
-29 │         assert self.my_house.size == 50
-   │                                      ^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:29:16
    │
 29 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:30:16
-   │
 30 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -411,23 +261,15 @@ note:
    ┌─ features/structs.fe:30:16
    │
 30 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:30:39
-   │
-30 │         assert self.my_house.price == 1
-   │                                       ^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:30:16
    │
 30 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:31:16
-   │
 31 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -435,13 +277,9 @@ note:
    ┌─ features/structs.fe:31:16
    │
 31 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:31:42
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ u8: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:31:39
@@ -454,10 +292,6 @@ note:
    │
 31 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:32:16
-   │
 32 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -465,23 +299,16 @@ note:
    ┌─ features/structs.fe:32:16
    │
 32 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:32:40
-   │
-32 │         assert self.my_house.vacant == false
-   │                                        ^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:32:16
    │
 32 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:34:9
-   │
+33 │         # We change only the price and check other fields are unchanged
 34 │         self.my_house.price = 1000
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -489,17 +316,9 @@ note:
    ┌─ features/structs.fe:34:9
    │
 34 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:34:31
-   │
-34 │         self.my_house.price = 1000
-   │                               ^^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:35:16
-   │
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value => None
+   │         │                      
+   │         u256: Storage { nonce: Some(0) } => None
 35 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -507,23 +326,15 @@ note:
    ┌─ features/structs.fe:35:16
    │
 35 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:35:38
-   │
-35 │         assert self.my_house.size == 50
-   │                                      ^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:35:16
    │
 35 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:36:16
-   │
 36 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -531,23 +342,15 @@ note:
    ┌─ features/structs.fe:36:16
    │
 36 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:36:39
-   │
-36 │         assert self.my_house.price == 1000
-   │                                       ^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value => None
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:36:16
    │
 36 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:37:16
-   │
 37 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -555,13 +358,9 @@ note:
    ┌─ features/structs.fe:37:16
    │
 37 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:37:42
-   │
-37 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ u8: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:37:39
@@ -574,10 +373,6 @@ note:
    │
 37 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:38:16
-   │
 38 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -585,23 +380,15 @@ note:
    ┌─ features/structs.fe:38:16
    │
 38 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:38:40
-   │
-38 │         assert self.my_house.vacant == false
-   │                                        ^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:38:16
    │
 38 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:39:9
-   │
 39 │         self.my_house.vacant = true
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -609,17 +396,9 @@ note:
    ┌─ features/structs.fe:39:9
    │
 39 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:39:32
-   │
-39 │         self.my_house.vacant = true
-   │                                ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:40:16
-   │
+   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value => None
+   │         │                       
+   │         bool: Storage { nonce: Some(0) } => None
 40 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -627,23 +406,15 @@ note:
    ┌─ features/structs.fe:40:16
    │
 40 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:40:38
-   │
-40 │         assert self.my_house.size == 50
-   │                                      ^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:40:16
    │
 40 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:41:16
-   │
 41 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -651,23 +422,15 @@ note:
    ┌─ features/structs.fe:41:16
    │
 41 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:41:39
-   │
-41 │         assert self.my_house.price == 1000
-   │                                       ^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value => None
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:41:16
    │
 41 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:42:16
-   │
 42 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -675,13 +438,9 @@ note:
    ┌─ features/structs.fe:42:16
    │
 42 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^ u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:42:42
-   │
-42 │         assert self.my_house.rooms == u8(5)
-   │                                          ^ u8: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:42:39
@@ -694,10 +453,6 @@ note:
    │
 42 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:43:16
-   │
 43 │         assert self.my_house.vacant
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -706,10 +461,6 @@ note:
    │
 43 │         assert self.my_house.vacant
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:44:9
-   │
 44 │         self.my_house.rooms = u8(100)
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -717,23 +468,15 @@ note:
    ┌─ features/structs.fe:44:9
    │
 44 │         self.my_house.rooms = u8(100)
-   │         ^^^^^^^^^^^^^^^^^^^ u8: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:44:34
-   │
-44 │         self.my_house.rooms = u8(100)
-   │                                  ^^^ u8: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value => None
+   │         │                         
+   │         u8: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/structs.fe:44:31
    │
 44 │         self.my_house.rooms = u8(100)
    │                               ^^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:45:16
-   │
 45 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -741,23 +484,15 @@ note:
    ┌─ features/structs.fe:45:16
    │
 45 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:45:38
-   │
-45 │         assert self.my_house.size == 50
-   │                                      ^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:45:16
    │
 45 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:46:16
-   │
 46 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -765,23 +500,15 @@ note:
    ┌─ features/structs.fe:46:16
    │
 46 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:46:39
-   │
-46 │         assert self.my_house.price == 1000
-   │                                       ^^^^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value => None
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:46:16
    │
 46 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:47:16
-   │
 47 │         assert self.my_house.rooms == u8(100)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -789,13 +516,9 @@ note:
    ┌─ features/structs.fe:47:16
    │
 47 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^^^^^^^ u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:47:42
-   │
-47 │         assert self.my_house.rooms == u8(100)
-   │                                          ^^^ u8: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^       ^^^ u8: Value => None
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Some(Value)
 
 note: 
    ┌─ features/structs.fe:47:39
@@ -808,10 +531,6 @@ note:
    │
 47 │         assert self.my_house.rooms == u8(100)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
 48 │         assert self.my_house.vacant
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
 
@@ -820,470 +539,6 @@ note:
    │
 48 │         assert self.my_house.vacant
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:52:19
-   │
-52 │             price=300,
-   │                   ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:53:18
-   │
-53 │             size=500,
-   │                  ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:54:22
-   │
-54 │             rooms=u8(20),
-   │                      ^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:54:19
-   │
-54 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:55:20
-   │
-55 │             vacant=true
-   │                    ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:51:31
-   │  
-51 │           let building: House = House(
-   │ ╭───────────────────────────────^
-52 │ │             price=300,
-53 │ │             size=500,
-54 │ │             rooms=u8(20),
-55 │ │             vacant=true
-56 │ │         )
-   │ ╰─────────^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:57:16
-   │
-57 │         assert building.size == 500
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:57:16
-   │
-57 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:57:33
-   │
-57 │         assert building.size == 500
-   │                                 ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:57:16
-   │
-57 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:58:16
-   │
-58 │         assert building.price == 300
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:58:16
-   │
-58 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:58:34
-   │
-58 │         assert building.price == 300
-   │                                  ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:58:16
-   │
-58 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^ u8: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:59:37
-   │
-59 │         assert building.rooms == u8(20)
-   │                                     ^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:59:34
-   │
-59 │         assert building.rooms == u8(20)
-   │                                  ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:60:16
-   │
-60 │         assert building.vacant
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:60:16
-   │
-60 │         assert building.vacant
-   │                ^^^^^^^^^^^^^^^ bool: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:62:9
-   │
-62 │         building.vacant = false
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:62:9
-   │
-62 │         building.vacant = false
-   │         ^^^^^^^^^^^^^^^ bool: Memory => None
-
-note: 
-   ┌─ features/structs.fe:62:27
-   │
-62 │         building.vacant = false
-   │                           ^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:63:9
-   │
-63 │         building.price = 1
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:63:9
-   │
-63 │         building.price = 1
-   │         ^^^^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/structs.fe:63:26
-   │
-63 │         building.price = 1
-   │                          ^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:64:9
-   │
-64 │         building.size = 2
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:64:9
-   │
-64 │         building.size = 2
-   │         ^^^^^^^^^^^^^ u256: Memory => None
-
-note: 
-   ┌─ features/structs.fe:64:25
-   │
-64 │         building.size = 2
-   │                         ^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:65:9
-   │
-65 │         building.rooms = u8(10)
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:65:9
-   │
-65 │         building.rooms = u8(10)
-   │         ^^^^^^^^^^^^^^ u8: Memory => None
-
-note: 
-   ┌─ features/structs.fe:65:29
-   │
-65 │         building.rooms = u8(10)
-   │                             ^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:65:26
-   │
-65 │         building.rooms = u8(10)
-   │                          ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert building.vacant == false
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^ bool: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:67:35
-   │
-67 │         assert building.vacant == false
-   │                                   ^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:68:16
-   │
-68 │         assert building.price == 1
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:68:16
-   │
-68 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:68:34
-   │
-68 │         assert building.price == 1
-   │                                  ^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:68:16
-   │
-68 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert building.size == 2
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:69:33
-   │
-69 │         assert building.size == 2
-   │                                 ^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:70:16
-   │
-70 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:70:16
-   │
-70 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^ u8: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:70:37
-   │
-70 │         assert building.rooms == u8(10)
-   │                                     ^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:70:34
-   │
-70 │         assert building.rooms == u8(10)
-   │                                  ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:70:16
-   │
-70 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:71:16
-   │
-71 │         return building.size
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:71:16
-   │
-71 │         return building.size
-   │                ^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:75:19
-   │
-75 │             price=300,
-   │                   ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:76:18
-   │
-76 │             size=500,
-   │                  ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:77:22
-   │
-77 │             rooms=u8(20),
-   │                      ^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:77:19
-   │
-77 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:78:20
-   │
-78 │             vacant=true
-   │                    ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:74:28
-   │  
-74 │           let house: House = House(
-   │ ╭────────────────────────────^
-75 │ │             price=300,
-76 │ │             size=500,
-77 │ │             rooms=u8(20),
-78 │ │             vacant=true
-79 │ │         )
-   │ ╰─────────^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:80:16
-   │
-80 │         return house.abi_encode()
-   │                ^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:80:16
-   │
-80 │         return house.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory => None
-
-note: 
-   ┌─ features/structs.fe:84:19
-   │
-84 │             price=300,
-   │                   ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:85:18
-   │
-85 │             size=500,
-   │                  ^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:86:22
-   │
-86 │             rooms=u8(20),
-   │                      ^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:86:19
-   │
-86 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:87:20
-   │
-87 │             vacant=true
-   │                    ^^^^ bool: Value => None
-
-note: 
-   ┌─ features/structs.fe:83:28
-   │  
-83 │           let house: House = House(
-   │ ╭────────────────────────────^
-84 │ │             price=300,
-85 │ │             size=500,
-86 │ │             rooms=u8(20),
-87 │ │             vacant=true
-88 │ │         )
-   │ ╰─────────^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:89:26
-   │
-89 │         return keccak256(house.abi_encode())
-   │                          ^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:89:26
-   │
-89 │         return keccak256(house.abi_encode())
-   │                          ^^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory => None
-
-note: 
-   ┌─ features/structs.fe:89:16
-   │
-89 │         return keccak256(house.abi_encode())
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:51:23
-   │
-51 │         let building: House = House(
-   │                       ^^^^^ House
-
-note: 
-   ┌─ features/structs.fe:74:20
-   │
-74 │         let house: House = House(
-   │                    ^^^^^ House
-
-note: 
-   ┌─ features/structs.fe:83:20
-   │
-83 │         let house: House = House(
-   │                    ^^^^^ House
-
-note: 
-   ┌─ features/structs.fe:14:16
-   │
-14 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
 
 note: 
    ┌─ features/structs.fe:17:25
@@ -1402,6 +657,254 @@ note:
      }
 
 note: 
+   ┌─ features/structs.fe:50:5
+   │  
+50 │ ╭     pub fn bar() -> u256:
+51 │ │         let building: House = House(
+52 │ │             price=300,
+53 │ │             size=500,
+   · │
+70 │ │         assert building.rooms == u8(10)
+71 │ │         return building.size
+   │ ╰────────────────────────────^ attributes hash: 17979516652885443340
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:51:23
+   │
+51 │         let building: House = House(
+   │                       ^^^^^ House
+
+note: 
+   ┌─ features/structs.fe:52:19
+   │
+52 │             price=300,
+   │                   ^^^ u256: Value => None
+53 │             size=500,
+   │                  ^^^ u256: Value => None
+54 │             rooms=u8(20),
+   │                      ^^ u8: Value => None
+
+note: 
+   ┌─ features/structs.fe:54:19
+   │
+54 │             rooms=u8(20),
+   │                   ^^^^^^ u8: Value => None
+55 │             vacant=true
+   │                    ^^^^ bool: Value => None
+
+note: 
+   ┌─ features/structs.fe:51:31
+   │  
+51 │           let building: House = House(
+   │ ╭───────────────────────────────^
+52 │ │             price=300,
+53 │ │             size=500,
+54 │ │             rooms=u8(20),
+55 │ │             vacant=true
+56 │ │         )
+   │ ╰─────────^ House: Memory => None
+57 │           assert building.size == 500
+   │                  ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:57:16
+   │
+57 │         assert building.size == 500
+   │                ^^^^^^^^^^^^^    ^^^ u256: Value => None
+   │                │                 
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:57:16
+   │
+57 │         assert building.size == 500
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+58 │         assert building.price == 300
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:58:16
+   │
+58 │         assert building.price == 300
+   │                ^^^^^^^^^^^^^^    ^^^ u256: Value => None
+   │                │                  
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:58:16
+   │
+58 │         assert building.price == 300
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+59 │         assert building.rooms == u8(20)
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert building.rooms == u8(20)
+   │                ^^^^^^^^^^^^^^       ^^ u8: Value => None
+   │                │                     
+   │                u8: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:59:34
+   │
+59 │         assert building.rooms == u8(20)
+   │                                  ^^^^^^ u8: Value => None
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert building.rooms == u8(20)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+60 │         assert building.vacant
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert building.vacant
+   │                ^^^^^^^^^^^^^^^ bool: Memory => Some(Value)
+61 │ 
+62 │         building.vacant = false
+   │         ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:62:9
+   │
+62 │         building.vacant = false
+   │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value => None
+   │         │                  
+   │         bool: Memory => None
+63 │         building.price = 1
+   │         ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:63:9
+   │
+63 │         building.price = 1
+   │         ^^^^^^^^^^^^^^   ^ u256: Value => None
+   │         │                 
+   │         u256: Memory => None
+64 │         building.size = 2
+   │         ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:64:9
+   │
+64 │         building.size = 2
+   │         ^^^^^^^^^^^^^   ^ u256: Value => None
+   │         │                
+   │         u256: Memory => None
+65 │         building.rooms = u8(10)
+   │         ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:65:9
+   │
+65 │         building.rooms = u8(10)
+   │         ^^^^^^^^^^^^^^      ^^ u8: Value => None
+   │         │                    
+   │         u8: Memory => None
+
+note: 
+   ┌─ features/structs.fe:65:26
+   │
+65 │         building.rooms = u8(10)
+   │                          ^^^^^^ u8: Value => None
+66 │ 
+67 │         assert building.vacant == false
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:67:16
+   │
+67 │         assert building.vacant == false
+   │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
+   │                │                   
+   │                bool: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:67:16
+   │
+67 │         assert building.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+68 │         assert building.price == 1
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:68:16
+   │
+68 │         assert building.price == 1
+   │                ^^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                  
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:68:16
+   │
+68 │         assert building.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value => None
+69 │         assert building.size == 2
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert building.size == 2
+   │                ^^^^^^^^^^^^^    ^ u256: Value => None
+   │                │                 
+   │                u256: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert building.size == 2
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value => None
+70 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^^^^^^^       ^^ u8: Value => None
+   │                │                     
+   │                u8: Memory => Some(Value)
+
+note: 
+   ┌─ features/structs.fe:70:34
+   │
+70 │         assert building.rooms == u8(10)
+   │                                  ^^^^^^ u8: Value => None
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+71 │         return building.size
+   │                ^^^^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:71:16
+   │
+71 │         return building.size
+   │                ^^^^^^^^^^^^^ u256: Memory => Some(Value)
+
+note: 
    ┌─ features/structs.fe:51:31
    │
 51 │         let building: House = House(
@@ -1476,6 +979,77 @@ note:
      }
 
 note: 
+   ┌─ features/structs.fe:73:5
+   │  
+73 │ ╭     pub fn encode_house() -> Array<u8, 128>:
+74 │ │         let house: House = House(
+75 │ │             price=300,
+76 │ │             size=500,
+   · │
+79 │ │         )
+80 │ │         return house.abi_encode()
+   │ ╰─────────────────────────────────^ attributes hash: 6092146250611764360
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Array(
+                 Array {
+                     size: 128,
+                     inner: Numeric(
+                         U8,
+                     ),
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:74:20
+   │
+74 │         let house: House = House(
+   │                    ^^^^^ House
+
+note: 
+   ┌─ features/structs.fe:75:19
+   │
+75 │             price=300,
+   │                   ^^^ u256: Value => None
+76 │             size=500,
+   │                  ^^^ u256: Value => None
+77 │             rooms=u8(20),
+   │                      ^^ u8: Value => None
+
+note: 
+   ┌─ features/structs.fe:77:19
+   │
+77 │             rooms=u8(20),
+   │                   ^^^^^^ u8: Value => None
+78 │             vacant=true
+   │                    ^^^^ bool: Value => None
+
+note: 
+   ┌─ features/structs.fe:74:28
+   │  
+74 │           let house: House = House(
+   │ ╭────────────────────────────^
+75 │ │             price=300,
+76 │ │             size=500,
+77 │ │             rooms=u8(20),
+78 │ │             vacant=true
+79 │ │         )
+   │ ╰─────────^ House: Memory => None
+80 │           return house.abi_encode()
+   │                  ^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:80:16
+   │
+80 │         return house.abi_encode()
+   │                ^^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory => None
+
+note: 
    ┌─ features/structs.fe:74:28
    │
 74 │         let house: House = House(
@@ -1514,6 +1088,80 @@ note:
    │                ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
    │
    = ValueAttribute
+
+note: 
+   ┌─ features/structs.fe:82:5
+   │  
+82 │ ╭     pub fn hashed_house() -> u256:
+83 │ │         let house: House = House(
+84 │ │             price=300,
+85 │ │             size=500,
+   · │
+88 │ │         )
+89 │ │         return keccak256(house.abi_encode())
+   │ ╰────────────────────────────────────────────^ attributes hash: 17979516652885443340
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:83:20
+   │
+83 │         let house: House = House(
+   │                    ^^^^^ House
+
+note: 
+   ┌─ features/structs.fe:84:19
+   │
+84 │             price=300,
+   │                   ^^^ u256: Value => None
+85 │             size=500,
+   │                  ^^^ u256: Value => None
+86 │             rooms=u8(20),
+   │                      ^^ u8: Value => None
+
+note: 
+   ┌─ features/structs.fe:86:19
+   │
+86 │             rooms=u8(20),
+   │                   ^^^^^^ u8: Value => None
+87 │             vacant=true
+   │                    ^^^^ bool: Value => None
+
+note: 
+   ┌─ features/structs.fe:83:28
+   │  
+83 │           let house: House = House(
+   │ ╭────────────────────────────^
+84 │ │             price=300,
+85 │ │             size=500,
+86 │ │             rooms=u8(20),
+87 │ │             vacant=true
+88 │ │         )
+   │ ╰─────────^ House: Memory => None
+89 │           return keccak256(house.abi_encode())
+   │                            ^^^^^ House: Memory => None
+
+note: 
+   ┌─ features/structs.fe:89:26
+   │
+89 │         return keccak256(house.abi_encode())
+   │                          ^^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory => None
+
+note: 
+   ┌─ features/structs.fe:89:16
+   │
+89 │         return keccak256(house.abi_encode())
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
 
 note: 
    ┌─ features/structs.fe:83:28

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -16,20 +16,206 @@ note:
   │     ^^^^^^^^^^^^ bool
 
 note: 
-  ┌─ features/structs.fe:8:5
+  ┌─ features/structs.fe:7:5
+  │  
+7 │ ╭     pub fn encode(self) -> Array<u8, 128>:
+8 │ │         return self.abi_encode()
+  │ ╰────────────────────────────────^ attributes hash: 17909223604408730591
+  │  
+  = FunctionSignature {
+        self_decl: Some(
+            Mutable,
+        ),
+        params: [],
+        return_type: Ok(
+            Array(
+                Array {
+                    size: 128,
+                    inner: Numeric(
+                        U8,
+                    ),
+                },
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/structs.fe:8:16
   │
-8 │     my_house: House
-  │     ^^^^^^^^^^^^^^^ House
+8 │         return self.abi_encode()
+  │                ^^^^ House: Memory
+
+note: 
+  ┌─ features/structs.fe:8:16
+  │
+8 │         return self.abi_encode()
+  │                ^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory
+
+note: 
+  ┌─ features/structs.fe:8:16
+  │
+8 │         return self.abi_encode()
+  │                ^^^^^^^^^^^^^^^ BuiltinValueMethod(AbiEncode)
 
 note: 
    ┌─ features/structs.fe:10:5
    │  
-10 │ ╭     pub fn set_house(self, data: House):
-11 │ │         self.my_house = data
-   │ ╰────────────────────────────^ attributes hash: 12036165174380818533
+10 │ ╭     pub fn hash(self) -> u256:
+11 │ │         return keccak256(self.encode())
+   │ ╰───────────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:11:26
+   │
+11 │         return keccak256(self.encode())
+   │                          ^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:11:26
+   │
+11 │         return keccak256(self.encode())
+   │                          ^^^^^^^^^^^^^ Array<u8, 128>: Memory
+
+note: 
+   ┌─ features/structs.fe:11:16
+   │
+11 │         return keccak256(self.encode())
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+   ┌─ features/structs.fe:11:26
+   │
+11 │         return keccak256(self.encode())
+   │                          ^^^^^^^^^^^ ValueMethod { is_self: true, class: Struct(StructId(0)), method: FunctionId(0) }
+
+note: 
+   ┌─ features/structs.fe:11:16
+   │
+11 │         return keccak256(self.encode())
+   │                ^^^^^^^^^ BuiltinFunction(Keccak256)
+
+note: 
+   ┌─ features/structs.fe:13:5
+   │  
+13 │ ╭     pub fn price_per_sqft(self) -> u256:
+14 │ │         return self.price / self.size
+   │ ╰─────────────────────────────────────^ attributes hash: 2875164910451995213
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:14:16
+   │
+14 │         return self.price / self.size
+   │                ^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:14:16
+   │
+14 │         return self.price / self.size
+   │                ^^^^^^^^^^   ^^^^ House: Memory
+   │                │             
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:14:29
+   │
+14 │         return self.price / self.size
+   │                             ^^^^^^^^^ u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:14:16
+   │
+14 │         return self.price / self.size
+   │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+   ┌─ features/structs.fe:16:5
+   │  
+16 │ ╭     pub fn expand(self):
+17 │ │         self.rooms += 1
+18 │ │         self.size += 100
+   │ ╰────────────────────────^ attributes hash: 17603814563784536273
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:17:9
+   │
+17 │         self.rooms += 1
+   │         ^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:17:9
+   │
+17 │         self.rooms += 1
+   │         ^^^^^^^^^^    ^ u8: Value
+   │         │              
+   │         u8: Memory
+18 │         self.size += 100
+   │         ^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:18:9
+   │
+18 │         self.size += 100
+   │         ^^^^^^^^^    ^^^ u256: Value
+   │         │             
+   │         u256: Memory
+
+note: 
+   ┌─ features/structs.fe:21:5
+   │
+21 │     my_house: House
+   │     ^^^^^^^^^^^^^^^ House
+
+note: 
+   ┌─ features/structs.fe:23:5
+   │  
+23 │ ╭     pub fn set_house(self, data: House):
+24 │ │         self.my_house = data
+   │ ╰────────────────────────────^ attributes hash: 12541815911505045945
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "data",
@@ -54,22 +240,30 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:11:9
+   ┌─ features/structs.fe:24:9
    │
-11 │         self.my_house = data
-   │         ^^^^^^^^^^^^^   ^^^^ House: Memory => None
-   │         │                
-   │         House: Storage { nonce: Some(0) } => None
+24 │         self.my_house = data
+   │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:13:5
+   ┌─ features/structs.fe:24:9
+   │
+24 │         self.my_house = data
+   │         ^^^^^^^^^^^^^   ^^^^ House: Memory
+   │         │                
+   │         House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:26:5
    │  
-13 │ ╭     pub fn get_house(self) -> House:
-14 │ │         return self.my_house.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 11283349648861831810
+26 │ ╭     pub fn get_house(self) -> House:
+27 │ │         return self.my_house.to_mem()
+   │ ╰─────────────────────────────────────^ attributes hash: 15995799457870358812
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Struct(
@@ -85,39 +279,45 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:14:16
+   ┌─ features/structs.fe:27:16
    │
-14 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+27 │         return self.my_house.to_mem()
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:14:16
+   ┌─ features/structs.fe:27:16
    │
-14 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Some(Memory)
+27 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:14:16
+   ┌─ features/structs.fe:27:16
    │
-14 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+27 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ features/structs.fe:16:5
+   ┌─ features/structs.fe:27:16
+   │
+27 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
+
+note: 
+   ┌─ features/structs.fe:29:5
    │  
-16 │ ╭     pub fn create_house(self):
-17 │ │         self.my_house = House(
-18 │ │             price=1,
-19 │ │             size=2,
+29 │ ╭     pub fn create_house(self):
+30 │ │         self.my_house = House(
+31 │ │             price=1,
+32 │ │             size=2,
    · │
-47 │ │         assert self.my_house.rooms == u8(100)
-48 │ │         assert self.my_house.vacant
-   │ ╰───────────────────────────────────^ attributes hash: 4369441865732737140
+60 │ │         assert self.my_house.rooms == u8(100)
+61 │ │         assert self.my_house.vacant
+   │ ╰───────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -127,545 +327,609 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:17:9
+   ┌─ features/structs.fe:30:9
    │
-17 │         self.my_house = House(
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-18 │             price=1,
-   │                   ^ u256: Value => None
-19 │             size=2,
-   │                  ^ u256: Value => None
-20 │             rooms=u8(5),
-   │                      ^ u8: Value => None
+30 │         self.my_house = House(
+   │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:20:19
+   ┌─ features/structs.fe:30:9
    │
-20 │             rooms=u8(5),
-   │                   ^^^^^ u8: Value => None
-21 │             vacant=false
-   │                    ^^^^^ bool: Value => None
+30 │         self.my_house = House(
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+31 │             price=1,
+   │                   ^ u256: Value
+32 │             size=2,
+   │                  ^ u256: Value
+33 │             rooms=u8(5),
+   │                      ^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:17:25
+   ┌─ features/structs.fe:33:19
+   │
+33 │             rooms=u8(5),
+   │                   ^^^^^ u8: Value
+34 │             vacant=false
+   │                    ^^^^^ bool: Value
+
+note: 
+   ┌─ features/structs.fe:30:25
    │  
-17 │           self.my_house = House(
+30 │           self.my_house = House(
    │ ╭─────────────────────────^
-18 │ │             price=1,
-19 │ │             size=2,
-20 │ │             rooms=u8(5),
-21 │ │             vacant=false
-22 │ │         )
-   │ ╰─────────^ House: Memory => None
-23 │           assert self.my_house.price == 1
-   │                  ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+31 │ │             price=1,
+32 │ │             size=2,
+33 │ │             rooms=u8(5),
+34 │ │             vacant=false
+35 │ │         )
+   │ ╰─────────^ House: Memory
+36 │           assert self.my_house.price == 1
+   │                  ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:23:16
+   ┌─ features/structs.fe:36:16
    │
-23 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value => None
+36 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:36:16
+   │
+36 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                       
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
+   │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:23:16
+   ┌─ features/structs.fe:36:16
    │
-23 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-24 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+36 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+37 │         assert self.my_house.size == 2
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:24:16
+   ┌─ features/structs.fe:37:16
    │
-24 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^^^^^^    ^ u256: Value => None
+37 │         assert self.my_house.size == 2
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:37:16
+   │
+37 │         assert self.my_house.size == 2
+   │                ^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                      
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
+   │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:24:16
+   ┌─ features/structs.fe:37:16
    │
-24 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-25 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+37 │         assert self.my_house.size == 2
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+38 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:25:16
+   ┌─ features/structs.fe:38:16
    │
-25 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
+38 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:38:16
+   │
+38 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
    │                │                          
-   │                u8: Storage { nonce: Some(0) } => Some(Value)
+   │                u8: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:25:39
+   ┌─ features/structs.fe:38:39
    │
-25 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value => None
+38 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^^^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:25:16
+   ┌─ features/structs.fe:38:16
    │
-25 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-26 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+38 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+39 │         assert self.my_house.vacant == false
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:26:16
+   ┌─ features/structs.fe:39:16
    │
-26 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
+39 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:39:16
+   │
+39 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
    │                │                        
-   │                bool: Storage { nonce: Some(0) } => Some(Value)
+   │                bool: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:26:16
+   ┌─ features/structs.fe:39:16
    │
-26 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-27 │         # We change only the size and check other fields are unchanged
-28 │         self.my_house.size = 50
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+39 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+40 │         # We change only the size and check other fields are unchanged
+41 │         self.my_house.size = 50
+   │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:28:9
+   ┌─ features/structs.fe:41:9
    │
-28 │         self.my_house.size = 50
-   │         ^^^^^^^^^^^^^^^^^^   ^^ u256: Value => None
+41 │         self.my_house.size = 50
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:41:9
+   │
+41 │         self.my_house.size = 50
+   │         ^^^^^^^^^^^^^^^^^^   ^^ u256: Value
    │         │                     
-   │         u256: Storage { nonce: Some(0) } => None
-29 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:29:16
-   │
-29 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:29:16
-   │
-29 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-30 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:30:16
-   │
-30 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value => None
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:30:16
-   │
-30 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-31 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:31:16
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:31:39
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:31:16
-   │
-31 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-32 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:32:16
-   │
-32 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:32:16
-   │
-32 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-33 │         # We change only the price and check other fields are unchanged
-34 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:34:9
-   │
-34 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value => None
-   │         │                      
-   │         u256: Storage { nonce: Some(0) } => None
-35 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:35:16
-   │
-35 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:35:16
-   │
-35 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-36 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:36:16
-   │
-36 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value => None
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:36:16
-   │
-36 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-37 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:37:16
-   │
-37 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:37:39
-   │
-37 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:37:16
-   │
-37 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-38 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:38:16
-   │
-38 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:38:16
-   │
-38 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-39 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:39:9
-   │
-39 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value => None
-   │         │                       
-   │         bool: Storage { nonce: Some(0) } => None
-40 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:40:16
-   │
-40 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:40:16
-   │
-40 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-41 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:41:16
-   │
-41 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value => None
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:41:16
-   │
-41 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-42 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: Some(0) }
+42 │         assert self.my_house.size == 50
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/structs.fe:42:16
    │
-42 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value => None
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:42:39
-   │
-42 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value => None
+42 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
    ┌─ features/structs.fe:42:16
    │
-42 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-43 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+42 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:42:16
+   │
+42 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+43 │         assert self.my_house.price == 1
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/structs.fe:43:16
    │
-43 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
-44 │         self.my_house.rooms = u8(100)
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+43 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:44:9
+   ┌─ features/structs.fe:43:16
    │
-44 │         self.my_house.rooms = u8(100)
-   │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value => None
-   │         │                         
-   │         u8: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:44:31
-   │
-44 │         self.my_house.rooms = u8(100)
-   │                               ^^^^^^^ u8: Value => None
-45 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:45:16
-   │
-45 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value => None
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:45:16
-   │
-45 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-46 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/structs.fe:46:16
-   │
-46 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value => None
+43 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                       
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
+   │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:46:16
+   ┌─ features/structs.fe:43:16
    │
-46 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-47 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+43 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+44 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:47:16
+   ┌─ features/structs.fe:44:16
    │
-47 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^^^^^^^       ^^^ u8: Value => None
+44 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:44:16
+   │
+44 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
    │                │                          
-   │                u8: Storage { nonce: Some(0) } => Some(Value)
+   │                u8: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:47:39
+   ┌─ features/structs.fe:44:39
    │
-47 │         assert self.my_house.rooms == u8(100)
-   │                                       ^^^^^^^ u8: Value => None
+44 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^^^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:47:16
+   ┌─ features/structs.fe:44:16
    │
-47 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-48 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => None
+44 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+45 │         assert self.my_house.vacant == false
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:45:16
+   │
+45 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:45:16
+   │
+45 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:45:16
+   │
+45 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+46 │         # We change only the price and check other fields are unchanged
+47 │         self.my_house.price = 1000
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:47:9
+   │
+47 │         self.my_house.price = 1000
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:47:9
+   │
+47 │         self.my_house.price = 1000
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
+   │         │                      
+   │         u256: Storage { nonce: Some(0) }
+48 │         assert self.my_house.size == 50
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/structs.fe:48:16
    │
-48 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Some(Value)
+48 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:17:25
+   ┌─ features/structs.fe:48:16
    │
-17 │         self.my_house = House(
-   │                         ^^^^^ attributes hash: 4962363512196753612
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 4,
-             },
-         ),
-     }
+48 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:20:19
+   ┌─ features/structs.fe:48:16
    │
-20 │             rooms=u8(5),
-   │                   ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+48 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+49 │         assert self.my_house.price == 1000
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:25:39
+   ┌─ features/structs.fe:49:16
    │
-25 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+49 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:31:39
+   ┌─ features/structs.fe:49:16
    │
-31 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+49 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:37:39
+   ┌─ features/structs.fe:49:16
    │
-37 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+49 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+50 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:42:39
+   ┌─ features/structs.fe:50:16
    │
-42 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+50 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:44:31
+   ┌─ features/structs.fe:50:16
    │
-44 │         self.my_house.rooms = u8(100)
-   │                               ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+50 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:47:39
+   ┌─ features/structs.fe:50:39
    │
-47 │         assert self.my_house.rooms == u8(100)
-   │                                       ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+50 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^^^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:50:5
+   ┌─ features/structs.fe:50:16
+   │
+50 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+51 │         assert self.my_house.vacant == false
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:51:16
+   │
+51 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:51:16
+   │
+51 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:51:16
+   │
+51 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+52 │         self.my_house.vacant = true
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:52:9
+   │
+52 │         self.my_house.vacant = true
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:52:9
+   │
+52 │         self.my_house.vacant = true
+   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value
+   │         │                       
+   │         bool: Storage { nonce: Some(0) }
+53 │         assert self.my_house.size == 50
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:53:16
+   │
+53 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:53:16
+   │
+53 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:53:16
+   │
+53 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+54 │         assert self.my_house.price == 1000
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:54:16
+   │
+54 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:54:16
+   │
+54 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:54:16
+   │
+54 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+55 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:55:16
+   │
+55 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:55:16
+   │
+55 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:55:39
+   │
+55 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^^^^ u8: Value
+
+note: 
+   ┌─ features/structs.fe:55:16
+   │
+55 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+56 │         assert self.my_house.vacant
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:56:16
+   │
+56 │         assert self.my_house.vacant
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:56:16
+   │
+56 │         assert self.my_house.vacant
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
+57 │         self.my_house.rooms = u8(100)
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:57:9
+   │
+57 │         self.my_house.rooms = u8(100)
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:57:9
+   │
+57 │         self.my_house.rooms = u8(100)
+   │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value
+   │         │                         
+   │         u8: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:57:31
+   │
+57 │         self.my_house.rooms = u8(100)
+   │                               ^^^^^^^ u8: Value
+58 │         assert self.my_house.size == 50
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:58:16
+   │
+58 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:58:16
+   │
+58 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:58:16
+   │
+58 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+59 │         assert self.my_house.price == 1000
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+60 │         assert self.my_house.rooms == u8(100)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert self.my_house.rooms == u8(100)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert self.my_house.rooms == u8(100)
+   │                ^^^^^^^^^^^^^^^^^^^       ^^^ u8: Value
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:60:39
+   │
+60 │         assert self.my_house.rooms == u8(100)
+   │                                       ^^^^^^^ u8: Value
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert self.my_house.rooms == u8(100)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+61 │         assert self.my_house.vacant
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:61:16
+   │
+61 │         assert self.my_house.vacant
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:61:16
+   │
+61 │         assert self.my_house.vacant
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:33:19
+   │
+33 │             rooms=u8(5),
+   │                   ^^ TypeConstructor(Base(Numeric(U8)))
+
+note: 
+   ┌─ features/structs.fe:30:25
+   │
+30 │         self.my_house = House(
+   │                         ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+   ·
+38 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+44 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+50 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+55 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+56 │         assert self.my_house.vacant
+57 │         self.my_house.rooms = u8(100)
+   │                               ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+60 │         assert self.my_house.rooms == u8(100)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+
+note: 
+   ┌─ features/structs.fe:63:5
    │  
-50 │ ╭     pub fn bar() -> u256:
-51 │ │         let building: House = House(
-52 │ │             price=300,
-53 │ │             size=500,
+63 │ ╭     pub fn bar() -> u256:
+64 │ │         let building: House = House(
+65 │ │             price=300,
+66 │ │             size=500,
    · │
-70 │ │         assert building.rooms == u8(10)
-71 │ │         return building.size
+88 │ │ 
+89 │ │         return building.size
    │ ╰────────────────────────────^ attributes hash: 17979516652885443340
    │  
    = FunctionSignature {
@@ -681,314 +945,306 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:51:23
+   ┌─ features/structs.fe:64:23
    │
-51 │         let building: House = House(
+64 │         let building: House = House(
    │                       ^^^^^ House
 
 note: 
-   ┌─ features/structs.fe:52:19
+   ┌─ features/structs.fe:65:19
    │
-52 │             price=300,
-   │                   ^^^ u256: Value => None
-53 │             size=500,
-   │                  ^^^ u256: Value => None
-54 │             rooms=u8(20),
-   │                      ^^ u8: Value => None
+65 │             price=300,
+   │                   ^^^ u256: Value
+66 │             size=500,
+   │                  ^^^ u256: Value
+67 │             rooms=u8(20),
+   │                      ^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:54:19
+   ┌─ features/structs.fe:67:19
    │
-54 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value => None
-55 │             vacant=true
-   │                    ^^^^ bool: Value => None
+67 │             rooms=u8(20),
+   │                   ^^^^^^ u8: Value
+68 │             vacant=true
+   │                    ^^^^ bool: Value
 
 note: 
-   ┌─ features/structs.fe:51:31
+   ┌─ features/structs.fe:64:31
    │  
-51 │           let building: House = House(
+64 │           let building: House = House(
    │ ╭───────────────────────────────^
-52 │ │             price=300,
-53 │ │             size=500,
-54 │ │             rooms=u8(20),
-55 │ │             vacant=true
-56 │ │         )
-   │ ╰─────────^ House: Memory => None
-57 │           assert building.size == 500
-   │                  ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:57:16
-   │
-57 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^    ^^^ u256: Value => None
-   │                │                 
-   │                u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:57:16
-   │
-57 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-58 │         assert building.price == 300
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:58:16
-   │
-58 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^    ^^^ u256: Value => None
-   │                │                  
-   │                u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:58:16
-   │
-58 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-59 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^       ^^ u8: Value => None
-   │                │                     
-   │                u8: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:59:34
-   │
-59 │         assert building.rooms == u8(20)
-   │                                  ^^^^^^ u8: Value => None
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-60 │         assert building.vacant
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:60:16
-   │
-60 │         assert building.vacant
-   │                ^^^^^^^^^^^^^^^ bool: Memory => Some(Value)
-61 │ 
-62 │         building.vacant = false
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:62:9
-   │
-62 │         building.vacant = false
-   │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value => None
-   │         │                  
-   │         bool: Memory => None
-63 │         building.price = 1
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:63:9
-   │
-63 │         building.price = 1
-   │         ^^^^^^^^^^^^^^   ^ u256: Value => None
-   │         │                 
-   │         u256: Memory => None
-64 │         building.size = 2
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:64:9
-   │
-64 │         building.size = 2
-   │         ^^^^^^^^^^^^^   ^ u256: Value => None
-   │         │                
-   │         u256: Memory => None
-65 │         building.rooms = u8(10)
-   │         ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:65:9
-   │
-65 │         building.rooms = u8(10)
-   │         ^^^^^^^^^^^^^^      ^^ u8: Value => None
-   │         │                    
-   │         u8: Memory => None
-
-note: 
-   ┌─ features/structs.fe:65:26
-   │
-65 │         building.rooms = u8(10)
-   │                          ^^^^^^ u8: Value => None
-66 │ 
-67 │         assert building.vacant == false
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value => None
-   │                │                   
-   │                bool: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-68 │         assert building.price == 1
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:68:16
-   │
-68 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^    ^ u256: Value => None
-   │                │                  
-   │                u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:68:16
-   │
-68 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ bool: Value => None
-69 │         assert building.size == 2
-   │                ^^^^^^^^ House: Memory => None
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^    ^ u256: Value => None
-   │                │                 
-   │                u256: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^^^^^^ bool: Value => None
-70 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^ House: Memory => None
+65 │ │             price=300,
+66 │ │             size=500,
+67 │ │             rooms=u8(20),
+68 │ │             vacant=true
+69 │ │         )
+   │ ╰─────────^ House: Memory
+70 │           assert building.size == 500
+   │                  ^^^^^^^^ House: Memory
 
 note: 
    ┌─ features/structs.fe:70:16
    │
-70 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^       ^^ u8: Value => None
-   │                │                     
-   │                u8: Memory => Some(Value)
-
-note: 
-   ┌─ features/structs.fe:70:34
-   │
-70 │         assert building.rooms == u8(10)
-   │                                  ^^^^^^ u8: Value => None
+70 │         assert building.size == 500
+   │                ^^^^^^^^^^^^^    ^^^ u256: Value
+   │                │                 
+   │                u256: Memory => Value
 
 note: 
    ┌─ features/structs.fe:70:16
    │
-70 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-71 │         return building.size
-   │                ^^^^^^^^ House: Memory => None
+70 │         assert building.size == 500
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+71 │         assert building.price == 300
+   │                ^^^^^^^^ House: Memory
 
 note: 
    ┌─ features/structs.fe:71:16
    │
-71 │         return building.size
-   │                ^^^^^^^^^^^^^ u256: Memory => Some(Value)
+71 │         assert building.price == 300
+   │                ^^^^^^^^^^^^^^    ^^^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:51:31
+   ┌─ features/structs.fe:71:16
    │
-51 │         let building: House = House(
-   │                               ^^^^^ attributes hash: 4962363512196753612
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 4,
-             },
-         ),
-     }
+71 │         assert building.price == 300
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
+72 │         assert building.rooms == u8(20)
+   │                ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:54:19
+   ┌─ features/structs.fe:72:16
    │
-54 │             rooms=u8(20),
-   │                   ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+72 │         assert building.rooms == u8(20)
+   │                ^^^^^^^^^^^^^^       ^^ u8: Value
+   │                │                     
+   │                u8: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:59:34
+   ┌─ features/structs.fe:72:34
    │
-59 │         assert building.rooms == u8(20)
-   │                                  ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+72 │         assert building.rooms == u8(20)
+   │                                  ^^^^^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:65:26
+   ┌─ features/structs.fe:72:16
    │
-65 │         building.rooms = u8(10)
-   │                          ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+72 │         assert building.rooms == u8(20)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+73 │         assert building.vacant
+   │                ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:70:34
+   ┌─ features/structs.fe:73:16
    │
-70 │         assert building.rooms == u8(10)
-   │                                  ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+73 │         assert building.vacant
+   │                ^^^^^^^^^^^^^^^ bool: Memory => Value
+74 │ 
+75 │         building.vacant = false
+   │         ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:73:5
+   ┌─ features/structs.fe:75:9
+   │
+75 │         building.vacant = false
+   │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value
+   │         │                  
+   │         bool: Memory
+76 │         building.price = 1
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:76:9
+   │
+76 │         building.price = 1
+   │         ^^^^^^^^^^^^^^   ^ u256: Value
+   │         │                 
+   │         u256: Memory
+77 │         building.size = 2
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:77:9
+   │
+77 │         building.size = 2
+   │         ^^^^^^^^^^^^^   ^ u256: Value
+   │         │                
+   │         u256: Memory
+78 │         building.rooms = u8(10)
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:78:9
+   │
+78 │         building.rooms = u8(10)
+   │         ^^^^^^^^^^^^^^      ^^ u8: Value
+   │         │                    
+   │         u8: Memory
+
+note: 
+   ┌─ features/structs.fe:78:26
+   │
+78 │         building.rooms = u8(10)
+   │                          ^^^^^^ u8: Value
+79 │ 
+80 │         assert building.vacant == false
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:80:16
+   │
+80 │         assert building.vacant == false
+   │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+   │                │                   
+   │                bool: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:80:16
+   │
+80 │         assert building.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+81 │         assert building.price == 1
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:81:16
+   │
+81 │         assert building.price == 1
+   │                ^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:81:16
+   │
+81 │         assert building.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+82 │         assert building.size == 2
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:82:16
+   │
+82 │         assert building.size == 2
+   │                ^^^^^^^^^^^^^    ^ u256: Value
+   │                │                 
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:82:16
+   │
+82 │         assert building.size == 2
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value
+83 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:83:16
+   │
+83 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^^^^^^^       ^^ u8: Value
+   │                │                     
+   │                u8: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:83:34
+   │
+83 │         assert building.rooms == u8(10)
+   │                                  ^^^^^^ u8: Value
+
+note: 
+   ┌─ features/structs.fe:83:16
+   │
+83 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+84 │ 
+85 │         building.expand()
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:85:9
+   │
+85 │         building.expand()
+   │         ^^^^^^^^^^^^^^^^^ (): Value
+86 │         assert building.size == 102
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:86:16
+   │
+86 │         assert building.size == 102
+   │                ^^^^^^^^^^^^^    ^^^ u256: Value
+   │                │                 
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:86:16
+   │
+86 │         assert building.size == 102
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+87 │         assert building.rooms == 11
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:87:16
+   │
+87 │         assert building.rooms == 11
+   │                ^^^^^^^^^^^^^^    ^^ u8: Value
+   │                │                  
+   │                u8: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:87:16
+   │
+87 │         assert building.rooms == 11
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+88 │ 
+89 │         return building.size
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:89:16
+   │
+89 │         return building.size
+   │                ^^^^^^^^^^^^^ u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:67:19
+   │
+67 │             rooms=u8(20),
+   │                   ^^ TypeConstructor(Base(Numeric(U8)))
+
+note: 
+   ┌─ features/structs.fe:64:31
+   │
+64 │         let building: House = House(
+   │                               ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+   ·
+72 │         assert building.rooms == u8(20)
+   │                                  ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+78 │         building.rooms = u8(10)
+   │                          ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+83 │         assert building.rooms == u8(10)
+   │                                  ^^ TypeConstructor(Base(Numeric(U8)))
+84 │ 
+85 │         building.expand()
+   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(3) }
+
+note: 
+   ┌─ features/structs.fe:91:5
    │  
-73 │ ╭     pub fn encode_house() -> Array<u8, 128>:
-74 │ │         let house: House = House(
-75 │ │             price=300,
-76 │ │             size=500,
+91 │ ╭     pub fn encode_house() -> Array<u8, 128>:
+92 │ │         let house: House = House(
+93 │ │             price=300,
+94 │ │             size=500,
    · │
-79 │ │         )
-80 │ │         return house.abi_encode()
-   │ ╰─────────────────────────────────^ attributes hash: 6092146250611764360
+97 │ │         )
+98 │ │         return house.encode()
+   │ ╰─────────────────────────────^ attributes hash: 6092146250611764360
    │  
    = FunctionSignature {
          self_decl: None,
@@ -1006,211 +1262,145 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:74:20
+   ┌─ features/structs.fe:92:20
    │
-74 │         let house: House = House(
+92 │         let house: House = House(
    │                    ^^^^^ House
 
 note: 
-   ┌─ features/structs.fe:75:19
+   ┌─ features/structs.fe:93:19
    │
-75 │             price=300,
-   │                   ^^^ u256: Value => None
-76 │             size=500,
-   │                  ^^^ u256: Value => None
-77 │             rooms=u8(20),
-   │                      ^^ u8: Value => None
+93 │             price=300,
+   │                   ^^^ u256: Value
+94 │             size=500,
+   │                  ^^^ u256: Value
+95 │             rooms=u8(20),
+   │                      ^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:77:19
+   ┌─ features/structs.fe:95:19
    │
-77 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value => None
-78 │             vacant=true
-   │                    ^^^^ bool: Value => None
+95 │             rooms=u8(20),
+   │                   ^^^^^^ u8: Value
+96 │             vacant=true
+   │                    ^^^^ bool: Value
 
 note: 
-   ┌─ features/structs.fe:74:28
+   ┌─ features/structs.fe:92:28
    │  
-74 │           let house: House = House(
+92 │           let house: House = House(
    │ ╭────────────────────────────^
-75 │ │             price=300,
-76 │ │             size=500,
-77 │ │             rooms=u8(20),
-78 │ │             vacant=true
-79 │ │         )
-   │ ╰─────────^ House: Memory => None
-80 │           return house.abi_encode()
-   │                  ^^^^^ House: Memory => None
+93 │ │             price=300,
+94 │ │             size=500,
+95 │ │             rooms=u8(20),
+96 │ │             vacant=true
+97 │ │         )
+   │ ╰─────────^ House: Memory
+98 │           return house.encode()
+   │                  ^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:80:16
+   ┌─ features/structs.fe:98:16
    │
-80 │         return house.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory => None
+98 │         return house.encode()
+   │                ^^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-   ┌─ features/structs.fe:74:28
+   ┌─ features/structs.fe:95:19
    │
-74 │         let house: House = House(
-   │                            ^^^^^ attributes hash: 4962363512196753612
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 4,
-             },
-         ),
-     }
+95 │             rooms=u8(20),
+   │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-   ┌─ features/structs.fe:77:19
+   ┌─ features/structs.fe:92:28
    │
-77 │             rooms=u8(20),
-   │                   ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
+92 │         let house: House = House(
+   │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+   ·
+98 │         return house.encode()
+   │                ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(0) }
 
 note: 
-   ┌─ features/structs.fe:80:16
-   │
-80 │         return house.abi_encode()
-   │                ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+    ┌─ features/structs.fe:100:5
+    │  
+100 │ ╭     pub fn hashed_house() -> u256:
+101 │ │         let house: House = House(
+102 │ │             price=300,
+103 │ │             size=500,
+    · │
+106 │ │         )
+107 │ │         return house.hash()
+    │ ╰───────────────────────────^ attributes hash: 17979516652885443340
+    │  
+    = FunctionSignature {
+          self_decl: None,
+          params: [],
+          return_type: Ok(
+              Base(
+                  Numeric(
+                      U256,
+                  ),
+              ),
+          ),
+      }
 
 note: 
-   ┌─ features/structs.fe:82:5
-   │  
-82 │ ╭     pub fn hashed_house() -> u256:
-83 │ │         let house: House = House(
-84 │ │             price=300,
-85 │ │             size=500,
-   · │
-88 │ │         )
-89 │ │         return keccak256(house.abi_encode())
-   │ ╰────────────────────────────────────────────^ attributes hash: 17979516652885443340
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+    ┌─ features/structs.fe:101:20
+    │
+101 │         let house: House = House(
+    │                    ^^^^^ House
 
 note: 
-   ┌─ features/structs.fe:83:20
-   │
-83 │         let house: House = House(
-   │                    ^^^^^ House
+    ┌─ features/structs.fe:102:19
+    │
+102 │             price=300,
+    │                   ^^^ u256: Value
+103 │             size=500,
+    │                  ^^^ u256: Value
+104 │             rooms=u8(20),
+    │                      ^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:84:19
-   │
-84 │             price=300,
-   │                   ^^^ u256: Value => None
-85 │             size=500,
-   │                  ^^^ u256: Value => None
-86 │             rooms=u8(20),
-   │                      ^^ u8: Value => None
+    ┌─ features/structs.fe:104:19
+    │
+104 │             rooms=u8(20),
+    │                   ^^^^^^ u8: Value
+105 │             vacant=true
+    │                    ^^^^ bool: Value
 
 note: 
-   ┌─ features/structs.fe:86:19
-   │
-86 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value => None
-87 │             vacant=true
-   │                    ^^^^ bool: Value => None
+    ┌─ features/structs.fe:101:28
+    │  
+101 │           let house: House = House(
+    │ ╭────────────────────────────^
+102 │ │             price=300,
+103 │ │             size=500,
+104 │ │             rooms=u8(20),
+105 │ │             vacant=true
+106 │ │         )
+    │ ╰─────────^ House: Memory
+107 │           return house.hash()
+    │                  ^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:83:28
-   │  
-83 │           let house: House = House(
-   │ ╭────────────────────────────^
-84 │ │             price=300,
-85 │ │             size=500,
-86 │ │             rooms=u8(20),
-87 │ │             vacant=true
-88 │ │         )
-   │ ╰─────────^ House: Memory => None
-89 │           return keccak256(house.abi_encode())
-   │                            ^^^^^ House: Memory => None
+    ┌─ features/structs.fe:107:16
+    │
+107 │         return house.hash()
+    │                ^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ features/structs.fe:89:26
-   │
-89 │         return keccak256(house.abi_encode())
-   │                          ^^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory => None
+    ┌─ features/structs.fe:104:19
+    │
+104 │             rooms=u8(20),
+    │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-   ┌─ features/structs.fe:89:16
-   │
-89 │         return keccak256(house.abi_encode())
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/structs.fe:83:28
-   │
-83 │         let house: House = House(
-   │                            ^^^^^ attributes hash: 4962363512196753612
-   │
-   = TypeConstructor {
-         typ: Struct(
-             Struct {
-                 name: "House",
-                 id: StructId(
-                     0,
-                 ),
-                 field_count: 4,
-             },
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:86:19
-   │
-86 │             rooms=u8(20),
-   │                   ^^ attributes hash: 4311289215688173045
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U8,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:89:16
-   │
-89 │         return keccak256(house.abi_encode())
-   │                ^^^^^^^^^ attributes hash: 3985281278010092305
-   │
-   = BuiltinFunction(
-         Keccak256,
-     )
-
-note: 
-   ┌─ features/structs.fe:89:26
-   │
-89 │         return keccak256(house.abi_encode())
-   │                          ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+    ┌─ features/structs.fe:101:28
+    │
+101 │         let house: House = House(
+    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+    ·
+107 │         return house.hash()
+    │                ^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(1) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
@@ -37,31 +37,18 @@ note:
   ┌─ features/ternary_expression.fe:4:21
   │
 4 │         return 1 if input > 5 else 0
-  │                     ^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/ternary_expression.fe:4:29
-  │
-4 │         return 1 if input > 5 else 0
-  │                             ^ u256: Value => None
-
-note: 
-  ┌─ features/ternary_expression.fe:4:21
-  │
-4 │         return 1 if input > 5 else 0
-  │                     ^^^^^^^^^ bool: Value => None
+  │                     ^^^^^   ^ u256: Value => None
+  │                     │        
+  │                     u256: Value => None
 
 note: 
   ┌─ features/ternary_expression.fe:4:16
   │
 4 │         return 1 if input > 5 else 0
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ features/ternary_expression.fe:4:36
-  │
-4 │         return 1 if input > 5 else 0
-  │                                    ^ u256: Value => None
+  │                ^    ^^^^^^^^^      ^ u256: Value => None
+  │                │    │               
+  │                │    bool: Value => None
+  │                u256: Value => None
 
 note: 
   ┌─ features/ternary_expression.fe:4:16

--- a/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
@@ -37,23 +37,23 @@ note:
   ┌─ features/ternary_expression.fe:4:21
   │
 4 │         return 1 if input > 5 else 0
-  │                     ^^^^^   ^ u256: Value => None
+  │                     ^^^^^   ^ u256: Value
   │                     │        
-  │                     u256: Value => None
+  │                     u256: Value
 
 note: 
   ┌─ features/ternary_expression.fe:4:16
   │
 4 │         return 1 if input > 5 else 0
-  │                ^    ^^^^^^^^^      ^ u256: Value => None
+  │                ^    ^^^^^^^^^      ^ u256: Value
   │                │    │               
-  │                │    bool: Value => None
-  │                u256: Value => None
+  │                │    bool: Value
+  │                u256: Value
 
 note: 
   ┌─ features/ternary_expression.fe:4:16
   │
 4 │         return 1 if input > 5 else 0
-  │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+  │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"stress/tuple_stress.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
 note: 
@@ -78,6 +78,21 @@ note:
      }
 
 note: 
+   ┌─ stress/tuple_stress.fe:12:17
+   │
+12 │         return (my_num, my_bool, my_address)
+   │                 ^^^^^^  ^^^^^^^  ^^^^^^^^^^ address: Value => None
+   │                 │       │         
+   │                 │       bool: Value => None
+   │                 u256: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:12:16
+   │
+12 │         return (my_num, my_bool, my_address)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory => None
+
+note: 
    ┌─ stress/tuple_stress.fe:14:5
    │  
 14 │ ╭     pub fn read_my_tuple_item0(my_tuple: (u256, bool, address)) -> u256:
@@ -120,6 +135,18 @@ note:
      }
 
 note: 
+   ┌─ stress/tuple_stress.fe:15:16
+   │
+15 │         return my_tuple.item0
+   │                ^^^^^^^^ (u256, bool, address): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:15:16
+   │
+15 │         return my_tuple.item0
+   │                ^^^^^^^^^^^^^^ u256: Memory => Some(Value)
+
+note: 
    ┌─ stress/tuple_stress.fe:17:5
    │  
 17 │ ╭     pub fn read_my_tuple_item1(my_tuple: (u256, bool, address)) -> bool:
@@ -160,6 +187,18 @@ note:
      }
 
 note: 
+   ┌─ stress/tuple_stress.fe:18:16
+   │
+18 │         return my_tuple.item1
+   │                ^^^^^^^^ (u256, bool, address): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:18:16
+   │
+18 │         return my_tuple.item1
+   │                ^^^^^^^^^^^^^^ bool: Memory => Some(Value)
+
+note: 
    ┌─ stress/tuple_stress.fe:20:5
    │  
 20 │ ╭     pub fn read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address:
@@ -198,6 +237,18 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/tuple_stress.fe:21:16
+   │
+21 │         return my_tuple.item2
+   │                ^^^^^^^^ (u256, bool, address): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:21:16
+   │
+21 │         return my_tuple.item2
+   │                ^^^^^^^^^^^^^^ address: Memory => Some(Value)
 
 note: 
    ┌─ stress/tuple_stress.fe:23:5
@@ -282,6 +333,18 @@ note:
      }
 
 note: 
+   ┌─ stress/tuple_stress.fe:24:16
+   │
+24 │         return my_tuple.item10
+   │                ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:24:16
+   │
+24 │         return my_tuple.item10
+   │                ^^^^^^^^^^^^^^^ address: Memory => Some(Value)
+
+note: 
    ┌─ stress/tuple_stress.fe:26:5
    │  
 26 │ ╭     pub fn emit_my_event(my_tuple: (u256, bool, address)):
@@ -319,6 +382,47 @@ note:
                  Unit,
              ),
          ),
+     }
+
+note: 
+   ┌─ stress/tuple_stress.fe:27:22
+   │
+27 │         emit MyEvent(my_tuple)
+   │                      ^^^^^^^^ (u256, bool, address): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:27:9
+   │
+27 │         emit MyEvent(my_tuple)
+   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12913536175581177750
+   │
+   = Event {
+         name: "MyEvent",
+         fields: [
+             EventField {
+                 name: "my_tuple",
+                 typ: Ok(
+                     Tuple(
+                         Tuple {
+                             items: [
+                                 Base(
+                                     Numeric(
+                                         U256,
+                                     ),
+                                 ),
+                                 Base(
+                                     Bool,
+                                 ),
+                                 Base(
+                                     Address,
+                                 ),
+                             ],
+                         },
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
      }
 
 note: 
@@ -361,6 +465,99 @@ note:
      }
 
 note: 
+   ┌─ stress/tuple_stress.fe:30:16
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:16
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^         ^ u256: Value => None
+   │                │                                
+   │                u256: Storage { nonce: Some(0) } => Some(Value)
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:43
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                           ^^^^^^^ u256: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:16
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+   │                │                                       
+   │                bool: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:55
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^        ^ i32: Value => None
+   │                                                       │                               
+   │                                                       i32: Storage { nonce: Some(0) } => Some(Value)
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:82
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                                                                  ^^^^^^ i32: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:55
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:16
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+31 │         self.my_sto_tuple = (my_u256, my_i32)
+   │         ^^^^^^^^^^^^^^^^^    ^^^^^^^  ^^^^^^ i32: Value => None
+   │         │                    │         
+   │         │                    u256: Value => None
+   │         (u256, i32): Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:31:29
+   │
+31 │         self.my_sto_tuple = (my_u256, my_i32)
+   │                             ^^^^^^^^^^^^^^^^^ (u256, i32): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:43
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                           ^^^^ attributes hash: 2391147244535208323
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 U256,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:82
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                                                                  ^^^ attributes hash: 14092528269543401556
+   │
+   = TypeConstructor {
+         typ: Base(
+             Numeric(
+                 I32,
+             ),
+         ),
+     }
+
+note: 
    ┌─ stress/tuple_stress.fe:33:5
    │  
 33 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32):
@@ -391,6 +588,26 @@ note:
      }
 
 note: 
+   ┌─ stress/tuple_stress.fe:34:16
+   │
+34 │         return self.my_sto_tuple.to_mem()
+   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:34:16
+   │
+34 │         return self.my_sto_tuple.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => Some(Memory)
+
+note: 
+   ┌─ stress/tuple_stress.fe:34:16
+   │
+34 │         return self.my_sto_tuple.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │
+   = ValueAttribute
+
+note: 
    ┌─ stress/tuple_stress.fe:36:5
    │  
 36 │ ╭     pub fn build_tuple_and_emit(self):
@@ -411,6 +628,96 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ stress/tuple_stress.fe:37:21
+   │
+37 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                     ^^^^ u256
+38 │         let my_tuple: (u256, bool, address) = (
+   │                       ^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address)
+
+note: 
+   ┌─ stress/tuple_stress.fe:37:28
+   │
+37 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                            ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:37:28
+   │
+37 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+38 │         let my_tuple: (u256, bool, address) = (
+39 │             self.my_sto_tuple.item0,
+   │             ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:39:13
+   │
+39 │             self.my_sto_tuple.item0,
+   │             ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+40 │             true and false,
+   │             ^^^^     ^^^^^ bool: Value => None
+   │             │         
+   │             bool: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:40:13
+   │
+40 │             true and false,
+   │             ^^^^^^^^^^^^^^ bool: Value => None
+41 │             address(26)
+   │                     ^^ u256: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:41:13
+   │
+41 │             address(26)
+   │             ^^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:38:47
+   │  
+38 │           let my_tuple: (u256, bool, address) = (
+   │ ╭───────────────────────────────────────────────^
+39 │ │             self.my_sto_tuple.item0,
+40 │ │             true and false,
+41 │ │             address(26)
+42 │ │         )
+   │ ╰─────────^ (u256, bool, address): Memory => None
+43 │           emit_my_event(my_tuple)
+   │                         ^^^^^^^^ (u256, bool, address): Memory => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:43:9
+   │
+43 │         emit_my_event(my_tuple)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+
+note: 
+   ┌─ stress/tuple_stress.fe:41:13
+   │
+41 │             address(26)
+   │             ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
+         ),
+     }
+
+note: 
+   ┌─ stress/tuple_stress.fe:43:9
+   │
+43 │         emit_my_event(my_tuple)
+   │         ^^^^^^^^^^^^^ attributes hash: 12310327282992125219
+   │
+   = Pure(
+         FunctionId(
+             5,
+         ),
+     )
 
 note: 
    ┌─ stress/tuple_stress.fe:45:5
@@ -458,263 +765,6 @@ note:
      }
 
 note: 
-   ┌─ stress/tuple_stress.fe:12:17
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                 ^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:12:25
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                         ^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:12:34
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                                  ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:12:16
-   │
-12 │         return (my_num, my_bool, my_address)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:15:16
-   │
-15 │         return my_tuple.item0
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:15:16
-   │
-15 │         return my_tuple.item0
-   │                ^^^^^^^^^^^^^^ u256: Memory => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:18:16
-   │
-18 │         return my_tuple.item1
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:18:16
-   │
-18 │         return my_tuple.item1
-   │                ^^^^^^^^^^^^^^ bool: Memory => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:21:16
-   │
-21 │         return my_tuple.item2
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:21:16
-   │
-21 │         return my_tuple.item2
-   │                ^^^^^^^^^^^^^^ address: Memory => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:24:16
-   │
-24 │         return my_tuple.item10
-   │                ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:24:16
-   │
-24 │         return my_tuple.item10
-   │                ^^^^^^^^^^^^^^^ address: Memory => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:22
-   │
-27 │         emit MyEvent(my_tuple)
-   │                      ^^^^^^^^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:16
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:16
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:48
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                ^ u256: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:43
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                           ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:16
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:55
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:55
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^ i32: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:86
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                      ^ i32: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:82
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                  ^^^^^^ i32: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:55
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:16
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:31:9
-   │
-31 │         self.my_sto_tuple = (my_u256, my_i32)
-   │         ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:31:30
-   │
-31 │         self.my_sto_tuple = (my_u256, my_i32)
-   │                              ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:31:39
-   │
-31 │         self.my_sto_tuple = (my_u256, my_i32)
-   │                                       ^^^^^^ i32: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:31:29
-   │
-31 │         self.my_sto_tuple = (my_u256, my_i32)
-   │                             ^^^^^^^^^^^^^^^^^ (u256, i32): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:34:16
-   │
-34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:34:16
-   │
-34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => Some(Memory)
-
-note: 
-   ┌─ stress/tuple_stress.fe:37:28
-   │
-37 │         let my_num: u256 = self.my_sto_tuple.item0
-   │                            ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:37:28
-   │
-37 │         let my_num: u256 = self.my_sto_tuple.item0
-   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:39:13
-   │
-39 │             self.my_sto_tuple.item0,
-   │             ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:39:13
-   │
-39 │             self.my_sto_tuple.item0,
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-   ┌─ stress/tuple_stress.fe:40:13
-   │
-40 │             true and false,
-   │             ^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:40:22
-   │
-40 │             true and false,
-   │                      ^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:40:13
-   │
-40 │             true and false,
-   │             ^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:41:21
-   │
-41 │             address(26)
-   │                     ^^ u256: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:41:13
-   │
-41 │             address(26)
-   │             ^^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:38:47
-   │  
-38 │           let my_tuple: (u256, bool, address) = (
-   │ ╭───────────────────────────────────────────────^
-39 │ │             self.my_sto_tuple.item0,
-40 │ │             true and false,
-41 │ │             address(26)
-42 │ │         )
-   │ ╰─────────^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:43:23
-   │
-43 │         emit_my_event(my_tuple)
-   │                       ^^^^^^^^ (u256, bool, address): Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:43:9
-   │
-43 │         emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
    ┌─ stress/tuple_stress.fe:46:16
    │
 46 │         return my_tuple.abi_encode()
@@ -725,113 +775,6 @@ note:
    │
 46 │         return my_tuple.abi_encode()
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u8, 96>: Memory => None
-
-note: 
-   ┌─ stress/tuple_stress.fe:27:9
-   │
-27 │         emit MyEvent(my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12913536175581177750
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:37:21
-   │
-37 │         let my_num: u256 = self.my_sto_tuple.item0
-   │                     ^^^^ u256
-
-note: 
-   ┌─ stress/tuple_stress.fe:38:23
-   │
-38 │         let my_tuple: (u256, bool, address) = (
-   │                       ^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address)
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:43
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                           ^^^^ attributes hash: 2391147244535208323
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:82
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                  ^^^ attributes hash: 14092528269543401556
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:34:16
-   │
-34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ stress/tuple_stress.fe:41:13
-   │
-41 │             address(26)
-   │             ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:43:9
-   │
-43 │         emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^ attributes hash: 12310327282992125219
-   │
-   = Pure(
-         FunctionId(
-             5,
-         ),
-     )
 
 note: 
    ┌─ stress/tuple_stress.fe:46:16

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -81,16 +81,16 @@ note:
    ┌─ stress/tuple_stress.fe:12:17
    │
 12 │         return (my_num, my_bool, my_address)
-   │                 ^^^^^^  ^^^^^^^  ^^^^^^^^^^ address: Value => None
+   │                 ^^^^^^  ^^^^^^^  ^^^^^^^^^^ address: Value
    │                 │       │         
-   │                 │       bool: Value => None
-   │                 u256: Value => None
+   │                 │       bool: Value
+   │                 u256: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:12:16
    │
 12 │         return (my_num, my_bool, my_address)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:14:5
@@ -138,13 +138,13 @@ note:
    ┌─ stress/tuple_stress.fe:15:16
    │
 15 │         return my_tuple.item0
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
+   │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:15:16
    │
 15 │         return my_tuple.item0
-   │                ^^^^^^^^^^^^^^ u256: Memory => Some(Value)
+   │                ^^^^^^^^^^^^^^ u256: Memory => Value
 
 note: 
    ┌─ stress/tuple_stress.fe:17:5
@@ -190,13 +190,13 @@ note:
    ┌─ stress/tuple_stress.fe:18:16
    │
 18 │         return my_tuple.item1
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
+   │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:18:16
    │
 18 │         return my_tuple.item1
-   │                ^^^^^^^^^^^^^^ bool: Memory => Some(Value)
+   │                ^^^^^^^^^^^^^^ bool: Memory => Value
 
 note: 
    ┌─ stress/tuple_stress.fe:20:5
@@ -242,13 +242,13 @@ note:
    ┌─ stress/tuple_stress.fe:21:16
    │
 21 │         return my_tuple.item2
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
+   │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:21:16
    │
 21 │         return my_tuple.item2
-   │                ^^^^^^^^^^^^^^ address: Memory => Some(Value)
+   │                ^^^^^^^^^^^^^^ address: Memory => Value
 
 note: 
    ┌─ stress/tuple_stress.fe:23:5
@@ -336,13 +336,13 @@ note:
    ┌─ stress/tuple_stress.fe:24:16
    │
 24 │         return my_tuple.item10
-   │                ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory => None
+   │                ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:24:16
    │
 24 │         return my_tuple.item10
-   │                ^^^^^^^^^^^^^^^ address: Memory => Some(Value)
+   │                ^^^^^^^^^^^^^^^ address: Memory => Value
 
 note: 
    ┌─ stress/tuple_stress.fe:26:5
@@ -388,7 +388,7 @@ note:
    ┌─ stress/tuple_stress.fe:27:22
    │
 27 │         emit MyEvent(my_tuple)
-   │                      ^^^^^^^^ (u256, bool, address): Memory => None
+   │                      ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:27:9
@@ -431,10 +431,12 @@ note:
 29 │ ╭     pub fn set_my_sto_tuple(self, my_u256: u256, my_i32: i32):
 30 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
 31 │ │         self.my_sto_tuple = (my_u256, my_i32)
-   │ ╰─────────────────────────────────────────────^ attributes hash: 5930645998145376015
+   │ ╰─────────────────────────────────────────────^ attributes hash: 13883869095305465208
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "my_u256",
@@ -468,104 +470,104 @@ note:
    ┌─ stress/tuple_stress.fe:30:16
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:16
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^         ^ u256: Value => None
+   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:16
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^         ^ u256: Value
    │                │                                
-   │                u256: Storage { nonce: Some(0) } => Some(Value)
+   │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:43
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                           ^^^^^^^ u256: Value => None
+   │                                           ^^^^^^^ u256: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:16
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^ Foo: Value
    │                │                                       
-   │                bool: Value => None
+   │                bool: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:55
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^        ^ i32: Value => None
+   │                                                       ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/tuple_stress.fe:30:55
+   │
+30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^        ^ i32: Value
    │                                                       │                               
-   │                                                       i32: Storage { nonce: Some(0) } => Some(Value)
+   │                                                       i32: Storage { nonce: Some(0) } => Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:82
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                  ^^^^^^ i32: Value => None
+   │                                                                                  ^^^^^^ i32: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:55
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:30:16
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 31 │         self.my_sto_tuple = (my_u256, my_i32)
-   │         ^^^^^^^^^^^^^^^^^    ^^^^^^^  ^^^^^^ i32: Value => None
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ stress/tuple_stress.fe:31:9
+   │
+31 │         self.my_sto_tuple = (my_u256, my_i32)
+   │         ^^^^^^^^^^^^^^^^^    ^^^^^^^  ^^^^^^ i32: Value
    │         │                    │         
-   │         │                    u256: Value => None
-   │         (u256, i32): Storage { nonce: Some(0) } => None
+   │         │                    u256: Value
+   │         (u256, i32): Storage { nonce: Some(0) }
 
 note: 
    ┌─ stress/tuple_stress.fe:31:29
    │
 31 │         self.my_sto_tuple = (my_u256, my_i32)
-   │                             ^^^^^^^^^^^^^^^^^ (u256, i32): Memory => None
+   │                             ^^^^^^^^^^^^^^^^^ (u256, i32): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:30:43
    │
 30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                           ^^^^ attributes hash: 2391147244535208323
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 U256,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:30:82
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                                                                  ^^^ attributes hash: 14092528269543401556
-   │
-   = TypeConstructor {
-         typ: Base(
-             Numeric(
-                 I32,
-             ),
-         ),
-     }
+   │                                           ^^^^                                   ^^^ TypeConstructor(Base(Numeric(I32)))
+   │                                           │                                       
+   │                                           TypeConstructor(Base(Numeric(U256)))
 
 note: 
    ┌─ stress/tuple_stress.fe:33:5
    │  
 33 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32):
 34 │ │         return self.my_sto_tuple.to_mem()
-   │ ╰─────────────────────────────────────────^ attributes hash: 8140983257972799311
+   │ ╰─────────────────────────────────────────^ attributes hash: 6192946144527924451
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Tuple(
@@ -591,21 +593,25 @@ note:
    ┌─ stress/tuple_stress.fe:34:16
    │
 34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+   │                ^^^^ Foo: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:34:16
    │
 34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => Some(Memory)
+   │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
 
 note: 
    ┌─ stress/tuple_stress.fe:34:16
    │
 34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => Memory
+
+note: 
+   ┌─ stress/tuple_stress.fe:34:16
    │
-   = ValueAttribute
+34 │         return self.my_sto_tuple.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 note: 
    ┌─ stress/tuple_stress.fe:36:5
@@ -617,10 +623,12 @@ note:
    · │
 42 │ │         )
 43 │ │         emit_my_event(my_tuple)
-   │ ╰───────────────────────────────^ attributes hash: 4369441865732737140
+   │ ╰───────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -641,40 +649,52 @@ note:
    ┌─ stress/tuple_stress.fe:37:28
    │
 37 │         let my_num: u256 = self.my_sto_tuple.item0
-   │                            ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+   │                            ^^^^ Foo: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:37:28
    │
 37 │         let my_num: u256 = self.my_sto_tuple.item0
-   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+   │                            ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/tuple_stress.fe:37:28
+   │
+37 │         let my_num: u256 = self.my_sto_tuple.item0
+   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 38 │         let my_tuple: (u256, bool, address) = (
 39 │             self.my_sto_tuple.item0,
-   │             ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => None
+   │             ^^^^ Foo: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:39:13
    │
 39 │             self.my_sto_tuple.item0,
-   │             ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Some(Value)
+   │             ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
+
+note: 
+   ┌─ stress/tuple_stress.fe:39:13
+   │
+39 │             self.my_sto_tuple.item0,
+   │             ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 40 │             true and false,
-   │             ^^^^     ^^^^^ bool: Value => None
+   │             ^^^^     ^^^^^ bool: Value
    │             │         
-   │             bool: Value => None
+   │             bool: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:40:13
    │
 40 │             true and false,
-   │             ^^^^^^^^^^^^^^ bool: Value => None
+   │             ^^^^^^^^^^^^^^ bool: Value
 41 │             address(26)
-   │                     ^^ u256: Value => None
+   │                     ^^ u256: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:41:13
    │
 41 │             address(26)
-   │             ^^^^^^^^^^^ address: Value => None
+   │             ^^^^^^^^^^^ address: Value
 
 note: 
    ┌─ stress/tuple_stress.fe:38:47
@@ -685,39 +705,24 @@ note:
 40 │ │             true and false,
 41 │ │             address(26)
 42 │ │         )
-   │ ╰─────────^ (u256, bool, address): Memory => None
+   │ ╰─────────^ (u256, bool, address): Memory
 43 │           emit_my_event(my_tuple)
-   │                         ^^^^^^^^ (u256, bool, address): Memory => None
+   │                         ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:43:9
    │
 43 │         emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
    ┌─ stress/tuple_stress.fe:41:13
    │
 41 │             address(26)
-   │             ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ stress/tuple_stress.fe:43:9
-   │
+   │             ^^^^^^^ TypeConstructor(Base(Address))
+42 │         )
 43 │         emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^ attributes hash: 12310327282992125219
-   │
-   = Pure(
-         FunctionId(
-             5,
-         ),
-     )
+   │         ^^^^^^^^^^^^^ Pure(FunctionId(5))
 
 note: 
    ┌─ stress/tuple_stress.fe:45:5
@@ -768,20 +773,18 @@ note:
    ┌─ stress/tuple_stress.fe:46:16
    │
 46 │         return my_tuple.abi_encode()
-   │                ^^^^^^^^ (u256, bool, address): Memory => None
+   │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:46:16
    │
 46 │         return my_tuple.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u8, 96>: Memory => None
+   │                ^^^^^^^^^^^^^^^^^^^^^ Array<u8, 96>: Memory
 
 note: 
    ┌─ stress/tuple_stress.fe:46:16
    │
 46 │         return my_tuple.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(AbiEncode)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -32,62 +32,43 @@ note:
   ┌─ features/two_contracts.fe:6:28
   │
 6 │         return Bar(address(0)).bar()
-  │                            ^ u256: Value => None
+  │                            ^ u256: Value
 
 note: 
   ┌─ features/two_contracts.fe:6:20
   │
 6 │         return Bar(address(0)).bar()
-  │                    ^^^^^^^^^^ address: Value => None
+  │                    ^^^^^^^^^^ address: Value
 
 note: 
   ┌─ features/two_contracts.fe:6:16
   │
 6 │         return Bar(address(0)).bar()
-  │                ^^^^^^^^^^^^^^^ Bar: Value => None
+  │                ^^^^^^^^^^^^^^^ Bar: Value
 
 note: 
   ┌─ features/two_contracts.fe:6:16
   │
 6 │         return Bar(address(0)).bar()
-  │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/two_contracts.fe:6:16
-  │
-6 │         return Bar(address(0)).bar()
-  │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-  │
-  = ValueAttribute
-
-note: 
-  ┌─ features/two_contracts.fe:6:16
-  │
-6 │         return Bar(address(0)).bar()
-  │                ^^^ attributes hash: 6689852709950325620
-  │
-  = TypeConstructor {
-        typ: Contract(
-            Contract {
-                name: "Bar",
-                id: ContractId(
-                    1,
-                ),
-            },
-        ),
-    }
+  │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
   ┌─ features/two_contracts.fe:6:20
   │
 6 │         return Bar(address(0)).bar()
-  │                    ^^^^^^^ attributes hash: 14203407709342965641
+  │                    ^^^^^^^ TypeConstructor(Base(Address))
+
+note: 
+  ┌─ features/two_contracts.fe:6:16
   │
-  = TypeConstructor {
-        typ: Base(
-            Address,
-        ),
-    }
+6 │         return Bar(address(0)).bar()
+  │                ^^^ TypeConstructor(Contract(Contract { name: "Bar", id: ContractId(1) }))
+
+note: 
+  ┌─ features/two_contracts.fe:6:16
+  │
+6 │         return Bar(address(0)).bar()
+  │                ^^^^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(1)), method: FunctionId(3) }
 
 note: 
   ┌─ features/two_contracts.fe:8:5
@@ -112,7 +93,7 @@ note:
   ┌─ features/two_contracts.fe:9:16
   │
 9 │         return 42
-  │                ^^ u256: Value => None
+  │                ^^ u256: Value
 
 note: 
    ┌─ features/two_contracts.fe:13:5
@@ -143,62 +124,43 @@ note:
    ┌─ features/two_contracts.fe:16:28
    │
 16 │         return Foo(address(0)).foo()
-   │                            ^ u256: Value => None
+   │                            ^ u256: Value
 
 note: 
    ┌─ features/two_contracts.fe:16:20
    │
 16 │         return Foo(address(0)).foo()
-   │                    ^^^^^^^^^^ address: Value => None
+   │                    ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ features/two_contracts.fe:16:16
    │
 16 │         return Foo(address(0)).foo()
-   │                ^^^^^^^^^^^^^^^ Foo: Value => None
+   │                ^^^^^^^^^^^^^^^ Foo: Value
 
 note: 
    ┌─ features/two_contracts.fe:16:16
    │
 16 │         return Foo(address(0)).foo()
-   │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/two_contracts.fe:16:16
-   │
-16 │         return Foo(address(0)).foo()
-   │                ^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
-
-note: 
-   ┌─ features/two_contracts.fe:16:16
-   │
-16 │         return Foo(address(0)).foo()
-   │                ^^^ attributes hash: 1647454659037951517
-   │
-   = TypeConstructor {
-         typ: Contract(
-             Contract {
-                 name: "Foo",
-                 id: ContractId(
-                     0,
-                 ),
-             },
-         ),
-     }
+   │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ features/two_contracts.fe:16:20
    │
 16 │         return Foo(address(0)).foo()
-   │                    ^^^^^^^ attributes hash: 14203407709342965641
+   │                    ^^^^^^^ TypeConstructor(Base(Address))
+
+note: 
+   ┌─ features/two_contracts.fe:16:16
    │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+16 │         return Foo(address(0)).foo()
+   │                ^^^ TypeConstructor(Contract(Contract { name: "Foo", id: ContractId(0) }))
+
+note: 
+   ┌─ features/two_contracts.fe:16:16
+   │
+16 │         return Foo(address(0)).foo()
+   │                ^^^^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
 
 note: 
    ┌─ features/two_contracts.fe:18:5
@@ -223,6 +185,6 @@ note:
    ┌─ features/two_contracts.fe:19:16
    │
 19 │         return 26
-   │                ^^ u256: Value => None
+   │                ^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -10,12 +10,6 @@ note:
   │     ^^^^^^^^^^ Bar
 
 note: 
-   ┌─ features/two_contracts.fe:13:5
-   │
-13 │     other: Foo
-   │     ^^^^^^^^^^ Foo
-
-note: 
   ┌─ features/two_contracts.fe:5:5
   │  
 5 │ ╭     pub fn external_bar() -> u256:
@@ -33,63 +27,6 @@ note:
             ),
         ),
     }
-
-note: 
-  ┌─ features/two_contracts.fe:8:5
-  │  
-8 │ ╭     pub fn foo() -> u256:
-9 │ │         return 42
-  │ ╰─────────────────^ attributes hash: 17979516652885443340
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
-
-note: 
-   ┌─ features/two_contracts.fe:15:5
-   │  
-15 │ ╭     pub fn external_foo() -> u256:
-16 │ │         return Foo(address(0)).foo()
-   │ ╰────────────────────────────────────^ attributes hash: 17979516652885443340
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/two_contracts.fe:18:5
-   │  
-18 │ ╭     pub fn bar() -> u256:
-19 │ │         return 26
-   │ ╰─────────────────^ attributes hash: 17979516652885443340
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
 
 note: 
   ┌─ features/two_contracts.fe:6:28
@@ -114,42 +51,6 @@ note:
   │
 6 │         return Bar(address(0)).bar()
   │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/two_contracts.fe:9:16
-  │
-9 │         return 42
-  │                ^^ u256: Value => None
-
-note: 
-   ┌─ features/two_contracts.fe:16:28
-   │
-16 │         return Foo(address(0)).foo()
-   │                            ^ u256: Value => None
-
-note: 
-   ┌─ features/two_contracts.fe:16:20
-   │
-16 │         return Foo(address(0)).foo()
-   │                    ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/two_contracts.fe:16:16
-   │
-16 │         return Foo(address(0)).foo()
-   │                ^^^^^^^^^^^^^^^ Foo: Value => None
-
-note: 
-   ┌─ features/two_contracts.fe:16:16
-   │
-16 │         return Foo(address(0)).foo()
-   │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/two_contracts.fe:19:16
-   │
-19 │         return 26
-   │                ^^ u256: Value => None
 
 note: 
   ┌─ features/two_contracts.fe:6:16
@@ -189,6 +90,80 @@ note:
     }
 
 note: 
+  ┌─ features/two_contracts.fe:8:5
+  │  
+8 │ ╭     pub fn foo() -> u256:
+9 │ │         return 42
+  │ ╰─────────────────^ attributes hash: 17979516652885443340
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [],
+        return_type: Ok(
+            Base(
+                Numeric(
+                    U256,
+                ),
+            ),
+        ),
+    }
+
+note: 
+  ┌─ features/two_contracts.fe:9:16
+  │
+9 │         return 42
+  │                ^^ u256: Value => None
+
+note: 
+   ┌─ features/two_contracts.fe:13:5
+   │
+13 │     other: Foo
+   │     ^^^^^^^^^^ Foo
+
+note: 
+   ┌─ features/two_contracts.fe:15:5
+   │  
+15 │ ╭     pub fn external_foo() -> u256:
+16 │ │         return Foo(address(0)).foo()
+   │ ╰────────────────────────────────────^ attributes hash: 17979516652885443340
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/two_contracts.fe:16:28
+   │
+16 │         return Foo(address(0)).foo()
+   │                            ^ u256: Value => None
+
+note: 
+   ┌─ features/two_contracts.fe:16:20
+   │
+16 │         return Foo(address(0)).foo()
+   │                    ^^^^^^^^^^ address: Value => None
+
+note: 
+   ┌─ features/two_contracts.fe:16:16
+   │
+16 │         return Foo(address(0)).foo()
+   │                ^^^^^^^^^^^^^^^ Foo: Value => None
+
+note: 
+   ┌─ features/two_contracts.fe:16:16
+   │
+16 │         return Foo(address(0)).foo()
+   │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
    ┌─ features/two_contracts.fe:16:16
    │
 16 │         return Foo(address(0)).foo()
@@ -224,5 +199,30 @@ note:
              Address,
          ),
      }
+
+note: 
+   ┌─ features/two_contracts.fe:18:5
+   │  
+18 │ ╭     pub fn bar() -> u256:
+19 │ │         return 26
+   │ ╰─────────────────^ attributes hash: 17979516652885443340
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/two_contracts.fe:19:16
+   │
+19 │         return 26
+   │                ^^ u256: Value => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -50,16 +50,8 @@ note:
    │
 11 │     posts: Posts
    │     ^^^^^^^^^^^^ Map<u256, String<32>>
-
-note: 
-   ┌─ features/type_aliases.fe:12:5
-   │
 12 │     authors: AuthorPosts
    │     ^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-
-note: 
-   ┌─ features/type_aliases.fe:13:5
-   │
 13 │     scoreboard: Scoreboard
    │     ^^^^^^^^^^^^^^^^^^^^^^ Map<u256, u64>
 
@@ -96,6 +88,52 @@ note:
      }
 
 note: 
+   ┌─ features/type_aliases.fe:17:17
+   │
+17 │         let id: PostId = 0
+   │                 ^^^^^^ u256
+
+note: 
+   ┌─ features/type_aliases.fe:17:26
+   │
+17 │         let id: PostId = 0
+   │                          ^ u256: Value => None
+18 │         self.posts[id] = body
+   │         ^^^^^^^^^^ ^^ u256: Value => None
+   │         │           
+   │         Map<u256, String<32>>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ features/type_aliases.fe:18:9
+   │
+18 │         self.posts[id] = body
+   │         ^^^^^^^^^^^^^^   ^^^^ String<32>: Memory => None
+   │         │                 
+   │         String<32>: Storage { nonce: None } => None
+19 │         self.authors[msg.sender]
+   │         ^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+   │         │             
+   │         Map<address, u256>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ features/type_aliases.fe:19:9
+   │
+19 │         self.authors[msg.sender]
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+20 │         self.scoreboard[id] = 0
+   │         ^^^^^^^^^^^^^^^ ^^ u256: Value => None
+   │         │                
+   │         Map<u256, u64>: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ features/type_aliases.fe:20:9
+   │
+20 │         self.scoreboard[id] = 0
+   │         ^^^^^^^^^^^^^^^^^^^   ^ u64: Value => None
+   │         │                      
+   │         u64: Storage { nonce: None } => None
+
+note: 
    ┌─ features/type_aliases.fe:22:5
    │  
 22 │ ╭     pub fn upvote(self, id: PostId) -> Score:
@@ -128,6 +166,48 @@ note:
      }
 
 note: 
+   ┌─ features/type_aliases.fe:23:20
+   │
+23 │         let score: Score = self.scoreboard[id] + 1
+   │                    ^^^^^ u64
+
+note: 
+   ┌─ features/type_aliases.fe:23:28
+   │
+23 │         let score: Score = self.scoreboard[id] + 1
+   │                            ^^^^^^^^^^^^^^^ ^^ u256: Value => None
+   │                            │                
+   │                            Map<u256, u64>: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ features/type_aliases.fe:23:28
+   │
+23 │         let score: Score = self.scoreboard[id] + 1
+   │                            ^^^^^^^^^^^^^^^^^^^   ^ u64: Value => None
+   │                            │                      
+   │                            u64: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ features/type_aliases.fe:23:28
+   │
+23 │         let score: Score = self.scoreboard[id] + 1
+   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u64: Value => None
+24 │         self.scoreboard[id] = score
+   │         ^^^^^^^^^^^^^^^ ^^ u256: Value => None
+   │         │                
+   │         Map<u256, u64>: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ features/type_aliases.fe:24:9
+   │
+24 │         self.scoreboard[id] = score
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^ u64: Value => None
+   │         │                      
+   │         u64: Storage { nonce: None } => None
+25 │         return score
+   │                ^^^^^ u64: Value => None
+
+note: 
    ┌─ features/type_aliases.fe:27:5
    │  
 27 │ ╭     pub fn get_post(self, id: PostId) -> PostBody:
@@ -158,148 +238,12 @@ note:
      }
 
 note: 
-   ┌─ features/type_aliases.fe:17:26
-   │
-17 │         let id: PostId = 0
-   │                          ^ u256: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:18:9
-   │
-18 │         self.posts[id] = body
-   │         ^^^^^^^^^^ Map<u256, String<32>>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/type_aliases.fe:18:20
-   │
-18 │         self.posts[id] = body
-   │                    ^^ u256: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:18:9
-   │
-18 │         self.posts[id] = body
-   │         ^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/type_aliases.fe:18:26
-   │
-18 │         self.posts[id] = body
-   │                          ^^^^ String<32>: Memory => None
-
-note: 
-   ┌─ features/type_aliases.fe:19:9
-   │
-19 │         self.authors[msg.sender]
-   │         ^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ features/type_aliases.fe:19:22
-   │
-19 │         self.authors[msg.sender]
-   │                      ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:19:9
-   │
-19 │         self.authors[msg.sender]
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/type_aliases.fe:20:9
-   │
-20 │         self.scoreboard[id] = 0
-   │         ^^^^^^^^^^^^^^^ Map<u256, u64>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ features/type_aliases.fe:20:25
-   │
-20 │         self.scoreboard[id] = 0
-   │                         ^^ u256: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:20:9
-   │
-20 │         self.scoreboard[id] = 0
-   │         ^^^^^^^^^^^^^^^^^^^ u64: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/type_aliases.fe:20:31
-   │
-20 │         self.scoreboard[id] = 0
-   │                               ^ u64: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:23:28
-   │
-23 │         let score: Score = self.scoreboard[id] + 1
-   │                            ^^^^^^^^^^^^^^^ Map<u256, u64>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ features/type_aliases.fe:23:44
-   │
-23 │         let score: Score = self.scoreboard[id] + 1
-   │                                            ^^ u256: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:23:28
-   │
-23 │         let score: Score = self.scoreboard[id] + 1
-   │                            ^^^^^^^^^^^^^^^^^^^ u64: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ features/type_aliases.fe:23:50
-   │
-23 │         let score: Score = self.scoreboard[id] + 1
-   │                                                  ^ u64: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:23:28
-   │
-23 │         let score: Score = self.scoreboard[id] + 1
-   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:24:9
-   │
-24 │         self.scoreboard[id] = score
-   │         ^^^^^^^^^^^^^^^ Map<u256, u64>: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ features/type_aliases.fe:24:25
-   │
-24 │         self.scoreboard[id] = score
-   │                         ^^ u256: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:24:9
-   │
-24 │         self.scoreboard[id] = score
-   │         ^^^^^^^^^^^^^^^^^^^ u64: Storage { nonce: None } => None
-
-note: 
-   ┌─ features/type_aliases.fe:24:31
-   │
-24 │         self.scoreboard[id] = score
-   │                               ^^^^^ u64: Value => None
-
-note: 
-   ┌─ features/type_aliases.fe:25:16
-   │
-25 │         return score
-   │                ^^^^^ u64: Value => None
-
-note: 
    ┌─ features/type_aliases.fe:28:16
    │
 28 │         return self.posts[id].to_mem()
-   │                ^^^^^^^^^^ Map<u256, String<32>>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ features/type_aliases.fe:28:27
-   │
-28 │         return self.posts[id].to_mem()
-   │                           ^^ u256: Value => None
+   │                ^^^^^^^^^^ ^^ u256: Value => None
+   │                │           
+   │                Map<u256, String<32>>: Storage { nonce: Some(0) } => None
 
 note: 
    ┌─ features/type_aliases.fe:28:16
@@ -312,18 +256,6 @@ note:
    │
 28 │         return self.posts[id].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => Some(Memory)
-
-note: 
-   ┌─ features/type_aliases.fe:17:17
-   │
-17 │         let id: PostId = 0
-   │                 ^^^^^^ u256
-
-note: 
-   ┌─ features/type_aliases.fe:23:20
-   │
-23 │         let score: Score = self.scoreboard[id] + 1
-   │                    ^^^^^ u64
 
 note: 
    ┌─ features/type_aliases.fe:28:16

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -64,10 +64,12 @@ note:
 18 │ │         self.posts[id] = body
 19 │ │         self.authors[msg.sender]
 20 │ │         self.scoreboard[id] = 0
-   │ ╰───────────────────────────────^ attributes hash: 771627946712539769
+   │ ╰───────────────────────────────^ attributes hash: 6408769268982658350
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "body",
@@ -97,41 +99,59 @@ note:
    ┌─ features/type_aliases.fe:17:26
    │
 17 │         let id: PostId = 0
-   │                          ^ u256: Value => None
+   │                          ^ u256: Value
 18 │         self.posts[id] = body
-   │         ^^^^^^^^^^ ^^ u256: Value => None
-   │         │           
-   │         Map<u256, String<32>>: Storage { nonce: Some(0) } => None
+   │         ^^^^ Forum: Value
 
 note: 
    ┌─ features/type_aliases.fe:18:9
    │
 18 │         self.posts[id] = body
-   │         ^^^^^^^^^^^^^^   ^^^^ String<32>: Memory => None
+   │         ^^^^^^^^^^ ^^ u256: Value
+   │         │           
+   │         Map<u256, String<32>>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/type_aliases.fe:18:9
+   │
+18 │         self.posts[id] = body
+   │         ^^^^^^^^^^^^^^   ^^^^ String<32>: Memory
    │         │                 
-   │         String<32>: Storage { nonce: None } => None
+   │         String<32>: Storage { nonce: None }
 19 │         self.authors[msg.sender]
-   │         ^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
-   │         │             
-   │         Map<address, u256>: Storage { nonce: Some(1) } => None
+   │         ^^^^ Forum: Value
 
 note: 
    ┌─ features/type_aliases.fe:19:9
    │
 19 │         self.authors[msg.sender]
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
+   │         │             
+   │         Map<address, u256>: Storage { nonce: Some(1) }
+
+note: 
+   ┌─ features/type_aliases.fe:19:9
+   │
+19 │         self.authors[msg.sender]
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None }
 20 │         self.scoreboard[id] = 0
-   │         ^^^^^^^^^^^^^^^ ^^ u256: Value => None
-   │         │                
-   │         Map<u256, u64>: Storage { nonce: Some(2) } => None
+   │         ^^^^ Forum: Value
 
 note: 
    ┌─ features/type_aliases.fe:20:9
    │
 20 │         self.scoreboard[id] = 0
-   │         ^^^^^^^^^^^^^^^^^^^   ^ u64: Value => None
+   │         ^^^^^^^^^^^^^^^ ^^ u256: Value
+   │         │                
+   │         Map<u256, u64>: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ features/type_aliases.fe:20:9
+   │
+20 │         self.scoreboard[id] = 0
+   │         ^^^^^^^^^^^^^^^^^^^   ^ u64: Value
    │         │                      
-   │         u64: Storage { nonce: None } => None
+   │         u64: Storage { nonce: None }
 
 note: 
    ┌─ features/type_aliases.fe:22:5
@@ -140,10 +160,12 @@ note:
 23 │ │         let score: Score = self.scoreboard[id] + 1
 24 │ │         self.scoreboard[id] = score
 25 │ │         return score
-   │ ╰────────────────────^ attributes hash: 8245519384016556717
+   │ ╰────────────────────^ attributes hash: 1071444898341558853
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "id",
@@ -175,47 +197,61 @@ note:
    ┌─ features/type_aliases.fe:23:28
    │
 23 │         let score: Score = self.scoreboard[id] + 1
-   │                            ^^^^^^^^^^^^^^^ ^^ u256: Value => None
+   │                            ^^^^ Forum: Value
+
+note: 
+   ┌─ features/type_aliases.fe:23:28
+   │
+23 │         let score: Score = self.scoreboard[id] + 1
+   │                            ^^^^^^^^^^^^^^^ ^^ u256: Value
    │                            │                
-   │                            Map<u256, u64>: Storage { nonce: Some(2) } => None
+   │                            Map<u256, u64>: Storage { nonce: Some(2) }
 
 note: 
    ┌─ features/type_aliases.fe:23:28
    │
 23 │         let score: Score = self.scoreboard[id] + 1
-   │                            ^^^^^^^^^^^^^^^^^^^   ^ u64: Value => None
+   │                            ^^^^^^^^^^^^^^^^^^^   ^ u64: Value
    │                            │                      
-   │                            u64: Storage { nonce: None } => Some(Value)
+   │                            u64: Storage { nonce: None } => Value
 
 note: 
    ┌─ features/type_aliases.fe:23:28
    │
 23 │         let score: Score = self.scoreboard[id] + 1
-   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u64: Value => None
+   │                            ^^^^^^^^^^^^^^^^^^^^^^^ u64: Value
 24 │         self.scoreboard[id] = score
-   │         ^^^^^^^^^^^^^^^ ^^ u256: Value => None
-   │         │                
-   │         Map<u256, u64>: Storage { nonce: Some(2) } => None
+   │         ^^^^ Forum: Value
 
 note: 
    ┌─ features/type_aliases.fe:24:9
    │
 24 │         self.scoreboard[id] = score
-   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^ u64: Value => None
+   │         ^^^^^^^^^^^^^^^ ^^ u256: Value
+   │         │                
+   │         Map<u256, u64>: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ features/type_aliases.fe:24:9
+   │
+24 │         self.scoreboard[id] = score
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^ u64: Value
    │         │                      
-   │         u64: Storage { nonce: None } => None
+   │         u64: Storage { nonce: None }
 25 │         return score
-   │                ^^^^^ u64: Value => None
+   │                ^^^^^ u64: Value
 
 note: 
    ┌─ features/type_aliases.fe:27:5
    │  
 27 │ ╭     pub fn get_post(self, id: PostId) -> PostBody:
 28 │ │         return self.posts[id].to_mem()
-   │ ╰──────────────────────────────────────^ attributes hash: 10352242143184749414
+   │ ╰──────────────────────────────────────^ attributes hash: 39724703738812134
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "id",
@@ -241,28 +277,32 @@ note:
    ┌─ features/type_aliases.fe:28:16
    │
 28 │         return self.posts[id].to_mem()
-   │                ^^^^^^^^^^ ^^ u256: Value => None
+   │                ^^^^ Forum: Value
+
+note: 
+   ┌─ features/type_aliases.fe:28:16
+   │
+28 │         return self.posts[id].to_mem()
+   │                ^^^^^^^^^^ ^^ u256: Value
    │                │           
-   │                Map<u256, String<32>>: Storage { nonce: Some(0) } => None
+   │                Map<u256, String<32>>: Storage { nonce: Some(0) }
 
 note: 
    ┌─ features/type_aliases.fe:28:16
    │
 28 │         return self.posts[id].to_mem()
-   │                ^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => None
+   │                ^^^^^^^^^^^^^^ String<32>: Storage { nonce: None }
 
 note: 
    ┌─ features/type_aliases.fe:28:16
    │
 28 │         return self.posts[id].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => Some(Memory)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => Memory
 
 note: 
    ┌─ features/type_aliases.fe:28:16
    │
 28 │         return self.posts[id].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-   │
-   = ValueAttribute
+   │                ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(ToMem)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
@@ -40,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/u128_u128_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^ ^^^ u128: Value => None
+  │                │         
+  │                Map<u128, u128>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/u128_u128_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u128: Storage { nonce: None } => Some(Value)
+
+note: 
   ┌─ features/u128_u128_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u128, value: u128):
@@ -78,45 +92,19 @@ note:
     }
 
 note: 
-  ┌─ features/u128_u128_map.fe:5:16
+  ┌─ features/u128_u128_map.fe:8:9
   │
-5 │         return self.bar[key]
-  │                ^^^^^^^^ Map<u128, u128>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u128_u128_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ u128: Value => None
-
-note: 
-  ┌─ features/u128_u128_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u128: Storage { nonce: None } => Some(Value)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ u128: Value => None
+  │         │         
+  │         Map<u128, u128>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/u128_u128_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<u128, u128>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u128_u128_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ u128: Value => None
-
-note: 
-  ┌─ features/u128_u128_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ u128: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/u128_u128_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ u128: Value => None
+  │         ^^^^^^^^^^^^^   ^^^^^ u128: Value => None
+  │         │                
+  │         u128: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: u128) -> u128:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 14613607248451204655
+  │ ╰────────────────────────────^ attributes hash: 15921380287166345990
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -43,25 +45,33 @@ note:
   ┌─ features/u128_u128_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^ ^^^ u128: Value => None
-  │                │         
-  │                Map<u128, u128>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/u128_u128_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u128: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^^ u128: Value
+  │                │         
+  │                Map<u128, u128>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u128_u128_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u128: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/u128_u128_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u128, value: u128):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 10041566038914781122
+  │ ╰─────────────────────────────^ attributes hash: 10550763710156453898
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -95,16 +105,22 @@ note:
   ┌─ features/u128_u128_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ u128: Value => None
-  │         │         
-  │         Map<u128, u128>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/u128_u128_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ u128: Value => None
+  │         ^^^^^^^^ ^^^ u128: Value
+  │         │         
+  │         Map<u128, u128>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u128_u128_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ u128: Value
   │         │                
-  │         u128: Storage { nonce: None } => None
+  │         u128: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
@@ -40,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/u16_u16_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^ ^^^ u16: Value => None
+  │                │         
+  │                Map<u16, u16>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/u16_u16_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u16: Storage { nonce: None } => Some(Value)
+
+note: 
   ┌─ features/u16_u16_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u16, value: u16):
@@ -78,45 +92,19 @@ note:
     }
 
 note: 
-  ┌─ features/u16_u16_map.fe:5:16
+  ┌─ features/u16_u16_map.fe:8:9
   │
-5 │         return self.bar[key]
-  │                ^^^^^^^^ Map<u16, u16>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u16_u16_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ u16: Value => None
-
-note: 
-  ┌─ features/u16_u16_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u16: Storage { nonce: None } => Some(Value)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ u16: Value => None
+  │         │         
+  │         Map<u16, u16>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/u16_u16_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<u16, u16>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u16_u16_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ u16: Value => None
-
-note: 
-  ┌─ features/u16_u16_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ u16: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/u16_u16_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ u16: Value => None
+  │         ^^^^^^^^^^^^^   ^^^^^ u16: Value => None
+  │         │                
+  │         u16: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: u16) -> u16:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 13277112481715403660
+  │ ╰────────────────────────────^ attributes hash: 9873798429331488760
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -43,25 +45,33 @@ note:
   ┌─ features/u16_u16_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^ ^^^ u16: Value => None
-  │                │         
-  │                Map<u16, u16>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/u16_u16_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u16: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^^ u16: Value
+  │                │         
+  │                Map<u16, u16>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u16_u16_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u16: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/u16_u16_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u16, value: u16):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 14682981866604087396
+  │ ╰─────────────────────────────^ attributes hash: 6039485858219602437
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -95,16 +105,22 @@ note:
   ┌─ features/u16_u16_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ u16: Value => None
-  │         │         
-  │         Map<u16, u16>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/u16_u16_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ u16: Value => None
+  │         ^^^^^^^^ ^^^ u16: Value
+  │         │         
+  │         Map<u16, u16>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u16_u16_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ u16: Value
   │         │                
-  │         u16: Storage { nonce: None } => None
+  │         u16: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: u256) -> u256:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 9838590781041991414
+  │ ╰────────────────────────────^ attributes hash: 13989427457258349001
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -43,25 +45,33 @@ note:
   ┌─ features/u256_u256_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^ ^^^ u256: Value => None
-  │                │         
-  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/u256_u256_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^^ u256: Value
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u256_u256_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/u256_u256_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u256, value: u256):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 3191106537475594935
+  │ ╰─────────────────────────────^ attributes hash: 17554891933203542281
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -95,16 +105,22 @@ note:
   ┌─ features/u256_u256_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ u256: Value => None
-  │         │         
-  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/u256_u256_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+  │         ^^^^^^^^ ^^^ u256: Value
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u256_u256_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ u256: Value
   │         │                
-  │         u256: Storage { nonce: None } => None
+  │         u256: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
@@ -40,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/u256_u256_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^ ^^^ u256: Value => None
+  │                │         
+  │                Map<u256, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/u256_u256_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+
+note: 
   ┌─ features/u256_u256_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u256, value: u256):
@@ -78,45 +92,19 @@ note:
     }
 
 note: 
-  ┌─ features/u256_u256_map.fe:5:16
+  ┌─ features/u256_u256_map.fe:8:9
   │
-5 │         return self.bar[key]
-  │                ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u256_u256_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ u256: Value => None
-
-note: 
-  ┌─ features/u256_u256_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ u256: Value => None
+  │         │         
+  │         Map<u256, u256>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/u256_u256_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<u256, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u256_u256_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ u256: Value => None
-
-note: 
-  ┌─ features/u256_u256_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/u256_u256_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ u256: Value => None
+  │         ^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+  │         │                
+  │         u256: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
@@ -40,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/u32_u32_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^ ^^^ u32: Value => None
+  │                │         
+  │                Map<u32, u32>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/u32_u32_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u32: Storage { nonce: None } => Some(Value)
+
+note: 
   ┌─ features/u32_u32_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u32, value: u32):
@@ -78,45 +92,19 @@ note:
     }
 
 note: 
-  ┌─ features/u32_u32_map.fe:5:16
+  ┌─ features/u32_u32_map.fe:8:9
   │
-5 │         return self.bar[key]
-  │                ^^^^^^^^ Map<u32, u32>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u32_u32_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ u32: Value => None
-
-note: 
-  ┌─ features/u32_u32_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u32: Storage { nonce: None } => Some(Value)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ u32: Value => None
+  │         │         
+  │         Map<u32, u32>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/u32_u32_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<u32, u32>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u32_u32_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ u32: Value => None
-
-note: 
-  ┌─ features/u32_u32_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ u32: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/u32_u32_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ u32: Value => None
+  │         ^^^^^^^^^^^^^   ^^^^^ u32: Value => None
+  │         │                
+  │         u32: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: u32) -> u32:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 12968923434860104131
+  │ ╰────────────────────────────^ attributes hash: 4480266149426793665
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -43,25 +45,33 @@ note:
   ┌─ features/u32_u32_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^ ^^^ u32: Value => None
-  │                │         
-  │                Map<u32, u32>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/u32_u32_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u32: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^^ u32: Value
+  │                │         
+  │                Map<u32, u32>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u32_u32_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u32: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/u32_u32_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u32, value: u32):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 13487692495644521282
+  │ ╰─────────────────────────────^ attributes hash: 13443964769696753072
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -95,16 +105,22 @@ note:
   ┌─ features/u32_u32_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ u32: Value => None
-  │         │         
-  │         Map<u32, u32>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/u32_u32_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ u32: Value => None
+  │         ^^^^^^^^ ^^^ u32: Value
+  │         │         
+  │         Map<u32, u32>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u32_u32_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ u32: Value
   │         │                
-  │         u32: Storage { nonce: None } => None
+  │         u32: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
@@ -40,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/u64_u64_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^ ^^^ u64: Value => None
+  │                │         
+  │                Map<u64, u64>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/u64_u64_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u64: Storage { nonce: None } => Some(Value)
+
+note: 
   ┌─ features/u64_u64_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u64, value: u64):
@@ -78,45 +92,19 @@ note:
     }
 
 note: 
-  ┌─ features/u64_u64_map.fe:5:16
+  ┌─ features/u64_u64_map.fe:8:9
   │
-5 │         return self.bar[key]
-  │                ^^^^^^^^ Map<u64, u64>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u64_u64_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ u64: Value => None
-
-note: 
-  ┌─ features/u64_u64_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u64: Storage { nonce: None } => Some(Value)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ u64: Value => None
+  │         │         
+  │         Map<u64, u64>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/u64_u64_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<u64, u64>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u64_u64_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ u64: Value => None
-
-note: 
-  ┌─ features/u64_u64_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ u64: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/u64_u64_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ u64: Value => None
+  │         ^^^^^^^^^^^^^   ^^^^^ u64: Value => None
+  │         │                
+  │         u64: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: u64) -> u64:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 17303700247191832614
+  │ ╰────────────────────────────^ attributes hash: 1379832045823173251
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -43,25 +45,33 @@ note:
   ┌─ features/u64_u64_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^ ^^^ u64: Value => None
-  │                │         
-  │                Map<u64, u64>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/u64_u64_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u64: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^^ u64: Value
+  │                │         
+  │                Map<u64, u64>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u64_u64_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u64: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/u64_u64_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u64, value: u64):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 1768718553543894917
+  │ ╰─────────────────────────────^ attributes hash: 3852360532719040454
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -95,16 +105,22 @@ note:
   ┌─ features/u64_u64_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ u64: Value => None
-  │         │         
-  │         Map<u64, u64>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/u64_u64_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ u64: Value => None
+  │         ^^^^^^^^ ^^^ u64: Value
+  │         │         
+  │         Map<u64, u64>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u64_u64_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ u64: Value
   │         │                
-  │         u64: Storage { nonce: None } => None
+  │         u64: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
@@ -40,6 +40,20 @@ note:
     }
 
 note: 
+  ┌─ features/u8_u8_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^ ^^^ u8: Value => None
+  │                │         
+  │                Map<u8, u8>: Storage { nonce: Some(0) } => None
+
+note: 
+  ┌─ features/u8_u8_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u8: Storage { nonce: None } => Some(Value)
+
+note: 
   ┌─ features/u8_u8_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u8, value: u8):
@@ -78,45 +92,19 @@ note:
     }
 
 note: 
-  ┌─ features/u8_u8_map.fe:5:16
+  ┌─ features/u8_u8_map.fe:8:9
   │
-5 │         return self.bar[key]
-  │                ^^^^^^^^ Map<u8, u8>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u8_u8_map.fe:5:25
-  │
-5 │         return self.bar[key]
-  │                         ^^^ u8: Value => None
-
-note: 
-  ┌─ features/u8_u8_map.fe:5:16
-  │
-5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u8: Storage { nonce: None } => Some(Value)
+8 │         self.bar[key] = value
+  │         ^^^^^^^^ ^^^ u8: Value => None
+  │         │         
+  │         Map<u8, u8>: Storage { nonce: Some(0) } => None
 
 note: 
   ┌─ features/u8_u8_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ Map<u8, u8>: Storage { nonce: Some(0) } => None
-
-note: 
-  ┌─ features/u8_u8_map.fe:8:18
-  │
-8 │         self.bar[key] = value
-  │                  ^^^ u8: Value => None
-
-note: 
-  ┌─ features/u8_u8_map.fe:8:9
-  │
-8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^ u8: Storage { nonce: None } => None
-
-note: 
-  ┌─ features/u8_u8_map.fe:8:25
-  │
-8 │         self.bar[key] = value
-  │                         ^^^^^ u8: Value => None
+  │         ^^^^^^^^^^^^^   ^^^^^ u8: Value => None
+  │         │                
+  │         u8: Storage { nonce: None } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
@@ -14,10 +14,12 @@ note:
   │  
 4 │ ╭     pub fn read_bar(self, key: u8) -> u8:
 5 │ │         return self.bar[key]
-  │ ╰────────────────────────────^ attributes hash: 12371532813153398159
+  │ ╰────────────────────────────^ attributes hash: 2018683894208622187
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -43,25 +45,33 @@ note:
   ┌─ features/u8_u8_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^ ^^^ u8: Value => None
-  │                │         
-  │                Map<u8, u8>: Storage { nonce: Some(0) } => None
+  │                ^^^^ Foo: Value
 
 note: 
   ┌─ features/u8_u8_map.fe:5:16
   │
 5 │         return self.bar[key]
-  │                ^^^^^^^^^^^^^ u8: Storage { nonce: None } => Some(Value)
+  │                ^^^^^^^^ ^^^ u8: Value
+  │                │         
+  │                Map<u8, u8>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u8_u8_map.fe:5:16
+  │
+5 │         return self.bar[key]
+  │                ^^^^^^^^^^^^^ u8: Storage { nonce: None } => Value
 
 note: 
   ┌─ features/u8_u8_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: u8, value: u8):
 8 │ │         self.bar[key] = value
-  │ ╰─────────────────────────────^ attributes hash: 334915651172467174
+  │ ╰─────────────────────────────^ attributes hash: 10617957370555248465
   │  
   = FunctionSignature {
-        self_decl: Mutable,
+        self_decl: Some(
+            Mutable,
+        ),
         params: [
             FunctionParam {
                 name: "key",
@@ -95,16 +105,22 @@ note:
   ┌─ features/u8_u8_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^ ^^^ u8: Value => None
-  │         │         
-  │         Map<u8, u8>: Storage { nonce: Some(0) } => None
+  │         ^^^^ Foo: Value
 
 note: 
   ┌─ features/u8_u8_map.fe:8:9
   │
 8 │         self.bar[key] = value
-  │         ^^^^^^^^^^^^^   ^^^^^ u8: Value => None
+  │         ^^^^^^^^ ^^^ u8: Value
+  │         │         
+  │         Map<u8, u8>: Storage { nonce: Some(0) }
+
+note: 
+  ┌─ features/u8_u8_map.fe:8:9
+  │
+8 │         self.bar[key] = value
+  │         ^^^^^^^^^^^^^   ^^^^^ u8: Value
   │         │                
-  │         u8: Storage { nonce: None } => None
+  │         u8: Storage { nonce: None }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -1,266 +1,8 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(files, module, &db)"
+expression: "build_snapshot(&files, module, &db)"
 
 ---
-note: 
-   ┌─ demos/uniswap.fe:12:5
-   │
-12 │     balances: Map<address, u256>
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-
-note: 
-   ┌─ demos/uniswap.fe:13:5
-   │
-13 │     allowances: Map<address, Map<address, u256>>
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>
-
-note: 
-   ┌─ demos/uniswap.fe:14:5
-   │
-14 │     total_supply: u256
-   │     ^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:16:5
-   │
-16 │     nonces: Map<address, u256>
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-
-note: 
-   ┌─ demos/uniswap.fe:18:5
-   │
-18 │     factory: address
-   │     ^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:19:5
-   │
-19 │     token0: address
-   │     ^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:20:5
-   │
-20 │     token1: address
-   │     ^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:22:5
-   │
-22 │     reserve0: u256
-   │     ^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:23:5
-   │
-23 │     reserve1: u256
-   │     ^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:24:5
-   │
-24 │     block_timestamp_last: u256
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:26:5
-   │
-26 │     price0_cumulative_last: u256
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:27:5
-   │
-27 │     price1_cumulative_last: u256
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:28:5
-   │
-28 │     k_last: u256
-   │     ^^^^^^^^^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:285:5
-    │
-285 │     fee_to: address
-    │     ^^^^^^^^^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:286:5
-    │
-286 │     fee_to_setter: address
-    │     ^^^^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:288:5
-    │
-288 │     pairs: Map<address, Map<address, address>>
-    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, address>>
-
-note: 
-    ┌─ demos/uniswap.fe:290:5
-    │
-290 │     all_pairs: Array<address, 100>
-    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 100>
-
-note: 
-    ┌─ demos/uniswap.fe:291:5
-    │
-291 │     pair_counter: u256
-    │     ^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:31:9
-   │
-31 │         idx owner: address
-   │         ^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:32:9
-   │
-32 │         idx spender: address
-   │         ^^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:33:9
-   │
-33 │         value: u256
-   │         ^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:36:9
-   │
-36 │         idx from: address
-   │         ^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:37:9
-   │
-37 │         idx to: address
-   │         ^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:38:9
-   │
-38 │         value: u256
-   │         ^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:41:9
-   │
-41 │         idx sender: address
-   │         ^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:42:9
-   │
-42 │         amount0: u256
-   │         ^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:43:9
-   │
-43 │         amount1: u256
-   │         ^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:46:9
-   │
-46 │         idx sender: address
-   │         ^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:47:9
-   │
-47 │         amount0: u256
-   │         ^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:48:9
-   │
-48 │         amount1: u256
-   │         ^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:49:9
-   │
-49 │         idx to: address
-   │         ^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:52:9
-   │
-52 │         idx sender: address
-   │         ^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:53:9
-   │
-53 │         amount0_in: u256
-   │         ^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:54:9
-   │
-54 │         amount1_in: u256
-   │         ^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:55:9
-   │
-55 │         amount0_out: u256
-   │         ^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:56:9
-   │
-56 │         amount1_out: u256
-   │         ^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:57:9
-   │
-57 │         idx to: address
-   │         ^^^^^^^^^^^^^^^ address
-
-note: 
-   ┌─ demos/uniswap.fe:60:9
-   │
-60 │         reserve0: u256
-   │         ^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ demos/uniswap.fe:61:9
-   │
-61 │         reserve1: u256
-   │         ^^^^^^^^^^^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:294:9
-    │
-294 │         idx token0: address
-    │         ^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:295:9
-    │
-295 │         idx token1: address
-    │         ^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:296:9
-    │
-296 │         pair: address
-    │         ^^^^^^^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:297:9
-    │
-297 │         index: u256
-    │         ^^^^^^^^^^^ u256
-
 note: 
   ┌─ demos/uniswap.fe:2:5
   │  
@@ -288,6 +30,12 @@ note:
             ),
         ),
     }
+
+note: 
+  ┌─ demos/uniswap.fe:3:16
+  │
+3 │         return 0
+  │                ^ u256: Value => None
 
 note: 
   ┌─ demos/uniswap.fe:5:5
@@ -326,21 +74,110 @@ note:
     }
 
 note: 
-   ┌─ demos/uniswap.fe:63:5
-   │  
-63 │ ╭     pub fn __init__(self):
-64 │ │         self.factory = msg.sender
-   │ ╰─────────────────────────────────^ attributes hash: 4369441865732737140
-   │  
-   = FunctionSignature {
-         self_decl: Mutable,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+  ┌─ demos/uniswap.fe:6:16
+  │
+6 │         return false
+  │                ^^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:12:5
+   │
+12 │     balances: Map<address, u256>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
+13 │     allowances: Map<address, Map<address, u256>>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>
+14 │     total_supply: u256
+   │     ^^^^^^^^^^^^^^^^^^ u256
+15 │ 
+16 │     nonces: Map<address, u256>
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
+17 │ 
+18 │     factory: address
+   │     ^^^^^^^^^^^^^^^^ address
+19 │     token0: address
+   │     ^^^^^^^^^^^^^^^ address
+20 │     token1: address
+   │     ^^^^^^^^^^^^^^^ address
+21 │ 
+22 │     reserve0: u256
+   │     ^^^^^^^^^^^^^^ u256
+23 │     reserve1: u256
+   │     ^^^^^^^^^^^^^^ u256
+24 │     block_timestamp_last: u256
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
+25 │ 
+26 │     price0_cumulative_last: u256
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
+27 │     price1_cumulative_last: u256
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
+28 │     k_last: u256
+   │     ^^^^^^^^^^^^ u256
+
+note: 
+   ┌─ demos/uniswap.fe:31:9
+   │
+31 │         idx owner: address
+   │         ^^^^^^^^^^^^^^^^^^ address
+32 │         idx spender: address
+   │         ^^^^^^^^^^^^^^^^^^^^ address
+33 │         value: u256
+   │         ^^^^^^^^^^^ u256
+
+note: 
+   ┌─ demos/uniswap.fe:36:9
+   │
+36 │         idx from: address
+   │         ^^^^^^^^^^^^^^^^^ address
+37 │         idx to: address
+   │         ^^^^^^^^^^^^^^^ address
+38 │         value: u256
+   │         ^^^^^^^^^^^ u256
+
+note: 
+   ┌─ demos/uniswap.fe:41:9
+   │
+41 │         idx sender: address
+   │         ^^^^^^^^^^^^^^^^^^^ address
+42 │         amount0: u256
+   │         ^^^^^^^^^^^^^ u256
+43 │         amount1: u256
+   │         ^^^^^^^^^^^^^ u256
+
+note: 
+   ┌─ demos/uniswap.fe:46:9
+   │
+46 │         idx sender: address
+   │         ^^^^^^^^^^^^^^^^^^^ address
+47 │         amount0: u256
+   │         ^^^^^^^^^^^^^ u256
+48 │         amount1: u256
+   │         ^^^^^^^^^^^^^ u256
+49 │         idx to: address
+   │         ^^^^^^^^^^^^^^^ address
+
+note: 
+   ┌─ demos/uniswap.fe:52:9
+   │
+52 │         idx sender: address
+   │         ^^^^^^^^^^^^^^^^^^^ address
+53 │         amount0_in: u256
+   │         ^^^^^^^^^^^^^^^^ u256
+54 │         amount1_in: u256
+   │         ^^^^^^^^^^^^^^^^ u256
+55 │         amount0_out: u256
+   │         ^^^^^^^^^^^^^^^^^ u256
+56 │         amount1_out: u256
+   │         ^^^^^^^^^^^^^^^^^ u256
+57 │         idx to: address
+   │         ^^^^^^^^^^^^^^^ address
+
+note: 
+   ┌─ demos/uniswap.fe:60:9
+   │
+60 │         reserve0: u256
+   │         ^^^^^^^^^^^^^^ u256
+61 │         reserve1: u256
+   │         ^^^^^^^^^^^^^^ u256
 
 note: 
    ┌─ demos/uniswap.fe:66:5
@@ -360,6 +197,12 @@ note:
      }
 
 note: 
+   ┌─ demos/uniswap.fe:67:16
+   │
+67 │         return self.factory
+   │                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
+
+note: 
    ┌─ demos/uniswap.fe:69:5
    │  
 69 │ ╭     pub fn token0(self) -> address:
@@ -377,6 +220,12 @@ note:
      }
 
 note: 
+   ┌─ demos/uniswap.fe:70:16
+   │
+70 │         return self.token0
+   │                ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
    ┌─ demos/uniswap.fe:72:5
    │  
 72 │ ╭     pub fn token1(self) -> address:
@@ -392,6 +241,12 @@ note:
              ),
          ),
      }
+
+note: 
+   ┌─ demos/uniswap.fe:73:16
+   │
+73 │         return self.token1
+   │                ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
 
 note: 
    ┌─ demos/uniswap.fe:75:5
@@ -432,6 +287,112 @@ note:
      }
 
 note: 
+   ┌─ demos/uniswap.fe:76:9
+   │
+76 │         self.total_supply = self.total_supply + value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         │                   │                    
+   │         │                   u256: Storage { nonce: Some(2) } => Some(Value)
+   │         u256: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:76:29
+   │
+76 │         self.total_supply = self.total_supply + value
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+77 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^^^^^^^^^^ ^^ address: Value => None
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:77:9
+   │
+77 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^ address: Value => None
+   │         │                   │              
+   │         │                   Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/uniswap.fe:77:29
+   │
+77 │         self.balances[to] = self.balances[to] + value
+   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                             │                    
+   │                             u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/uniswap.fe:77:29
+   │
+77 │         self.balances[to] = self.balances[to] + value
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+78 │         emit Transfer(from=address(0), to, value)
+   │                                    ^ u256: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:78:28
+   │
+78 │         emit Transfer(from=address(0), to, value)
+   │                            ^^^^^^^^^^  ^^  ^^^^^ u256: Value => None
+   │                            │           │    
+   │                            │           address: Value => None
+   │                            address: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:78:9
+   │
+78 │         emit Transfer(from=address(0), to, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+   │
+   = Event {
+         name: "Transfer",
+         fields: [
+             EventField {
+                 name: "from",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "to",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
+   ┌─ demos/uniswap.fe:78:28
+   │
+78 │         emit Transfer(from=address(0), to, value)
+   │                            ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
+         ),
+     }
+
+note: 
    ┌─ demos/uniswap.fe:80:5
    │  
 80 │ ╭     fn _burn(self, from: address, value: u256):
@@ -466,6 +427,113 @@ note:
              Base(
                  Unit,
              ),
+         ),
+     }
+
+note: 
+   ┌─ demos/uniswap.fe:81:9
+   │
+81 │         self.balances[from] = self.balances[from] - value
+   │         ^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:81:9
+   │
+81 │         self.balances[from] = self.balances[from] - value
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │         │                     │              
+   │         │                     Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/uniswap.fe:81:31
+   │
+81 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                               │                      
+   │                               u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/uniswap.fe:81:31
+   │
+81 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+82 │         self.total_supply = self.total_supply - value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         │                   │                    
+   │         │                   u256: Storage { nonce: Some(2) } => Some(Value)
+   │         u256: Storage { nonce: Some(2) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:82:29
+   │
+82 │         self.total_supply = self.total_supply - value
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+83 │         emit Transfer(from, to=address(0), value)
+   │                       ^^^^             ^ u256: Value => None
+   │                       │                 
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:83:32
+   │
+83 │         emit Transfer(from, to=address(0), value)
+   │                                ^^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                │            
+   │                                address: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:83:9
+   │
+83 │         emit Transfer(from, to=address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+   │
+   = Event {
+         name: "Transfer",
+         fields: [
+             EventField {
+                 name: "from",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "to",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
+   ┌─ demos/uniswap.fe:83:32
+   │
+83 │         emit Transfer(from, to=address(0), value)
+   │                                ^^^^^^^ attributes hash: 14203407709342965641
+   │
+   = TypeConstructor {
+         typ: Base(
+             Address,
          ),
      }
 
@@ -515,6 +583,76 @@ note:
      }
 
 note: 
+   ┌─ demos/uniswap.fe:86:9
+   │
+86 │         self.allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^ ^^^^^ address: Value => None
+   │         │                
+   │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:86:9
+   │
+86 │         self.allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         │                       
+   │         Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/uniswap.fe:86:9
+   │
+86 │         self.allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         │                                  
+   │         u256: Storage { nonce: None } => None
+87 │         emit Approval(owner, spender, value)
+   │                       ^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                       │      │         
+   │                       │      address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:87:9
+   │
+87 │         emit Approval(owner, spender, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8893313742751514912
+   │
+   = Event {
+         name: "Approval",
+         fields: [
+             EventField {
+                 name: "owner",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "spender",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
    ┌─ demos/uniswap.fe:89:5
    │  
 89 │ ╭     fn _transfer(self, from: address, to: address, value: u256):
@@ -561,6 +699,110 @@ note:
      }
 
 note: 
+   ┌─ demos/uniswap.fe:90:9
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │         ^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:90:9
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^^^ address: Value => None
+   │         │                     │              
+   │         │                     Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/uniswap.fe:90:31
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                               │                      
+   │                               u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/uniswap.fe:90:31
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+91 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^^^^^^^^^^ ^^ address: Value => None
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+   ┌─ demos/uniswap.fe:91:9
+   │
+91 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^ address: Value => None
+   │         │                   │              
+   │         │                   Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         u256: Storage { nonce: None } => None
+
+note: 
+   ┌─ demos/uniswap.fe:91:29
+   │
+91 │         self.balances[to] = self.balances[to] + value
+   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                             │                    
+   │                             u256: Storage { nonce: None } => Some(Value)
+
+note: 
+   ┌─ demos/uniswap.fe:91:29
+   │
+91 │         self.balances[to] = self.balances[to] + value
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+92 │         emit Transfer(from, to, value)
+   │                       ^^^^  ^^  ^^^^^ u256: Value => None
+   │                       │     │    
+   │                       │     address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:92:9
+   │
+92 │         emit Transfer(from, to, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+   │
+   = Event {
+         name: "Transfer",
+         fields: [
+             EventField {
+                 name: "from",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "to",
+                 typ: Ok(
+                     Base(
+                         Address,
+                     ),
+                 ),
+                 is_indexed: true,
+             },
+             EventField {
+                 name: "value",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+                 is_indexed: false,
+             },
+         ],
+     }
+
+note: 
    ┌─ demos/uniswap.fe:94:5
    │  
 94 │ ╭     pub fn approve(self, spender: address, value: u256) -> bool:
@@ -595,6 +837,34 @@ note:
                  Bool,
              ),
          ),
+     }
+
+note: 
+   ┌─ demos/uniswap.fe:95:23
+   │
+95 │         self._approve(msg.sender, spender, value)
+   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                       │           │         
+   │                       │           address: Value => None
+   │                       address: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:95:9
+   │
+95 │         self._approve(msg.sender, spender, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+96 │         return true
+   │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:95:9
+   │
+95 │         self._approve(msg.sender, spender, value)
+   │         ^^^^^^^^^^^^^ attributes hash: 14531113974490967627
+   │
+   = SelfAttribute {
+         func_name: "_approve",
+         self_span: 2409..2413,
      }
 
 note: 
@@ -633,6 +903,34 @@ note:
               ),
           ),
       }
+
+note: 
+   ┌─ demos/uniswap.fe:99:24
+   │
+99 │         self._transfer(msg.sender, to, value)
+   │                        ^^^^^^^^^^  ^^  ^^^^^ u256: Value => None
+   │                        │           │    
+   │                        │           address: Value => None
+   │                        address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:99:9
+    │
+ 99 │         self._transfer(msg.sender, to, value)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+100 │         return true
+    │                ^^^^ bool: Value => None
+
+note: 
+   ┌─ demos/uniswap.fe:99:9
+   │
+99 │         self._transfer(msg.sender, to, value)
+   │         ^^^^^^^^^^^^^^ attributes hash: 7946469693452924957
+   │
+   = SelfAttribute {
+         func_name: "_transfer",
+         self_span: 2541..2545,
+     }
 
 note: 
     ┌─ demos/uniswap.fe:102:5
@@ -683,6 +981,104 @@ note:
       }
 
 note: 
+    ┌─ demos/uniswap.fe:103:16
+    │
+103 │         assert self.allowances[from][msg.sender] >= value
+    │                ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
+    │                │                
+    │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:103:16
+    │
+103 │         assert self.allowances[from][msg.sender] >= value
+    │                ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+    │                │                      
+    │                Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:103:16
+    │
+103 │         assert self.allowances[from][msg.sender] >= value
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value => None
+    │                │                                     
+    │                u256: Storage { nonce: None } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:103:16
+    │
+103 │         assert self.allowances[from][msg.sender] >= value
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+104 │ 
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │         ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
+    │         │                
+    │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:105:9
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │         ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+    │         │                      
+    │         Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:105:9
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
+    │         │                                   │                
+    │         │                                   Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+    │         u256: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:105:45
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │                                             ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+    │                                             │                      
+    │                                             Map<address, u256>: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:105:45
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+    │                                             │                                    
+    │                                             u256: Storage { nonce: None } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:105:45
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+106 │         self._transfer(from, to, value)
+    │                        ^^^^  ^^  ^^^^^ u256: Value => None
+    │                        │     │    
+    │                        │     address: Value => None
+    │                        address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:106:9
+    │
+106 │         self._transfer(from, to, value)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+107 │         return true
+    │                ^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:106:9
+    │
+106 │         self._transfer(from, to, value)
+    │         ^^^^^^^^^^^^^^ attributes hash: 9013399514526062924
+    │
+    = SelfAttribute {
+          func_name: "_transfer",
+          self_span: 2833..2837,
+      }
+
+note: 
     ┌─ demos/uniswap.fe:109:5
     │  
 109 │ ╭     pub fn balanceOf(self, account: address) -> u256:
@@ -709,6 +1105,20 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ demos/uniswap.fe:110:16
+    │
+110 │         return self.balances[account]
+    │                ^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+    │                │              
+    │                Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:110:16
+    │
+110 │         return self.balances[account]
+    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
 
 note: 
     ┌─ demos/uniswap.fe:112:5
@@ -746,6 +1156,21 @@ note:
       }
 
 note: 
+    ┌─ demos/uniswap.fe:113:17
+    │
+113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+    │                 ^^^^^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Some(Value)
+    │                 │              │               
+    │                 │              u256: Storage { nonce: Some(8) } => Some(Value)
+    │                 u256: Storage { nonce: Some(7) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:113:16
+    │
+113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, u256, u256): Memory => None
+
+note: 
     ┌─ demos/uniswap.fe:116:5
     │  
 116 │ ╭     pub fn initialize(self, token0: address, token1: address):
@@ -780,6 +1205,30 @@ note:
               ),
           ),
       }
+
+note: 
+    ┌─ demos/uniswap.fe:117:16
+    │
+117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
+    │                ^^^^^^^^^^    ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
+    │                │              
+    │                address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:117:16
+    │
+117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
+    │                │                            
+    │                bool: Value => None
+118 │         self.token0 = token0
+    │         ^^^^^^^^^^^   ^^^^^^ address: Value => None
+    │         │              
+    │         address: Storage { nonce: Some(5) } => None
+119 │         self.token1 = token1
+    │         ^^^^^^^^^^^   ^^^^^^ address: Value => None
+    │         │              
+    │         address: Storage { nonce: Some(6) } => None
 
 note: 
     ┌─ demos/uniswap.fe:122:5
@@ -845,6 +1294,191 @@ note:
       }
 
 note: 
+    ┌─ demos/uniswap.fe:124:30
+    │
+124 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                              ^^^^ u256
+125 │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
+126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                           ^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:124:37
+    │
+124 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                     ^^^^^^^^^^^^^^^   ^  ^^ u256: Value => None
+    │                                     │                 │   
+    │                                     │                 u256: Value => None
+    │                                     u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:124:55
+    │
+124 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                                       ^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:124:37
+    │
+124 │         let block_timestamp: u256 = block.timestamp % 2**32
+    │                                     ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+125 │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
+126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                                  ^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Some(Value)
+    │                                  │                  
+    │                                  u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:126:34
+    │
+126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
+    │            ^^^^^^^^^^^^   ^ u256: Value => None
+    │            │               
+    │            u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:127:12
+    │
+127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
+    │            ^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value => None
+    │            │                    │            
+    │            │                    u256: Value => None
+    │            bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:127:33
+    │
+127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
+    │                                 ^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:127:12
+    │
+127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
+    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value => None
+    │            │                                      │            
+    │            │                                      u256: Value => None
+    │            bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:127:51
+    │
+127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
+    │                                                   ^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:127:12
+    │
+127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
+    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+128 │             # `*` never overflows, and + overflow is desired
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │             │                             │                              │           
+    │             │                             │                              u256: Value => None
+    │             │                             u256: Storage { nonce: Some(10) } => Some(Value)
+    │             u256: Storage { nonce: Some(10) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:129:73
+    │
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                                                                         │                        
+    │                                                                         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:129:73
+    │
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:129:43
+    │
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │             │                             │                              │           
+    │             │                             │                              u256: Value => None
+    │             │                             u256: Storage { nonce: Some(11) } => Some(Value)
+    │             u256: Storage { nonce: Some(11) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:130:73
+    │
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                                                                         │                        
+    │                                                                         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:130:73
+    │
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:130:43
+    │
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+131 │ 
+132 │         self.reserve0 = balance0
+    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │         │                
+    │         u256: Storage { nonce: Some(7) } => None
+133 │         self.reserve1 = balance1
+    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │         │                
+    │         u256: Storage { nonce: Some(8) } => None
+134 │         self.block_timestamp_last = block_timestamp
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value => None
+    │         │                            
+    │         u256: Storage { nonce: Some(9) } => None
+135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
+    │                            ^^^^^^^^^^^^^           ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                            │                        
+    │                            u256: Storage { nonce: Some(7) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:135:9
+    │
+135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11491202868117077488
+    │
+    = Event {
+          name: "Sync",
+          fields: [
+              EventField {
+                  name: "reserve0",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "reserve1",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+          ],
+      }
+
+note: 
     ┌─ demos/uniswap.fe:138:5
     │  
 138 │ ╭     fn _mint_fee(self, reserve0: u256, reserve1: u256) -> bool:
@@ -888,1382 +1522,26 @@ note:
       }
 
 note: 
-    ┌─ demos/uniswap.fe:158:5
-    │  
-158 │ ╭     pub fn mint(self, to: address) -> u256:
-159 │ │         let MINIMUM_LIQUIDITY: u256 = 1000
-160 │ │         let reserve0: u256 = self.reserve0
-161 │ │         let reserve1: u256 = self.reserve1
-    · │
-184 │ │         emit Mint(sender=msg.sender, amount0, amount1)
-185 │ │         return liquidity
-    │ ╰────────────────────────^ attributes hash: 13052412037608309076
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:188:5
-    │  
-188 │ ╭     pub fn burn(self, to: address) -> (u256, u256):
-189 │ │         let reserve0: u256 = self.reserve0
-190 │ │         let reserve1: u256 = self.reserve1
-191 │ │         let token0: ERC20 = ERC20(self.token0)
-    · │
-213 │ │         emit Burn(sender=msg.sender, amount0, amount1, to)
-214 │ │         return (amount0, amount1)
-    │ ╰─────────────────────────────────^ attributes hash: 2656431017065792419
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Tuple(
-                  Tuple {
-                      items: [
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      ],
-                  },
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:219:5
-    │  
-219 │ ╭     pub fn swap(self, amount0_out: u256, amount1_out: u256, to: address):
-220 │ │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-221 │ │         let reserve0: u256 = self.reserve0
-222 │ │         let reserve1: u256 = self.reserve1
-    · │
-252 │ │         self._update(balance0, balance1, reserve0, reserve1)
-253 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13380171127738201451
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "amount0_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  name: "amount1_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:256:5
-    │  
-256 │ ╭     pub fn skim(self, to: address):
-257 │ │         let token0: ERC20 = ERC20(self.token0) # gas savings
-258 │ │         let token1: ERC20 = ERC20(self.token1) # gas savings
-259 │ │ 
-260 │ │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-261 │ │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 2346286316485274384
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:264:5
-    │  
-264 │ ╭     pub fn sync(self):
-265 │ │         let token0: ERC20 = ERC20(self.token0)
-266 │ │         let token1: ERC20 = ERC20(self.token1)
-267 │ │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 4369441865732737140
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:269:5
-    │  
-269 │ ╭     fn sqrt(val: u256) -> u256:
-270 │ │         let z: u256
-271 │ │         if (val > 3):
-272 │ │             z = val
-    · │
-278 │ │             z = 1
-279 │ │         return z
-    │ ╰────────────────^ attributes hash: 3075818098030342593
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          params: [
-              FunctionParam {
-                  name: "val",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:281:5
-    │  
-281 │ ╭     fn min(x: u256, y: u256) -> u256:
-282 │ │         return x if x < y else y
-    │ ╰────────────────────────────────^ attributes hash: 4022593831796629401
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          params: [
-              FunctionParam {
-                  name: "x",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  name: "y",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:299:5
-    │  
-299 │ ╭     pub fn __init__(self, fee_to_setter: address):
-300 │ │        self.fee_to_setter = fee_to_setter
-    │ ╰─────────────────────────────────────────^ attributes hash: 10732478853163688613
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "fee_to_setter",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:302:5
-    │  
-302 │ ╭     pub fn fee_to(self) -> address:
-303 │ │         return self.fee_to
-    │ ╰──────────────────────────^ attributes hash: 17651916811868111914
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Address,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:305:5
-    │  
-305 │ ╭     pub fn fee_to_setter(self) -> address:
-306 │ │         return self.fee_to_setter
-    │ ╰─────────────────────────────────^ attributes hash: 17651916811868111914
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Address,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:308:5
-    │  
-308 │ ╭     pub fn all_pairs_length(self) -> u256:
-309 │ │         return self.pair_counter
-    │ ╰────────────────────────────────^ attributes hash: 16482263331346774611
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:311:5
-    │  
-311 │ ╭     pub fn create_pair(self, token_a: address, token_b: address) -> address:
-312 │ │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-313 │ │ 
-314 │ │         let token0: address = token_a if token_a < token_b else token_b
-    · │
-328 │ │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-329 │ │         return address(pair)
-    │ ╰────────────────────────────^ attributes hash: 12932031939304465073
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "token_a",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  name: "token_b",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Address,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:331:5
-    │  
-331 │ ╭     pub fn set_fee_to(self, fee_to: address):
-332 │ │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-333 │ │         self.fee_to = fee_to
-    │ ╰────────────────────────────^ attributes hash: 14618921052791880235
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "fee_to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:335:5
-    │  
-335 │ ╭     pub fn set_fee_to_setter(self, fee_to_setter: address):
-336 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-337 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 10732478853163688613
-    │  
-    = FunctionSignature {
-          self_decl: Mutable,
-          params: [
-              FunctionParam {
-                  name: "fee_to_setter",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
-
-note: 
-  ┌─ demos/uniswap.fe:3:16
-  │
-3 │         return 0
-  │                ^ u256: Value => None
-
-note: 
-  ┌─ demos/uniswap.fe:6:16
-  │
-6 │         return false
-  │                ^^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:64:9
-   │
-64 │         self.factory = msg.sender
-   │         ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:64:24
-   │
-64 │         self.factory = msg.sender
-   │                        ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:67:16
-   │
-67 │         return self.factory
-   │                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:70:16
-   │
-70 │         return self.token0
-   │                ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:73:16
-   │
-73 │         return self.token1
-   │                ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:76:9
-   │
-76 │         self.total_supply = self.total_supply + value
-   │         ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:76:29
-   │
-76 │         self.total_supply = self.total_supply + value
-   │                             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:76:49
-   │
-76 │         self.total_supply = self.total_supply + value
-   │                                                 ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:76:29
-   │
-76 │         self.total_supply = self.total_supply + value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:9
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:23
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                       ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:9
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:29
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:43
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                                           ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:29
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:77:49
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                                                 ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:77:29
-   │
-77 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:78:36
-   │
-78 │         emit Transfer(from=address(0), to, value)
-   │                                    ^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:78:28
-   │
-78 │         emit Transfer(from=address(0), to, value)
-   │                            ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:78:40
-   │
-78 │         emit Transfer(from=address(0), to, value)
-   │                                        ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:78:44
-   │
-78 │         emit Transfer(from=address(0), to, value)
-   │                                            ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:9
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:23
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                       ^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:9
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:31
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:45
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                                             ^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:31
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:81:53
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                                                     ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:81:31
-   │
-81 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:82:9
-   │
-82 │         self.total_supply = self.total_supply - value
-   │         ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:82:29
-   │
-82 │         self.total_supply = self.total_supply - value
-   │                             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:82:49
-   │
-82 │         self.total_supply = self.total_supply - value
-   │                                                 ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:82:29
-   │
-82 │         self.total_supply = self.total_supply - value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:83:23
-   │
-83 │         emit Transfer(from, to=address(0), value)
-   │                       ^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:83:40
-   │
-83 │         emit Transfer(from, to=address(0), value)
-   │                                        ^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:83:32
-   │
-83 │         emit Transfer(from, to=address(0), value)
-   │                                ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:83:44
-   │
-83 │         emit Transfer(from, to=address(0), value)
-   │                                            ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:86:9
-   │
-86 │         self.allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:86:25
-   │
-86 │         self.allowances[owner][spender] = value
-   │                         ^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:86:9
-   │
-86 │         self.allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:86:32
-   │
-86 │         self.allowances[owner][spender] = value
-   │                                ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:86:9
-   │
-86 │         self.allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:86:43
-   │
-86 │         self.allowances[owner][spender] = value
-   │                                           ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:87:23
-   │
-87 │         emit Approval(owner, spender, value)
-   │                       ^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:87:30
-   │
-87 │         emit Approval(owner, spender, value)
-   │                              ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:87:39
-   │
-87 │         emit Approval(owner, spender, value)
-   │                                       ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:9
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:23
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                       ^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:9
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:31
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:45
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                                             ^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:31
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:90:53
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                                                     ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:31
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:9
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:23
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                       ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:9
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:29
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:43
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                                           ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:29
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:91:49
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                                                 ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:91:29
-   │
-91 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:92:23
-   │
-92 │         emit Transfer(from, to, value)
-   │                       ^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:92:29
-   │
-92 │         emit Transfer(from, to, value)
-   │                             ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:92:33
-   │
-92 │         emit Transfer(from, to, value)
-   │                                 ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:95:23
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │                       ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:95:35
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │                                   ^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:95:44
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │                                            ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:95:9
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:96:16
-   │
-96 │         return true
-   │                ^^^^ bool: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:99:24
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │                        ^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:99:36
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │                                    ^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:99:40
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │                                        ^^^^^ u256: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:99:9
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:100:16
-    │
-100 │         return true
-    │                ^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:103:16
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:103:32
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                                ^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:103:16
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:103:38
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                                      ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:103:16
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:103:53
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                                                     ^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:103:16
-    │
-103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:9
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │         ^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:25
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                         ^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:9
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │         ^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:31
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                               ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:9
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:45
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:61
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                                             ^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:45
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:67
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                                                   ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:45
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:105:81
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                                                                 ^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:105:45
-    │
-105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:106:24
-    │
-106 │         self._transfer(from, to, value)
-    │                        ^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:106:30
-    │
-106 │         self._transfer(from, to, value)
-    │                              ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:106:34
-    │
-106 │         self._transfer(from, to, value)
-    │                                  ^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:106:9
-    │
-106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:107:16
-    │
-107 │         return true
-    │                ^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:110:16
-    │
-110 │         return self.balances[account]
-    │                ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:110:30
-    │
-110 │         return self.balances[account]
-    │                              ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:110:16
-    │
-110 │         return self.balances[account]
-    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:113:17
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                 ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:113:32
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                                ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:113:47
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:113:16
-    │
-113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, u256, u256): Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:117:16
-    │
-117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:117:30
-    │
-117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                              ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:117:16
-    │
-117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:117:44
-    │
-117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                                            ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:118:9
-    │
-118 │         self.token0 = token0
-    │         ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:118:23
-    │
-118 │         self.token0 = token0
-    │                       ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:119:9
-    │
-119 │         self.token1 = token1
-    │         ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:119:23
-    │
-119 │         self.token1 = token1
-    │                       ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:124:37
-    │
-124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                     ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:124:55
-    │
-124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                                       ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:124:58
-    │
-124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                                          ^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:124:55
-    │
-124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                                       ^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:124:37
-    │
-124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                     ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:126:34
-    │
-126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                  ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:126:52
-    │
-126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:126:34
-    │
-126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:12
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:27
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                           ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:12
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:33
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                 ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:45
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                             ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:33
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                 ^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:12
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:51
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                   ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:63
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                               ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:51
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                   ^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:127:12
-    │
-127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:13
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(10) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:43
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(10) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:129:74
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:85
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                                     ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:73
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:97
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                                                 ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:73
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:43
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:13
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(11) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:43
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(11) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:130:74
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:85
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                                     ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:73
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:97
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                                                 ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:73
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:130:43
-    │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:132:9
-    │
-132 │         self.reserve0 = balance0
-    │         ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:132:25
-    │
-132 │         self.reserve0 = balance0
-    │                         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:133:9
-    │
-133 │         self.reserve1 = balance1
-    │         ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:133:25
-    │
-133 │         self.reserve1 = balance1
-    │                         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:134:9
-    │
-134 │         self.block_timestamp_last = block_timestamp
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:134:37
-    │
-134 │         self.block_timestamp_last = block_timestamp
-    │                                     ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:135:28
-    │
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │                            ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:135:52
-    │
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │                                                    ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    ┌─ demos/uniswap.fe:139:21
+    │
+139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                     ^^^^^^^ address
+140 │         let fee_on: bool = fee_to != address(0)
+    │                     ^^^^ bool
+141 │         let k_last: u256 = self.k_last # gas savings
+    │                     ^^^^ u256
+    ·
+144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+    │                             ^^^^ u256
+145 │                 let root_k_last: u256 = sqrt(k_last)
+    │                                  ^^^^ u256
+146 │                 if root_k > root_k_last:
+147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                    ^^^^ u256
+148 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                      ^^^^ u256
+149 │                     let liquidity: u256 = numerator / denominator
+    │                                    ^^^^ u256
 
 note: 
     ┌─ demos/uniswap.fe:139:48
@@ -2282,18 +1560,10 @@ note:
     │
 139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:140:28
-    │
 140 │         let fee_on: bool = fee_to != address(0)
-    │                            ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:140:46
-    │
-140 │         let fee_on: bool = fee_to != address(0)
-    │                                              ^ u256: Value => None
+    │                            ^^^^^^            ^ u256: Value => None
+    │                            │                  
+    │                            address: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:140:38
@@ -2306,48 +1576,24 @@ note:
     │
 140 │         let fee_on: bool = fee_to != address(0)
     │                            ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:141:28
-    │
 141 │         let k_last: u256 = self.k_last # gas savings
     │                            ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:142:12
-    │
 142 │         if fee_on:
     │            ^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:143:16
-    │
 143 │             if k_last != 0:
-    │                ^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:143:26
-    │
-143 │             if k_last != 0:
-    │                          ^ u256: Value => None
+    │                ^^^^^^    ^ u256: Value => None
+    │                │          
+    │                u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:143:16
     │
 143 │             if k_last != 0:
     │                ^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:144:41
-    │
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:144:52
-    │
-144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                                    ^^^^^^^^ u256: Value => None
+    │                                         ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                                         │           
+    │                                         u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:144:41
@@ -2360,10 +1606,6 @@ note:
     │
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
     │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:145:46
-    │
 145 │                 let root_k_last: u256 = sqrt(k_last)
     │                                              ^^^^^^ u256: Value => None
 
@@ -2372,3462 +1614,99 @@ note:
     │
 145 │                 let root_k_last: u256 = sqrt(k_last)
     │                                         ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:146:20
-    │
 146 │                 if root_k > root_k_last:
-    │                    ^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:146:29
-    │
-146 │                 if root_k > root_k_last:
-    │                             ^^^^^^^^^^^ u256: Value => None
+    │                    ^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                    │         
+    │                    u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:146:20
     │
 146 │                 if root_k > root_k_last:
     │                    ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                           ^^^^^^^^^^^^^^^^^   ^^^^^^ u256: Value => None
+    │                                           │                    
+    │                                           u256: Storage { nonce: Some(2) } => Some(Value)
 
 note: 
     ┌─ demos/uniswap.fe:147:43
     │
 147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                           ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:147:63
-    │
-147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                                               ^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:147:43
-    │
-147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:147:72
-    │
-147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                                                        ^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                           │                             
+    │                                           u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:147:43
     │
 147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+148 │                     let denominator: u256 = root_k * 5 + root_k_last
+    │                                             ^^^^^^   ^ u256: Value => None
+    │                                             │         
+    │                                             u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:148:45
     │
 148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                             ^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:148:54
-    │
-148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                                      ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:148:45
-    │
-148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                             ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:148:58
-    │
-148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                                          ^^^^^^^^^^^ u256: Value => None
+    │                                             ^^^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                             │             
+    │                                             u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:148:45
     │
 148 │                     let denominator: u256 = root_k * 5 + root_k_last
     │                                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:149:43
-    │
 149 │                     let liquidity: u256 = numerator / denominator
-    │                                           ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:149:55
-    │
-149 │                     let liquidity: u256 = numerator / denominator
-    │                                                       ^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                           │            
+    │                                           u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:149:43
     │
 149 │                     let liquidity: u256 = numerator / denominator
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:150:24
-    │
 150 │                     if liquidity > 0:
-    │                        ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:150:36
-    │
-150 │                     if liquidity > 0:
-    │                                    ^ u256: Value => None
+    │                        ^^^^^^^^^   ^ u256: Value => None
+    │                        │            
+    │                        u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:150:24
     │
 150 │                     if liquidity > 0:
     │                        ^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:151:36
-    │
 151 │                         self._mint(fee_to, liquidity)
-    │                                    ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:151:44
-    │
-151 │                         self._mint(fee_to, liquidity)
-    │                                            ^^^^^^^^^ u256: Value => None
+    │                                    ^^^^^^  ^^^^^^^^^ u256: Value => None
+    │                                    │        
+    │                                    address: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:151:25
     │
 151 │                         self._mint(fee_to, liquidity)
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:152:14
-    │
 152 │         elif k_last != 0:
-    │              ^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:152:24
-    │
-152 │         elif k_last != 0:
-    │                        ^ u256: Value => None
+    │              ^^^^^^    ^ u256: Value => None
+    │              │          
+    │              u256: Value => None
 
 note: 
     ┌─ demos/uniswap.fe:152:14
     │
 152 │         elif k_last != 0:
     │              ^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:153:13
-    │
 153 │             self.k_last = 0
-    │             ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:153:27
-    │
-153 │             self.k_last = 0
-    │                           ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:155:16
-    │
+    │             ^^^^^^^^^^^   ^ u256: Value => None
+    │             │              
+    │             u256: Storage { nonce: Some(12) } => None
+154 │ 
 155 │         return fee_on
     │                ^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:159:39
-    │
-159 │         let MINIMUM_LIQUIDITY: u256 = 1000
-    │                                       ^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:160:30
-    │
-160 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:161:30
-    │
-161 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:162:36
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:162:30
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:162:59
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                                           ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:162:30
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:163:36
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:163:30
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:163:59
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                                           ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:163:30
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:164:29
-    │
-164 │         let amount0: u256 = balance0 - self.reserve0
-    │                             ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:164:40
-    │
-164 │         let amount0: u256 = balance0 - self.reserve0
-    │                                        ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:164:29
-    │
-164 │         let amount0: u256 = balance0 - self.reserve0
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:165:29
-    │
-165 │         let amount1: u256 = balance1 - self.reserve1
-    │                             ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:165:40
-    │
-165 │         let amount1: u256 = balance1 - self.reserve1
-    │                                        ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:165:29
-    │
-165 │         let amount1: u256 = balance1 - self.reserve1
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:167:43
-    │
-167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                           ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:167:53
-    │
-167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                                     ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:167:28
-    │
-167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:168:34
-    │
-168 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:169:31
-    │
-169 │         let liquidity: u256 = 0
-    │                               ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:170:12
-    │
-170 │         if total_supply == 0:
-    │            ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:170:28
-    │
-170 │         if total_supply == 0:
-    │                            ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:170:12
-    │
-170 │         if total_supply == 0:
-    │            ^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:13
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │             ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:30
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                              ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:40
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                        ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:30
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                              ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:25
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:51
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                                                   ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:171:25
-    │
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:172:32
-    │
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                                ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:172:24
-    │
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                        ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:172:36
-    │
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                                    ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:172:13
-    │
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:13
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │             ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:30
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                              ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:40
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                        ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:29
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:56
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                        ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:29
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:67
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                   ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:77
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                             ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:66
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:93
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                                             ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:66
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:174:25
-    │
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:176:16
-    │
-176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:176:28
-    │
-176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                            ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:176:16
-    │
-176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                ^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:176:31
-    │
-176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:178:20
-    │
-178 │         self._mint(to, liquidity)
-    │                    ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:178:24
-    │
-178 │         self._mint(to, liquidity)
-    │                        ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:178:9
-    │
-178 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:179:22
-    │
-179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:179:32
-    │
-179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:179:42
-    │
-179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:179:52
-    │
-179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                                    ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:179:9
-    │
-179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:181:12
-    │
-181 │         if fee_on:
-    │            ^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:182:13
-    │
-182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │             ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:182:27
-    │
-182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:182:38
-    │
-182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                                      ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:182:27
-    │
-182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:184:26
-    │
-184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │                          ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:184:38
-    │
-184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │                                      ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:184:47
-    │
-184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │                                               ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:185:16
-    │
-185 │         return liquidity
-    │                ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:189:30
-    │
-189 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:190:30
-    │
-190 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:191:35
-    │
-191 │         let token0: ERC20 = ERC20(self.token0)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:191:29
-    │
-191 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:192:35
-    │
-192 │         let token1: ERC20 = ERC20(self.token1)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:192:29
-    │
-192 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:193:30
-    │
-193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:193:47
-    │
-193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                                               ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:193:30
-    │
-193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:194:30
-    │
-194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:194:47
-    │
-194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                                               ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:194:30
-    │
-194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:195:31
-    │
-195 │         let liquidity: u256 = self.balances[self.address]
-    │                               ^^^^^^^^^^^^^ Map<address, u256>: Storage { nonce: Some(0) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:195:45
-    │
-195 │         let liquidity: u256 = self.balances[self.address]
-    │                                             ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:195:31
-    │
-195 │         let liquidity: u256 = self.balances[self.address]
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:197:43
-    │
-197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                           ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:197:53
-    │
-197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                                     ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:197:28
-    │
-197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:198:34
-    │
-198 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:199:30
-    │
-199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                              ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:199:42
-    │
-199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:199:29
-    │
-199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:199:54
-    │
-199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                                                      ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:199:29
-    │
-199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:200:30
-    │
-200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                              ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:200:42
-    │
-200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:200:29
-    │
-200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:200:54
-    │
-200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                                                      ^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:200:29
-    │
-200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:16
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:26
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                          ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:16
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:32
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:42
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                          ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:32
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                ^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:16
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:201:45
-    │
-201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:202:20
-    │
-202 │         self._burn(self.address, liquidity)
-    │                    ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:202:34
-    │
-202 │         self._burn(self.address, liquidity)
-    │                                  ^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:202:9
-    │
-202 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:203:9
-    │
-203 │         token0.transfer(to, amount0)
-    │         ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:203:25
-    │
-203 │         token0.transfer(to, amount0)
-    │                         ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:203:29
-    │
-203 │         token0.transfer(to, amount0)
-    │                             ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:203:9
-    │
-203 │         token0.transfer(to, amount0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:204:9
-    │
-204 │         token1.transfer(to, amount1)
-    │         ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:204:25
-    │
-204 │         token1.transfer(to, amount1)
-    │                         ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:204:29
-    │
-204 │         token1.transfer(to, amount1)
-    │                             ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:204:9
-    │
-204 │         token1.transfer(to, amount1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:205:9
-    │
-205 │         balance0 = token0.balanceOf(self.address)
-    │         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:205:20
-    │
-205 │         balance0 = token0.balanceOf(self.address)
-    │                    ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:205:37
-    │
-205 │         balance0 = token0.balanceOf(self.address)
-    │                                     ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:205:20
-    │
-205 │         balance0 = token0.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:206:9
-    │
-206 │         balance1 = token1.balanceOf(self.address)
-    │         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:206:20
-    │
-206 │         balance1 = token1.balanceOf(self.address)
-    │                    ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:206:37
-    │
-206 │         balance1 = token1.balanceOf(self.address)
-    │                                     ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:206:20
-    │
-206 │         balance1 = token1.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:208:22
-    │
-208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:208:32
-    │
-208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:208:42
-    │
-208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:208:52
-    │
-208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                                    ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:208:9
-    │
-208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:210:12
-    │
-210 │         if fee_on:
-    │            ^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:211:13
-    │
-211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │             ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:211:27
-    │
-211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:211:38
-    │
-211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                                      ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:211:27
-    │
-211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:213:26
-    │
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │                          ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:213:38
-    │
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │                                      ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:213:47
-    │
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │                                               ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:213:56
-    │
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │                                                        ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:214:17
-    │
-214 │         return (amount0, amount1)
-    │                 ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:214:26
-    │
-214 │         return (amount0, amount1)
-    │                          ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:214:16
-    │
-214 │         return (amount0, amount1)
-    │                ^^^^^^^^^^^^^^^^^^ (u256, u256): Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:16
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:30
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                              ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:16
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:35
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                   ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:49
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                                 ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:35
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                   ^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:16
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:220:52
-    │
-220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<37>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:221:30
-    │
-221 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:222:30
-    │
-222 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:223:16
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:30
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                              ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:16
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:43
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                           ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:57
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                                         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:43
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:16
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:223:67
-    │
-223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<33>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:225:35
-    │
-225 │         let token0: ERC20 = ERC20(self.token0)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:225:29
-    │
-225 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:226:35
-    │
-226 │         let token1: ERC20 = ERC20(self.token1)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:226:29
-    │
-226 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:16
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:30
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                              ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:22
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                      ^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:16
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:42
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                          ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:56
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                        ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:48
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                ^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:42
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                          ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:16
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:229:65
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                                 ^^^^^^^^^^^^^^^^^^^^^^^ String<21>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:231:12
-    │
-231 │         if amount0_out > 0:
-    │            ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:231:26
-    │
-231 │         if amount0_out > 0:
-    │                          ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:231:12
-    │
-231 │         if amount0_out > 0:
-    │            ^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:232:13
-    │
-232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │             ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:232:29
-    │
-232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │                             ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:232:33
-    │
-232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │                                 ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:232:13
-    │
-232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:233:12
-    │
-233 │         if amount1_out > 0:
-    │            ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:233:26
-    │
-233 │         if amount1_out > 0:
-    │                          ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:233:12
-    │
-233 │         if amount1_out > 0:
-    │            ^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:234:13
-    │
-234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │             ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:234:29
-    │
-234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │                             ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:234:33
-    │
-234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │                                 ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:234:13
-    │
-234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:239:30
-    │
-239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:239:47
-    │
-239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                                               ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:239:30
-    │
-239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:240:30
-    │
-240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:240:47
-    │
-240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                                               ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:240:30
-    │
-240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:71
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                       ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:82
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                  ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:93
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                             ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:82
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:71
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:32
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:44
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                            ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:55
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                       ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:43
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:32
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:110
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                                              ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:242:32
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:71
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                       ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:82
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                  ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:93
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                             ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:82
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:71
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:32
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:44
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                            ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:55
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                       ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:43
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:32
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:110
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                                              ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:243:32
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:16
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:29
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                             ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:16
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:34
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                  ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:47
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                               ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:34
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                  ^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:16
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:245:50
-    │
-245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<36>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:39
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                       ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:50
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                  ^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:39
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                       ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:57
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                         ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:70
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                                      ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:57
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                         ^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:247:39
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:39
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                       ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:50
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                  ^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:39
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                       ^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:57
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                         ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:70
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                                      ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:57
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                         ^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:248:39
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:16
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:36
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                    ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:16
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:57
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:68
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                                    ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:57
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:79
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                                               ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:57
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:16
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:250:88
-    │
-250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                                                        ^^^^^^^^^^^^^^ String<12>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:252:22
-    │
-252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:252:32
-    │
-252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:252:42
-    │
-252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                          ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:252:52
-    │
-252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                                                    ^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:252:9
-    │
-252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:253:26
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                          ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:253:38
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                      ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:253:50
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                  ^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:253:62
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                              ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:253:75
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                                           ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:253:88
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                                                                                        ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:257:35
-    │
-257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:257:29
-    │
-257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:258:35
-    │
-258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:258:29
-    │
-258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:9
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │         ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:25
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                         ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:29
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:46
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                                              ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:29
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:62
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                                                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:260:29
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:260:9
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:9
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │         ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:25
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                         ^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:29
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:46
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                                              ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:29
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:62
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                                                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:261:29
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:261:9
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:265:35
-    │
-265 │         let token0: ERC20 = ERC20(self.token0)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:265:29
-    │
-265 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:266:35
-    │
-266 │         let token1: ERC20 = ERC20(self.token1)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:266:29
-    │
-266 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:22
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:39
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                       ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:22
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:54
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                      ^^^^^^ ERC20: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:71
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                                       ^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:54
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:267:86
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                                                      ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:267:101
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                                                                     ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:267:9
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:271:13
-    │
-271 │         if (val > 3):
-    │             ^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:271:19
-    │
-271 │         if (val > 3):
-    │                   ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:271:12
-    │
-271 │         if (val > 3):
-    │            ^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:272:13
-    │
-272 │             z = val
-    │             ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:272:17
-    │
-272 │             z = val
-    │                 ^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:273:27
-    │
-273 │             let x: u256 = val / 2 + 1
-    │                           ^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:273:33
-    │
-273 │             let x: u256 = val / 2 + 1
-    │                                 ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:273:27
-    │
-273 │             let x: u256 = val / 2 + 1
-    │                           ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:273:37
-    │
-273 │             let x: u256 = val / 2 + 1
-    │                                     ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:273:27
-    │
-273 │             let x: u256 = val / 2 + 1
-    │                           ^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:274:20
-    │
-274 │             while (x < z):
-    │                    ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:274:24
-    │
-274 │             while (x < z):
-    │                        ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:274:19
-    │
-274 │             while (x < z):
-    │                   ^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:275:17
-    │
-275 │                 z = x
-    │                 ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:275:21
-    │
-275 │                 z = x
-    │                     ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:17
-    │
-276 │                 x = (val / x + x) / 2
-    │                 ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:22
-    │
-276 │                 x = (val / x + x) / 2
-    │                      ^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:28
-    │
-276 │                 x = (val / x + x) / 2
-    │                            ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:22
-    │
-276 │                 x = (val / x + x) / 2
-    │                      ^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:32
-    │
-276 │                 x = (val / x + x) / 2
-    │                                ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:21
-    │
-276 │                 x = (val / x + x) / 2
-    │                     ^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:37
-    │
-276 │                 x = (val / x + x) / 2
-    │                                     ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:276:21
-    │
-276 │                 x = (val / x + x) / 2
-    │                     ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:277:15
-    │
-277 │         elif (val != 0):
-    │               ^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:277:22
-    │
-277 │         elif (val != 0):
-    │                      ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:277:14
-    │
-277 │         elif (val != 0):
-    │              ^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:278:13
-    │
-278 │             z = 1
-    │             ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:278:17
-    │
-278 │             z = 1
-    │                 ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:279:16
-    │
-279 │         return z
-    │                ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:282:21
-    │
-282 │         return x if x < y else y
-    │                     ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:282:25
-    │
-282 │         return x if x < y else y
-    │                         ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:282:21
-    │
-282 │         return x if x < y else y
-    │                     ^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:282:16
-    │
-282 │         return x if x < y else y
-    │                ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:282:32
-    │
-282 │         return x if x < y else y
-    │                                ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:282:16
-    │
-282 │         return x if x < y else y
-    │                ^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:300:8
-    │
-300 │        self.fee_to_setter = fee_to_setter
-    │        ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:300:29
-    │
-300 │        self.fee_to_setter = fee_to_setter
-    │                             ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:303:16
-    │
-303 │         return self.fee_to
-    │                ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:306:16
-    │
-306 │         return self.fee_to_setter
-    │                ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:309:16
-    │
-309 │         return self.pair_counter
-    │                ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:312:16
-    │
-312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:312:27
-    │
-312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                           ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:312:16
-    │
-312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                ^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:312:36
-    │
-312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<30>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:314:42
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                                          ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:314:52
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                                                    ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:314:42
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                                          ^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:314:31
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                               ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:314:65
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                                                                 ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:314:31
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:315:42
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                                          ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:315:52
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                                                    ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:315:42
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                                          ^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:315:31
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                               ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:315:65
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                                                                 ^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:315:31
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:316:16
-    │
-316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:316:34
-    │
-316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                                  ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:316:26
-    │
-316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                          ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:316:16
-    │
-316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:316:38
-    │
-316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                                      ^^^^^^^^^^^^^^^^^^^^^^^^^ String<23>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:16
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^ Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:27
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                           ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:16
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^ Map<address, address>: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:35
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                   ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:16
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:317:54
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                                      ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:46
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                              ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:16
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:317:58
-    │
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                                          ^^^^^^^^^^^^^^^^^^^^^^^^ String<22>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:319:37
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                     ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:319:45
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                             ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:319:36
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                    ^^^^^^^^^^^^^^^^ (address, address): Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:319:36
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 64>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:319:26
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:320:57
-    │
-320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                         ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:320:60
-    │
-320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                            ^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:320:35
-    │
-320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:321:9
-    │
-321 │         pair.initialize(token0, token1)
-    │         ^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:321:25
-    │
-321 │         pair.initialize(token0, token1)
-    │                         ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:321:33
-    │
-321 │         pair.initialize(token0, token1)
-    │                                 ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:321:9
-    │
-321 │         pair.initialize(token0, token1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:9
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^^^^^^^ Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:20
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │                    ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:9
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^ Map<address, address>: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:28
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │                            ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:9
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:46
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │                                              ^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:323:38
-    │
-323 │         self.pairs[token0][token1] = address(pair)
-    │                                      ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:9
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │         ^^^^^^^^^^ Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:20
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │                    ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:9
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^ Map<address, address>: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:28
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │                            ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:9
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:46
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │                                              ^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:324:38
-    │
-324 │         self.pairs[token1][token0] = address(pair)
-    │                                      ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:325:9
-    │
-325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │         ^^^^^^^^^^^^^^ Array<address, 100>: Storage { nonce: Some(3) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:325:24
-    │
-325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                        ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:325:9
-    │
-325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => None
-
-note: 
-    ┌─ demos/uniswap.fe:325:53
-    │
-325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                                     ^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:325:45
-    │
-325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                             ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:326:9
-    │
-326 │         self.pair_counter = self.pair_counter + 1
-    │         ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:326:29
-    │
-326 │         self.pair_counter = self.pair_counter + 1
-    │                             ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:326:49
-    │
-326 │         self.pair_counter = self.pair_counter + 1
-    │                                                 ^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:326:29
-    │
-326 │         self.pair_counter = self.pair_counter + 1
-    │                             ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:328:26
-    │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                          ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:328:34
-    │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                  ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:328:55
-    │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                                       ^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:328:47
-    │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                               ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:328:68
-    │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                                                    ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:329:24
-    │
-329 │         return address(pair)
-    │                        ^^^^ UniswapV2Pair: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:329:16
-    │
-329 │         return address(pair)
-    │                ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:332:16
-    │
-332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:332:30
-    │
-332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                              ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Some(Value)
-
-note: 
-    ┌─ demos/uniswap.fe:332:16
-    │
-332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:332:50
-    │
-332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                                                  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:333:9
-    │
-333 │         self.fee_to = fee_to
-    │         ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:333:23
-    │
-333 │         self.fee_to = fee_to
-    │                       ^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:336:16
-    │
-336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:336:30
-    │
-336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                              ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:336:16
-    │
-336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:336:45
-    │
-336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
-
-note: 
-    ┌─ demos/uniswap.fe:337:9
-    │
-337 │         self.fee_to_setter = fee_to_setter
-    │         ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => None
-
-note: 
-    ┌─ demos/uniswap.fe:337:30
-    │
-337 │         self.fee_to_setter = fee_to_setter
-    │                              ^^^^^^^^^^^^^ address: Value => None
-
-note: 
-   ┌─ demos/uniswap.fe:78:9
-   │
-78 │         emit Transfer(from=address(0), to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:83:9
-   │
-83 │         emit Transfer(from, to=address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:87:9
-   │
-87 │         emit Approval(owner, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8893313742751514912
-   │
-   = Event {
-         name: "Approval",
-         fields: [
-             EventField {
-                 name: "owner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:92:9
-   │
-92 │         emit Transfer(from, to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
-    ┌─ demos/uniswap.fe:135:9
-    │
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11491202868117077488
-    │
-    = Event {
-          name: "Sync",
-          fields: [
-              EventField {
-                  name: "reserve0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "reserve1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:184:9
-    │
-184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4243961805717991435
-    │
-    = Event {
-          name: "Mint",
-          fields: [
-              EventField {
-                  name: "sender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "amount0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:213:9
-    │
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10738919684795162003
-    │
-    = Event {
-          name: "Burn",
-          fields: [
-              EventField {
-                  name: "sender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "amount0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-          ],
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:253:9
-    │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16055667627771619025
-    │
-    = Event {
-          name: "Swap",
-          fields: [
-              EventField {
-                  name: "sender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "amount0_in",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1_in",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount0_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-          ],
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:328:9
-    │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13094055123344570742
-    │
-    = Event {
-          name: "PairCreated",
-          fields: [
-              EventField {
-                  name: "token0",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "token1",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "pair",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "index",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:124:30
-    │
-124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                              ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:126:27
-    │
-126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                           ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:139:21
-    │
-139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                     ^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:140:21
-    │
-140 │         let fee_on: bool = fee_to != address(0)
-    │                     ^^^^ bool
-
-note: 
-    ┌─ demos/uniswap.fe:141:21
-    │
-141 │         let k_last: u256 = self.k_last # gas savings
-    │                     ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:144:29
-    │
-144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                             ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:145:34
-    │
-145 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                  ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:147:36
-    │
-147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                    ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:148:38
-    │
-148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                      ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:149:36
-    │
-149 │                     let liquidity: u256 = numerator / denominator
-    │                                    ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:159:32
-    │
-159 │         let MINIMUM_LIQUIDITY: u256 = 1000
-    │                                ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:160:23
-    │
-160 │         let reserve0: u256 = self.reserve0
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:161:23
-    │
-161 │         let reserve1: u256 = self.reserve1
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:162:23
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:163:23
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:164:22
-    │
-164 │         let amount0: u256 = balance0 - self.reserve0
-    │                      ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:165:22
-    │
-165 │         let amount1: u256 = balance1 - self.reserve1
-    │                      ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:167:21
-    │
-167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                     ^^^^ bool
-
-note: 
-    ┌─ demos/uniswap.fe:168:27
-    │
-168 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │                           ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:169:24
-    │
-169 │         let liquidity: u256 = 0
-    │                        ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:189:23
-    │
-189 │         let reserve0: u256 = self.reserve0
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:190:23
-    │
-190 │         let reserve1: u256 = self.reserve1
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:191:21
-    │
-191 │         let token0: ERC20 = ERC20(self.token0)
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:192:21
-    │
-192 │         let token1: ERC20 = ERC20(self.token1)
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:193:23
-    │
-193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:194:23
-    │
-194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:195:24
-    │
-195 │         let liquidity: u256 = self.balances[self.address]
-    │                        ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:197:21
-    │
-197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                     ^^^^ bool
-
-note: 
-    ┌─ demos/uniswap.fe:198:27
-    │
-198 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │                           ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:199:22
-    │
-199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                      ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:200:22
-    │
-200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                      ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:221:23
-    │
-221 │         let reserve0: u256 = self.reserve0
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:222:23
-    │
-222 │         let reserve1: u256 = self.reserve1
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:225:21
-    │
-225 │         let token0: ERC20 = ERC20(self.token0)
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:226:21
-    │
-226 │         let token1: ERC20 = ERC20(self.token1)
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:239:23
-    │
-239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:240:23
-    │
-240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                       ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:242:25
-    │
-242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                         ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:243:25
-    │
-243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                         ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:247:32
-    │
-247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:248:32
-    │
-248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:257:21
-    │
-257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:258:21
-    │
-258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:265:21
-    │
-265 │         let token0: ERC20 = ERC20(self.token0)
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:266:21
-    │
-266 │         let token1: ERC20 = ERC20(self.token1)
-    │                     ^^^^^ ERC20
-
-note: 
-    ┌─ demos/uniswap.fe:270:16
-    │
-270 │         let z: u256
-    │                ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:273:20
-    │
-273 │             let x: u256 = val / 2 + 1
-    │                    ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:314:21
-    │
-314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                     ^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:315:21
-    │
-315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                     ^^^^^^^ address
-
-note: 
-    ┌─ demos/uniswap.fe:319:19
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                   ^^^^ u256
-
-note: 
-    ┌─ demos/uniswap.fe:320:19
-    │
-320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                   ^^^^^^^^^^^^^ UniswapV2Pair
-
-note: 
-   ┌─ demos/uniswap.fe:78:28
-   │
-78 │         emit Transfer(from=address(0), to, value)
-   │                            ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:83:32
-   │
-83 │         emit Transfer(from, to=address(0), value)
-   │                                ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:95:9
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 14531113974490967627
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 2409..2413,
-     }
-
-note: 
-   ┌─ demos/uniswap.fe:99:9
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 7946469693452924957
-   │
-   = SelfAttribute {
-         func_name: "_transfer",
-         self_span: 2541..2545,
-     }
-
-note: 
-    ┌─ demos/uniswap.fe:106:9
-    │
-106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^ attributes hash: 9013399514526062924
-    │
-    = SelfAttribute {
-          func_name: "_transfer",
-          self_span: 2833..2837,
-      }
 
 note: 
     ┌─ demos/uniswap.fe:139:31
@@ -5899,6 +1778,336 @@ note:
     = SelfAttribute {
           func_name: "_mint",
           self_span: 5111..5115,
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:158:5
+    │  
+158 │ ╭     pub fn mint(self, to: address) -> u256:
+159 │ │         let MINIMUM_LIQUIDITY: u256 = 1000
+160 │ │         let reserve0: u256 = self.reserve0
+161 │ │         let reserve1: u256 = self.reserve1
+    · │
+184 │ │         emit Mint(sender=msg.sender, amount0, amount1)
+185 │ │         return liquidity
+    │ ╰────────────────────────^ attributes hash: 13052412037608309076
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Numeric(
+                      U256,
+                  ),
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:159:32
+    │
+159 │         let MINIMUM_LIQUIDITY: u256 = 1000
+    │                                ^^^^ u256
+160 │         let reserve0: u256 = self.reserve0
+    │                       ^^^^ u256
+161 │         let reserve1: u256 = self.reserve1
+    │                       ^^^^ u256
+162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                       ^^^^ u256
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                       ^^^^ u256
+164 │         let amount0: u256 = balance0 - self.reserve0
+    │                      ^^^^ u256
+165 │         let amount1: u256 = balance1 - self.reserve1
+    │                      ^^^^ u256
+166 │ 
+167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                     ^^^^ bool
+168 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+    │                           ^^^^ u256
+169 │         let liquidity: u256 = 0
+    │                        ^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:159:39
+    │
+159 │         let MINIMUM_LIQUIDITY: u256 = 1000
+    │                                       ^^^^ u256: Value => None
+160 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+161 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:162:30
+    │
+162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              │                             
+    │                              ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:162:30
+    │
+162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:163:30
+    │
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              │                             
+    │                              ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:163:30
+    │
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+164 │         let amount0: u256 = balance0 - self.reserve0
+    │                             ^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                             │           
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:164:29
+    │
+164 │         let amount0: u256 = balance0 - self.reserve0
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+165 │         let amount1: u256 = balance1 - self.reserve1
+    │                             ^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                             │           
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:165:29
+    │
+165 │         let amount1: u256 = balance1 - self.reserve1
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+166 │ 
+167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                                           ^^^^^^^^  ^^^^^^^^ u256: Value => None
+    │                                           │          
+    │                                           u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:167:28
+    │
+167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+168 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+169 │         let liquidity: u256 = 0
+    │                               ^ u256: Value => None
+170 │         if total_supply == 0:
+    │            ^^^^^^^^^^^^    ^ u256: Value => None
+    │            │                
+    │            u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:170:12
+    │
+170 │         if total_supply == 0:
+    │            ^^^^^^^^^^^^^^^^^ bool: Value => None
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^ u256: Value => None
+    │             │                │          
+    │             │                u256: Value => None
+    │             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:171:30
+    │
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                              ^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:171:25
+    │
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                         │                          
+    │                         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:171:25
+    │
+171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+    │                                ^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:172:24
+    │
+172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+    │                        ^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                        │            
+    │                        address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:172:13
+    │
+172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+173 │         else:
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │             │                │          
+    │             │                u256: Value => None
+    │             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:174:29
+    │
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                             │                           
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:174:29
+    │
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                             │                                     │          
+    │                             │                                     u256: Value => None
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:174:66
+    │
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                                                                  │                           
+    │                                                                  u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:174:66
+    │
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:174:25
+    │
+174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+175 │ 
+176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
+    │                ^^^^^^^^^   ^ u256: Value => None
+    │                │            
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:176:16
+    │
+176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
+    │                ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory => None
+    │                │               
+    │                bool: Value => None
+177 │ 
+178 │         self._mint(to, liquidity)
+    │                    ^^  ^^^^^^^^^ u256: Value => None
+    │                    │    
+    │                    address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:178:9
+    │
+178 │         self._mint(to, liquidity)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+179 │         self._update(balance0, balance1, reserve0, reserve1)
+    │                      ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value => None
+    │                      │         │         │          
+    │                      │         │         u256: Value => None
+    │                      │         u256: Value => None
+    │                      u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:179:9
+    │
+179 │         self._update(balance0, balance1, reserve0, reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+180 │ 
+181 │         if fee_on:
+    │            ^^^^^^ bool: Value => None
+182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+    │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │             │             │           
+    │             │             u256: Value => None
+    │             u256: Storage { nonce: Some(12) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:182:27
+    │
+182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+183 │ 
+184 │         emit Mint(sender=msg.sender, amount0, amount1)
+    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^ u256: Value => None
+    │                          │           │         
+    │                          │           u256: Value => None
+    │                          address: Value => None
+185 │         return liquidity
+    │                ^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:184:9
+    │
+184 │         emit Mint(sender=msg.sender, amount0, amount1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4243961805717991435
+    │
+    = Event {
+          name: "Mint",
+          fields: [
+              EventField {
+                  name: "sender",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+              EventField {
+                  name: "amount0",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "amount1",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+          ],
       }
 
 note: 
@@ -6032,6 +2241,357 @@ note:
       }
 
 note: 
+    ┌─ demos/uniswap.fe:188:5
+    │  
+188 │ ╭     pub fn burn(self, to: address) -> (u256, u256):
+189 │ │         let reserve0: u256 = self.reserve0
+190 │ │         let reserve1: u256 = self.reserve1
+191 │ │         let token0: ERC20 = ERC20(self.token0)
+    · │
+213 │ │         emit Burn(sender=msg.sender, amount0, amount1, to)
+214 │ │         return (amount0, amount1)
+    │ ╰─────────────────────────────────^ attributes hash: 2656431017065792419
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Tuple(
+                  Tuple {
+                      items: [
+                          Base(
+                              Numeric(
+                                  U256,
+                              ),
+                          ),
+                          Base(
+                              Numeric(
+                                  U256,
+                              ),
+                          ),
+                      ],
+                  },
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:189:23
+    │
+189 │         let reserve0: u256 = self.reserve0
+    │                       ^^^^ u256
+190 │         let reserve1: u256 = self.reserve1
+    │                       ^^^^ u256
+191 │         let token0: ERC20 = ERC20(self.token0)
+    │                     ^^^^^ ERC20
+192 │         let token1: ERC20 = ERC20(self.token1)
+    │                     ^^^^^ ERC20
+193 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                       ^^^^ u256
+194 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                       ^^^^ u256
+195 │         let liquidity: u256 = self.balances[self.address]
+    │                        ^^^^ u256
+196 │ 
+197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                     ^^^^ bool
+198 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+    │                           ^^^^ u256
+199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                      ^^^^ u256
+200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                      ^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:189:30
+    │
+189 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+190 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+191 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:191:29
+    │
+191 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+192 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:192:29
+    │
+192 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+193 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              │                 
+    │                              ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:193:30
+    │
+193 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+194 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              │                 
+    │                              ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:194:30
+    │
+194 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+195 │         let liquidity: u256 = self.balances[self.address]
+    │                               ^^^^^^^^^^^^^ ^^^^^^^^^^^^ address: Value => None
+    │                               │              
+    │                               Map<address, u256>: Storage { nonce: Some(0) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:195:31
+    │
+195 │         let liquidity: u256 = self.balances[self.address]
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+196 │ 
+197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                                           ^^^^^^^^  ^^^^^^^^ u256: Value => None
+    │                                           │          
+    │                                           u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:197:28
+    │
+197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
+    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+198 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                              ^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                              │            
+    │                              u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:199:29
+    │
+199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                             │                         
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:199:29
+    │
+199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                              ^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                              │            
+    │                              u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:200:29
+    │
+200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                             │                         
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:200:29
+    │
+200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+    │                ^^^^^^^   ^ u256: Value => None
+    │                │          
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:201:16
+    │
+201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+    │                ^^^^^^^^^^^     ^^^^^^^   ^ u256: Value => None
+    │                │               │          
+    │                │               u256: Value => None
+    │                bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:201:32
+    │
+201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+    │                                ^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:201:16
+    │
+201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory => None
+    │                │                             
+    │                bool: Value => None
+202 │         self._burn(self.address, liquidity)
+    │                    ^^^^^^^^^^^^  ^^^^^^^^^ u256: Value => None
+    │                    │              
+    │                    address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:202:9
+    │
+202 │         self._burn(self.address, liquidity)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+203 │         token0.transfer(to, amount0)
+    │         ^^^^^^          ^^  ^^^^^^^ u256: Value => None
+    │         │               │    
+    │         │               address: Value => None
+    │         ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:203:9
+    │
+203 │         token0.transfer(to, amount0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+204 │         token1.transfer(to, amount1)
+    │         ^^^^^^          ^^  ^^^^^^^ u256: Value => None
+    │         │               │    
+    │         │               address: Value => None
+    │         ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:204:9
+    │
+204 │         token1.transfer(to, amount1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+205 │         balance0 = token0.balanceOf(self.address)
+    │         ^^^^^^^^   ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         │          │                 
+    │         │          ERC20: Value => None
+    │         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:205:20
+    │
+205 │         balance0 = token0.balanceOf(self.address)
+    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+206 │         balance1 = token1.balanceOf(self.address)
+    │         ^^^^^^^^   ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         │          │                 
+    │         │          ERC20: Value => None
+    │         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:206:20
+    │
+206 │         balance1 = token1.balanceOf(self.address)
+    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+207 │ 
+208 │         self._update(balance0, balance1, reserve0, reserve1)
+    │                      ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value => None
+    │                      │         │         │          
+    │                      │         │         u256: Value => None
+    │                      │         u256: Value => None
+    │                      u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:208:9
+    │
+208 │         self._update(balance0, balance1, reserve0, reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+209 │ 
+210 │         if fee_on:
+    │            ^^^^^^ bool: Value => None
+211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+    │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │             │             │           
+    │             │             u256: Value => None
+    │             u256: Storage { nonce: Some(12) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:211:27
+    │
+211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+212 │ 
+213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
+    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^  ^^ address: Value => None
+    │                          │           │        │         
+    │                          │           │        u256: Value => None
+    │                          │           u256: Value => None
+    │                          address: Value => None
+214 │         return (amount0, amount1)
+    │                 ^^^^^^^  ^^^^^^^ u256: Value => None
+    │                 │         
+    │                 u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:214:16
+    │
+214 │         return (amount0, amount1)
+    │                ^^^^^^^^^^^^^^^^^^ (u256, u256): Memory => None
+
+note: 
+    ┌─ demos/uniswap.fe:213:9
+    │
+213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10738919684795162003
+    │
+    = Event {
+          name: "Burn",
+          fields: [
+              EventField {
+                  name: "sender",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+              EventField {
+                  name: "amount0",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "amount1",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+          ],
+      }
+
+note: 
     ┌─ demos/uniswap.fe:191:29
     │
 191 │         let token0: ERC20 = ERC20(self.token0)
@@ -6147,6 +2707,573 @@ note:
       }
 
 note: 
+    ┌─ demos/uniswap.fe:219:5
+    │  
+219 │ ╭     pub fn swap(self, amount0_out: u256, amount1_out: u256, to: address):
+220 │ │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+221 │ │         let reserve0: u256 = self.reserve0
+222 │ │         let reserve1: u256 = self.reserve1
+    · │
+252 │ │         self._update(balance0, balance1, reserve0, reserve1)
+253 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13380171127738201451
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "amount0_out",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+              },
+              FunctionParam {
+                  name: "amount1_out",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+              },
+              FunctionParam {
+                  name: "to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Unit,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:221:23
+    │
+221 │         let reserve0: u256 = self.reserve0
+    │                       ^^^^ u256
+222 │         let reserve1: u256 = self.reserve1
+    │                       ^^^^ u256
+    ·
+225 │         let token0: ERC20 = ERC20(self.token0)
+    │                     ^^^^^ ERC20
+226 │         let token1: ERC20 = ERC20(self.token1)
+    │                     ^^^^^ ERC20
+    ·
+239 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                       ^^^^ u256
+240 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                       ^^^^ u256
+241 │ 
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                         ^^^^ u256
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                         ^^^^ u256
+    ·
+247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                ^^^^ u256
+248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                ^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:220:16
+    │
+220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+    │                ^^^^^^^^^^^   ^ u256: Value => None
+    │                │              
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:220:16
+    │
+220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+    │                ^^^^^^^^^^^^^^^    ^^^^^^^^^^^   ^ u256: Value => None
+    │                │                  │              
+    │                │                  u256: Value => None
+    │                bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:220:35
+    │
+220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+    │                                   ^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:220:16
+    │
+220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<37>: Memory => None
+    │                │                                    
+    │                bool: Value => None
+221 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+222 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+    │                ^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                │              
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:223:16
+    │
+223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+    │                ^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                │                          │              
+    │                │                          u256: Value => None
+    │                bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:223:43
+    │
+223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:223:16
+    │
+223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<33>: Memory => None
+    │                │                                                   
+    │                bool: Value => None
+224 │ 
+225 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:225:29
+    │
+225 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+226 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:226:29
+    │
+226 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    ·
+229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+    │                ^^            ^^^^^^ ERC20: Value => None
+    │                │              
+    │                address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:229:22
+    │
+229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+    │                      ^^^^^^^^^^^^^^^ address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:229:16
+    │
+229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+    │                ^^^^^^^^^^^^^^^^^^^^^     ^^            ^^^^^^ ERC20: Value => None
+    │                │                         │              
+    │                │                         address: Value => None
+    │                bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:229:48
+    │
+229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+    │                                                ^^^^^^^^^^^^^^^ address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:229:42
+    │
+229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+    │                                          ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:229:16
+    │
+229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^ String<21>: Memory => None
+    │                │                                                 
+    │                bool: Value => None
+230 │ 
+231 │         if amount0_out > 0:
+    │            ^^^^^^^^^^^   ^ u256: Value => None
+    │            │              
+    │            u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:231:12
+    │
+231 │         if amount0_out > 0:
+    │            ^^^^^^^^^^^^^^^ bool: Value => None
+232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
+    │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value => None
+    │             │               │    
+    │             │               address: Value => None
+    │             ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:232:13
+    │
+232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+233 │         if amount1_out > 0:
+    │            ^^^^^^^^^^^   ^ u256: Value => None
+    │            │              
+    │            u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:233:12
+    │
+233 │         if amount1_out > 0:
+    │            ^^^^^^^^^^^^^^^ bool: Value => None
+234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
+    │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value => None
+    │             │               │    
+    │             │               address: Value => None
+    │             ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:234:13
+    │
+234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    ·
+239 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              │                 
+    │                              ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:239:30
+    │
+239 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+240 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              │                 
+    │                              ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:240:30
+    │
+240 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+241 │ 
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                                                       │          │           
+    │                                                                       │          u256: Value => None
+    │                                                                       u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:242:82
+    │
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:242:32
+    │
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                                │                                       
+    │                                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:242:44
+    │
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                            │           
+    │                                            u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:242:43
+    │
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:242:32
+    │
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value => None
+    │                                │                                                                              
+    │                                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:242:32
+    │
+242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                                                       │          │           
+    │                                                                       │          u256: Value => None
+    │                                                                       u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:243:82
+    │
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:243:32
+    │
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                                │                                       
+    │                                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:243:44
+    │
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                            │           
+    │                                            u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:243:43
+    │
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:243:32
+    │
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value => None
+    │                                │                                                                              
+    │                                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:243:32
+    │
+243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+244 │ 
+245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+    │                ^^^^^^^^^^   ^ u256: Value => None
+    │                │             
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:245:16
+    │
+245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+    │                ^^^^^^^^^^^^^^    ^^^^^^^^^^   ^ u256: Value => None
+    │                │                 │             
+    │                │                 u256: Value => None
+    │                bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:245:34
+    │
+245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+    │                                  ^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:245:16
+    │
+245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<36>: Memory => None
+    │                │                                  
+    │                bool: Value => None
+246 │ 
+247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                       ^^^^^^^^   ^^^^ u256: Value => None
+    │                                       │           
+    │                                       u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:247:39
+    │
+247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value => None
+    │                                       │                 │             
+    │                                       │                 u256: Value => None
+    │                                       u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:247:57
+    │
+247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                                         ^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:247:39
+    │
+247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                       ^^^^^^^^   ^^^^ u256: Value => None
+    │                                       │           
+    │                                       u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:248:39
+    │
+248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value => None
+    │                                       │                 │             
+    │                                       │                 u256: Value => None
+    │                                       u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:248:57
+    │
+248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                                         ^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:248:39
+    │
+248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+249 │ 
+250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+    │                ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                │                    
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:250:16
+    │
+250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                │                                        │           
+    │                │                                        u256: Value => None
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:250:57
+    │
+250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+    │                                                         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^ u256: Value => None
+    │                                                         │                      
+    │                                                         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:250:57
+    │
+250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+    │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:250:16
+    │
+250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ String<12>: Memory => None
+    │                │                                                                        
+    │                bool: Value => None
+251 │ 
+252 │         self._update(balance0, balance1, reserve0, reserve1)
+    │                      ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value => None
+    │                      │         │         │          
+    │                      │         │         u256: Value => None
+    │                      │         u256: Value => None
+    │                      u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:252:9
+    │
+252 │         self._update(balance0, balance1, reserve0, reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+    │                          ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^  ^^ address: Value => None
+    │                          │           │           │           │            │             
+    │                          │           │           │           │            u256: Value => None
+    │                          │           │           │           u256: Value => None
+    │                          │           │           u256: Value => None
+    │                          │           u256: Value => None
+    │                          address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:253:9
+    │
+253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16055667627771619025
+    │
+    = Event {
+          name: "Swap",
+          fields: [
+              EventField {
+                  name: "sender",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+              EventField {
+                  name: "amount0_in",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "amount1_in",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "amount0_out",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "amount1_out",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+          ],
+      }
+
+note: 
     ┌─ demos/uniswap.fe:225:29
     │
 225 │         let token0: ERC20 = ERC20(self.token0)
@@ -6248,6 +3375,117 @@ note:
       }
 
 note: 
+    ┌─ demos/uniswap.fe:256:5
+    │  
+256 │ ╭     pub fn skim(self, to: address):
+257 │ │         let token0: ERC20 = ERC20(self.token0) # gas savings
+258 │ │         let token1: ERC20 = ERC20(self.token1) # gas savings
+259 │ │ 
+260 │ │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+261 │ │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 2346286316485274384
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Unit,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:257:21
+    │
+257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                     ^^^^^ ERC20
+258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                     ^^^^^ ERC20
+
+note: 
+    ┌─ demos/uniswap.fe:257:35
+    │
+257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:257:29
+    │
+257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:258:29
+    │
+258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+259 │ 
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │         ^^^^^^          ^^  ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         │               │   │                 
+    │         │               │   ERC20: Value => None
+    │         │               address: Value => None
+    │         ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:260:29
+    │
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                             │                                 
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:260:29
+    │
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:260:9
+    │
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │         ^^^^^^          ^^  ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         │               │   │                 
+    │         │               │   ERC20: Value => None
+    │         │               address: Value => None
+    │         ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:261:29
+    │
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                             │                                 
+    │                             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:261:29
+    │
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:261:9
+    │
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+
+note: 
     ┌─ demos/uniswap.fe:257:29
     │
 257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
@@ -6314,6 +3552,81 @@ note:
     = ValueAttribute
 
 note: 
+    ┌─ demos/uniswap.fe:264:5
+    │  
+264 │ ╭     pub fn sync(self):
+265 │ │         let token0: ERC20 = ERC20(self.token0)
+266 │ │         let token1: ERC20 = ERC20(self.token1)
+267 │ │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 4369441865732737140
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [],
+          return_type: Ok(
+              Base(
+                  Unit,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:265:21
+    │
+265 │         let token0: ERC20 = ERC20(self.token0)
+    │                     ^^^^^ ERC20
+266 │         let token1: ERC20 = ERC20(self.token1)
+    │                     ^^^^^ ERC20
+
+note: 
+    ┌─ demos/uniswap.fe:265:35
+    │
+265 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:265:29
+    │
+265 │         let token0: ERC20 = ERC20(self.token0)
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+266 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:266:29
+    │
+266 │         let token1: ERC20 = ERC20(self.token1)
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                      ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                      │                 
+    │                      ERC20: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:267:22
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                      │                               │                 
+    │                      │                               ERC20: Value => None
+    │                      u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:267:54
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                                                      │                               │               
+    │                                                      │                               u256: Storage { nonce: Some(7) } => Some(Value)
+    │                                                      u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:267:9
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+
+note: 
     ┌─ demos/uniswap.fe:265:29
     │
 265 │         let token0: ERC20 = ERC20(self.token0)
@@ -6373,6 +3686,662 @@ note:
     │                                                      ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
     │
     = ValueAttribute
+
+note: 
+    ┌─ demos/uniswap.fe:269:5
+    │  
+269 │ ╭     fn sqrt(val: u256) -> u256:
+270 │ │         let z: u256
+271 │ │         if (val > 3):
+272 │ │             z = val
+    · │
+278 │ │             z = 1
+279 │ │         return z
+    │ ╰────────────────^ attributes hash: 3075818098030342593
+    │  
+    = FunctionSignature {
+          self_decl: None,
+          params: [
+              FunctionParam {
+                  name: "val",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Numeric(
+                      U256,
+                  ),
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:270:16
+    │
+270 │         let z: u256
+    │                ^^^^ u256
+    ·
+273 │             let x: u256 = val / 2 + 1
+    │                    ^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:271:13
+    │
+271 │         if (val > 3):
+    │             ^^^   ^ u256: Value => None
+    │             │      
+    │             u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:271:12
+    │
+271 │         if (val > 3):
+    │            ^^^^^^^^^ bool: Value => None
+272 │             z = val
+    │             ^   ^^^ u256: Value => None
+    │             │    
+    │             u256: Value => None
+273 │             let x: u256 = val / 2 + 1
+    │                           ^^^   ^ u256: Value => None
+    │                           │      
+    │                           u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:273:27
+    │
+273 │             let x: u256 = val / 2 + 1
+    │                           ^^^^^^^   ^ u256: Value => None
+    │                           │          
+    │                           u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:273:27
+    │
+273 │             let x: u256 = val / 2 + 1
+    │                           ^^^^^^^^^^^ u256: Value => None
+274 │             while (x < z):
+    │                    ^   ^ u256: Value => None
+    │                    │    
+    │                    u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:274:19
+    │
+274 │             while (x < z):
+    │                   ^^^^^^^ bool: Value => None
+275 │                 z = x
+    │                 ^   ^ u256: Value => None
+    │                 │    
+    │                 u256: Value => None
+276 │                 x = (val / x + x) / 2
+    │                 ^    ^^^   ^ u256: Value => None
+    │                 │    │      
+    │                 │    u256: Value => None
+    │                 u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:276:22
+    │
+276 │                 x = (val / x + x) / 2
+    │                      ^^^^^^^   ^ u256: Value => None
+    │                      │          
+    │                      u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:276:21
+    │
+276 │                 x = (val / x + x) / 2
+    │                     ^^^^^^^^^^^^^   ^ u256: Value => None
+    │                     │                
+    │                     u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:276:21
+    │
+276 │                 x = (val / x + x) / 2
+    │                     ^^^^^^^^^^^^^^^^^ u256: Value => None
+277 │         elif (val != 0):
+    │               ^^^    ^ u256: Value => None
+    │               │       
+    │               u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:277:14
+    │
+277 │         elif (val != 0):
+    │              ^^^^^^^^^^ bool: Value => None
+278 │             z = 1
+    │             ^   ^ u256: Value => None
+    │             │    
+    │             u256: Value => None
+279 │         return z
+    │                ^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:281:5
+    │  
+281 │ ╭     fn min(x: u256, y: u256) -> u256:
+282 │ │         return x if x < y else y
+    │ ╰────────────────────────────────^ attributes hash: 4022593831796629401
+    │  
+    = FunctionSignature {
+          self_decl: None,
+          params: [
+              FunctionParam {
+                  name: "x",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+              },
+              FunctionParam {
+                  name: "y",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Numeric(
+                      U256,
+                  ),
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:282:21
+    │
+282 │         return x if x < y else y
+    │                     ^   ^ u256: Value => None
+    │                     │    
+    │                     u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:282:16
+    │
+282 │         return x if x < y else y
+    │                ^    ^^^^^      ^ u256: Value => None
+    │                │    │           
+    │                │    bool: Value => None
+    │                u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:282:16
+    │
+282 │         return x if x < y else y
+    │                ^^^^^^^^^^^^^^^^^ u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:285:5
+    │
+285 │     fee_to: address
+    │     ^^^^^^^^^^^^^^^ address
+286 │     fee_to_setter: address
+    │     ^^^^^^^^^^^^^^^^^^^^^^ address
+287 │ 
+288 │     pairs: Map<address, Map<address, address>>
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, address>>
+289 │ 
+290 │     all_pairs: Array<address, 100>
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 100>
+291 │     pair_counter: u256
+    │     ^^^^^^^^^^^^^^^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:294:9
+    │
+294 │         idx token0: address
+    │         ^^^^^^^^^^^^^^^^^^^ address
+295 │         idx token1: address
+    │         ^^^^^^^^^^^^^^^^^^^ address
+296 │         pair: address
+    │         ^^^^^^^^^^^^^ address
+297 │         index: u256
+    │         ^^^^^^^^^^^ u256
+
+note: 
+    ┌─ demos/uniswap.fe:302:5
+    │  
+302 │ ╭     pub fn fee_to(self) -> address:
+303 │ │         return self.fee_to
+    │ ╰──────────────────────────^ attributes hash: 17651916811868111914
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [],
+          return_type: Ok(
+              Base(
+                  Address,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:303:16
+    │
+303 │         return self.fee_to
+    │                ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:305:5
+    │  
+305 │ ╭     pub fn fee_to_setter(self) -> address:
+306 │ │         return self.fee_to_setter
+    │ ╰─────────────────────────────────^ attributes hash: 17651916811868111914
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [],
+          return_type: Ok(
+              Base(
+                  Address,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:306:16
+    │
+306 │         return self.fee_to_setter
+    │                ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:308:5
+    │  
+308 │ ╭     pub fn all_pairs_length(self) -> u256:
+309 │ │         return self.pair_counter
+    │ ╰────────────────────────────────^ attributes hash: 16482263331346774611
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [],
+          return_type: Ok(
+              Base(
+                  Numeric(
+                      U256,
+                  ),
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:309:16
+    │
+309 │         return self.pair_counter
+    │                ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:311:5
+    │  
+311 │ ╭     pub fn create_pair(self, token_a: address, token_b: address) -> address:
+312 │ │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
+313 │ │ 
+314 │ │         let token0: address = token_a if token_a < token_b else token_b
+    · │
+328 │ │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+329 │ │         return address(pair)
+    │ ╰────────────────────────────^ attributes hash: 12932031939304465073
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "token_a",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+              FunctionParam {
+                  name: "token_b",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Address,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:314:21
+    │
+314 │         let token0: address = token_a if token_a < token_b else token_b
+    │                     ^^^^^^^ address
+315 │         let token1: address = token_a if token_a > token_b else token_b
+    │                     ^^^^^^^ address
+    ·
+319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                   ^^^^ u256
+320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                   ^^^^^^^^^^^^^ UniswapV2Pair
+
+note: 
+    ┌─ demos/uniswap.fe:312:16
+    │
+312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
+    │                ^^^^^^^    ^^^^^^^ address: Value => None
+    │                │           
+    │                address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:312:16
+    │
+312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
+    │                ^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<30>: Memory => None
+    │                │                    
+    │                bool: Value => None
+313 │ 
+314 │         let token0: address = token_a if token_a < token_b else token_b
+    │                                          ^^^^^^^   ^^^^^^^ address: Value => None
+    │                                          │          
+    │                                          address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:314:31
+    │
+314 │         let token0: address = token_a if token_a < token_b else token_b
+    │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value => None
+    │                               │          │                       
+    │                               │          bool: Value => None
+    │                               address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:314:31
+    │
+314 │         let token0: address = token_a if token_a < token_b else token_b
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
+315 │         let token1: address = token_a if token_a > token_b else token_b
+    │                                          ^^^^^^^   ^^^^^^^ address: Value => None
+    │                                          │          
+    │                                          address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:315:31
+    │
+315 │         let token1: address = token_a if token_a > token_b else token_b
+    │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value => None
+    │                               │          │                       
+    │                               │          bool: Value => None
+    │                               address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:315:31
+    │
+315 │         let token1: address = token_a if token_a > token_b else token_b
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
+316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
+    │                ^^^^^^            ^ u256: Value => None
+    │                │                  
+    │                address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:316:26
+    │
+316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
+    │                          ^^^^^^^^^^ address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:316:16
+    │
+316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
+    │                ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ String<23>: Memory => None
+    │                │                      
+    │                bool: Value => None
+317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+    │                ^^^^^^^^^^ ^^^^^^ address: Value => None
+    │                │           
+    │                Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:317:16
+    │
+317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+    │                ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+    │                │                   
+    │                Map<address, address>: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:317:16
+    │
+317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^            ^ u256: Value => None
+    │                │                                      
+    │                address: Storage { nonce: None } => Some(Value)
+
+note: 
+    ┌─ demos/uniswap.fe:317:46
+    │
+317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+    │                                              ^^^^^^^^^^ address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:317:16
+    │
+317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^ String<22>: Memory => None
+    │                │                                          
+    │                bool: Value => None
+318 │ 
+319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                     ^^^^^^  ^^^^^^ address: Value => None
+    │                                     │        
+    │                                     address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:319:36
+    │
+319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                    ^^^^^^^^^^^^^^^^ (address, address): Memory => None
+
+note: 
+    ┌─ demos/uniswap.fe:319:36
+    │
+319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 64>: Memory => None
+
+note: 
+    ┌─ demos/uniswap.fe:319:26
+    │
+319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                                                         ^  ^^^^ u256: Value => None
+    │                                                         │   
+    │                                                         u256: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:320:35
+    │
+320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
+    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Pair: Value => None
+321 │         pair.initialize(token0, token1)
+    │         ^^^^            ^^^^^^  ^^^^^^ address: Value => None
+    │         │               │        
+    │         │               address: Value => None
+    │         UniswapV2Pair: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:321:9
+    │
+321 │         pair.initialize(token0, token1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+322 │ 
+323 │         self.pairs[token0][token1] = address(pair)
+    │         ^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         │           
+    │         Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:323:9
+    │
+323 │         self.pairs[token0][token1] = address(pair)
+    │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         │                   
+    │         Map<address, address>: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:323:9
+    │
+323 │         self.pairs[token0][token1] = address(pair)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value => None
+    │         │                                     
+    │         address: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:323:38
+    │
+323 │         self.pairs[token0][token1] = address(pair)
+    │                                      ^^^^^^^^^^^^^ address: Value => None
+324 │         self.pairs[token1][token0] = address(pair)
+    │         ^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         │           
+    │         Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:324:9
+    │
+324 │         self.pairs[token1][token0] = address(pair)
+    │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         │                   
+    │         Map<address, address>: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:324:9
+    │
+324 │         self.pairs[token1][token0] = address(pair)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value => None
+    │         │                                     
+    │         address: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:324:38
+    │
+324 │         self.pairs[token1][token0] = address(pair)
+    │                                      ^^^^^^^^^^^^^ address: Value => None
+325 │         self.all_pairs[self.pair_counter] = address(pair)
+    │         ^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
+    │         │               
+    │         Array<address, 100>: Storage { nonce: Some(3) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:325:9
+    │
+325 │         self.all_pairs[self.pair_counter] = address(pair)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value => None
+    │         │                                            
+    │         address: Storage { nonce: None } => None
+
+note: 
+    ┌─ demos/uniswap.fe:325:45
+    │
+325 │         self.all_pairs[self.pair_counter] = address(pair)
+    │                                             ^^^^^^^^^^^^^ address: Value => None
+326 │         self.pair_counter = self.pair_counter + 1
+    │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^   ^ u256: Value => None
+    │         │                   │                    
+    │         │                   u256: Storage { nonce: Some(4) } => Some(Value)
+    │         u256: Storage { nonce: Some(4) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:326:29
+    │
+326 │         self.pair_counter = self.pair_counter + 1
+    │                             ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+327 │ 
+328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+    │                          ^^^^^^  ^^^^^^               ^^^^ UniswapV2Pair: Value => None
+    │                          │       │                     
+    │                          │       address: Value => None
+    │                          address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:328:47
+    │
+328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+    │                                               ^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
+    │                                               │                     
+    │                                               address: Value => None
+329 │         return address(pair)
+    │                        ^^^^ UniswapV2Pair: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:329:16
+    │
+329 │         return address(pair)
+    │                ^^^^^^^^^^^^^ address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:328:9
+    │
+328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13094055123344570742
+    │
+    = Event {
+          name: "PairCreated",
+          fields: [
+              EventField {
+                  name: "token0",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+              EventField {
+                  name: "token1",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: true,
+              },
+              EventField {
+                  name: "pair",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+              EventField {
+                  name: "index",
+                  typ: Ok(
+                      Base(
+                          Numeric(
+                              U256,
+                          ),
+                      ),
+                  ),
+                  is_indexed: false,
+              },
+          ],
+      }
 
 note: 
     ┌─ demos/uniswap.fe:316:26
@@ -6501,5 +4470,99 @@ note:
               Address,
           ),
       }
+
+note: 
+    ┌─ demos/uniswap.fe:331:5
+    │  
+331 │ ╭     pub fn set_fee_to(self, fee_to: address):
+332 │ │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+333 │ │         self.fee_to = fee_to
+    │ ╰────────────────────────────^ attributes hash: 14618921052791880235
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "fee_to",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Unit,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:332:16
+    │
+332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+    │                ^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Some(Value)
+    │                │              
+    │                address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:332:16
+    │
+332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
+    │                │                                  
+    │                bool: Value => None
+333 │         self.fee_to = fee_to
+    │         ^^^^^^^^^^^   ^^^^^^ address: Value => None
+    │         │              
+    │         address: Storage { nonce: Some(0) } => None
+
+note: 
+    ┌─ demos/uniswap.fe:335:5
+    │  
+335 │ ╭     pub fn set_fee_to_setter(self, fee_to_setter: address):
+336 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
+337 │ │         self.fee_to_setter = fee_to_setter
+    │ ╰──────────────────────────────────────────^ attributes hash: 10732478853163688613
+    │  
+    = FunctionSignature {
+          self_decl: Mutable,
+          params: [
+              FunctionParam {
+                  name: "fee_to_setter",
+                  typ: Ok(
+                      Base(
+                          Address,
+                      ),
+                  ),
+              },
+          ],
+          return_type: Ok(
+              Base(
+                  Unit,
+              ),
+          ),
+      }
+
+note: 
+    ┌─ demos/uniswap.fe:336:16
+    │
+336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
+    │                ^^^^^^^^^^    ^^^^^^^^^^^^^ address: Value => None
+    │                │              
+    │                address: Value => None
+
+note: 
+    ┌─ demos/uniswap.fe:336:16
+    │
+336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
+    │                │                             
+    │                bool: Value => None
+337 │         self.fee_to_setter = fee_to_setter
+    │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ address: Value => None
+    │         │                     
+    │         address: Storage { nonce: Some(1) } => None
 
 

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -35,7 +35,7 @@ note:
   ┌─ demos/uniswap.fe:3:16
   │
 3 │         return 0
-  │                ^ u256: Value => None
+  │                ^ u256: Value
 
 note: 
   ┌─ demos/uniswap.fe:5:5
@@ -77,7 +77,7 @@ note:
   ┌─ demos/uniswap.fe:6:16
   │
 6 │         return false
-  │                ^^^^^ bool: Value => None
+  │                ^^^^^ bool: Value
 
 note: 
    ┌─ demos/uniswap.fe:12:5
@@ -184,10 +184,12 @@ note:
    │  
 66 │ ╭     pub fn factory(self) -> address:
 67 │ │         return self.factory
-   │ ╰───────────────────────────^ attributes hash: 17651916811868111914
+   │ ╰───────────────────────────^ attributes hash: 10447292744135180405
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -200,17 +202,25 @@ note:
    ┌─ demos/uniswap.fe:67:16
    │
 67 │         return self.factory
-   │                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
+   │                ^^^^ UniswapV2Pair: Value
+
+note: 
+   ┌─ demos/uniswap.fe:67:16
+   │
+67 │         return self.factory
+   │                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Value
 
 note: 
    ┌─ demos/uniswap.fe:69:5
    │  
 69 │ ╭     pub fn token0(self) -> address:
 70 │ │         return self.token0
-   │ ╰──────────────────────────^ attributes hash: 17651916811868111914
+   │ ╰──────────────────────────^ attributes hash: 10447292744135180405
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -223,17 +233,25 @@ note:
    ┌─ demos/uniswap.fe:70:16
    │
 70 │         return self.token0
-   │                ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+   │                ^^^^ UniswapV2Pair: Value
+
+note: 
+   ┌─ demos/uniswap.fe:70:16
+   │
+70 │         return self.token0
+   │                ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Value
 
 note: 
    ┌─ demos/uniswap.fe:72:5
    │  
 72 │ ╭     pub fn token1(self) -> address:
 73 │ │         return self.token1
-   │ ╰──────────────────────────^ attributes hash: 17651916811868111914
+   │ ╰──────────────────────────^ attributes hash: 10447292744135180405
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [],
          return_type: Ok(
              Base(
@@ -246,7 +264,13 @@ note:
    ┌─ demos/uniswap.fe:73:16
    │
 73 │         return self.token1
-   │                ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+   │                ^^^^ UniswapV2Pair: Value
+
+note: 
+   ┌─ demos/uniswap.fe:73:16
+   │
+73 │         return self.token1
+   │                ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Value
 
 note: 
    ┌─ demos/uniswap.fe:75:5
@@ -255,10 +279,12 @@ note:
 76 │ │         self.total_supply = self.total_supply + value
 77 │ │         self.balances[to] = self.balances[to] + value
 78 │ │         emit Transfer(from=address(0), to, value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 1135367514371429330
+   │ ╰─────────────────────────────────────────────────^ attributes hash: 12612842918375381504
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "to",
@@ -290,54 +316,80 @@ note:
    ┌─ demos/uniswap.fe:76:9
    │
 76 │         self.total_supply = self.total_supply + value
-   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
-   │         │                   │                    
-   │         │                   u256: Storage { nonce: Some(2) } => Some(Value)
-   │         u256: Storage { nonce: Some(2) } => None
+   │         ^^^^ UniswapV2Pair: Value
+
+note: 
+   ┌─ demos/uniswap.fe:76:9
+   │
+76 │         self.total_supply = self.total_supply + value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+   │         │                    
+   │         u256: Storage { nonce: Some(2) }
 
 note: 
    ┌─ demos/uniswap.fe:76:29
    │
 76 │         self.total_supply = self.total_supply + value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                             │                    
+   │                             u256: Storage { nonce: Some(2) } => Value
+
+note: 
+   ┌─ demos/uniswap.fe:76:29
+   │
+76 │         self.total_supply = self.total_supply + value
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 77 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^ ^^ address: Value => None
-   │         │              
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ UniswapV2Pair: Value
 
 note: 
    ┌─ demos/uniswap.fe:77:9
    │
 77 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^ address: Value => None
-   │         │                   │              
-   │         │                   Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^ ^^ address: Value
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:77:9
+   │
+77 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+   │         │                    
+   │         u256: Storage { nonce: None }
 
 note: 
    ┌─ demos/uniswap.fe:77:29
    │
 77 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                             ^^^^^^^^^^^^^ ^^ address: Value
+   │                             │              
+   │                             Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:77:29
+   │
+77 │         self.balances[to] = self.balances[to] + value
+   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                             │                    
-   │                             u256: Storage { nonce: None } => Some(Value)
+   │                             u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/uniswap.fe:77:29
    │
 77 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 78 │         emit Transfer(from=address(0), to, value)
-   │                                    ^ u256: Value => None
+   │                                    ^ u256: Value
 
 note: 
    ┌─ demos/uniswap.fe:78:28
    │
 78 │         emit Transfer(from=address(0), to, value)
-   │                            ^^^^^^^^^^  ^^  ^^^^^ u256: Value => None
+   │                            ^^^^^^^^^^  ^^  ^^^^^ u256: Value
    │                            │           │    
-   │                            │           address: Value => None
-   │                            address: Value => None
+   │                            │           address: Value
+   │                            address: Value
 
 note: 
    ┌─ demos/uniswap.fe:78:9
@@ -384,13 +436,7 @@ note:
    ┌─ demos/uniswap.fe:78:28
    │
 78 │         emit Transfer(from=address(0), to, value)
-   │                            ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                            ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/uniswap.fe:80:5
@@ -399,10 +445,12 @@ note:
 81 │ │         self.balances[from] = self.balances[from] - value
 82 │ │         self.total_supply = self.total_supply - value
 83 │ │         emit Transfer(from, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 18052677761580718632
+   │ ╰─────────────────────────────────────────────────^ attributes hash: 1338340295882506748
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "from",
@@ -434,55 +482,81 @@ note:
    ┌─ demos/uniswap.fe:81:9
    │
 81 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^ ^^^^ address: Value => None
-   │         │              
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ UniswapV2Pair: Value
 
 note: 
    ┌─ demos/uniswap.fe:81:9
    │
 81 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^^^ address: Value => None
-   │         │                     │              
-   │         │                     Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^ ^^^^ address: Value
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:81:9
+   │
+81 │         self.balances[from] = self.balances[from] - value
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+   │         │                      
+   │         u256: Storage { nonce: None }
 
 note: 
    ┌─ demos/uniswap.fe:81:31
    │
 81 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                               ^^^^^^^^^^^^^ ^^^^ address: Value
+   │                               │              
+   │                               Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:81:31
+   │
+81 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                               │                      
-   │                               u256: Storage { nonce: None } => Some(Value)
+   │                               u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/uniswap.fe:81:31
    │
 81 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 82 │         self.total_supply = self.total_supply - value
-   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
-   │         │                   │                    
-   │         │                   u256: Storage { nonce: Some(2) } => Some(Value)
-   │         u256: Storage { nonce: Some(2) } => None
+   │         ^^^^ UniswapV2Pair: Value
+
+note: 
+   ┌─ demos/uniswap.fe:82:9
+   │
+82 │         self.total_supply = self.total_supply - value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+   │         │                    
+   │         u256: Storage { nonce: Some(2) }
 
 note: 
    ┌─ demos/uniswap.fe:82:29
    │
 82 │         self.total_supply = self.total_supply - value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                             │                    
+   │                             u256: Storage { nonce: Some(2) } => Value
+
+note: 
+   ┌─ demos/uniswap.fe:82:29
+   │
+82 │         self.total_supply = self.total_supply - value
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 83 │         emit Transfer(from, to=address(0), value)
-   │                       ^^^^             ^ u256: Value => None
+   │                       ^^^^             ^ u256: Value
    │                       │                 
-   │                       address: Value => None
+   │                       address: Value
 
 note: 
    ┌─ demos/uniswap.fe:83:32
    │
 83 │         emit Transfer(from, to=address(0), value)
-   │                                ^^^^^^^^^^  ^^^^^ u256: Value => None
+   │                                ^^^^^^^^^^  ^^^^^ u256: Value
    │                                │            
-   │                                address: Value => None
+   │                                address: Value
 
 note: 
    ┌─ demos/uniswap.fe:83:9
@@ -529,13 +603,7 @@ note:
    ┌─ demos/uniswap.fe:83:32
    │
 83 │         emit Transfer(from, to=address(0), value)
-   │                                ^^^^^^^ attributes hash: 14203407709342965641
-   │
-   = TypeConstructor {
-         typ: Base(
-             Address,
-         ),
-     }
+   │                                ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ demos/uniswap.fe:85:5
@@ -543,10 +611,12 @@ note:
 85 │ ╭     fn _approve(self, owner: address, spender: address, value: u256):
 86 │ │         self.allowances[owner][spender] = value
 87 │ │         emit Approval(owner, spender, value)
-   │ ╰────────────────────────────────────────────^ attributes hash: 2670276789438195364
+   │ ╰────────────────────────────────────────────^ attributes hash: 18402794614707408512
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "owner",
@@ -586,30 +656,36 @@ note:
    ┌─ demos/uniswap.fe:86:9
    │
 86 │         self.allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^ ^^^^^ address: Value => None
+   │         ^^^^ UniswapV2Pair: Value
+
+note: 
+   ┌─ demos/uniswap.fe:86:9
+   │
+86 │         self.allowances[owner][spender] = value
+   │         ^^^^^^^^^^^^^^^ ^^^^^ address: Value
    │         │                
-   │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+   │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
    ┌─ demos/uniswap.fe:86:9
    │
 86 │         self.allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │         │                       
-   │         Map<address, u256>: Storage { nonce: None } => None
+   │         Map<address, u256>: Storage { nonce: None }
 
 note: 
    ┌─ demos/uniswap.fe:86:9
    │
 86 │         self.allowances[owner][spender] = value
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │         │                                  
-   │         u256: Storage { nonce: None } => None
+   │         u256: Storage { nonce: None }
 87 │         emit Approval(owner, spender, value)
-   │                       ^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
+   │                       ^^^^^  ^^^^^^^  ^^^^^ u256: Value
    │                       │      │         
-   │                       │      address: Value => None
-   │                       address: Value => None
+   │                       │      address: Value
+   │                       address: Value
 
 note: 
    ┌─ demos/uniswap.fe:87:9
@@ -659,10 +735,12 @@ note:
 90 │ │         self.balances[from] = self.balances[from] - value
 91 │ │         self.balances[to] = self.balances[to] + value
 92 │ │         emit Transfer(from, to, value)
-   │ ╰──────────────────────────────────────^ attributes hash: 1279967340500149849
+   │ ╰──────────────────────────────────────^ attributes hash: 10286209570728537585
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "from",
@@ -702,64 +780,90 @@ note:
    ┌─ demos/uniswap.fe:90:9
    │
 90 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^ ^^^^ address: Value => None
-   │         │              
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         ^^^^ UniswapV2Pair: Value
 
 note: 
    ┌─ demos/uniswap.fe:90:9
    │
 90 │         self.balances[from] = self.balances[from] - value
-   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^^^ address: Value => None
-   │         │                     │              
-   │         │                     Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
-
-note: 
-   ┌─ demos/uniswap.fe:90:31
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
-   │                               │                      
-   │                               u256: Storage { nonce: None } => Some(Value)
-
-note: 
-   ┌─ demos/uniswap.fe:90:31
-   │
-90 │         self.balances[from] = self.balances[from] - value
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-91 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^ ^^ address: Value => None
+   │         ^^^^^^^^^^^^^ ^^^^ address: Value
    │         │              
-   │         Map<address, u256>: Storage { nonce: Some(0) } => None
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:90:9
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+   │         │                      
+   │         u256: Storage { nonce: None }
+
+note: 
+   ┌─ demos/uniswap.fe:90:31
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^ ^^^^ address: Value
+   │                               │              
+   │                               Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:90:31
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                               │                      
+   │                               u256: Storage { nonce: None } => Value
+
+note: 
+   ┌─ demos/uniswap.fe:90:31
+   │
+90 │         self.balances[from] = self.balances[from] - value
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+91 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^ UniswapV2Pair: Value
 
 note: 
    ┌─ demos/uniswap.fe:91:9
    │
 91 │         self.balances[to] = self.balances[to] + value
-   │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ ^^ address: Value => None
-   │         │                   │              
-   │         │                   Map<address, u256>: Storage { nonce: Some(0) } => None
-   │         u256: Storage { nonce: None } => None
+   │         ^^^^^^^^^^^^^ ^^ address: Value
+   │         │              
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:91:9
+   │
+91 │         self.balances[to] = self.balances[to] + value
+   │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+   │         │                    
+   │         u256: Storage { nonce: None }
 
 note: 
    ┌─ demos/uniswap.fe:91:29
    │
 91 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+   │                             ^^^^^^^^^^^^^ ^^ address: Value
+   │                             │              
+   │                             Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ demos/uniswap.fe:91:29
+   │
+91 │         self.balances[to] = self.balances[to] + value
+   │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                             │                    
-   │                             u256: Storage { nonce: None } => Some(Value)
+   │                             u256: Storage { nonce: None } => Value
 
 note: 
    ┌─ demos/uniswap.fe:91:29
    │
 91 │         self.balances[to] = self.balances[to] + value
-   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+   │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 92 │         emit Transfer(from, to, value)
-   │                       ^^^^  ^^  ^^^^^ u256: Value => None
+   │                       ^^^^  ^^  ^^^^^ u256: Value
    │                       │     │    
-   │                       │     address: Value => None
-   │                       address: Value => None
+   │                       │     address: Value
+   │                       address: Value
 
 note: 
    ┌─ demos/uniswap.fe:92:9
@@ -808,10 +912,12 @@ note:
 94 │ ╭     pub fn approve(self, spender: address, value: u256) -> bool:
 95 │ │         self._approve(msg.sender, spender, value)
 96 │ │         return true
-   │ ╰───────────────────^ attributes hash: 10662679418650794263
+   │ ╰───────────────────^ attributes hash: 844763422390851240
    │  
    = FunctionSignature {
-         self_decl: Mutable,
+         self_decl: Some(
+             Mutable,
+         ),
          params: [
              FunctionParam {
                  name: "spender",
@@ -840,32 +946,28 @@ note:
      }
 
 note: 
-   ┌─ demos/uniswap.fe:95:23
+   ┌─ demos/uniswap.fe:95:9
    │
 95 │         self._approve(msg.sender, spender, value)
-   │                       ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value => None
-   │                       │           │         
-   │                       │           address: Value => None
-   │                       address: Value => None
+   │         ^^^^          ^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value
+   │         │             │           │         
+   │         │             │           address: Value
+   │         │             address: Value
+   │         UniswapV2Pair: Value
 
 note: 
    ┌─ demos/uniswap.fe:95:9
    │
 95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 96 │         return true
-   │                ^^^^ bool: Value => None
+   │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/uniswap.fe:95:9
    │
 95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 14531113974490967627
-   │
-   = SelfAttribute {
-         func_name: "_approve",
-         self_span: 2409..2413,
-     }
+   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(8) }
 
 note: 
     ┌─ demos/uniswap.fe:98:5
@@ -873,10 +975,12 @@ note:
  98 │ ╭     pub fn transfer(self, to: address, value: u256) -> bool:
  99 │ │         self._transfer(msg.sender, to, value)
 100 │ │         return true
-    │ ╰───────────────────^ attributes hash: 3518107939221722675
+    │ ╰───────────────────^ attributes hash: 2643035404557072522
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "to",
@@ -905,32 +1009,28 @@ note:
       }
 
 note: 
-   ┌─ demos/uniswap.fe:99:24
+   ┌─ demos/uniswap.fe:99:9
    │
 99 │         self._transfer(msg.sender, to, value)
-   │                        ^^^^^^^^^^  ^^  ^^^^^ u256: Value => None
-   │                        │           │    
-   │                        │           address: Value => None
-   │                        address: Value => None
+   │         ^^^^           ^^^^^^^^^^  ^^  ^^^^^ u256: Value
+   │         │              │           │    
+   │         │              │           address: Value
+   │         │              address: Value
+   │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:99:9
     │
  99 │         self._transfer(msg.sender, to, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 100 │         return true
-    │                ^^^^ bool: Value => None
+    │                ^^^^ bool: Value
 
 note: 
    ┌─ demos/uniswap.fe:99:9
    │
 99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 7946469693452924957
-   │
-   = SelfAttribute {
-         func_name: "_transfer",
-         self_span: 2541..2545,
-     }
+   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(9) }
 
 note: 
     ┌─ demos/uniswap.fe:102:5
@@ -941,10 +1041,12 @@ note:
 105 │ │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
 106 │ │         self._transfer(from, to, value)
 107 │ │         return true
-    │ ╰───────────────────^ attributes hash: 8152647388321889889
+    │ ╰───────────────────^ attributes hash: 9819594473760969007
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "from",
@@ -984,109 +1086,126 @@ note:
     ┌─ demos/uniswap.fe:103:16
     │
 103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
+    │                ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:103:16
+    │
+103 │         assert self.allowances[from][msg.sender] >= value
+    │                ^^^^^^^^^^^^^^^ ^^^^ address: Value
     │                │                
-    │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+    │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
     ┌─ demos/uniswap.fe:103:16
     │
 103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
     │                │                      
-    │                Map<address, u256>: Storage { nonce: None } => None
+    │                Map<address, u256>: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:103:16
     │
 103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value
     │                │                                     
-    │                u256: Storage { nonce: None } => Some(Value)
+    │                u256: Storage { nonce: None } => Value
 
 note: 
     ┌─ demos/uniswap.fe:103:16
     │
 103 │         assert self.allowances[from][msg.sender] >= value
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 104 │ 
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │         ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:105:9
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │         ^^^^^^^^^^^^^^^ ^^^^ address: Value
     │         │                
-    │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
+    │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
     ┌─ demos/uniswap.fe:105:9
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │         ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
     │         │                      
-    │         Map<address, u256>: Storage { nonce: None } => None
+    │         Map<address, u256>: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:105:9
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ ^^^^ address: Value => None
-    │         │                                   │                
-    │         │                                   Map<address, Map<address, u256>>: Storage { nonce: Some(1) } => None
-    │         u256: Storage { nonce: None } => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+    │         │                                    
+    │         u256: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:105:45
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value => None
+    │                                             ^^^^^^^^^^^^^^^ ^^^^ address: Value
+    │                                             │                
+    │                                             Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
+
+note: 
+    ┌─ demos/uniswap.fe:105:45
+    │
+105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
+    │                                             ^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^^^^ address: Value
     │                                             │                      
-    │                                             Map<address, u256>: Storage { nonce: None } => None
+    │                                             Map<address, u256>: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:105:45
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value => None
+    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │                                             │                                    
-    │                                             u256: Storage { nonce: None } => Some(Value)
+    │                                             u256: Storage { nonce: None } => Value
 
 note: 
     ┌─ demos/uniswap.fe:105:45
     │
 105 │         self.allowances[from][msg.sender] = self.allowances[from][msg.sender] - value
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 106 │         self._transfer(from, to, value)
-    │                        ^^^^  ^^  ^^^^^ u256: Value => None
-    │                        │     │    
-    │                        │     address: Value => None
-    │                        address: Value => None
+    │         ^^^^           ^^^^  ^^  ^^^^^ u256: Value
+    │         │              │     │    
+    │         │              │     address: Value
+    │         │              address: Value
+    │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:106:9
     │
 106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 107 │         return true
-    │                ^^^^ bool: Value => None
+    │                ^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:106:9
     │
 106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^ attributes hash: 9013399514526062924
-    │
-    = SelfAttribute {
-          func_name: "_transfer",
-          self_span: 2833..2837,
-      }
+    │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(9) }
 
 note: 
     ┌─ demos/uniswap.fe:109:5
     │  
 109 │ ╭     pub fn balanceOf(self, account: address) -> u256:
 110 │ │         return self.balances[account]
-    │ ╰─────────────────────────────────────^ attributes hash: 11484923544867751175
+    │ ╰─────────────────────────────────────^ attributes hash: 993550877953897347
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "account",
@@ -1110,25 +1229,33 @@ note:
     ┌─ demos/uniswap.fe:110:16
     │
 110 │         return self.balances[account]
-    │                ^^^^^^^^^^^^^ ^^^^^^^ address: Value => None
-    │                │              
-    │                Map<address, u256>: Storage { nonce: Some(0) } => None
+    │                ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:110:16
     │
 110 │         return self.balances[account]
-    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+    │                ^^^^^^^^^^^^^ ^^^^^^^ address: Value
+    │                │              
+    │                Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ demos/uniswap.fe:110:16
+    │
+110 │         return self.balances[account]
+    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
     ┌─ demos/uniswap.fe:112:5
     │  
 112 │ ╭     pub fn get_reserves(self) -> (u256, u256, u256):
 113 │ │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │ ╰────────────────────────────────────────────────────────────────────────^ attributes hash: 1362480321321505196
+    │ ╰────────────────────────────────────────────────────────────────────────^ attributes hash: 9520366806068670781
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [],
           return_type: Ok(
               Tuple(
@@ -1159,16 +1286,35 @@ note:
     ┌─ demos/uniswap.fe:113:17
     │
 113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                 ^^^^^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Some(Value)
-    │                 │              │               
-    │                 │              u256: Storage { nonce: Some(8) } => Some(Value)
-    │                 u256: Storage { nonce: Some(7) } => Some(Value)
+    │                 ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:113:17
+    │
+113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+    │                 ^^^^^^^^^^^^^  ^^^^ UniswapV2Pair: Value
+    │                 │               
+    │                 u256: Storage { nonce: Some(7) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:113:32
+    │
+113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+    │                                ^^^^^^^^^^^^^  ^^^^ UniswapV2Pair: Value
+    │                                │               
+    │                                u256: Storage { nonce: Some(8) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:113:47
+    │
+113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+    │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:113:16
     │
 113 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, u256, u256): Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, u256, u256): Memory
 
 note: 
     ┌─ demos/uniswap.fe:116:5
@@ -1177,10 +1323,12 @@ note:
 117 │ │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
 118 │ │         self.token0 = token0
 119 │ │         self.token1 = token1
-    │ ╰────────────────────────────^ attributes hash: 9762098062283689454
+    │ ╰────────────────────────────^ attributes hash: 10764996905806361023
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "token0",
@@ -1210,25 +1358,43 @@ note:
     ┌─ demos/uniswap.fe:117:16
     │
 117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^    ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
+    │                ^^^^^^^^^^    ^^^^ UniswapV2Pair: Value
     │                │              
-    │                address: Value => None
+    │                address: Value
+
+note: 
+    ┌─ demos/uniswap.fe:117:30
+    │
+117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
+    │                              ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:117:16
     │
 117 │         assert msg.sender == self.factory, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory
     │                │                            
-    │                bool: Value => None
+    │                bool: Value
 118 │         self.token0 = token0
-    │         ^^^^^^^^^^^   ^^^^^^ address: Value => None
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:118:9
+    │
+118 │         self.token0 = token0
+    │         ^^^^^^^^^^^   ^^^^^^ address: Value
     │         │              
-    │         address: Storage { nonce: Some(5) } => None
+    │         address: Storage { nonce: Some(5) }
 119 │         self.token1 = token1
-    │         ^^^^^^^^^^^   ^^^^^^ address: Value => None
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:119:9
+    │
+119 │         self.token1 = token1
+    │         ^^^^^^^^^^^   ^^^^^^ address: Value
     │         │              
-    │         address: Storage { nonce: Some(6) } => None
+    │         address: Storage { nonce: Some(6) }
 
 note: 
     ┌─ demos/uniswap.fe:122:5
@@ -1240,10 +1406,12 @@ note:
     · │
 134 │ │         self.block_timestamp_last = block_timestamp
 135 │ │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 13082574297248451564
+    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 15880403329314631128
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "balance0",
@@ -1306,143 +1474,205 @@ note:
     ┌─ demos/uniswap.fe:124:37
     │
 124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                     ^^^^^^^^^^^^^^^   ^  ^^ u256: Value => None
+    │                                     ^^^^^^^^^^^^^^^   ^  ^^ u256: Value
     │                                     │                 │   
-    │                                     │                 u256: Value => None
-    │                                     u256: Value => None
+    │                                     │                 u256: Value
+    │                                     u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:124:55
     │
 124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                                       ^^^^^ u256: Value => None
+    │                                                       ^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:124:37
     │
 124 │         let block_timestamp: u256 = block.timestamp % 2**32
-    │                                     ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                     ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 125 │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
 126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                  ^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Some(Value)
+    │                                  ^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                                  │                  
-    │                                  u256: Value => None
+    │                                  u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:126:52
+    │
+126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
+    │                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:126:34
     │
 126 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last # overflow is desired
-    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^   ^ u256: Value => None
+    │            ^^^^^^^^^^^^   ^ u256: Value
     │            │               
-    │            u256: Value => None
+    │            u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:127:12
     │
 127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value => None
+    │            ^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value
     │            │                    │            
-    │            │                    u256: Value => None
-    │            bool: Value => None
+    │            │                    u256: Value
+    │            bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:127:33
     │
 127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                 ^^^^^^^^^^^^^ bool: Value => None
+    │                                 ^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:127:12
     │
 127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value => None
+    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value
     │            │                                      │            
-    │            │                                      u256: Value => None
-    │            bool: Value => None
+    │            │                                      u256: Value
+    │            bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:127:51
     │
 127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │                                                   ^^^^^^^^^^^^^ bool: Value => None
+    │                                                   ^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:127:12
     │
 127 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0:
-    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 128 │             # `*` never overflows, and + overflow is desired
 129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value => None
-    │             │                             │                              │           
-    │             │                             │                              u256: Value => None
-    │             │                             u256: Storage { nonce: Some(10) } => Some(Value)
-    │             u256: Storage { nonce: Some(10) } => None
+    │             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ demos/uniswap.fe:129:73
+    ┌─ demos/uniswap.fe:129:13
     │
 129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
-    │                                                                         │                        
-    │                                                                         u256: Value => None
-
-note: 
-    ┌─ demos/uniswap.fe:129:73
-    │
-129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+    │             │                              
+    │             u256: Storage { nonce: Some(10) }
 
 note: 
     ┌─ demos/uniswap.fe:129:43
     │
 129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value => None
-    │             │                             │                              │           
-    │             │                             │                              u256: Value => None
-    │             │                             u256: Storage { nonce: Some(11) } => Some(Value)
-    │             u256: Storage { nonce: Some(11) } => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value
+    │                                           │                              │           
+    │                                           │                              u256: Value
+    │                                           u256: Storage { nonce: Some(10) } => Value
 
 note: 
-    ┌─ demos/uniswap.fe:130:73
+    ┌─ demos/uniswap.fe:129:73
     │
-130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                                                                         │                        
-    │                                                                         u256: Value => None
+    │                                                                         u256: Value
 
 note: 
-    ┌─ demos/uniswap.fe:130:73
+    ┌─ demos/uniswap.fe:129:73
+    │
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:129:43
+    │
+129 │             self.price0_cumulative_last = self.price0_cumulative_last + (reserve1 / reserve0) * time_elapsed
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │             ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:130:13
     │
 130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+    │             │                              
+    │             u256: Storage { nonce: Some(11) }
 
 note: 
     ┌─ demos/uniswap.fe:130:43
     │
 130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value
+    │                                           │                              │           
+    │                                           │                              u256: Value
+    │                                           u256: Storage { nonce: Some(11) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:130:73
+    │
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
+    │                                                                         │                        
+    │                                                                         u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:130:73
+    │
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:130:43
+    │
+130 │             self.price1_cumulative_last = self.price1_cumulative_last + (reserve0 / reserve1) * time_elapsed
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 131 │ 
 132 │         self.reserve0 = balance0
-    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:132:9
+    │
+132 │         self.reserve0 = balance0
+    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │         │                
-    │         u256: Storage { nonce: Some(7) } => None
+    │         u256: Storage { nonce: Some(7) }
 133 │         self.reserve1 = balance1
-    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:133:9
+    │
+133 │         self.reserve1 = balance1
+    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │         │                
-    │         u256: Storage { nonce: Some(8) } => None
+    │         u256: Storage { nonce: Some(8) }
 134 │         self.block_timestamp_last = block_timestamp
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value => None
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:134:9
+    │
+134 │         self.block_timestamp_last = block_timestamp
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value
     │         │                            
-    │         u256: Storage { nonce: Some(9) } => None
+    │         u256: Storage { nonce: Some(9) }
 135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │                            ^^^^^^^^^^^^^           ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                            ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:135:28
+    │
+135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
+    │                            ^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │                            │                        
-    │                            u256: Storage { nonce: Some(7) } => Some(Value)
+    │                            u256: Storage { nonce: Some(7) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:135:52
+    │
+135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
+    │                                                    ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:135:9
@@ -1488,10 +1718,12 @@ note:
     · │
 154 │ │ 
 155 │ │         return fee_on
-    │ ╰─────────────────────^ attributes hash: 9365170424361356438
+    │ ╰─────────────────────^ attributes hash: 1326723887586965558
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "reserve0",
@@ -1547,238 +1779,213 @@ note:
     ┌─ demos/uniswap.fe:139:48
     │
 139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                                                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Some(Value)
+    │                                                ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:139:48
+    │
+139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+    │                                                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:139:31
     │
 139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Factory: Value => None
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Factory: Value
 
 note: 
     ┌─ demos/uniswap.fe:139:31
     │
 139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value
 140 │         let fee_on: bool = fee_to != address(0)
-    │                            ^^^^^^            ^ u256: Value => None
+    │                            ^^^^^^            ^ u256: Value
     │                            │                  
-    │                            address: Value => None
+    │                            address: Value
 
 note: 
     ┌─ demos/uniswap.fe:140:38
     │
 140 │         let fee_on: bool = fee_to != address(0)
-    │                                      ^^^^^^^^^^ address: Value => None
+    │                                      ^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:140:28
     │
 140 │         let fee_on: bool = fee_to != address(0)
-    │                            ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                            ^^^^^^^^^^^^^^^^^^^^ bool: Value
 141 │         let k_last: u256 = self.k_last # gas savings
-    │                            ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => Some(Value)
+    │                            ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:141:28
+    │
+141 │         let k_last: u256 = self.k_last # gas savings
+    │                            ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => Value
 142 │         if fee_on:
-    │            ^^^^^^ bool: Value => None
+    │            ^^^^^^ bool: Value
 143 │             if k_last != 0:
-    │                ^^^^^^    ^ u256: Value => None
+    │                ^^^^^^    ^ u256: Value
     │                │          
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:143:16
     │
 143 │             if k_last != 0:
-    │                ^^^^^^^^^^^ bool: Value => None
+    │                ^^^^^^^^^^^ bool: Value
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                         ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                                         ^^^^^^^^   ^^^^^^^^ u256: Value
     │                                         │           
-    │                                         u256: Value => None
+    │                                         u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:144:41
     │
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                         ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                         ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:144:36
     │
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 145 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                              ^^^^^^ u256: Value => None
+    │                                              ^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:145:41
     │
 145 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                         ^^^^^^^^^^^^ u256: Value => None
+    │                                         ^^^^^^^^^^^^ u256: Value
 146 │                 if root_k > root_k_last:
-    │                    ^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                    ^^^^^^   ^^^^^^^^^^^ u256: Value
     │                    │         
-    │                    u256: Value => None
+    │                    u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:146:20
     │
 146 │                 if root_k > root_k_last:
-    │                    ^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                    ^^^^^^^^^^^^^^^^^^^^ bool: Value
 147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                           ^^^^^^^^^^^^^^^^^   ^^^^^^ u256: Value => None
+    │                                           ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:147:43
+    │
+147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+    │                                           ^^^^^^^^^^^^^^^^^   ^^^^^^ u256: Value
     │                                           │                    
-    │                                           u256: Storage { nonce: Some(2) } => Some(Value)
+    │                                           u256: Storage { nonce: Some(2) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:147:43
     │
 147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                           │                             
-    │                                           u256: Value => None
+    │                                           u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:147:43
     │
 147 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                             ^^^^^^   ^ u256: Value => None
+    │                                             ^^^^^^   ^ u256: Value
     │                                             │         
-    │                                             u256: Value => None
+    │                                             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:148:45
     │
 148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                             ^^^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                             ^^^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                             │             
-    │                                             u256: Value => None
+    │                                             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:148:45
     │
 148 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 149 │                     let liquidity: u256 = numerator / denominator
-    │                                           ^^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                           │            
-    │                                           u256: Value => None
+    │                                           u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:149:43
     │
 149 │                     let liquidity: u256 = numerator / denominator
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 150 │                     if liquidity > 0:
-    │                        ^^^^^^^^^   ^ u256: Value => None
+    │                        ^^^^^^^^^   ^ u256: Value
     │                        │            
-    │                        u256: Value => None
+    │                        u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:150:24
     │
 150 │                     if liquidity > 0:
-    │                        ^^^^^^^^^^^^^ bool: Value => None
+    │                        ^^^^^^^^^^^^^ bool: Value
 151 │                         self._mint(fee_to, liquidity)
-    │                                    ^^^^^^  ^^^^^^^^^ u256: Value => None
-    │                                    │        
-    │                                    address: Value => None
+    │                         ^^^^       ^^^^^^  ^^^^^^^^^ u256: Value
+    │                         │          │        
+    │                         │          address: Value
+    │                         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:151:25
     │
 151 │                         self._mint(fee_to, liquidity)
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 152 │         elif k_last != 0:
-    │              ^^^^^^    ^ u256: Value => None
+    │              ^^^^^^    ^ u256: Value
     │              │          
-    │              u256: Value => None
+    │              u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:152:14
     │
 152 │         elif k_last != 0:
-    │              ^^^^^^^^^^^ bool: Value => None
+    │              ^^^^^^^^^^^ bool: Value
 153 │             self.k_last = 0
-    │             ^^^^^^^^^^^   ^ u256: Value => None
+    │             ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:153:13
+    │
+153 │             self.k_last = 0
+    │             ^^^^^^^^^^^   ^ u256: Value
     │             │              
-    │             u256: Storage { nonce: Some(12) } => None
+    │             u256: Storage { nonce: Some(12) }
 154 │ 
 155 │         return fee_on
-    │                ^^^^^^ bool: Value => None
+    │                ^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:139:31
     │
 139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
+    │                               ^^^^^^^^^^^^^^^^ TypeConstructor(Contract(Contract { name: "UniswapV2Factory", id: ContractId(2) }))
 
 note: 
     ┌─ demos/uniswap.fe:139:31
     │
 139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                               ^^^^^^^^^^^^^^^^ attributes hash: 6793491359790860355
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Factory",
-                  id: ContractId(
-                      2,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:140:38
-    │
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(2)), method: FunctionId(26) }
 140 │         let fee_on: bool = fee_to != address(0)
-    │                                      ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:144:36
-    │
+    │                                      ^^^^^^^ TypeConstructor(Base(Address))
+    ·
 144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                    ^^^^ attributes hash: 3607074860458368047
-    │
-    = Pure(
-          FunctionId(
-              23,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:145:41
-    │
+    │                                    ^^^^ Pure(FunctionId(23))
 145 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                         ^^^^ attributes hash: 3607074860458368047
-    │
-    = Pure(
-          FunctionId(
-              23,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:151:25
-    │
+    │                                         ^^^^ Pure(FunctionId(23))
+    ·
 151 │                         self._mint(fee_to, liquidity)
-    │                         ^^^^^^^^^^ attributes hash: 12418659184498534900
-    │
-    = SelfAttribute {
-          func_name: "_mint",
-          self_span: 5111..5115,
-      }
+    │                         ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(6) }
 
 note: 
     ┌─ demos/uniswap.fe:158:5
@@ -1790,10 +1997,12 @@ note:
     · │
 184 │ │         emit Mint(sender=msg.sender, amount0, amount1)
 185 │ │         return liquidity
-    │ ╰────────────────────────^ attributes hash: 13052412037608309076
+    │ ╰────────────────────────^ attributes hash: 11001367211577482977
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "to",
@@ -1842,230 +2051,295 @@ note:
     ┌─ demos/uniswap.fe:159:39
     │
 159 │         let MINIMUM_LIQUIDITY: u256 = 1000
-    │                                       ^^^^ u256: Value => None
+    │                                       ^^^^ u256: Value
 160 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:160:30
+    │
+160 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
 161 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:161:30
+    │
+161 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+    │                                    ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:162:36
+    │
+162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:162:30
     │
 162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │                              │                             
-    │                              ERC20: Value => None
+    │                              ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:162:59
+    │
+162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
+    │                                                           ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:162:30
     │
 162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+    │                                    ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:163:36
+    │
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:163:30
     │
 163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │                              │                             
-    │                              ERC20: Value => None
+    │                              ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:163:59
+    │
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                                                           ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:163:30
     │
 163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 164 │         let amount0: u256 = balance0 - self.reserve0
-    │                             ^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                             ^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │           
-    │                             u256: Value => None
+    │                             u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:164:40
+    │
+164 │         let amount0: u256 = balance0 - self.reserve0
+    │                                        ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:164:29
     │
 164 │         let amount0: u256 = balance0 - self.reserve0
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 165 │         let amount1: u256 = balance1 - self.reserve1
-    │                             ^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                             ^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │           
-    │                             u256: Value => None
+    │                             u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:165:40
+    │
+165 │         let amount1: u256 = balance1 - self.reserve1
+    │                                        ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:165:29
     │
 165 │         let amount1: u256 = balance1 - self.reserve1
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 166 │ 
 167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                           ^^^^^^^^  ^^^^^^^^ u256: Value => None
-    │                                           │          
-    │                                           u256: Value => None
+    │                            ^^^^           ^^^^^^^^  ^^^^^^^^ u256: Value
+    │                            │              │          
+    │                            │              u256: Value
+    │                            UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:167:28
     │
 167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 168 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+    │                                  ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:168:34
+    │
+168 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 169 │         let liquidity: u256 = 0
-    │                               ^ u256: Value => None
+    │                               ^ u256: Value
 170 │         if total_supply == 0:
-    │            ^^^^^^^^^^^^    ^ u256: Value => None
+    │            ^^^^^^^^^^^^    ^ u256: Value
     │            │                
-    │            u256: Value => None
+    │            u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:170:12
     │
 170 │         if total_supply == 0:
-    │            ^^^^^^^^^^^^^^^^^ bool: Value => None
+    │            ^^^^^^^^^^^^^^^^^ bool: Value
 171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^ u256: Value => None
+    │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^ u256: Value
     │             │                │          
-    │             │                u256: Value => None
-    │             u256: Value => None
+    │             │                u256: Value
+    │             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:171:30
     │
 171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                              ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:171:25
     │
 171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value
     │                         │                          
-    │                         u256: Value => None
+    │                         u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:171:25
     │
 171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                                ^ u256: Value => None
+    │             ^^^^               ^ u256: Value
+    │             │                   
+    │             UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:172:24
     │
 172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                        ^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                        ^^^^^^^^^^  ^^^^^^^^^^^^^^^^^ u256: Value
     │                        │            
-    │                        address: Value => None
+    │                        address: Value
 
 note: 
     ┌─ demos/uniswap.fe:172:13
     │
 172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 173 │         else:
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │             │                │          
-    │             │                u256: Value => None
-    │             u256: Value => None
+    │             │                u256: Value
+    │             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:174:29
     │
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                             │                           
-    │                             u256: Value => None
+    │                             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:174:29
     │
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                                     │          
-    │                             │                                     u256: Value => None
-    │                             u256: Value => None
+    │                             │                                     u256: Value
+    │                             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:174:66
     │
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                                                                  │                           
-    │                                                                  u256: Value => None
+    │                                                                  u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:174:66
     │
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:174:25
     │
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 175 │ 
 176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                ^^^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^^^   ^ u256: Value
     │                │            
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:176:16
     │
 176 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
-    │                ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory => None
+    │                ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory
     │                │               
-    │                bool: Value => None
+    │                bool: Value
 177 │ 
 178 │         self._mint(to, liquidity)
-    │                    ^^  ^^^^^^^^^ u256: Value => None
-    │                    │    
-    │                    address: Value => None
+    │         ^^^^       ^^  ^^^^^^^^^ u256: Value
+    │         │          │    
+    │         │          address: Value
+    │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:178:9
     │
 178 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value => None
-    │                      │         │         │          
-    │                      │         │         u256: Value => None
-    │                      │         u256: Value => None
-    │                      u256: Value => None
+    │         ^^^^         ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
+    │         │            │         │         │          
+    │         │            │         │         u256: Value
+    │         │            │         u256: Value
+    │         │            u256: Value
+    │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:179:9
     │
 179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 180 │ 
 181 │         if fee_on:
-    │            ^^^^^^ bool: Value => None
+    │            ^^^^^^ bool: Value
 182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │             ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:182:13
+    │
+182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+    │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │             │             │           
-    │             │             u256: Value => None
-    │             u256: Storage { nonce: Some(12) } => None
+    │             │             u256: Value
+    │             u256: Storage { nonce: Some(12) }
 
 note: 
     ┌─ demos/uniswap.fe:182:27
     │
 182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
 183 │ 
 184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^ u256: Value => None
+    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^ u256: Value
     │                          │           │         
-    │                          │           u256: Value => None
-    │                          address: Value => None
+    │                          │           u256: Value
+    │                          address: Value
 185 │         return liquidity
-    │                ^^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:184:9
@@ -2114,131 +2388,43 @@ note:
     ┌─ demos/uniswap.fe:162:30
     │
 162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
+    │                              ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 
 note: 
     ┌─ demos/uniswap.fe:162:30
     │
 162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
+163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
+    │                              ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 
 note: 
     ┌─ demos/uniswap.fe:163:30
     │
 163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:163:30
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:167:28
-    │
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
+    ·
 167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ attributes hash: 16080475652312567395
-    │
-    = SelfAttribute {
-          func_name: "_mint_fee",
-          self_span: 5772..5776,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:171:25
-    │
+    │                            ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(17) }
+    ·
 171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^ attributes hash: 3607074860458368047
-    │
-    = Pure(
-          FunctionId(
-              23,
-          ),
-      )
+    │                         ^^^^ Pure(FunctionId(23))
+172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+    │                        ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
     ┌─ demos/uniswap.fe:172:13
     │
 172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^ attributes hash: 7856352234549907196
-    │
-    = SelfAttribute {
-          func_name: "_mint",
-          self_span: 6077..6081,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:172:24
-    │
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                        ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:174:25
-    │
+    │             ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(6) }
+173 │         else:
 174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^ attributes hash: 1164657736943769014
-    │
-    = Pure(
-          FunctionId(
-              24,
-          ),
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:178:9
-    │
+    │                         ^^^ Pure(FunctionId(24))
+    ·
 178 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^ attributes hash: 15101716191511699734
-    │
-    = SelfAttribute {
-          func_name: "_mint",
-          self_span: 6372..6376,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:179:9
-    │
+    │         ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(6) }
 179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 3915756169872662167
-    │
-    = SelfAttribute {
-          func_name: "_update",
-          self_span: 6406..6410,
-      }
+    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ demos/uniswap.fe:188:5
@@ -2250,10 +2436,12 @@ note:
     · │
 213 │ │         emit Burn(sender=msg.sender, amount0, amount1, to)
 214 │ │         return (amount0, amount1)
-    │ ╰─────────────────────────────────^ attributes hash: 2656431017065792419
+    │ ╰─────────────────────────────────^ attributes hash: 2815259610692259424
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "to",
@@ -2315,229 +2503,311 @@ note:
     ┌─ demos/uniswap.fe:189:30
     │
 189 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:189:30
+    │
+189 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
 190 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:190:30
+    │
+190 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 191 │         let token0: ERC20 = ERC20(self.token0)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:191:35
+    │
+191 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:191:29
     │
 191 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 192 │         let token1: ERC20 = ERC20(self.token1)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:192:35
+    │
+192 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:192:29
     │
 192 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              ^^^^^^           ^^^^ UniswapV2Pair: Value
     │                              │                 
-    │                              ERC20: Value => None
+    │                              ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:193:47
+    │
+193 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:193:30
     │
 193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              ^^^^^^           ^^^^ UniswapV2Pair: Value
     │                              │                 
-    │                              ERC20: Value => None
+    │                              ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:194:47
+    │
+194 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:194:30
     │
 194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 195 │         let liquidity: u256 = self.balances[self.address]
-    │                               ^^^^^^^^^^^^^ ^^^^^^^^^^^^ address: Value => None
-    │                               │              
-    │                               Map<address, u256>: Storage { nonce: Some(0) } => None
+    │                               ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:195:31
     │
 195 │         let liquidity: u256 = self.balances[self.address]
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Some(Value)
+    │                               ^^^^^^^^^^^^^ ^^^^ UniswapV2Pair: Value
+    │                               │              
+    │                               Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ demos/uniswap.fe:195:45
+    │
+195 │         let liquidity: u256 = self.balances[self.address]
+    │                                             ^^^^^^^^^^^^ address: Value
+
+note: 
+    ┌─ demos/uniswap.fe:195:31
+    │
+195 │         let liquidity: u256 = self.balances[self.address]
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 196 │ 
 197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                                           ^^^^^^^^  ^^^^^^^^ u256: Value => None
-    │                                           │          
-    │                                           u256: Value => None
+    │                            ^^^^           ^^^^^^^^  ^^^^^^^^ u256: Value
+    │                            │              │          
+    │                            │              u256: Value
+    │                            UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:197:28
     │
 197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 198 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Some(Value)
+    │                                  ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:198:34
+    │
+198 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+    │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                              ^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^   ^^^^^^^^ u256: Value
     │                              │            
-    │                              u256: Value => None
+    │                              u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:199:29
     │
 199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                         
-    │                             u256: Value => None
+    │                             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:199:29
     │
 199 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                              ^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^   ^^^^^^^^ u256: Value
     │                              │            
-    │                              u256: Value => None
+    │                              u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:200:29
     │
 200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                         
-    │                             u256: Value => None
+    │                             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:200:29
     │
 200 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^   ^ u256: Value
     │                │          
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:201:16
     │
 201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^^^^^     ^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^^^^^     ^^^^^^^   ^ u256: Value
     │                │               │          
-    │                │               u256: Value => None
-    │                bool: Value => None
+    │                │               u256: Value
+    │                bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:201:32
     │
 201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                                ^^^^^^^^^^^ bool: Value => None
+    │                                ^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:201:16
     │
 201 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory
     │                │                             
-    │                bool: Value => None
+    │                bool: Value
 202 │         self._burn(self.address, liquidity)
-    │                    ^^^^^^^^^^^^  ^^^^^^^^^ u256: Value => None
+    │         ^^^^       ^^^^ UniswapV2Pair: Value
+    │         │           
+    │         UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:202:20
+    │
+202 │         self._burn(self.address, liquidity)
+    │                    ^^^^^^^^^^^^  ^^^^^^^^^ u256: Value
     │                    │              
-    │                    address: Value => None
+    │                    address: Value
 
 note: 
     ┌─ demos/uniswap.fe:202:9
     │
 202 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 203 │         token0.transfer(to, amount0)
-    │         ^^^^^^          ^^  ^^^^^^^ u256: Value => None
+    │         ^^^^^^          ^^  ^^^^^^^ u256: Value
     │         │               │    
-    │         │               address: Value => None
-    │         ERC20: Value => None
+    │         │               address: Value
+    │         ERC20: Value
 
 note: 
     ┌─ demos/uniswap.fe:203:9
     │
 203 │         token0.transfer(to, amount0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 204 │         token1.transfer(to, amount1)
-    │         ^^^^^^          ^^  ^^^^^^^ u256: Value => None
+    │         ^^^^^^          ^^  ^^^^^^^ u256: Value
     │         │               │    
-    │         │               address: Value => None
-    │         ERC20: Value => None
+    │         │               address: Value
+    │         ERC20: Value
 
 note: 
     ┌─ demos/uniswap.fe:204:9
     │
 204 │         token1.transfer(to, amount1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 205 │         balance0 = token0.balanceOf(self.address)
-    │         ^^^^^^^^   ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         ^^^^^^^^   ^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │          │                 
-    │         │          ERC20: Value => None
-    │         u256: Value => None
+    │         │          ERC20: Value
+    │         u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:205:37
+    │
+205 │         balance0 = token0.balanceOf(self.address)
+    │                                     ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:205:20
     │
 205 │         balance0 = token0.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 206 │         balance1 = token1.balanceOf(self.address)
-    │         ^^^^^^^^   ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         ^^^^^^^^   ^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │          │                 
-    │         │          ERC20: Value => None
-    │         u256: Value => None
+    │         │          ERC20: Value
+    │         u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:206:37
+    │
+206 │         balance1 = token1.balanceOf(self.address)
+    │                                     ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:206:20
     │
 206 │         balance1 = token1.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 207 │ 
 208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value => None
-    │                      │         │         │          
-    │                      │         │         u256: Value => None
-    │                      │         u256: Value => None
-    │                      u256: Value => None
+    │         ^^^^         ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
+    │         │            │         │         │          
+    │         │            │         │         u256: Value
+    │         │            │         u256: Value
+    │         │            u256: Value
+    │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:208:9
     │
 208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 209 │ 
 210 │         if fee_on:
-    │            ^^^^^^ bool: Value => None
+    │            ^^^^^^ bool: Value
 211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │             ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:211:13
+    │
+211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+    │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │             │             │           
-    │             │             u256: Value => None
-    │             u256: Storage { nonce: Some(12) } => None
+    │             │             u256: Value
+    │             u256: Storage { nonce: Some(12) }
 
 note: 
     ┌─ demos/uniswap.fe:211:27
     │
 211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
-    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
 212 │ 
 213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^  ^^ address: Value => None
+    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^  ^^ address: Value
     │                          │           │        │         
-    │                          │           │        u256: Value => None
-    │                          │           u256: Value => None
-    │                          address: Value => None
+    │                          │           │        u256: Value
+    │                          │           u256: Value
+    │                          address: Value
 214 │         return (amount0, amount1)
-    │                 ^^^^^^^  ^^^^^^^ u256: Value => None
+    │                 ^^^^^^^  ^^^^^^^ u256: Value
     │                 │         
-    │                 u256: Value => None
+    │                 u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:214:16
     │
 214 │         return (amount0, amount1)
-    │                ^^^^^^^^^^^^^^^^^^ (u256, u256): Memory => None
+    │                ^^^^^^^^^^^^^^^^^^ (u256, u256): Memory
 
 note: 
     ┌─ demos/uniswap.fe:213:9
@@ -2595,116 +2865,30 @@ note:
     ┌─ demos/uniswap.fe:191:29
     │
 191 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:192:29
-    │
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 192 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:193:30
-    │
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:194:30
-    │
+    │                              ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:197:28
-    │
+    │                              ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
+    ·
 197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ attributes hash: 9805941357832028794
-    │
-    = SelfAttribute {
-          func_name: "_mint_fee",
-          self_span: 7186..7190,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:202:9
-    │
+    │                            ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(17) }
+    ·
 202 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^ attributes hash: 11916723560899393221
-    │
-    = SelfAttribute {
-          func_name: "_burn",
-          self_span: 7671..7675,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:203:9
-    │
+    │         ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(7) }
 203 │         token0.transfer(to, amount0)
-    │         ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:204:9
-    │
+    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
 204 │         token1.transfer(to, amount1)
-    │         ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:205:20
-    │
+    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
 205 │         balance0 = token0.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:206:20
-    │
+    │                    ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 206 │         balance1 = token1.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:208:9
-    │
+    │                    ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
+207 │ 
 208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 2808373337661029670
-    │
-    = SelfAttribute {
-          func_name: "_update",
-          self_span: 7890..7894,
-      }
+    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ demos/uniswap.fe:219:5
@@ -2716,10 +2900,12 @@ note:
     · │
 252 │ │         self._update(balance0, balance1, reserve0, reserve1)
 253 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 13380171127738201451
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 5877065548740974671
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "amount0_out",
@@ -2789,415 +2975,452 @@ note:
     ┌─ demos/uniswap.fe:220:16
     │
 220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^^^^^   ^ u256: Value
     │                │              
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:220:16
     │
 220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^    ^^^^^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^    ^^^^^^^^^^^   ^ u256: Value
     │                │                  │              
-    │                │                  u256: Value => None
-    │                bool: Value => None
+    │                │                  u256: Value
+    │                bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:220:35
     │
 220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                                   ^^^^^^^^^^^^^^^ bool: Value => None
+    │                                   ^^^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:220:16
     │
 220 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<37>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<37>: Memory
     │                │                                    
-    │                bool: Value => None
+    │                bool: Value
 221 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:221:30
+    │
+221 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
 222 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:222:30
+    │
+222 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                │              
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:223:16
     │
 223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                │                          │              
-    │                │                          u256: Value => None
-    │                bool: Value => None
+    │                │                          u256: Value
+    │                bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:223:43
     │
 223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:223:16
     │
 223 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<33>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<33>: Memory
     │                │                                                   
-    │                bool: Value => None
+    │                bool: Value
 224 │ 
 225 │         let token0: ERC20 = ERC20(self.token0)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:225:35
+    │
+225 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:225:29
     │
 225 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 226 │         let token1: ERC20 = ERC20(self.token1)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:226:35
+    │
+226 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:226:29
     │
 226 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
     ·
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^            ^^^^^^ ERC20: Value => None
+    │                ^^            ^^^^^^ ERC20: Value
     │                │              
-    │                address: Value => None
+    │                address: Value
 
 note: 
     ┌─ demos/uniswap.fe:229:22
     │
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                      ^^^^^^^^^^^^^^^ address: Value => None
+    │                      ^^^^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:229:16
     │
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^^^^^^^^^^^^^^^^^^^^     ^^            ^^^^^^ ERC20: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^     ^^            ^^^^^^ ERC20: Value
     │                │                         │              
-    │                │                         address: Value => None
-    │                bool: Value => None
+    │                │                         address: Value
+    │                bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:229:48
     │
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                ^^^^^^^^^^^^^^^ address: Value => None
+    │                                                ^^^^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:229:42
     │
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                          ^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                                          ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:229:16
     │
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^ String<21>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^ String<21>: Memory
     │                │                                                 
-    │                bool: Value => None
+    │                bool: Value
 230 │ 
 231 │         if amount0_out > 0:
-    │            ^^^^^^^^^^^   ^ u256: Value => None
+    │            ^^^^^^^^^^^   ^ u256: Value
     │            │              
-    │            u256: Value => None
+    │            u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:231:12
     │
 231 │         if amount0_out > 0:
-    │            ^^^^^^^^^^^^^^^ bool: Value => None
+    │            ^^^^^^^^^^^^^^^ bool: Value
 232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value => None
+    │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value
     │             │               │    
-    │             │               address: Value => None
-    │             ERC20: Value => None
+    │             │               address: Value
+    │             ERC20: Value
 
 note: 
     ┌─ demos/uniswap.fe:232:13
     │
 232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 233 │         if amount1_out > 0:
-    │            ^^^^^^^^^^^   ^ u256: Value => None
+    │            ^^^^^^^^^^^   ^ u256: Value
     │            │              
-    │            u256: Value => None
+    │            u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:233:12
     │
 233 │         if amount1_out > 0:
-    │            ^^^^^^^^^^^^^^^ bool: Value => None
+    │            ^^^^^^^^^^^^^^^ bool: Value
 234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value => None
+    │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value
     │             │               │    
-    │             │               address: Value => None
-    │             ERC20: Value => None
+    │             │               address: Value
+    │             ERC20: Value
 
 note: 
     ┌─ demos/uniswap.fe:234:13
     │
 234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     ·
 239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              ^^^^^^           ^^^^ UniswapV2Pair: Value
     │                              │                 
-    │                              ERC20: Value => None
+    │                              ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:239:47
+    │
+239 │         let balance0: u256 = token0.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:239:30
     │
 239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                              ^^^^^^           ^^^^ UniswapV2Pair: Value
     │                              │                 
-    │                              ERC20: Value => None
+    │                              ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:240:47
+    │
+240 │         let balance1: u256 = token1.balanceOf(self.address)
+    │                                               ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:240:30
     │
 240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 241 │ 
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                                                       │          │           
-    │                                                                       │          u256: Value => None
-    │                                                                       u256: Value => None
+    │                                                                       │          u256: Value
+    │                                                                       u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:242:82
     │
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:242:32
     │
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     │                                │                                       
-    │                                u256: Value => None
+    │                                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:242:44
     │
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                            │           
-    │                                            u256: Value => None
+    │                                            u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:242:43
     │
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:242:32
     │
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value => None
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value
     │                                │                                                                              
-    │                                u256: Value => None
+    │                                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:242:32
     │
 242 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                                                       │          │           
-    │                                                                       │          u256: Value => None
-    │                                                                       u256: Value => None
+    │                                                                       │          u256: Value
+    │                                                                       u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:243:82
     │
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:243:32
     │
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     │                                │                                       
-    │                                u256: Value => None
+    │                                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:243:44
     │
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value => None
+    │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                            │           
-    │                                            u256: Value => None
+    │                                            u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:243:43
     │
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:243:32
     │
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value => None
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value
     │                                │                                                                              
-    │                                u256: Value => None
+    │                                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:243:32
     │
 243 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 244 │ 
 245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^^^^   ^ u256: Value
     │                │             
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:245:16
     │
 245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^    ^^^^^^^^^^   ^ u256: Value => None
+    │                ^^^^^^^^^^^^^^    ^^^^^^^^^^   ^ u256: Value
     │                │                 │             
-    │                │                 u256: Value => None
-    │                bool: Value => None
+    │                │                 u256: Value
+    │                bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:245:34
     │
 245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                                  ^^^^^^^^^^^^^^ bool: Value => None
+    │                                  ^^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:245:16
     │
 245 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<36>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<36>: Memory
     │                │                                  
-    │                bool: Value => None
+    │                bool: Value
 246 │ 
 247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                       ^^^^^^^^   ^^^^ u256: Value => None
+    │                                       ^^^^^^^^   ^^^^ u256: Value
     │                                       │           
-    │                                       u256: Value => None
+    │                                       u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:247:39
     │
 247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value => None
+    │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value
     │                                       │                 │             
-    │                                       │                 u256: Value => None
-    │                                       u256: Value => None
+    │                                       │                 u256: Value
+    │                                       u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:247:57
     │
 247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                                         ^^^^^^^^^^^^^^ u256: Value => None
+    │                                                         ^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:247:39
     │
 247 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                       ^^^^^^^^   ^^^^ u256: Value => None
+    │                                       ^^^^^^^^   ^^^^ u256: Value
     │                                       │           
-    │                                       u256: Value => None
+    │                                       u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:248:39
     │
 248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value => None
+    │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value
     │                                       │                 │             
-    │                                       │                 u256: Value => None
-    │                                       u256: Value => None
+    │                                       │                 u256: Value
+    │                                       u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:248:57
     │
 248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                                         ^^^^^^^^^^^^^^ u256: Value => None
+    │                                                         ^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:248:39
     │
 248 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 249 │ 
 250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value
     │                │                    
-    │                u256: Value => None
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:250:16
     │
 250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value
     │                │                                        │           
-    │                │                                        u256: Value => None
-    │                u256: Value => None
+    │                │                                        u256: Value
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:250:57
     │
 250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^ u256: Value => None
+    │                                                         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^ u256: Value
     │                                                         │                      
-    │                                                         u256: Value => None
+    │                                                         u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:250:57
     │
 250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:250:16
     │
 250 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ String<12>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ String<12>: Memory
     │                │                                                                        
-    │                bool: Value => None
+    │                bool: Value
 251 │ 
 252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │                      ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value => None
-    │                      │         │         │          
-    │                      │         │         u256: Value => None
-    │                      │         u256: Value => None
-    │                      u256: Value => None
+    │         ^^^^         ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
+    │         │            │         │         │          
+    │         │            │         │         u256: Value
+    │         │            │         u256: Value
+    │         │            u256: Value
+    │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:252:9
     │
 252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                          ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^  ^^ address: Value => None
+    │                          ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^  ^^ address: Value
     │                          │           │           │           │            │             
-    │                          │           │           │           │            u256: Value => None
-    │                          │           │           │           u256: Value => None
-    │                          │           │           u256: Value => None
-    │                          │           u256: Value => None
-    │                          address: Value => None
+    │                          │           │           │           │            u256: Value
+    │                          │           │           │           u256: Value
+    │                          │           │           u256: Value
+    │                          │           u256: Value
+    │                          address: Value
 
 note: 
     ┌─ demos/uniswap.fe:253:9
@@ -3277,102 +3500,28 @@ note:
     ┌─ demos/uniswap.fe:225:29
     │
 225 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:226:29
-    │
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 226 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:229:22
-    │
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
+    ·
 229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                      ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:229:48
-    │
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                                                ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:232:13
-    │
+    │                      ^^^^^^^                   ^^^^^^^ TypeConstructor(Base(Address))
+    │                      │                          
+    │                      TypeConstructor(Base(Address))
+    ·
 232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:234:13
-    │
+    │             ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
+233 │         if amount1_out > 0:
 234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:239:30
-    │
+    │             ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
+    ·
 239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:240:30
-    │
+    │                              ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:252:9
-    │
+    │                              ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
+    ·
 252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 2670672044438645764
-    │
-    = SelfAttribute {
-          func_name: "_update",
-          self_span: 10100..10104,
-      }
+    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ demos/uniswap.fe:256:5
@@ -3383,10 +3532,12 @@ note:
 259 │ │ 
 260 │ │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
 261 │ │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 2346286316485274384
+    │ ╰───────────────────────────────────────────────────────────────────────────^ attributes hash: 2743839557985291820
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "to",
@@ -3416,140 +3567,135 @@ note:
     ┌─ demos/uniswap.fe:257:35
     │
 257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:257:35
+    │
+257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:257:29
     │
 257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:258:35
+    │
+258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:258:29
     │
 258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 259 │ 
 260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │         ^^^^^^          ^^  ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         ^^^^^^          ^^  ^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │               │   │                 
-    │         │               │   ERC20: Value => None
-    │         │               address: Value => None
-    │         ERC20: Value => None
+    │         │               │   ERC20: Value
+    │         │               address: Value
+    │         ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:260:46
+    │
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │                                              ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:260:29
     │
 260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Some(Value)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │                                 
-    │                             u256: Value => None
+    │                             u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:260:62
+    │
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │                                                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:260:29
     │
 260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:260:9
     │
 260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │         ^^^^^^          ^^  ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │         ^^^^^^          ^^  ^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │               │   │                 
-    │         │               │   ERC20: Value => None
-    │         │               address: Value => None
-    │         ERC20: Value => None
+    │         │               │   ERC20: Value
+    │         │               address: Value
+    │         ERC20: Value
+
+note: 
+    ┌─ demos/uniswap.fe:261:46
+    │
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │                                              ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:261:29
     │
 261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │                                 
-    │                             u256: Value => None
+    │                             u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:261:62
+    │
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │                                                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:261:29
     │
 261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:261:9
     │
 261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
     ┌─ demos/uniswap.fe:257:29
     │
 257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:258:29
-    │
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
+259 │ 
+260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
+    │                             ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 note: 
     ┌─ demos/uniswap.fe:260:9
     │
 260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │         ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:260:29
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
+    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
+261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
+    │                             ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 note: 
     ┌─ demos/uniswap.fe:261:9
     │
 261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │         ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:261:29
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
+    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(1) }
 
 note: 
     ┌─ demos/uniswap.fe:264:5
@@ -3558,10 +3704,12 @@ note:
 265 │ │         let token0: ERC20 = ERC20(self.token0)
 266 │ │         let token1: ERC20 = ERC20(self.token1)
 267 │ │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 4369441865732737140
+    │ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 17603814563784536273
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [],
           return_type: Ok(
               Base(
@@ -3582,110 +3730,105 @@ note:
     ┌─ demos/uniswap.fe:265:35
     │
 265 │         let token0: ERC20 = ERC20(self.token0)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:265:35
+    │
+265 │         let token0: ERC20 = ERC20(self.token0)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(5) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:265:29
     │
 265 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 266 │         let token1: ERC20 = ERC20(self.token1)
-    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Some(Value)
+    │                                   ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:266:35
+    │
+266 │         let token1: ERC20 = ERC20(self.token1)
+    │                                   ^^^^^^^^^^^ address: Storage { nonce: Some(6) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:266:29
     │
 266 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value => None
+    │                             ^^^^^^^^^^^^^^^^^^ ERC20: Value
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^           ^^^^^^^^^^^^ address: Value => None
-    │                      │                 
-    │                      ERC20: Value => None
+    │         ^^^^         ^^^^^^           ^^^^ UniswapV2Pair: Value
+    │         │            │                 
+    │         │            ERC20: Value
+    │         UniswapV2Pair: Value
+
+note: 
+    ┌─ demos/uniswap.fe:267:39
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                                       ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:267:22
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^           ^^^^^^^^^^^^ address: Value => None
+    │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^           ^^^^ UniswapV2Pair: Value
     │                      │                               │                 
-    │                      │                               ERC20: Value => None
-    │                      u256: Value => None
+    │                      │                               ERC20: Value
+    │                      u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:267:71
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                                                                       ^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:267:54
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^  ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Some(Value)
-    │                                                      │                               │               
-    │                                                      │                               u256: Storage { nonce: Some(7) } => Some(Value)
-    │                                                      u256: Value => None
+    │                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^ UniswapV2Pair: Value
+    │                                                      │                                
+    │                                                      u256: Value
+
+note: 
+    ┌─ demos/uniswap.fe:267:86
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                                                                                      ^^^^^^^^^^^^^  ^^^^ UniswapV2Pair: Value
+    │                                                                                      │               
+    │                                                                                      u256: Storage { nonce: Some(7) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:267:101
+    │
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                                                                                                     ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:267:9
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
     ┌─ demos/uniswap.fe:265:29
     │
 265 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:266:29
-    │
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
 266 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^ attributes hash: 8534973420157135002
-    │
-    = TypeConstructor {
-          typ: Contract(
-              Contract {
-                  name: "ERC20",
-                  id: ContractId(
-                      0,
-                  ),
-              },
-          ),
-      }
+    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
+267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
+    │                      ^^^^^^^^^^^^^^^^                ^^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
+    │                      │                                
+    │                      ValueMethod { is_self: false, class: Contract(ContractId(0)), method: FunctionId(0) }
 
 note: 
     ┌─ demos/uniswap.fe:267:9
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 11941105680565576248
-    │
-    = SelfAttribute {
-          func_name: "_update",
-          self_span: 10760..10764,
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:267:22
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:267:54
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                                                      ^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
+    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ demos/uniswap.fe:269:5
@@ -3735,94 +3878,94 @@ note:
     ┌─ demos/uniswap.fe:271:13
     │
 271 │         if (val > 3):
-    │             ^^^   ^ u256: Value => None
+    │             ^^^   ^ u256: Value
     │             │      
-    │             u256: Value => None
+    │             u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:271:12
     │
 271 │         if (val > 3):
-    │            ^^^^^^^^^ bool: Value => None
+    │            ^^^^^^^^^ bool: Value
 272 │             z = val
-    │             ^   ^^^ u256: Value => None
+    │             ^   ^^^ u256: Value
     │             │    
-    │             u256: Value => None
+    │             u256: Value
 273 │             let x: u256 = val / 2 + 1
-    │                           ^^^   ^ u256: Value => None
+    │                           ^^^   ^ u256: Value
     │                           │      
-    │                           u256: Value => None
+    │                           u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:273:27
     │
 273 │             let x: u256 = val / 2 + 1
-    │                           ^^^^^^^   ^ u256: Value => None
+    │                           ^^^^^^^   ^ u256: Value
     │                           │          
-    │                           u256: Value => None
+    │                           u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:273:27
     │
 273 │             let x: u256 = val / 2 + 1
-    │                           ^^^^^^^^^^^ u256: Value => None
+    │                           ^^^^^^^^^^^ u256: Value
 274 │             while (x < z):
-    │                    ^   ^ u256: Value => None
+    │                    ^   ^ u256: Value
     │                    │    
-    │                    u256: Value => None
+    │                    u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:274:19
     │
 274 │             while (x < z):
-    │                   ^^^^^^^ bool: Value => None
+    │                   ^^^^^^^ bool: Value
 275 │                 z = x
-    │                 ^   ^ u256: Value => None
+    │                 ^   ^ u256: Value
     │                 │    
-    │                 u256: Value => None
+    │                 u256: Value
 276 │                 x = (val / x + x) / 2
-    │                 ^    ^^^   ^ u256: Value => None
+    │                 ^    ^^^   ^ u256: Value
     │                 │    │      
-    │                 │    u256: Value => None
-    │                 u256: Value => None
+    │                 │    u256: Value
+    │                 u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:276:22
     │
 276 │                 x = (val / x + x) / 2
-    │                      ^^^^^^^   ^ u256: Value => None
+    │                      ^^^^^^^   ^ u256: Value
     │                      │          
-    │                      u256: Value => None
+    │                      u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:276:21
     │
 276 │                 x = (val / x + x) / 2
-    │                     ^^^^^^^^^^^^^   ^ u256: Value => None
+    │                     ^^^^^^^^^^^^^   ^ u256: Value
     │                     │                
-    │                     u256: Value => None
+    │                     u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:276:21
     │
 276 │                 x = (val / x + x) / 2
-    │                     ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                     ^^^^^^^^^^^^^^^^^ u256: Value
 277 │         elif (val != 0):
-    │               ^^^    ^ u256: Value => None
+    │               ^^^    ^ u256: Value
     │               │       
-    │               u256: Value => None
+    │               u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:277:14
     │
 277 │         elif (val != 0):
-    │              ^^^^^^^^^^ bool: Value => None
+    │              ^^^^^^^^^^ bool: Value
 278 │             z = 1
-    │             ^   ^ u256: Value => None
+    │             ^   ^ u256: Value
     │             │    
-    │             u256: Value => None
+    │             u256: Value
 279 │         return z
-    │                ^ u256: Value => None
+    │                ^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:281:5
@@ -3868,24 +4011,24 @@ note:
     ┌─ demos/uniswap.fe:282:21
     │
 282 │         return x if x < y else y
-    │                     ^   ^ u256: Value => None
+    │                     ^   ^ u256: Value
     │                     │    
-    │                     u256: Value => None
+    │                     u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:282:16
     │
 282 │         return x if x < y else y
-    │                ^    ^^^^^      ^ u256: Value => None
+    │                ^    ^^^^^      ^ u256: Value
     │                │    │           
-    │                │    bool: Value => None
-    │                u256: Value => None
+    │                │    bool: Value
+    │                u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:282:16
     │
 282 │         return x if x < y else y
-    │                ^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:285:5
@@ -3920,10 +4063,12 @@ note:
     │  
 302 │ ╭     pub fn fee_to(self) -> address:
 303 │ │         return self.fee_to
-    │ ╰──────────────────────────^ attributes hash: 17651916811868111914
+    │ ╰──────────────────────────^ attributes hash: 10447292744135180405
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [],
           return_type: Ok(
               Base(
@@ -3936,17 +4081,25 @@ note:
     ┌─ demos/uniswap.fe:303:16
     │
 303 │         return self.fee_to
-    │                ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Some(Value)
+    │                ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:303:16
+    │
+303 │         return self.fee_to
+    │                ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:305:5
     │  
 305 │ ╭     pub fn fee_to_setter(self) -> address:
 306 │ │         return self.fee_to_setter
-    │ ╰─────────────────────────────────^ attributes hash: 17651916811868111914
+    │ ╰─────────────────────────────────^ attributes hash: 10447292744135180405
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [],
           return_type: Ok(
               Base(
@@ -3959,17 +4112,25 @@ note:
     ┌─ demos/uniswap.fe:306:16
     │
 306 │         return self.fee_to_setter
-    │                ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Some(Value)
+    │                ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:306:16
+    │
+306 │         return self.fee_to_setter
+    │                ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:308:5
     │  
 308 │ ╭     pub fn all_pairs_length(self) -> u256:
 309 │ │         return self.pair_counter
-    │ ╰────────────────────────────────^ attributes hash: 16482263331346774611
+    │ ╰────────────────────────────────^ attributes hash: 2875164910451995213
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [],
           return_type: Ok(
               Base(
@@ -3984,7 +4145,13 @@ note:
     ┌─ demos/uniswap.fe:309:16
     │
 309 │         return self.pair_counter
-    │                ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
+    │                ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:309:16
+    │
+309 │         return self.pair_counter
+    │                ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:311:5
@@ -3996,10 +4163,12 @@ note:
     · │
 328 │ │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
 329 │ │         return address(pair)
-    │ ╰────────────────────────────^ attributes hash: 12932031939304465073
+    │ ╰────────────────────────────^ attributes hash: 1028840135620418462
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "token_a",
@@ -4042,256 +4211,305 @@ note:
     ┌─ demos/uniswap.fe:312:16
     │
 312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                ^^^^^^^    ^^^^^^^ address: Value => None
+    │                ^^^^^^^    ^^^^^^^ address: Value
     │                │           
-    │                address: Value => None
+    │                address: Value
 
 note: 
     ┌─ demos/uniswap.fe:312:16
     │
 312 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-    │                ^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<30>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<30>: Memory
     │                │                    
-    │                bool: Value => None
+    │                bool: Value
 313 │ 
 314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                                          ^^^^^^^   ^^^^^^^ address: Value => None
+    │                                          ^^^^^^^   ^^^^^^^ address: Value
     │                                          │          
-    │                                          address: Value => None
+    │                                          address: Value
 
 note: 
     ┌─ demos/uniswap.fe:314:31
     │
 314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value => None
+    │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value
     │                               │          │                       
-    │                               │          bool: Value => None
-    │                               address: Value => None
+    │                               │          bool: Value
+    │                               address: Value
 
 note: 
     ┌─ demos/uniswap.fe:314:31
     │
 314 │         let token0: address = token_a if token_a < token_b else token_b
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value
 315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                                          ^^^^^^^   ^^^^^^^ address: Value => None
+    │                                          ^^^^^^^   ^^^^^^^ address: Value
     │                                          │          
-    │                                          address: Value => None
+    │                                          address: Value
 
 note: 
     ┌─ demos/uniswap.fe:315:31
     │
 315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value => None
+    │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value
     │                               │          │                       
-    │                               │          bool: Value => None
-    │                               address: Value => None
+    │                               │          bool: Value
+    │                               address: Value
 
 note: 
     ┌─ demos/uniswap.fe:315:31
     │
 315 │         let token1: address = token_a if token_a > token_b else token_b
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value => None
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value
 316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                ^^^^^^            ^ u256: Value => None
+    │                ^^^^^^            ^ u256: Value
     │                │                  
-    │                address: Value => None
+    │                address: Value
 
 note: 
     ┌─ demos/uniswap.fe:316:26
     │
 316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                          ^^^^^^^^^^ address: Value => None
+    │                          ^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:316:16
     │
 316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ String<23>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ String<23>: Memory
     │                │                      
-    │                bool: Value => None
+    │                bool: Value
 317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^ ^^^^^^ address: Value => None
+    │                ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:317:16
+    │
+317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+    │                ^^^^^^^^^^ ^^^^^^ address: Value
     │                │           
-    │                Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
+    │                Map<address, Map<address, address>>: Storage { nonce: Some(2) }
 
 note: 
     ┌─ demos/uniswap.fe:317:16
     │
 317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+    │                ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
     │                │                   
-    │                Map<address, address>: Storage { nonce: None } => None
+    │                Map<address, address>: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:317:16
     │
 317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^            ^ u256: Value => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^            ^ u256: Value
     │                │                                      
-    │                address: Storage { nonce: None } => Some(Value)
+    │                address: Storage { nonce: None } => Value
 
 note: 
     ┌─ demos/uniswap.fe:317:46
     │
 317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                              ^^^^^^^^^^ address: Value => None
+    │                                              ^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:317:16
     │
 317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^ String<22>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^ String<22>: Memory
     │                │                                          
-    │                bool: Value => None
+    │                bool: Value
 318 │ 
 319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                     ^^^^^^  ^^^^^^ address: Value => None
+    │                                     ^^^^^^  ^^^^^^ address: Value
     │                                     │        
-    │                                     address: Value => None
+    │                                     address: Value
 
 note: 
     ┌─ demos/uniswap.fe:319:36
     │
 319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                    ^^^^^^^^^^^^^^^^ (address, address): Memory => None
+    │                                    ^^^^^^^^^^^^^^^^ (address, address): Memory
 
 note: 
     ┌─ demos/uniswap.fe:319:36
     │
 319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 64>: Memory => None
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 64>: Memory
 
 note: 
     ┌─ demos/uniswap.fe:319:26
     │
 319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                                         ^  ^^^^ u256: Value => None
+    │                                                         ^  ^^^^ u256: Value
     │                                                         │   
-    │                                                         u256: Value => None
+    │                                                         u256: Value
 
 note: 
     ┌─ demos/uniswap.fe:320:35
     │
 320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Pair: Value => None
+    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Pair: Value
 321 │         pair.initialize(token0, token1)
-    │         ^^^^            ^^^^^^  ^^^^^^ address: Value => None
+    │         ^^^^            ^^^^^^  ^^^^^^ address: Value
     │         │               │        
-    │         │               address: Value => None
-    │         UniswapV2Pair: Value => None
+    │         │               address: Value
+    │         UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:321:9
     │
 321 │         pair.initialize(token0, token1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 322 │ 
 323 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:323:9
+    │
+323 │         self.pairs[token0][token1] = address(pair)
+    │         ^^^^^^^^^^ ^^^^^^ address: Value
     │         │           
-    │         Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
+    │         Map<address, Map<address, address>>: Storage { nonce: Some(2) }
 
 note: 
     ┌─ demos/uniswap.fe:323:9
     │
 323 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
     │         │                   
-    │         Map<address, address>: Storage { nonce: None } => None
+    │         Map<address, address>: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:323:9
     │
 323 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │                                     
-    │         address: Storage { nonce: None } => None
+    │         address: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:323:38
     │
 323 │         self.pairs[token0][token1] = address(pair)
-    │                                      ^^^^^^^^^^^^^ address: Value => None
+    │                                      ^^^^^^^^^^^^^ address: Value
 324 │         self.pairs[token1][token0] = address(pair)
-    │         ^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:324:9
+    │
+324 │         self.pairs[token1][token0] = address(pair)
+    │         ^^^^^^^^^^ ^^^^^^ address: Value
     │         │           
-    │         Map<address, Map<address, address>>: Storage { nonce: Some(2) } => None
+    │         Map<address, Map<address, address>>: Storage { nonce: Some(2) }
 
 note: 
     ┌─ demos/uniswap.fe:324:9
     │
 324 │         self.pairs[token1][token0] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value => None
+    │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
     │         │                   
-    │         Map<address, address>: Storage { nonce: None } => None
+    │         Map<address, address>: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:324:9
     │
 324 │         self.pairs[token1][token0] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value => None
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │                                     
-    │         address: Storage { nonce: None } => None
+    │         address: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:324:38
     │
 324 │         self.pairs[token1][token0] = address(pair)
-    │                                      ^^^^^^^^^^^^^ address: Value => None
+    │                                      ^^^^^^^^^^^^^ address: Value
 325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │         ^^^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
-    │         │               
-    │         Array<address, 100>: Storage { nonce: Some(3) } => None
+    │         ^^^^ UniswapV2Factory: Value
 
 note: 
     ┌─ demos/uniswap.fe:325:9
     │
 325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value => None
+    │         ^^^^^^^^^^^^^^ ^^^^ UniswapV2Factory: Value
+    │         │               
+    │         Array<address, 100>: Storage { nonce: Some(3) }
+
+note: 
+    ┌─ demos/uniswap.fe:325:24
+    │
+325 │         self.all_pairs[self.pair_counter] = address(pair)
+    │                        ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:325:9
+    │
+325 │         self.all_pairs[self.pair_counter] = address(pair)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │                                            
-    │         address: Storage { nonce: None } => None
+    │         address: Storage { nonce: None }
 
 note: 
     ┌─ demos/uniswap.fe:325:45
     │
 325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                             ^^^^^^^^^^^^^ address: Value => None
+    │                                             ^^^^^^^^^^^^^ address: Value
 326 │         self.pair_counter = self.pair_counter + 1
-    │         ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^   ^ u256: Value => None
-    │         │                   │                    
-    │         │                   u256: Storage { nonce: Some(4) } => Some(Value)
-    │         u256: Storage { nonce: Some(4) } => None
+    │         ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:326:9
+    │
+326 │         self.pair_counter = self.pair_counter + 1
+    │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Factory: Value
+    │         │                    
+    │         u256: Storage { nonce: Some(4) }
 
 note: 
     ┌─ demos/uniswap.fe:326:29
     │
 326 │         self.pair_counter = self.pair_counter + 1
-    │                             ^^^^^^^^^^^^^^^^^^^^^ u256: Value => None
+    │                             ^^^^^^^^^^^^^^^^^   ^ u256: Value
+    │                             │                    
+    │                             u256: Storage { nonce: Some(4) } => Value
+
+note: 
+    ┌─ demos/uniswap.fe:326:29
+    │
+326 │         self.pair_counter = self.pair_counter + 1
+    │                             ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 327 │ 
 328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                          ^^^^^^  ^^^^^^               ^^^^ UniswapV2Pair: Value => None
+    │                          ^^^^^^  ^^^^^^               ^^^^ UniswapV2Pair: Value
     │                          │       │                     
-    │                          │       address: Value => None
-    │                          address: Value => None
+    │                          │       address: Value
+    │                          address: Value
 
 note: 
     ┌─ demos/uniswap.fe:328:47
     │
 328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                               ^^^^^^^^^^^^^        ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Some(Value)
+    │                                               ^^^^^^^^^^^^^        ^^^^ UniswapV2Factory: Value
     │                                               │                     
-    │                                               address: Value => None
+    │                                               address: Value
+
+note: 
+    ┌─ demos/uniswap.fe:328:68
+    │
+328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+    │                                                                    ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
 329 │         return address(pair)
-    │                        ^^^^ UniswapV2Pair: Value => None
+    │                        ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ demos/uniswap.fe:329:16
     │
 329 │         return address(pair)
-    │                ^^^^^^^^^^^^^ address: Value => None
+    │                ^^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ demos/uniswap.fe:328:9
@@ -4347,129 +4565,34 @@ note:
     ┌─ demos/uniswap.fe:316:26
     │
 316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                          ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:317:46
-    │
+    │                          ^^^^^^^ TypeConstructor(Base(Address))
 317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                              ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
+    │                                              ^^^^^^^ TypeConstructor(Base(Address))
+318 │ 
+319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod(AbiEncode)
 
 note: 
     ┌─ demos/uniswap.fe:319:26
     │
 319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                          ^^^^^^^^^ attributes hash: 3985281278010092305
-    │
-    = BuiltinFunction(
-          Keccak256,
-      )
-
-note: 
-    ┌─ demos/uniswap.fe:319:36
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:320:35
-    │
+    │                          ^^^^^^^^^ BuiltinFunction(Keccak256)
 320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                   ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13487454703654049111
-    │
-    = TypeAttribute {
-          typ: Contract(
-              Contract {
-                  name: "UniswapV2Pair",
-                  id: ContractId(
-                      1,
-                  ),
-              },
-          ),
-          func_name: "create2",
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:321:9
-    │
+    │                                   ^^^^^^^^^^^^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(1), function: Create2 }
 321 │         pair.initialize(token0, token1)
-    │         ^^^^^^^^^^^^^^^ attributes hash: 15856680294290209687
-    │
-    = ValueAttribute
-
-note: 
-    ┌─ demos/uniswap.fe:323:38
-    │
+    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Contract(ContractId(1)), method: FunctionId(15) }
+322 │ 
 323 │         self.pairs[token0][token1] = address(pair)
-    │                                      ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:324:38
-    │
+    │                                      ^^^^^^^ TypeConstructor(Base(Address))
 324 │         self.pairs[token1][token0] = address(pair)
-    │                                      ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:325:45
-    │
+    │                                      ^^^^^^^ TypeConstructor(Base(Address))
 325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                             ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:328:47
-    │
+    │                                             ^^^^^^^ TypeConstructor(Base(Address))
+    ·
 328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                               ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
-
-note: 
-    ┌─ demos/uniswap.fe:329:16
-    │
+    │                                               ^^^^^^^ TypeConstructor(Base(Address))
 329 │         return address(pair)
-    │                ^^^^^^^ attributes hash: 14203407709342965641
-    │
-    = TypeConstructor {
-          typ: Base(
-              Address,
-          ),
-      }
+    │                ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
     ┌─ demos/uniswap.fe:331:5
@@ -4477,10 +4600,12 @@ note:
 331 │ ╭     pub fn set_fee_to(self, fee_to: address):
 332 │ │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
 333 │ │         self.fee_to = fee_to
-    │ ╰────────────────────────────^ attributes hash: 14618921052791880235
+    │ ╰────────────────────────────^ attributes hash: 9065496511898574892
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "fee_to",
@@ -4502,21 +4627,33 @@ note:
     ┌─ demos/uniswap.fe:332:16
     │
 332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^    ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Some(Value)
+    │                ^^^^^^^^^^    ^^^^ UniswapV2Factory: Value
     │                │              
-    │                address: Value => None
+    │                address: Value
+
+note: 
+    ┌─ demos/uniswap.fe:332:30
+    │
+332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+    │                              ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Value
 
 note: 
     ┌─ demos/uniswap.fe:332:16
     │
 332 │         assert msg.sender == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory
     │                │                                  
-    │                bool: Value => None
+    │                bool: Value
 333 │         self.fee_to = fee_to
-    │         ^^^^^^^^^^^   ^^^^^^ address: Value => None
+    │         ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:333:9
+    │
+333 │         self.fee_to = fee_to
+    │         ^^^^^^^^^^^   ^^^^^^ address: Value
     │         │              
-    │         address: Storage { nonce: Some(0) } => None
+    │         address: Storage { nonce: Some(0) }
 
 note: 
     ┌─ demos/uniswap.fe:335:5
@@ -4524,10 +4661,12 @@ note:
 335 │ ╭     pub fn set_fee_to_setter(self, fee_to_setter: address):
 336 │ │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
 337 │ │         self.fee_to_setter = fee_to_setter
-    │ ╰──────────────────────────────────────────^ attributes hash: 10732478853163688613
+    │ ╰──────────────────────────────────────────^ attributes hash: 13278168041135876934
     │  
     = FunctionSignature {
-          self_decl: Mutable,
+          self_decl: Some(
+              Mutable,
+          ),
           params: [
               FunctionParam {
                   name: "fee_to_setter",
@@ -4549,20 +4688,26 @@ note:
     ┌─ demos/uniswap.fe:336:16
     │
 336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^    ^^^^^^^^^^^^^ address: Value => None
+    │                ^^^^^^^^^^    ^^^^^^^^^^^^^ address: Value
     │                │              
-    │                address: Value => None
+    │                address: Value
 
 note: 
     ┌─ demos/uniswap.fe:336:16
     │
 336 │         assert msg.sender == fee_to_setter, "UniswapV2: FORBIDDEN"
-    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory => None
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory
     │                │                             
-    │                bool: Value => None
+    │                bool: Value
 337 │         self.fee_to_setter = fee_to_setter
-    │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ address: Value => None
+    │         ^^^^ UniswapV2Factory: Value
+
+note: 
+    ┌─ demos/uniswap.fe:337:9
+    │
+337 │         self.fee_to_setter = fee_to_setter
+    │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ address: Value
     │         │                     
-    │         address: Storage { nonce: Some(1) } => None
+    │         address: Storage { nonce: Some(1) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop.snap
@@ -28,93 +28,52 @@ note:
     }
 
 note: 
+  ┌─ features/while_loop.fe:3:18
+  │
+3 │         let val: u256 = 0
+  │                  ^^^^ u256
+
+note: 
   ┌─ features/while_loop.fe:3:25
   │
 3 │         let val: u256 = 0
   │                         ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:4:15
-  │
 4 │         while val < 2:
-  │               ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:4:21
-  │
-4 │         while val < 2:
-  │                     ^ u256: Value => None
+  │               ^^^   ^ u256: Value => None
+  │               │      
+  │               u256: Value => None
 
 note: 
   ┌─ features/while_loop.fe:4:15
   │
 4 │         while val < 2:
   │               ^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:5:13
-  │
 5 │             val = val + 1
-  │             ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:5:19
-  │
-5 │             val = val + 1
-  │                   ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:5:25
-  │
-5 │             val = val + 1
-  │                         ^ u256: Value => None
+  │             ^^^   ^^^   ^ u256: Value => None
+  │             │     │      
+  │             │     u256: Value => None
+  │             u256: Value => None
 
 note: 
   ┌─ features/while_loop.fe:5:19
   │
 5 │             val = val + 1
   │                   ^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:6:16
-  │
 6 │             if val == 2:
-  │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:6:23
-  │
-6 │             if val == 2:
-  │                       ^ u256: Value => None
+  │                ^^^    ^ u256: Value => None
+  │                │       
+  │                u256: Value => None
 
 note: 
   ┌─ features/while_loop.fe:6:16
   │
 6 │             if val == 2:
   │                ^^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:7:17
-  │
 7 │                 val = 3
-  │                 ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:7:23
-  │
-7 │                 val = 3
-  │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:8:16
-  │
+  │                 ^^^   ^ u256: Value => None
+  │                 │      
+  │                 u256: Value => None
 8 │         return val
   │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop.fe:3:18
-  │
-3 │         let val: u256 = 0
-  │                  ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop.snap
@@ -37,43 +37,43 @@ note:
   ┌─ features/while_loop.fe:3:25
   │
 3 │         let val: u256 = 0
-  │                         ^ u256: Value => None
+  │                         ^ u256: Value
 4 │         while val < 2:
-  │               ^^^   ^ u256: Value => None
+  │               ^^^   ^ u256: Value
   │               │      
-  │               u256: Value => None
+  │               u256: Value
 
 note: 
   ┌─ features/while_loop.fe:4:15
   │
 4 │         while val < 2:
-  │               ^^^^^^^ bool: Value => None
+  │               ^^^^^^^ bool: Value
 5 │             val = val + 1
-  │             ^^^   ^^^   ^ u256: Value => None
+  │             ^^^   ^^^   ^ u256: Value
   │             │     │      
-  │             │     u256: Value => None
-  │             u256: Value => None
+  │             │     u256: Value
+  │             u256: Value
 
 note: 
   ┌─ features/while_loop.fe:5:19
   │
 5 │             val = val + 1
-  │                   ^^^^^^^ u256: Value => None
+  │                   ^^^^^^^ u256: Value
 6 │             if val == 2:
-  │                ^^^    ^ u256: Value => None
+  │                ^^^    ^ u256: Value
   │                │       
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/while_loop.fe:6:16
   │
 6 │             if val == 2:
-  │                ^^^^^^^^ bool: Value => None
+  │                ^^^^^^^^ bool: Value
 7 │                 val = 3
-  │                 ^^^   ^ u256: Value => None
+  │                 ^^^   ^ u256: Value
   │                 │      
-  │                 u256: Value => None
+  │                 u256: Value
 8 │         return val
-  │                ^^^ u256: Value => None
+  │                ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
@@ -27,63 +27,39 @@ note:
     }
 
 note: 
+  ┌─ features/while_loop_with_break.fe:3:18
+  │
+3 │         let val: u256 = 0
+  │                  ^^^^ u256
+
+note: 
   ┌─ features/while_loop_with_break.fe:3:25
   │
 3 │         let val: u256 = 0
   │                         ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:4:15
-  │
 4 │         while val < 2:
-  │               ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:4:21
-  │
-4 │         while val < 2:
-  │                     ^ u256: Value => None
+  │               ^^^   ^ u256: Value => None
+  │               │      
+  │               u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_break.fe:4:15
   │
 4 │         while val < 2:
   │               ^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:5:13
-  │
 5 │             val = val + 1
-  │             ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:5:19
-  │
-5 │             val = val + 1
-  │                   ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:5:25
-  │
-5 │             val = val + 1
-  │                         ^ u256: Value => None
+  │             ^^^   ^^^   ^ u256: Value => None
+  │             │     │      
+  │             │     u256: Value => None
+  │             u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_break.fe:5:19
   │
 5 │             val = val + 1
   │                   ^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:7:16
-  │
+6 │             break
 7 │         return val
   │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break.fe:3:18
-  │
-3 │         let val: u256 = 0
-  │                  ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
@@ -36,30 +36,30 @@ note:
   ┌─ features/while_loop_with_break.fe:3:25
   │
 3 │         let val: u256 = 0
-  │                         ^ u256: Value => None
+  │                         ^ u256: Value
 4 │         while val < 2:
-  │               ^^^   ^ u256: Value => None
+  │               ^^^   ^ u256: Value
   │               │      
-  │               u256: Value => None
+  │               u256: Value
 
 note: 
   ┌─ features/while_loop_with_break.fe:4:15
   │
 4 │         while val < 2:
-  │               ^^^^^^^ bool: Value => None
+  │               ^^^^^^^ bool: Value
 5 │             val = val + 1
-  │             ^^^   ^^^   ^ u256: Value => None
+  │             ^^^   ^^^   ^ u256: Value
   │             │     │      
-  │             │     u256: Value => None
-  │             u256: Value => None
+  │             │     u256: Value
+  │             u256: Value
 
 note: 
   ┌─ features/while_loop_with_break.fe:5:19
   │
 5 │             val = val + 1
-  │                   ^^^^^^^ u256: Value => None
+  │                   ^^^^^^^ u256: Value
 6 │             break
 7 │         return val
-  │                ^^^ u256: Value => None
+  │                ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
@@ -28,81 +28,49 @@ note:
     }
 
 note: 
+  ┌─ features/while_loop_with_break_2.fe:3:18
+  │
+3 │         let val: u256 = 0
+  │                  ^^^^ u256
+
+note: 
   ┌─ features/while_loop_with_break_2.fe:3:25
   │
 3 │         let val: u256 = 0
   │                         ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:4:15
-  │
 4 │         while val < 2:
-  │               ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:4:21
-  │
-4 │         while val < 2:
-  │                     ^ u256: Value => None
+  │               ^^^   ^ u256: Value => None
+  │               │      
+  │               u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_break_2.fe:4:15
   │
 4 │         while val < 2:
   │               ^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:5:13
-  │
 5 │             val = val + 1
-  │             ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:5:19
-  │
-5 │             val = val + 1
-  │                   ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:5:25
-  │
-5 │             val = val + 1
-  │                         ^ u256: Value => None
+  │             ^^^   ^^^   ^ u256: Value => None
+  │             │     │      
+  │             │     u256: Value => None
+  │             u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_break_2.fe:5:19
   │
 5 │             val = val + 1
   │                   ^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:6:16
-  │
 6 │             if val == 1:
-  │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:6:23
-  │
-6 │             if val == 1:
-  │                       ^ u256: Value => None
+  │                ^^^    ^ u256: Value => None
+  │                │       
+  │                u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_break_2.fe:6:16
   │
 6 │             if val == 1:
   │                ^^^^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:8:16
-  │
+7 │                 break
 8 │         return val
   │                ^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_break_2.fe:3:18
-  │
-3 │         let val: u256 = 0
-  │                  ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
@@ -37,40 +37,40 @@ note:
   ┌─ features/while_loop_with_break_2.fe:3:25
   │
 3 │         let val: u256 = 0
-  │                         ^ u256: Value => None
+  │                         ^ u256: Value
 4 │         while val < 2:
-  │               ^^^   ^ u256: Value => None
+  │               ^^^   ^ u256: Value
   │               │      
-  │               u256: Value => None
+  │               u256: Value
 
 note: 
   ┌─ features/while_loop_with_break_2.fe:4:15
   │
 4 │         while val < 2:
-  │               ^^^^^^^ bool: Value => None
+  │               ^^^^^^^ bool: Value
 5 │             val = val + 1
-  │             ^^^   ^^^   ^ u256: Value => None
+  │             ^^^   ^^^   ^ u256: Value
   │             │     │      
-  │             │     u256: Value => None
-  │             u256: Value => None
+  │             │     u256: Value
+  │             u256: Value
 
 note: 
   ┌─ features/while_loop_with_break_2.fe:5:19
   │
 5 │             val = val + 1
-  │                   ^^^^^^^ u256: Value => None
+  │                   ^^^^^^^ u256: Value
 6 │             if val == 1:
-  │                ^^^    ^ u256: Value => None
+  │                ^^^    ^ u256: Value
   │                │       
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
   ┌─ features/while_loop_with_break_2.fe:6:16
   │
 6 │             if val == 1:
-  │                ^^^^^^^^ bool: Value => None
+  │                ^^^^^^^^ bool: Value
 7 │                 break
 8 │         return val
-  │                ^^^ u256: Value => None
+  │                ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
@@ -28,117 +28,65 @@ note:
      }
 
 note: 
+  ┌─ features/while_loop_with_continue.fe:3:16
+  │
+3 │         let i: u256 = 0
+  │                ^^^^ u256
+4 │         let counter: u256 = 0
+  │                      ^^^^ u256
+
+note: 
   ┌─ features/while_loop_with_continue.fe:3:23
   │
 3 │         let i: u256 = 0
   │                       ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:4:29
-  │
 4 │         let counter: u256 = 0
   │                             ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:6:15
-  │
+5 │ 
 6 │         while i < 2:
-  │               ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:6:19
-  │
-6 │         while i < 2:
-  │                   ^ u256: Value => None
+  │               ^   ^ u256: Value => None
+  │               │    
+  │               u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_continue.fe:6:15
   │
 6 │         while i < 2:
   │               ^^^^^ bool: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:7:13
-  │
 7 │             i = i + 1
-  │             ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:7:17
-  │
-7 │             i = i + 1
-  │                 ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:7:21
-  │
-7 │             i = i + 1
-  │                     ^ u256: Value => None
+  │             ^   ^   ^ u256: Value => None
+  │             │   │    
+  │             │   u256: Value => None
+  │             u256: Value => None
 
 note: 
   ┌─ features/while_loop_with_continue.fe:7:17
   │
 7 │             i = i + 1
   │                 ^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:8:16
-  │
 8 │             if i == 1:
-  │                ^ u256: Value => None
+  │                ^    ^ u256: Value => None
+  │                │     
+  │                u256: Value => None
 
 note: 
-  ┌─ features/while_loop_with_continue.fe:8:21
-  │
-8 │             if i == 1:
-  │                     ^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:8:16
-  │
-8 │             if i == 1:
-  │                ^^^^^^ bool: Value => None
-
-note: 
-   ┌─ features/while_loop_with_continue.fe:10:13
+   ┌─ features/while_loop_with_continue.fe:8:16
    │
+ 8 │             if i == 1:
+   │                ^^^^^^ bool: Value => None
+ 9 │                 continue
 10 │             counter = counter + 1
-   │             ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/while_loop_with_continue.fe:10:23
-   │
-10 │             counter = counter + 1
-   │                       ^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/while_loop_with_continue.fe:10:33
-   │
-10 │             counter = counter + 1
-   │                                 ^ u256: Value => None
+   │             ^^^^^^^   ^^^^^^^   ^ u256: Value => None
+   │             │         │          
+   │             │         u256: Value => None
+   │             u256: Value => None
 
 note: 
    ┌─ features/while_loop_with_continue.fe:10:23
    │
 10 │             counter = counter + 1
    │                       ^^^^^^^^^^^ u256: Value => None
-
-note: 
-   ┌─ features/while_loop_with_continue.fe:11:16
-   │
 11 │         return counter
    │                ^^^^^^^ u256: Value => None
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:3:16
-  │
-3 │         let i: u256 = 0
-  │                ^^^^ u256
-
-note: 
-  ┌─ features/while_loop_with_continue.fe:4:22
-  │
-4 │         let counter: u256 = 0
-  │                      ^^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
@@ -39,54 +39,54 @@ note:
   ┌─ features/while_loop_with_continue.fe:3:23
   │
 3 │         let i: u256 = 0
-  │                       ^ u256: Value => None
+  │                       ^ u256: Value
 4 │         let counter: u256 = 0
-  │                             ^ u256: Value => None
+  │                             ^ u256: Value
 5 │ 
 6 │         while i < 2:
-  │               ^   ^ u256: Value => None
+  │               ^   ^ u256: Value
   │               │    
-  │               u256: Value => None
+  │               u256: Value
 
 note: 
   ┌─ features/while_loop_with_continue.fe:6:15
   │
 6 │         while i < 2:
-  │               ^^^^^ bool: Value => None
+  │               ^^^^^ bool: Value
 7 │             i = i + 1
-  │             ^   ^   ^ u256: Value => None
+  │             ^   ^   ^ u256: Value
   │             │   │    
-  │             │   u256: Value => None
-  │             u256: Value => None
+  │             │   u256: Value
+  │             u256: Value
 
 note: 
   ┌─ features/while_loop_with_continue.fe:7:17
   │
 7 │             i = i + 1
-  │                 ^^^^^ u256: Value => None
+  │                 ^^^^^ u256: Value
 8 │             if i == 1:
-  │                ^    ^ u256: Value => None
+  │                ^    ^ u256: Value
   │                │     
-  │                u256: Value => None
+  │                u256: Value
 
 note: 
    ┌─ features/while_loop_with_continue.fe:8:16
    │
  8 │             if i == 1:
-   │                ^^^^^^ bool: Value => None
+   │                ^^^^^^ bool: Value
  9 │                 continue
 10 │             counter = counter + 1
-   │             ^^^^^^^   ^^^^^^^   ^ u256: Value => None
+   │             ^^^^^^^   ^^^^^^^   ^ u256: Value
    │             │         │          
-   │             │         u256: Value => None
-   │             u256: Value => None
+   │             │         u256: Value
+   │             u256: Value
 
 note: 
    ┌─ features/while_loop_with_continue.fe:10:23
    │
 10 │             counter = counter + 1
-   │                       ^^^^^^^^^^^ u256: Value => None
+   │                       ^^^^^^^^^^^ u256: Value
 11 │         return counter
-   │                ^^^^^^^ u256: Value => None
+   │                ^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_builtin_object.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_builtin_object.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: no function `foo` exists on builtin `block`
+error: no function `foo` exists on `block`
   ┌─ compile_errors/call_builtin_object.fe:4:5
   │
 4 │     block.foo()

--- a/crates/analyzer/tests/snapshots/errors__call_create2_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_create2_with_wrong_type.snap
@@ -3,10 +3,26 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: function `create2` expects numeric parameters
-  ┌─ compile_errors/call_create2_with_wrong_type.fe:7:20
+error: incorrect type for argument to `Bar.create2`
+  ┌─ compile_errors/call_create2_with_wrong_type.fe:7:21
   │
 7 │         Bar.create2(true, 1)
-  │                    ^^^^^^^^^ invalid argument
+  │                     ^^^^ this has type `bool`; expected a number
+
+error: `create2` expects 2 arguments, but 1 was provided
+  ┌─ compile_errors/call_create2_with_wrong_type.fe:8:13
+  │
+8 │         Bar.create2(1)  # agroce #447
+  │             ^^^^^^^ - supplied 1 argument
+  │             │        
+  │             expects 2 arguments
+
+error: `create2` expects 2 arguments, but 0 were provided
+  ┌─ compile_errors/call_create2_with_wrong_type.fe:9:13
+  │
+9 │         Bar.create2()
+  │             ^^^^^^^-- supplied 0 arguments
+  │             │       
+  │             expects 2 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_create_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_create_with_wrong_type.snap
@@ -3,10 +3,18 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: function `create` expects numeric parameter
-  ┌─ compile_errors/call_create_with_wrong_type.fe:7:19
+error: incorrect type for argument to `Bar.create`
+  ┌─ compile_errors/call_create_with_wrong_type.fe:6:20
   │
-7 │         Bar.create(true)
-  │                   ^^^^^^ invalid argument
+6 │         Bar.create(true)
+  │                    ^^^^ this has type `bool`; expected a number
+
+error: `create` expects 1 argument, but 0 were provided
+  ┌─ compile_errors/call_create_with_wrong_type.fe:7:13
+  │
+7 │         Bar.create()     # agroce #447
+  │             ^^^^^^-- supplied 0 arguments
+  │             │      
+  │             expects 1 argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_to_pure_fn_on_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_to_pure_fn_on_self.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `pure` must be called without `self`
-  ┌─ compile_errors/call_to_pure_fn_on_self.fe:6:9
+  ┌─ compile_errors/call_to_pure_fn_on_self.fe:6:14
   │
 6 │         self.pure()
-  │         ^^^^^^^^^ function does not take self
+  │              ^^^^ function does not take self
   │
   = Suggestion: try `pure(...)` instead of `self.pure(...)`
 

--- a/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_contract.snap
@@ -3,10 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: no function named `doesnt_exist` exists in this contract
-  ┌─ [snippet]:3:3
+error: No function `doesnt_exist` exists on type `C`
+  ┌─ [snippet]:3:8
   │
 3 │   self.doesnt_exist()
-  │   ^^^^^^^^^^^^^^^^^ undefined function
+  │        ^^^^^^^^^^^^ undefined function
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_external_contract.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: No function `doesnt_exist` exists on contract `Foo`
+error: No function `doesnt_exist` exists on type `Foo`
   ┌─ compile_errors/call_undefined_function_on_external_contract.fe:7:21
   │
 7 │     Foo(address(0)).doesnt_exist()

--- a/crates/analyzer/tests/snapshots/errors__circular_dependency_create.snap
+++ b/crates/analyzer/tests/snapshots/errors__circular_dependency_create.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `Foo.create(...)` called within `Foo` creates an illegal circular dependency
-  ┌─ compile_errors/circular_dependency_create.fe:3:24
+  ┌─ compile_errors/circular_dependency_create.fe:3:28
   │
 3 │         let foo: Foo = Foo.create(0)
-  │                        ^^^^^^^^^^ Contract creation
+  │                            ^^^^^^ Contract creation
   │
   = Note: Consider using a dedicated factory contract to create instances of `Foo`
 

--- a/crates/analyzer/tests/snapshots/errors__circular_dependency_create2.snap
+++ b/crates/analyzer/tests/snapshots/errors__circular_dependency_create2.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: `Foo.create2(...)` called within `Foo` creates an illegal circular dependency
-  ┌─ compile_errors/circular_dependency_create2.fe:3:24
+  ┌─ compile_errors/circular_dependency_create2.fe:3:28
   │
 3 │         let foo: Foo = Foo.create2(2, 0)
-  │                        ^^^^^^^^^^^ Contract creation
+  │                            ^^^^^^^ Contract creation
   │
   = Note: Consider using a dedicated factory contract to create instances of `Foo`
 

--- a/crates/analyzer/tests/snapshots/errors__init_call_on_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__init_call_on_self.snap
@@ -3,11 +3,20 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: `__init__()` is not directly callable
+error: `self` is not defined
   ┌─ compile_errors/init_call_on_self.fe:6:5
   │
 6 │     self.__init__()
-  │     ^^^^^^^^^^^^^
+  │     ^^^^ undefined value
+  │
+  = add `self` to the scope by including it in the function signature
+  = Example: `fn bar(self, foo: bool)`
+
+error: `__init__()` is not directly callable
+  ┌─ compile_errors/init_call_on_self.fe:6:10
+  │
+6 │     self.__init__()
+  │          ^^^^^^^^
   │
   = Note: `__init__` is the constructor function, and can't be called at runtime.
 

--- a/crates/analyzer/tests/snapshots/errors__missing_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__missing_self.snap
@@ -10,6 +10,15 @@ error: `self` is not defined
   │         ^^^^ undefined value
   │
   = add `self` to the scope by including it in the function signature
-  = Example: `fn foo(self, bar: bool)`
+  = Example: `fn pure_fn(self, foo: bool)`
+
+error: `self` is not defined
+   ┌─ compile_errors/missing_self.fe:12:16
+   │
+12 │         return self.x
+   │                ^^^^ undefined value
+   │
+   = add `self` to the scope by including it in the function signature
+   = Example: `fn f(self, foo: bool)`
 
 

--- a/crates/analyzer/tests/snapshots/errors__not_callable.snap
+++ b/crates/analyzer/tests/snapshots/errors__not_callable.snap
@@ -27,6 +27,6 @@ error: `self` is not callable
    ┌─ compile_errors/not_callable.fe:16:5
    │
 16 │     self()
-   │     ^^^^ `self` is a built-in object, and can't be used as a function
+   │     ^^^^ can't be used as a function
 
 

--- a/crates/analyzer/tests/snapshots/errors__self_in_standalone_fn.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_in_standalone_fn.snap
@@ -3,17 +3,17 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, &src)"
 
 ---
-error: `self` can only be used in contract functions
+error: `self` can only be used in contract or struct functions
   ┌─ compile_errors/self_in_standalone_fn.fe:1:12
   │
 1 │ fn pure_fn(self):
-  │            ^^^^ not allowed in functions defined outside of a contract
+  │            ^^^^ not allowed in functions defined outside of a contract or struct
 
-error: `self` can only be used in contract functions
+error: `self` can only be used in contract or struct functions
   ┌─ compile_errors/self_in_standalone_fn.fe:2:5
   │
 2 │     self.mut_fn()
-  │     ^^^^ not allowed in functions defined outside of a contract
+  │     ^^^^ not allowed in functions defined outside of a contract or struct
 
 error: `pure_fn` expects 0 arguments, but 1 was provided
   ┌─ compile_errors/self_in_standalone_fn.fe:1:4

--- a/crates/analyzer/tests/snapshots/errors__self_misuse.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_misuse.snap
@@ -1,0 +1,41 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: `self` can't be used as a variable name
+  ┌─ compile_errors/self_misuse.fe:2:7
+  │
+2 │   let self: u8 = 10
+  │       ^^^^ expected a name, found keyword `self`
+
+error: `self` can only be used in contract or struct functions
+  ┌─ compile_errors/self_misuse.fe:3:3
+  │
+3 │   self = 5
+  │   ^^^^ not allowed in functions defined outside of a contract or struct
+
+error: `self` is not callable
+   ┌─ compile_errors/self_misuse.fe:15:5
+   │
+15 │     self()
+   │     ^^^^ can't be used as a function
+
+error: `g` must be called via `self`
+   ┌─ compile_errors/self_misuse.fe:26:6
+   │
+26 │   fn g(self):
+   │      ^ `g` is defined here as a function that takes `self`
+   ·
+30 │     g(self)
+   │     ^ `g` is called here as a standalone function
+   │
+   = Suggestion: use `self.g(...)` instead of `g(...)`
+
+error: invalid use of contract `self`
+   ┌─ compile_errors/self_misuse.fe:33:9
+   │
+33 │     bar(self)
+   │         ^^^^ `self` can't be used here
+
+

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_function.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_function.snap
@@ -21,10 +21,4 @@ error: function name `bool` conflicts with built-in type
 8 │   pub fn bool(x: u8) -> bool:
   │          ^^^^ `bool` is a built-in type
 
-error: function name `self` conflicts with built-in object
-   ┌─ compile_errors/shadow_builtin_function.fe:11:10
-   │
-11 │   pub fn self() -> bool:
-   │          ^^^^ `self` is a built-in object
-
 

--- a/crates/analyzer/tests/snapshots/errors__shadow_builtin_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__shadow_builtin_type.snap
@@ -51,22 +51,16 @@ error: type name conflicts with built-in object
 9 │ type chain = u8
   │      ^^^^^ `chain` is a built-in object
 
-error: type name conflicts with built-in object
-   ┌─ compile_errors/shadow_builtin_type.fe:10:6
-   │
-10 │ type self = u8
-   │      ^^^^ `self` is a built-in object
-
 error: function parameter name `u8` conflicts with built-in type
-   ┌─ compile_errors/shadow_builtin_type.fe:13:8
+   ┌─ compile_errors/shadow_builtin_type.fe:12:8
    │
-13 │   fn f(u8: u256):
+12 │   fn f(u8: u256):
    │        ^^ `u8` is a built-in type
 
 error: function parameter name `keccak256` conflicts with built-in function
-   ┌─ compile_errors/shadow_builtin_type.fe:16:8
+   ┌─ compile_errors/shadow_builtin_type.fe:15:8
    │
-16 │   fn g(keccak256: u8):
+15 │   fn g(keccak256: u8):
    │        ^^^^^^^^^ `keccak256` is a built-in function
 
 

--- a/crates/common/src/span.rs
+++ b/crates/common/src/span.rs
@@ -1,5 +1,6 @@
 use crate::files::SourceFileId;
 use serde::{Deserialize, Serialize};
+use std::cmp;
 use std::fmt::{Debug, Formatter};
 use std::ops::{Add, AddAssign, Range};
 
@@ -24,8 +25,8 @@ impl Span {
     pub fn new(file_id: SourceFileId, start: usize, end: usize) -> Self {
         Span {
             file_id,
-            start,
-            end,
+            start: cmp::min(start, end),
+            end: cmp::max(start, end),
         }
     }
 

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -92,7 +92,7 @@ pub fn main() {
     }
     let (content, id) = file.unwrap();
 
-    let compiled_module = match fe_driver::compile(id, &content, with_bytecode, optimize) {
+    let compiled_module = match fe_driver::compile(&files, id, &content, with_bytecode, optimize) {
         Ok(module) => module,
         Err(error) => {
             eprintln!("Unable to compile {}.", input_file);

--- a/crates/lowering/src/mappers/mod.rs
+++ b/crates/lowering/src/mappers/mod.rs
@@ -2,4 +2,5 @@ mod contracts;
 mod expressions;
 mod functions;
 pub mod module;
+mod structs;
 mod types;

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -1,5 +1,5 @@
 use crate::context::ModuleContext;
-use crate::mappers::{contracts, functions, types};
+use crate::mappers::{contracts, functions, structs, types};
 use crate::names;
 use crate::utils::ZeroSpanNode;
 use fe_analyzer::namespace::items::{Item, ModuleId, TypeDef};
@@ -41,7 +41,10 @@ pub fn module(db: &dyn AnalyzerDb, module: ModuleId) -> ast::Module {
                     id.span(db),
                 )))
             }
-            TypeDef::Struct(id) => Some(ast::ModuleStmt::Struct(id.data(db).ast.clone())),
+            TypeDef::Struct(id) => Some(ast::ModuleStmt::Struct(structs::struct_def(
+                &mut context,
+                *id,
+            ))),
             TypeDef::Contract(id) => Some(ast::ModuleStmt::Contract(contracts::contract_def(
                 &mut context,
                 *id,
@@ -97,6 +100,7 @@ fn build_tuple_struct(tuple: &Tuple) -> ast::Struct {
     ast::Struct {
         name: names::tuple_struct_name(tuple).into_node(),
         fields,
+        functions: vec![],
     }
 }
 

--- a/crates/lowering/src/mappers/structs.rs
+++ b/crates/lowering/src/mappers/structs.rs
@@ -1,0 +1,46 @@
+use crate::context::ModuleContext;
+use crate::mappers::{functions, types};
+use fe_analyzer::namespace::items::{StructFieldId, StructId};
+use fe_parser::ast;
+use fe_parser::node::Node;
+
+pub fn struct_def(context: &mut ModuleContext, struct_: StructId) -> Node<ast::Struct> {
+    let db = context.db;
+
+    let fields = struct_
+        .fields(db)
+        .values()
+        .map(|field| struct_field(context, *field))
+        .collect();
+
+    let functions = struct_
+        .functions(db)
+        .values()
+        .map(|function| functions::func_def(context, *function))
+        .collect();
+
+    let node = &struct_.data(context.db).ast;
+    Node::new(
+        ast::Struct {
+            name: node.kind.name.clone(),
+            fields,
+            functions,
+        },
+        node.span,
+    )
+}
+
+fn struct_field(context: &mut ModuleContext, field: StructFieldId) -> Node<ast::Field> {
+    let node = &field.data(context.db).ast;
+    let typ = field.typ(context.db).expect("struct field type error");
+    Node::new(
+        ast::Field {
+            is_pub: node.kind.is_pub,
+            is_const: node.kind.is_const,
+            name: node.kind.name.clone(),
+            typ: types::type_desc(context, node.kind.typ.clone(), &typ.into()),
+            value: node.kind.value.clone(),
+        },
+        node.span,
+    )
+}

--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -41,7 +41,7 @@ macro_rules! test_file {
             let mut files = FileStore::new();
 
             let src = test_files::fixture($path);
-            let src_id = files.add_file(src, $path);
+            let src_id = files.add_file($path, src);
             let lowered_code = format!("{}", lower(src, src_id, &files));
 
             if cfg!(target_arch = "wasm32") {
@@ -69,5 +69,6 @@ test_file! { type_alias_tuple, "lowering/type_alias_tuple.fe" }
 test_file! { tuple_destruct, "lowering/tuple_destruct.fe" }
 test_file! { module_const, "lowering/module_const.fe" }
 test_file! { module_fn, "lowering/module_fn.fe" }
+test_file! { struct_fn, "lowering/struct_fn.fe" }
 // TODO: the analyzer rejects lowered nested tuples.
 // test_file!(array_tuple, "lowering/array_tuple.fe");

--- a/crates/lowering/tests/snapshots/lowering__struct_fn.snap
+++ b/crates/lowering/tests/snapshots/lowering__struct_fn.snap
@@ -1,0 +1,21 @@
+---
+source: crates/lowering/tests/lowering.rs
+expression: lowered_code
+
+---
+struct Foo:
+    x: u256
+
+    pub fn set_x(self, new: u256) -> u256:
+        let old: u256 = self.get_x()
+        self.x = new
+        return old
+
+    pub fn get_x(self) -> u256:
+        return self.x
+
+fn main() -> ():
+    let foo: Foo = Foo(x=10)
+    foo.set_x(100)
+    assert foo.get_x() == 100
+    return ()

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -78,6 +78,7 @@ pub struct Contract {
 pub struct Struct {
     pub name: Node<String>,
     pub fields: Vec<Node<Field>>,
+    pub functions: Vec<Node<Function>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -505,10 +506,14 @@ impl fmt::Display for Contract {
 impl fmt::Display for Struct {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "struct {}:", self.name.kind)?;
-        if self.fields.is_empty() {
+        if self.fields.is_empty() && self.functions.is_empty() {
             write!(indented(f), "pass")
         } else {
-            write!(indented(f), "{}", node_line_joined(&self.fields))
+            write!(indented(f), "{}", node_line_joined(&self.fields))?;
+            if !self.fields.is_empty() && !self.functions.is_empty() {
+                write!(f, "\n\n")?;
+            }
+            write!(indented(f), "{}", double_line_joined(&self.functions))
         }
     }
 }
@@ -564,6 +569,12 @@ impl fmt::Display for Event {
         } else {
             write!(indented(f), "{}", node_line_joined(&self.fields))
         }
+    }
+}
+
+impl fmt::Display for Node<Function> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.kind.fmt(f)
     }
 }
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -185,7 +185,7 @@ fn parse_expr_head(par: &mut Parser) -> ParseResult<Node<Expr>> {
     use TokenKind::*;
 
     match par.peek_or_err()? {
-        Name | Int | Hex | Octal | Binary | Text | True | False => {
+        Name | SelfValue | Int | Hex | Octal | Binary | Text | True | False => {
             let tok = par.next()?;
             Ok(atom(par, &tok))
         }
@@ -355,7 +355,7 @@ fn atom(par: &mut Parser, tok: &Token) -> Node<Expr> {
     use TokenKind::*;
 
     let expr = match tok.kind {
-        Name => Expr::Name(tok.text.to_owned()),
+        Name | SelfValue => Expr::Name(tok.text.to_owned()),
         Int | Hex | Octal | Binary => Expr::Num(tok.text.to_owned()),
         True | False => Expr::Bool(tok.kind == True),
         Text => {

--- a/crates/parser/src/grammar/functions.rs
+++ b/crates/parser/src/grammar/functions.rs
@@ -103,10 +103,10 @@ fn parse_fn_param_list(par: &mut Parser) -> ParseResult<Node<Vec<Node<FunctionAr
                 span += par.next()?.span;
                 break;
             }
-            TokenKind::Name => {
+            TokenKind::Name | TokenKind::SelfValue => {
                 let name = par.next()?;
 
-                if name.text == "self" {
+                if name.kind == TokenKind::SelfValue {
                     params.push(Node::new(FunctionArg::Zelf, name.span));
                 } else {
                     par.expect_with_notes(
@@ -200,7 +200,7 @@ fn aug_assign_op(tk: TokenKind) -> Option<BinOperator> {
 /// Panics if the next token isn't one of the above.
 pub fn parse_single_word_stmt(par: &mut Parser) -> ParseResult<Node<FuncStmt>> {
     let tok = par.next()?;
-    par.expect_newline(tok.kind.symbol_str().unwrap())?;
+    par.expect_newline(tok.kind.describe())?;
     let stmt = match tok.kind {
         TokenKind::Continue => FuncStmt::Continue,
         TokenKind::Break => FuncStmt::Break,

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -89,7 +89,9 @@ mod tests {
     fn errors() {
         check(
             "contract Foo@ 5u8 \n  self.bar",
-            &[Contract, Name, Error, Int, Name, Newline, Name, Dot, Name],
+            &[
+                Contract, Name, Error, Int, Name, Newline, SelfValue, Dot, Name,
+            ],
         );
     }
 

--- a/crates/parser/src/lexer/token.rs
+++ b/crates/parser/src/lexer/token.rs
@@ -83,8 +83,6 @@ pub enum TokenKind {
     Idx,
     #[token("if")]
     If,
-    #[token("import")]
-    Import,
     #[token("pragma")]
     Pragma,
     #[token("pass")]
@@ -97,6 +95,8 @@ pub enum TokenKind {
     Return,
     #[token("revert")]
     Revert,
+    #[token("self")]
+    SelfValue,
     #[token("struct")]
     Struct,
     #[token("type")]
@@ -209,107 +209,97 @@ pub enum TokenKind {
 
 impl TokenKind {
     /// Return a user-friendly description of the token kind. E.g.
-    /// `TokenKind::Newline => "a newline"`
-    /// Returns [`TokenKind::symbol_str`] for symbol tokens.
-    pub fn friendly_str(&self) -> Option<&'static str> {
+    /// TokenKind::Newline => "a newline"
+    /// TokenKind::Colon => "`:`"
+    pub fn describe(&self) -> &str {
         use TokenKind::*;
-        let val = match self {
+        match self {
             Newline => "a newline",
             Dedent => "a dedent",
+            Indent => "an indentation",
             Name => "a name",
             Int => "a number",
             Hex => "a hexadecimal number",
             Octal => "an octal number",
             Binary => "a binary number",
             Text => "a string",
-            _ => return self.symbol_str(),
-        };
-        Some(val)
-    }
 
-    /// If the token is a symbol or keyword, return the string representation.
-    /// E.g. `TokenKind::EqEq => "=="`
-    pub fn symbol_str(&self) -> Option<&'static str> {
-        use TokenKind::*;
-        let val = match self {
-            True => "true",
-            False => "false",
-            Assert => "assert",
-            Break => "break",
-            Continue => "continue",
-            Contract => "contract",
-            Fn => "fn",
-            Const => "const",
-            Let => "let",
-            Elif => "elif",
-            Else => "else",
-            Emit => "emit",
-            Event => "event",
-            Idx => "idx",
-            If => "if",
-            Import => "import",
-            Pragma => "pragma",
-            Pass => "pass",
-            For => "for",
-            Pub => "pub",
-            Return => "return",
-            Revert => "revert",
-            Struct => "struct",
-            Type => "type",
-            Unsafe => "unsafe",
-            While => "while",
-            And => "and",
-            As => "as",
-            In => "in",
-            Not => "not",
-            Or => "or",
-            Use => "use",
-            ParenOpen => "(",
-            ParenClose => ")",
-            BracketOpen => "[",
-            BracketClose => "]",
-            BraceOpen => "{",
-            BraceClose => "}",
-            Colon => ":",
-            ColonColon => "::",
-            Comma => ",",
-            Semi => "",
-            Plus => "+",
-            Minus => "-",
-            Star => "*",
-            Slash => "/",
-            Pipe => "|",
-            Amper => "&",
-            Lt => "<",
-            LtLt => "<<",
-            Gt => ">",
-            GtGt => ">>",
-            Eq => "=",
-            Dot => ".",
-            Percent => "%",
-            EqEq => "==",
-            NotEq => "!=",
-            LtEq => "<=",
-            GtEq => ">=",
-            Tilde => "~",
-            Hat => "^",
-            StarStar => "**",
-            StarStarEq => "**=",
-            PlusEq => "+=",
-            MinusEq => "-=",
-            StarEq => "*=",
-            SlashEq => "/=",
-            PercentEq => "%=",
-            AmperEq => "&=",
-            PipeEq => "|=",
-            HatEq => "^=",
-            LtLtEq => "<<=",
-            GtGtEq => ">>=",
-            Arrow => "->",
-            Error | Newline | Indent | Dedent | Name | Int | Hex | Octal | Binary | Text => {
-                return None
-            }
-        };
-        Some(val)
+            True => "keyword `true`",
+            False => "keyword `false`",
+            Assert => "keyword `assert`",
+            Break => "keyword `break`",
+            Continue => "keyword `continue`",
+            Contract => "keyword `contract`",
+            Fn => "keyword `fn`",
+            Const => "keyword `const`",
+            Let => "keyword `let`",
+            Elif => "keyword `elif`",
+            Else => "keyword `else`",
+            Emit => "keyword `emit`",
+            Event => "keyword `event`",
+            Idx => "keyword `idx`",
+            If => "keyword `if`",
+            Pragma => "keyword `pragma`",
+            Pass => "keyword `pass`",
+            For => "keyword `for`",
+            Pub => "keyword `pub`",
+            Return => "keyword `return`",
+            Revert => "keyword `revert`",
+            SelfValue => "keyword `self`",
+            Struct => "keyword `struct`",
+            Type => "keyword `type`",
+            Unsafe => "keyword `unsafe`",
+            While => "keyword `while`",
+            And => "keyword `and`",
+            As => "keyword `as`",
+            In => "keyword `in`",
+            Not => "keyword `not`",
+            Or => "keyword `or`",
+            Use => "keyword `use`",
+            ParenOpen => "symbol `(`",
+            ParenClose => "symbol `)`",
+            BracketOpen => "symbol `[`",
+            BracketClose => "symbol `]`",
+            BraceOpen => "symbol `{`",
+            BraceClose => "symbol `}`",
+            Colon => "symbol `:`",
+            ColonColon => "symbol `::`",
+            Comma => "symbol `,`",
+            Semi => "symbol ``",
+            Plus => "symbol `+`",
+            Minus => "symbol `-`",
+            Star => "symbol `*`",
+            Slash => "symbol `/`",
+            Pipe => "symbol `|`",
+            Amper => "symbol `&`",
+            Lt => "symbol `<`",
+            LtLt => "symbol `<<`",
+            Gt => "symbol `>`",
+            GtGt => "symbol `>>`",
+            Eq => "symbol `=`",
+            Dot => "symbol `.`",
+            Percent => "symbol `%`",
+            EqEq => "symbol `==`",
+            NotEq => "symbol `!=`",
+            LtEq => "symbol `<=`",
+            GtEq => "symbol `>=`",
+            Tilde => "symbol `~`",
+            Hat => "symbol `^`",
+            StarStar => "symbol `**`",
+            StarStarEq => "symbol `**=`",
+            PlusEq => "symbol `+=`",
+            MinusEq => "symbol `-=`",
+            StarEq => "symbol `*=`",
+            SlashEq => "symbol `/=`",
+            PercentEq => "symbol `%=`",
+            AmperEq => "symbol `&=`",
+            PipeEq => "symbol `|=`",
+            HatEq => "symbol `^=`",
+            LtLtEq => "symbol `<<=`",
+            GtGtEq => "symbol `>>=`",
+            Arrow => "symbol `->`",
+
+            Error => unreachable!(),
+        }
     }
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -249,17 +249,16 @@ impl<'a> Parser<'a> {
         if tok.kind == expected {
             Ok(tok)
         } else {
-            let label = if let Some(symbol) = expected.symbol_str() {
-                format!("Unexpected token. Expected `{}`", symbol)
-            } else {
-                format!(
-                    "Unexpected token. Expected {}",
-                    expected.friendly_str().unwrap()
-                )
-            };
             self.fancy_error(
                 message.into(),
-                vec![Label::primary(tok.span, label)],
+                vec![Label::primary(
+                    tok.span,
+                    format!(
+                        "expected {}, found {}",
+                        expected.describe(),
+                        tok.kind.describe()
+                    ),
+                )],
                 notes_fn(&tok),
             );
             Err(ParseFailed)

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -90,7 +90,7 @@ test_parse_err! { if_no_body, functions::parse_stmt, true, "if x:\nelse:\n x" }
 test_parse_err! { use_bad_name, module::parse_use, true, "use x as 123" }
 test_parse_err! { module_bad_stmt, module::parse_module, true, "if x:\n y" }
 test_parse_err! { module_nonsense, module::parse_module, true, "))" }
-test_parse_err! { struct_bad_field_name, types::parse_struct_def, true, "struct f:\n pub fn" }
+test_parse_err! { struct_bad_field_name, types::parse_struct_def, true, "struct f:\n pub event" }
 test_parse_err! { stmt_vardecl_attr, functions::parse_stmt, true, "f.s : u" }
 test_parse_err! { stmt_vardecl_tuple, functions::parse_stmt, true, "(a, x+1) : u256" }
 test_parse_err! { stmt_vardecl_tuple_empty, functions::parse_stmt, true, "(a, ()) : u256" }
@@ -102,6 +102,13 @@ test_parse_err! { stmt_vardecl_invalid_type_annotation, functions::parse_stmt, t
 test_parse_err! { stmt_vardecl_invalid_name, functions::parse_stmt, true, "let x + y: u8" }
 test_parse_err! { array_old_syntax, functions::parse_stmt, false, "let x: u8[10]" }
 test_parse_err! { array_old_syntax_invalid, functions::parse_stmt, true, "let x: u8[10" }
+
+test_parse_err! { self_const, module::parse_module, true, "const self: u8 = 10" }
+test_parse_err! { self_contract, module::parse_module, true, "contract self:\n pass" }
+test_parse_err! { self_struct, module::parse_module, true, "struct self:\n pass" }
+test_parse_err! { self_fn, module::parse_module, true, "pub fn self():\n pass" }
+test_parse_err! { self_use1, module::parse_module, true, "use self as bar" }
+test_parse_err! { self_use2, module::parse_module, true, "use bar as self" }
 
 // assert_snapshot! doesn't like the invalid escape code
 #[test]

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -155,8 +155,13 @@ test_parse! { use_nested2, module::parse_use, r#"use std::bar::{
 test_parse! { struct_def, types::parse_struct_def, r#"struct S:
   x: address
   pub y: u8
-  const z: u8
-  pub const a: Map<u8, foo>
+  z: u8
+  pub a: Map<u8, foo>
+
+  pub fn foo(self) -> u8:
+    return self.z + self.y
+  unsafe fn bar():
+    pass
 "# }
 test_parse! { empty_struct_def, types::parse_struct_def, r#"struct S:
   pass

--- a/crates/parser/tests/cases/snapshots/cases__errors__contract_bad_name.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__contract_bad_name.snap
@@ -7,7 +7,7 @@ error: failed to parse contract definition
   ┌─ contract_bad_name:1:10
   │
 1 │ contract 1X:
-  │          ^ Unexpected token. Expected a name
+  │          ^ expected a name, found a number
   │
   = Note: `contract` must be followed by a name, which must start with a letter and contain only letters, numbers, or underscores
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__emit_expr.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__emit_expr.snap
@@ -7,6 +7,6 @@ error: failed to parse event invocation parameter list
   ┌─ emit_expr:1:8
   │
 1 │ emit x + 1
-  │        ^ Unexpected token. Expected `(`
+  │        ^ expected symbol `(`, found symbol `+`
 
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__fn_def_kw.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__fn_def_kw.snap
@@ -7,7 +7,7 @@ error: failed to parse field definition
   ┌─ fn_def_kw:2:10
   │
 2 │  pub def f(x: u8):
-  │          ^ Unexpected token. Expected `:`
+  │          ^ expected symbol `:`, found a name
   │
   = Hint: use `fn` to define a function
   = Example: `pub fn f( ...`

--- a/crates/parser/tests/cases/snapshots/cases__errors__for_no_in.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__for_no_in.snap
@@ -7,6 +7,6 @@ error: failed to parse `for` statement
   ┌─ for_no_in:1:6
   │
 1 │ for x:
-  │      ^ Unexpected token. Expected `in`
+  │      ^ expected keyword `in`, found symbol `:`
 
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_const.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_const.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_const), module::parse_module, true,\n           \"const self: u8 = 10\")"
+
+---
+error: failed to parse constant declaration
+  ┌─ self_const:1:7
+  │
+1 │ const self: u8 = 10
+  │       ^^^^ expected a name, found keyword `self`
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_contract.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_contract.snap
@@ -1,0 +1,14 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_contract), module::parse_module, true,\n           \"contract self:\\n pass\")"
+
+---
+error: failed to parse contract definition
+  ┌─ self_contract:1:10
+  │
+1 │ contract self:
+  │          ^^^^ expected a name, found keyword `self`
+  │
+  = Note: `contract` must be followed by a name, which must start with a letter and contain only letters, numbers, or underscores
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_fn.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_fn.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_fn), module::parse_module, true,\n           \"pub fn self():\\n pass\")"
+
+---
+error: failed to parse function definition
+  ┌─ self_fn:1:8
+  │
+1 │ pub fn self():
+  │        ^^^^ expected a name, found keyword `self`
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_struct.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_struct.snap
@@ -1,0 +1,14 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_struct), module::parse_module, true,\n           \"struct self:\\n pass\")"
+
+---
+error: failed to parse struct definition
+  ┌─ self_struct:1:8
+  │
+1 │ struct self:
+  │        ^^^^ expected a name, found keyword `self`
+  │
+  = Note: a struct name must start with a letter or underscore, and contain letters, numbers, or underscores
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_use.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_use.snap
@@ -1,0 +1,15 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_use), module::parse_module, true,\n           \"use self as self\")"
+
+---
+error: failed to parse path
+  ┌─ self_use:1:5
+  │
+1 │ use self as self
+  │     ^^^^ Expected a name, found keyword `self`. 
+  │
+  = Note: paths must start with a name
+  = Example: `foo::bar`
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_use1.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_use1.snap
@@ -1,0 +1,15 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_use1), module::parse_module, true,\n           \"use self as bar\")"
+
+---
+error: failed to parse path
+  ┌─ self_use1:1:5
+  │
+1 │ use self as bar
+  │     ^^^^ expected a name, found keyword `self`
+  │
+  = Note: paths must start with a name
+  = Example: `foo::bar`
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__self_use2.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__self_use2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(self_use2), module::parse_module, true,\n           \"use bar as self\")"
+
+---
+error: failed to parse `use` tree
+  ┌─ self_use2:1:12
+  │
+1 │ use bar as self
+  │            ^^^^ expected a name, found keyword `self`
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__struct_bad_field_name.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__struct_bad_field_name.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/parser/tests/cases/errors.rs
-expression: "err_string(stringify!(struct_bad_field_name), types::parse_struct_def, true,\n           \"struct f:\\n pub fn\")"
+expression: "err_string(stringify!(struct_bad_field_name), types::parse_struct_def, true,\n           \"struct f:\\n pub event\")"
 
 ---
-error: failed to parse field definition
+error: failed to parse struct definition
   ┌─ struct_bad_field_name:2:6
   │
-2 │  pub fn
-  │      ^^ Unexpected token. Expected a name
+2 │  pub event
+  │      ^^^^^ unexpected token
 
 

--- a/crates/parser/tests/cases/snapshots/cases__errors__use_bad_name.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__use_bad_name.snap
@@ -7,6 +7,6 @@ error: failed to parse `use` tree
   ┌─ use_bad_name:1:10
   │
 1 │ use x as 123
-  │          ^^^ Unexpected token. Expected a name
+  │          ^^^ expected a name, found a number
 
 

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_struct_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_struct_def.snap
@@ -13,6 +13,7 @@ Node(
       ),
     ),
     fields: [],
+    functions: [],
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(struct_def), types::parse_struct_def,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  const z: u8\n  pub const a: Map<u8, foo>\n\"#)"
+expression: "ast_string(stringify!(struct_def), types::parse_struct_def,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8:\n    return self.z + self.y\n  unsafe fn bar():\n    pass\n\"#)"
 
 ---
 Node(
@@ -70,12 +70,12 @@ Node(
       Node(
         kind: Field(
           is_pub: false,
-          is_const: true,
+          is_const: false,
           name: Node(
             kind: "z",
             span: Span(
-              start: 43,
-              end: 44,
+              start: 37,
+              end: 38,
             ),
           ),
           typ: Node(
@@ -83,26 +83,26 @@ Node(
               base: "u8",
             ),
             span: Span(
-              start: 46,
-              end: 48,
+              start: 40,
+              end: 42,
             ),
           ),
           value: None,
         ),
         span: Span(
           start: 37,
-          end: 48,
+          end: 42,
         ),
       ),
       Node(
         kind: Field(
           is_pub: true,
-          is_const: true,
+          is_const: false,
           name: Node(
             kind: "a",
             span: Span(
-              start: 61,
-              end: 62,
+              start: 49,
+              end: 50,
             ),
           ),
           typ: Node(
@@ -110,8 +110,8 @@ Node(
               base: Node(
                 kind: "Map",
                 span: Span(
-                  start: 64,
-                  end: 67,
+                  start: 52,
+                  end: 55,
                 ),
               ),
               args: Node(
@@ -121,8 +121,8 @@ Node(
                       base: "u8",
                     ),
                     span: Span(
-                      start: 68,
-                      end: 70,
+                      start: 56,
+                      end: 58,
                     ),
                   )),
                   TypeDesc(Node(
@@ -130,33 +130,173 @@ Node(
                       base: "foo",
                     ),
                     span: Span(
-                      start: 72,
-                      end: 75,
+                      start: 60,
+                      end: 63,
                     ),
                   )),
                 ],
                 span: Span(
-                  start: 67,
-                  end: 76,
+                  start: 55,
+                  end: 64,
                 ),
               ),
             ),
             span: Span(
-              start: 64,
-              end: 76,
+              start: 52,
+              end: 64,
             ),
           ),
           value: None,
         ),
         span: Span(
-          start: 51,
-          end: 76,
+          start: 45,
+          end: 64,
+        ),
+      ),
+    ],
+    functions: [
+      Node(
+        kind: Function(
+          pub_: Some(Span(
+            start: 68,
+            end: 71,
+          )),
+          unsafe_: None,
+          name: Node(
+            kind: "foo",
+            span: Span(
+              start: 75,
+              end: 78,
+            ),
+          ),
+          args: [
+            Node(
+              kind: Zelf,
+              span: Span(
+                start: 79,
+                end: 83,
+              ),
+            ),
+          ],
+          return_type: Some(Node(
+            kind: Base(
+              base: "u8",
+            ),
+            span: Span(
+              start: 88,
+              end: 90,
+            ),
+          )),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: BinOperation(
+                    left: Node(
+                      kind: Attribute(
+                        value: Node(
+                          kind: Name("self"),
+                          span: Span(
+                            start: 103,
+                            end: 107,
+                          ),
+                        ),
+                        attr: Node(
+                          kind: "z",
+                          span: Span(
+                            start: 108,
+                            end: 109,
+                          ),
+                        ),
+                      ),
+                      span: Span(
+                        start: 103,
+                        end: 109,
+                      ),
+                    ),
+                    op: Node(
+                      kind: Add,
+                      span: Span(
+                        start: 110,
+                        end: 111,
+                      ),
+                    ),
+                    right: Node(
+                      kind: Attribute(
+                        value: Node(
+                          kind: Name("self"),
+                          span: Span(
+                            start: 112,
+                            end: 116,
+                          ),
+                        ),
+                        attr: Node(
+                          kind: "y",
+                          span: Span(
+                            start: 117,
+                            end: 118,
+                          ),
+                        ),
+                      ),
+                      span: Span(
+                        start: 112,
+                        end: 118,
+                      ),
+                    ),
+                  ),
+                  span: Span(
+                    start: 103,
+                    end: 118,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 96,
+                end: 118,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 68,
+          end: 118,
+        ),
+      ),
+      Node(
+        kind: Function(
+          pub_: None,
+          unsafe_: Some(Span(
+            start: 121,
+            end: 127,
+          )),
+          name: Node(
+            kind: "bar",
+            span: Span(
+              start: 131,
+              end: 134,
+            ),
+          ),
+          args: [],
+          return_type: None,
+          body: [
+            Node(
+              kind: Pass,
+              span: Span(
+                start: 142,
+                end: 146,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 121,
+          end: 146,
         ),
       ),
     ],
   ),
   span: Span(
     start: 0,
-    end: 76,
+    end: 64,
   ),
 )

--- a/crates/test-files/fixtures/compile_errors/call_create2_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_create2_with_wrong_type.fe
@@ -5,3 +5,5 @@ contract Foo:
 
     pub fn foo():
         Bar.create2(true, 1)
+        Bar.create2(1)  # agroce #447
+        Bar.create2()

--- a/crates/test-files/fixtures/compile_errors/call_create_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_create_with_wrong_type.fe
@@ -2,6 +2,6 @@ contract Bar:
     pass
 
 contract Foo:
-
     pub fn foo():
         Bar.create(true)
+        Bar.create()     # agroce #447

--- a/crates/test-files/fixtures/compile_errors/missing_self.fe
+++ b/crates/test-files/fixtures/compile_errors/missing_self.fe
@@ -4,3 +4,9 @@ contract Foo:
 
     fn mut_fn(self):
         pass
+
+struct Bar:
+    x: u8
+
+    fn f() -> u8:
+        return self.x

--- a/crates/test-files/fixtures/compile_errors/self_misuse.fe
+++ b/crates/test-files/fixtures/compile_errors/self_misuse.fe
@@ -1,0 +1,33 @@
+fn foo():
+  let self: u8 = 10
+  self = 5
+
+fn change_x(s: S):
+  s.x = 100
+
+fn bar(c: C):
+  pass
+
+struct S:
+  x: u8
+
+  fn f(self):
+    self()
+
+  fn g(self):
+    self = S(x = 10)
+
+  fn h(self):
+    change_x(self) # allowed
+
+contract C:
+  x: u8
+
+  fn g(self):
+    pass
+
+  fn h(self):
+    g(self)
+
+  fn i(self):
+    bar(self)

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_function.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_function.fe
@@ -7,6 +7,3 @@ contract C:
 
   pub fn bool(x: u8) -> bool:
     return x != 0
-
-  pub fn self() -> bool:
-    return false

--- a/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
+++ b/crates/test-files/fixtures/compile_errors/shadow_builtin_type.fe
@@ -7,7 +7,6 @@ type keccak256 = u8
 type block = u8
 type msg = u8
 type chain = u8
-type self = u8
 
 contract C:
   fn f(u8: u256):

--- a/crates/test-files/fixtures/features/associated_fns.fe
+++ b/crates/test-files/fixtures/features/associated_fns.fe
@@ -1,0 +1,16 @@
+
+struct Lib: # This can't be a contract, yet
+  pub fn square(x: u256) -> u256:
+    return x * x
+
+struct MyStruct:
+  x: u256
+  pub fn new(x: u256) -> MyStruct:
+    return MyStruct(x)
+
+contract Foo:
+  my_struct: MyStruct
+
+  pub fn bar(self, val: u256) -> u256:
+    self.my_struct = MyStruct.new(val)
+    return Lib.square(self.my_struct.x)

--- a/crates/test-files/fixtures/features/struct_fns.fe
+++ b/crates/test-files/fixtures/features/struct_fns.fe
@@ -1,0 +1,56 @@
+struct Point:
+  x: u64
+  y: u64
+
+  pub fn new(x: u64, y: u64) -> Point:
+    return Point(x, y)
+
+  pub fn origin() -> Point:
+    return Point(x=0, y=0)
+
+  # function name can match field name
+  pub fn x(self) -> u64:
+    return self.x
+
+  pub fn set_x(self, x: u64) -> u64:
+    let old: u64 = self.x
+    self.x = x
+    return old
+
+  pub fn reflect(self):
+    let x: u64 = self.x
+    let y: u64 = self.y
+    # self.x = self.y panics. see issue #590
+    self.x = y
+    self.y = x
+
+  pub fn translate(self, x: u64, y: u64):
+    self.x += x
+    self.y += y
+
+  pub fn add(self, other: Point) -> Point:
+    let x: u64 = self.x + other.x
+    let y: u64 = self.y + other.y
+    return Point(x, y)
+
+pub fn do_pointy_things():
+  let p1: Point = Point.origin()
+  p1.translate(5, 10)
+
+  let p2: Point = Point(x=1, y=2)
+  let p3: Point = p1.add(p2)
+
+  assert p3.x == 6 and p3.y == 12
+
+
+contract Foo:
+
+  pub fn bar(x: u64, y: u64) -> u64:
+    do_pointy_things()
+
+    let p: Point = Point.new(x, y)
+    assert p.x == x and p.y == y
+    p.set_x(100)
+    p.reflect()
+    assert p.x() == y and p.y == 100
+    return p.y

--- a/crates/test-files/fixtures/features/structs.fe
+++ b/crates/test-files/fixtures/features/structs.fe
@@ -4,6 +4,19 @@ struct House:
     rooms: u8
     vacant: bool
 
+    pub fn encode(self) -> Array<u8, 128>:
+        return self.abi_encode()
+
+    pub fn hash(self) -> u256:
+        return keccak256(self.encode())
+
+    pub fn price_per_sqft(self) -> u256:
+        return self.price / self.size
+
+    pub fn expand(self):
+        self.rooms += 1
+        self.size += 100
+
 contract Foo:
     my_house: House
 
@@ -68,6 +81,11 @@ contract Foo:
         assert building.price == 1
         assert building.size == 2
         assert building.rooms == u8(10)
+
+        building.expand()
+        assert building.size == 102
+        assert building.rooms == 11
+
         return building.size
 
     pub fn encode_house() -> Array<u8, 128>:
@@ -77,7 +95,7 @@ contract Foo:
             rooms=u8(20),
             vacant=true
         )
-        return house.abi_encode()
+        return house.encode()
 
     pub fn hashed_house() -> u256:
         let house: House = House(
@@ -86,4 +104,4 @@ contract Foo:
             rooms=u8(20),
             vacant=true
         )
-        return keccak256(house.abi_encode())
+        return house.hash()

--- a/crates/test-files/fixtures/lowering/struct_fn.fe
+++ b/crates/test-files/fixtures/lowering/struct_fn.fe
@@ -1,0 +1,15 @@
+struct Foo:
+  x: u256
+
+  pub fn set_x(self, new: u256) -> u256:
+    let old: u256 = self.get_x()
+    self.x = new
+    return old
+
+  pub fn get_x(self) -> u256:
+    return self.x
+
+fn main():
+  let foo: Foo = Foo(x = 10)
+  foo.set_x(100)
+  assert foo.get_x() == 100

--- a/crates/test-files/fixtures/printing/defs.fe
+++ b/crates/test-files/fixtures/printing/defs.fe
@@ -13,6 +13,9 @@ struct MyStruct:
     field2: u256
     field3: address
 
+    pub fn field2_squared(self) -> u256:
+        return self.field2 * self.field2
+
 struct EmptyType:
     pass
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -245,7 +245,7 @@ pub fn deploy_contract(
     let mut files = FileStore::new();
     let id = files.add_file(fixture, src);
 
-    let compiled_module = match driver::compile(id, src, true, true) {
+    let compiled_module = match driver::compile(&files, id, src, true, true) {
         Ok(module) => module,
         Err(error) => {
             fe_common::diagnostics::print_diagnostics(&error.0, &files);
@@ -448,7 +448,7 @@ pub fn load_contract(address: H160, fixture: &str, contract_name: &str) -> Contr
     let mut files = FileStore::new();
     let src = test_files::fixture(fixture);
     let id = files.add_file(fixture, src);
-    let compiled_module = match driver::compile(id, src, true, true) {
+    let compiled_module = match driver::compile(&files, id, src, true, true) {
         Ok(module) => module,
         Err(err) => {
             print_diagnostics(&err.0, &files);

--- a/crates/tests/src/crashes.rs
+++ b/crates/tests/src/crashes.rs
@@ -1,4 +1,4 @@
-use fe_common::files::SourceFileId;
+use fe_common::files::FileStore;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 macro_rules! test_file {
@@ -8,7 +8,9 @@ macro_rules! test_file {
         fn $name() {
             let path = concat!("crashes/", stringify!($name), ".fe");
             let src = test_files::fixture(path);
-            fe_driver::compile(SourceFileId::default(), src, true, true).ok();
+            let mut files = FileStore::new();
+            let id = files.add_file(path, src);
+            fe_driver::compile(&files, id, src, true, true).ok();
         }
     };
 }

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -388,6 +388,8 @@ fn test_assert() {
     case("radix_binary.fe", &[], uint_token(0b10)),
     case::map_tuple("map_tuple.fe", &[uint_token(1234)], uint_token(1234)),
     case::int_literal_coercion("int_literal_coercion.fe", &[], uint_token(300)),
+    case::associated_fns("associated_fns.fe", &[uint_token(12)], uint_token(144)),
+    case::struct_fns("struct_fns.fe", &[uint_token(10), uint_token(20)], uint_token(100)),
 )]
 fn test_method_return(fixture_file: &str, input: &[ethabi::Token], expected: ethabi::Token) {
     with_executor(&|mut executor| {
@@ -1154,7 +1156,7 @@ fn structs() {
         let harness = deploy_contract(&mut executor, "structs.fe", "Foo", &[]);
 
         harness.test_function(&mut executor, "create_house", &[], None);
-        harness.test_function(&mut executor, "bar", &[], Some(&uint_token(2)));
+        harness.test_function(&mut executor, "bar", &[], Some(&uint_token(102)));
 
         let encoded_house = [
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/crates/yulgen/src/mappers/mod.rs
+++ b/crates/yulgen/src/mappers/mod.rs
@@ -2,5 +2,5 @@ mod assignments;
 mod contracts;
 mod declarations;
 mod expressions;
-mod functions;
+pub mod functions;
 pub mod module;

--- a/crates/yulgen/src/names/mod.rs
+++ b/crates/yulgen/src/names/mod.rs
@@ -65,6 +65,17 @@ pub fn func_name(name: &str) -> yul::Identifier {
     identifier! { (format!("$${}", name)) }
 }
 
+/// Generate a safe function name for a function defined within a struct.
+/// Contract function names currently use [`func_name`] above, but should probably use
+/// this instead to avoid name collisions with functions defined at the module level.
+/// This is for functions that take self, and those that don't.
+/// Note that this assumes that there can't be two "classes" with the same name, which
+/// won't be the case when we support using items from other modules.
+/// Eg. `othermod::Foo::bar()` and `Foo::bar()` yul fn names will collide.
+pub fn associated_function_name(class_name: &str, func_name: &str) -> yul::Identifier {
+    identifier! { (format!("$${}${}", class_name, func_name)) }
+}
+
 /// Generate a safe variable name for a user defined function
 pub fn var_name(name: &str) -> yul::Identifier {
     identifier! { (format!("${}", name)) }
@@ -83,12 +94,6 @@ pub fn contract_call(contract_name: &str, func_name: &str) -> yul::Identifier {
     identifier! { (name) }
 }
 
-/// Generates a function name for to interact with a certain struct type
-pub fn struct_function_name(struct_name: &str, func_name: &str) -> yul::Identifier {
-    let name = format!("struct_{}_{}", struct_name, func_name);
-    identifier! { (name) }
-}
-
 /// Generates a function name for creating a certain struct type
 pub fn struct_new_call(struct_name: &str) -> yul::Identifier {
     struct_function_name(struct_name, "new")
@@ -98,4 +103,10 @@ pub fn struct_new_call(struct_name: &str) -> yul::Identifier {
 /// type
 pub fn struct_getter_call(struct_name: &str, field_name: &str) -> yul::Identifier {
     struct_function_name(struct_name, &format!("get_{}_ptr", field_name))
+}
+
+/// Generates a function name for to interact with a certain struct type
+fn struct_function_name(struct_name: &str, func_name: &str) -> yul::Identifier {
+    let name = format!("struct_{}_{}", struct_name, func_name);
+    identifier! { (name) }
 }

--- a/crates/yulgen/src/operations/contracts.rs
+++ b/crates/yulgen/src/operations/contracts.rs
@@ -1,27 +1,9 @@
-use crate::names;
-use fe_analyzer::namespace::types::Contract;
 use yultsur::*;
-
-/// Make a call to a contract of the given type and address with a set of
-/// parameters.
-pub fn call(
-    contract: Contract,
-    func_name: &str,
-    address: yul::Expression,
-    params: Vec<yul::Expression>,
-) -> yul::Expression {
-    let func_name = names::contract_call(&contract.name, func_name);
-    expression! { [func_name]([address], [params...]) }
-}
 
 /// Executes the `create2` operation for a given contract with the given value
 /// and salt.
-pub fn create2(
-    contract: &Contract,
-    value: yul::Expression,
-    salt: yul::Expression,
-) -> yul::Expression {
-    let name = literal_expression! { (format!("\"{}\"", contract.name)) };
+pub fn create2(name: &str, value: yul::Expression, salt: yul::Expression) -> yul::Expression {
+    let name = literal_expression! { (format!("\"{}\"", name)) };
     expression! {
         contract_create2(
             (dataoffset([name.clone()])),
@@ -33,8 +15,8 @@ pub fn create2(
 }
 
 /// Executes the `create` operation for a given contract with the given value.
-pub fn create(contract: &Contract, value: yul::Expression) -> yul::Expression {
-    let name = literal_expression! { (format!("\"{}\"", contract.name)) };
+pub fn create(name: &str, value: yul::Expression) -> yul::Expression {
+    let name = literal_expression! { (format!("\"{}\"", name)) };
     expression! {
         contract_create(
             (dataoffset([name.clone()])),

--- a/crates/yulgen/src/runtime/mod.rs
+++ b/crates/yulgen/src/runtime/mod.rs
@@ -1,8 +1,10 @@
 pub mod abi_dispatcher;
 pub mod functions;
 use crate::context::ContractContext;
+use crate::mappers;
+use crate::names;
 use crate::types::{to_abi_types, AbiDecodeLocation, AbiType, AsAbiType};
-use fe_analyzer::namespace::items::ContractId;
+use fe_analyzer::namespace::items::{ContractId, Item};
 use fe_analyzer::namespace::types::FunctionSignature;
 use fe_analyzer::AnalyzerDb;
 use std::rc::Rc;
@@ -11,17 +13,64 @@ use yultsur::*;
 /// Builds the set of function statements that are needed during runtime.
 pub fn build(
     db: &dyn AnalyzerDb,
-    context: &ContractContext,
+    context: &mut ContractContext,
     contract: ContractId,
 ) -> Vec<yul::Statement> {
-    // TODO: db should provide easier access to these things.
-    // Eg. contract.public_functions(db)
+    let module = contract.module(db);
+    let module_functions = module
+        .items(db)
+        .values()
+        .filter_map(|item| match item {
+            Item::Function(fid) => Some(mappers::functions::func_def(
+                db,
+                context,
+                names::func_name(&fid.name(db)),
+                *fid,
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
 
-    let std = functions::std();
+    let struct_apis = module
+        .all_structs(db)
+        .iter()
+        .map(|struct_| {
+            let fields = struct_
+                .fields(db)
+                .iter()
+                .map(|(name, id)| {
+                    (
+                        name.to_string(),
+                        id.typ(db).expect("struct field type error"),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            let struct_name = struct_.name(db);
+            let member_functions = struct_
+                .functions(db)
+                .values()
+                .map(|fid| {
+                    mappers::functions::func_def(
+                        db,
+                        context,
+                        names::associated_function_name(&struct_name, &fid.name(db)),
+                        *fid,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            [
+                functions::structs::struct_apis(&struct_.name(db), &fields),
+                member_functions,
+            ]
+            .concat()
+        })
+        .collect::<Vec<_>>()
+        .concat();
 
     let contract_name = contract.name(db);
-    let external_contracts: Vec<ContractId> = contract
-        .module(db)
+    let external_contracts: Vec<ContractId> = module
         .all_contracts(db)
         .iter()
         .filter_map(|id| (id.name(db) != contract_name).then(|| *id))
@@ -29,8 +78,8 @@ pub fn build(
     let external_functions = external_contracts
         .iter()
         .map(|id| {
-            id.all_functions(db)
-                .iter()
+            id.functions(db)
+                .values()
                 .map(|func| func.signature(db))
                 .collect::<Vec<Rc<FunctionSignature>>>()
         })
@@ -53,8 +102,8 @@ pub fn build(
             .collect::<Vec<_>>();
 
         let events_batch: Vec<Vec<AbiType>> = contract
-            .all_events(db)
-            .iter()
+            .events(db)
+            .values()
             .map(|event| {
                 event
                     .typ(db)
@@ -90,8 +139,8 @@ pub fn build(
             .map(|struct_| {
                 struct_
                     .id
-                    .all_fields(db)
-                    .iter()
+                    .fields(db)
+                    .values()
                     .map(|field| {
                         field
                             .typ(db)
@@ -104,8 +153,7 @@ pub fn build(
 
         let revert_panic_batch = vec![vec![AbiType::Uint { size: 32 }]];
 
-        let structs_batch: Vec<Vec<AbiType>> = contract
-            .module(db)
+        let structs_batch: Vec<Vec<AbiType>> = module
             .all_structs(db)
             .iter()
             .map(|struc| vec![struc.typ(db).as_abi_type(db)])
@@ -164,26 +212,6 @@ pub fn build(
             .concat()
     };
 
-    let struct_apis = contract
-        .module(db)
-        .all_structs(db)
-        .iter()
-        .map(|struct_| {
-            let fields = struct_
-                .fields(db)
-                .iter()
-                .map(|(name, id)| {
-                    (
-                        name.to_string(),
-                        id.typ(db).expect("struct field type error"),
-                    )
-                })
-                .collect::<Vec<_>>();
-            functions::structs::struct_apis(&struct_.name(db), &fields)
-        })
-        .collect::<Vec<_>>()
-        .concat();
-
     let revert_calls_from_assert = context
         .assert_strings
         .iter()
@@ -197,13 +225,14 @@ pub fn build(
         .collect::<Vec<_>>();
 
     let mut funcs = [
-        std,
+        functions::std(),
         encoding,
         decoding,
         contract_calls,
         revert_calls_from_assert,
         revert_calls,
         struct_apis,
+        module_functions,
     ]
     .concat();
     funcs.sort();
@@ -211,12 +240,7 @@ pub fn build(
     funcs
 }
 
-/// Builds the set of function statements that are needed during runtime as well as an ABI dispatcher statement.
-pub fn build_with_abi_dispatcher(
-    db: &dyn AnalyzerDb,
-    context: &ContractContext,
-    contract: ContractId,
-) -> Vec<yul::Statement> {
+pub fn build_abi_dispatcher(db: &dyn AnalyzerDb, contract: ContractId) -> yul::Statement {
     let public_functions = contract
         .public_functions(db)
         .iter()
@@ -240,7 +264,5 @@ pub fn build_with_abi_dispatcher(
         })
         .collect::<Vec<_>>();
 
-    let mut runtime = build(db, context, contract);
-    runtime.push(abi_dispatcher::dispatcher(public_functions));
-    runtime
+    abi_dispatcher::dispatcher(public_functions)
 }

--- a/crates/yulgen/src/types.rs
+++ b/crates/yulgen/src/types.rs
@@ -222,8 +222,8 @@ impl AsAbiType for Struct {
     fn as_abi_type(&self, db: &dyn AnalyzerDb) -> AbiType {
         let components = self
             .id
-            .all_fields(db)
-            .iter()
+            .fields(db)
+            .values()
             .map(|field| {
                 field
                     .typ(db)

--- a/newsfragments/577.feature.md
+++ b/newsfragments/577.feature.md
@@ -1,0 +1,34 @@
+Functions can now be defined on struct types. Example:
+
+```
+struct Point:
+  x: u64
+  y: u64
+
+  # Doesn't take `self`. Callable as `Point.origin()`.
+  # Note that the syntax for this will soon be changed to `Point::origin()`.
+  pub fn origin() -> Point:
+    return Point(x=0, y=0)
+
+  # Takes `self`. Callable on a value of type `Point`.
+  pub fn translate(self, x: u64, y: u64):
+    self.x += x
+    self.y += y
+
+  pub fn add(self, other: Point) -> Point:
+    let x: u64 = self.x + other.x
+    let y: u64 = self.y + other.y
+    return Point(x, y)
+
+  pub fn hash(self) -> u256:
+    return keccak256(self.abi_encode())
+
+pub fn do_pointy_things():
+  let p1: Point = Point.origin()
+  p1.translate(5, 10)
+
+  let p2: Point = Point(x=1, y=2)
+  let p3: Point = p1.add(p2)
+
+  assert p3.x == 6 and p3.y == 12
+```


### PR DESCRIPTION
This required a good bit'o refactoring of the way we handle `self` in the analyzer, because `self` structs can be used anywhere an expression can, which is not the case for the mystical `self` contract. It also "required" refactoring the `CallType` stuff. A better person than I could have done much of this refactoring in a separate PR, but they didn't.

Just for funsies, I also reworked the analysis test snapshot output, because the current snapshot printing was hard to use for debugging. Stuff is mostly printed in order now. Where possible, labels are combined into a single diagnostic to cut down on the noise and line count a bit (hence the -3k lines).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
