### PR TITLE
Don't coerce type of right hand side of binary operation

### DIFF
--- a/crates/test-files/fixtures/crashes/agroce550.fe
+++ b/crates/test-files/fixtures/crashes/agroce550.fe
@@ -1,0 +1,3 @@
+contract Foo:
+  pub fn o():
+    [-1>>0]

--- a/crates/test-files/fixtures/features/return_bitwiseshl_i64_coerced.fe
+++ b/crates/test-files/fixtures/features/return_bitwiseshl_i64_coerced.fe
@@ -1,0 +1,4 @@
+contract Foo:
+    pub fn bar() -> i64:
+        let x: i64 = -1 << 0
+        return x

--- a/crates/tests/src/crashes.rs
+++ b/crates/tests/src/crashes.rs
@@ -16,3 +16,4 @@ macro_rules! test_file {
 }
 
 test_file! { agroce531 }
+test_file! { agroce550 }

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -326,6 +326,7 @@ fn test_assert() {
     case("return_bitwiseshr_u256.fe", &[uint_token(212), uint_token(1)], uint_token(106)),
     case("return_bitwiseshr_i256.fe", &[int_token(212), uint_token(0)], int_token(212)),
     case("return_bitwiseshr_i256.fe", &[int_token(212), uint_token(1)], int_token(106)),
+    case("return_bitwiseshl_i64_coerced.fe", &[], int_token(-1)),
     // comparison operators
     case("return_eq_u256.fe", &[uint_token(1), uint_token(1)], bool_token(true)),
     case("return_eq_u256.fe", &[uint_token(1), uint_token(2)], bool_token(false)),

--- a/newsfragments/550.bugfix.md
+++ b/newsfragments/550.bugfix.md
@@ -1,0 +1,9 @@
+Fixed a rare compiler crash.
+
+Example:
+
+```
+let my_array: i256[1] = [-1 << 1] 
+```
+
+Previous to this fix, the given example would lead to an ICE.


### PR DESCRIPTION
### What was wrong?

Fixes #550

The following code crashes:

```
let my_array: i256[1] = [-1 << 1] 
```

The interesting part is that this crashes **after lowering** with the following error:

>The right hand side of the `>>` operation must be unsigned"

Clearly, the right hand side **is** an unsigned integer so what's the problem here and why isn't it detected in the first analyzer pass?

The issue is that this gets lowered to something like this:

```
fn list_expr_array_i256_1(val0: i256) -> i256[1]:
    let generated_array: i256[1]
    generated_array[0] = val0
    return generated_array

contract Foo:
    pub fn o() -> ():
        list_expr_array_i256_1(-1 >> 0)
        return ()
```

Now that `-1 >> 0` is passed into the function `list_expr_array_i256_1` we try to coerce the types of both the left and the right hand side.

However, since only the left hand side determines the outcome of the type for the expression, I believe the fix is to not try to coerce the right hand side.

### How was it fixed?

Removed coercion for right hand side.
