### PR TITLE
Make differential proptests opt-in (via --include-ingored)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build
         run: cargo build --all-features --verbose
       - name: Run tests
-        run: cargo test --workspace --features solc-backend --verbose
+        run: cargo test --workspace --features solc-backend --verbose -- --include-ignored
 
   wasm-test:
       runs-on: ubuntu-latest

--- a/crates/analyzer/src/errors.rs
+++ b/crates/analyzer/src/errors.rs
@@ -22,13 +22,7 @@ use std::fmt::Display;
 /// by calling an error function on an [`AnalyzerContext`](crate::context::AnalyzerContext).
 /// Please don't try to work around this restriction.
 ///
-/// # Example
-/// ```ignore
-/// pub fn check_something(context: &mut dyn AnalyzerContext, span: Span) -> Result<(), TypeError> {
-///     // check failed! emit a diagnostic and return an error
-///     let voucher = context.error("something is wrong", span, "this");
-///     Err(TypeError::new(voucher))
-/// }
+/// Example: `TypeError::new(context.error("something is wrong", some_span, "this thing"))`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeError(DiagnosticVoucher);
 impl TypeError {

--- a/crates/tests/src/differential.rs
+++ b/crates/tests/src/differential.rs
@@ -92,6 +92,7 @@ impl<'a> DualHarness {
 proptest! {
 
     #[test]
+    #[ignore]
     fn math_u8(val in 0u8..=255, val2 in 0u8..=255) {
         with_executor(&|mut executor| {
 
@@ -117,6 +118,7 @@ proptest! {
     }
 
     #[test]
+    #[ignore]
     fn math_i8(val in -128i8..=127i8, val2 in -128i8..=127i8, val3 in 0u8..=255, val4 in 0u8..=255) {
         with_executor(&|mut executor| {
             let harness = DualHarness::from_fixture(&mut executor, "math_i8", "Foo", &[]);


### PR DESCRIPTION
### What was wrong?

`cargo test --workspace --all-features` takes too long when running locally.

### How was it fixed?

I `#[ignore]`d the proptest-based tests, and added a `--include-ignored` flag to the gh workflow so they still run there.

They can be run separately with something like `cargo test --workspace --all-features -- --ignored`
