### PR TITLE
Re-enable differential testing as a cronjob

### DIFF
--- a/.github/workflows/expensive.yml
+++ b/.github/workflows/expensive.yml
@@ -1,0 +1,51 @@
+name: Expensive
+
+on:
+  schedule:
+    - cron:  '*/30 * * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    # Build & Test runs on all platforms
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Rust dependencies
+        uses: actions/cache@v1.1.2
+        with:
+          # There's a problem with caching serde, hence we exclude it here
+          path: |
+            target
+            !target/**/*serde*
+          key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Mac System dependencies
+        if: startsWith(matrix.os,'macOS')
+        run: |
+          brew install boost
+      - name: Install Linux dependencies
+        if: startsWith(matrix.os,'ubuntu')
+        run: |
+          "${GITHUB_WORKSPACE}/.github/install_deps.sh"
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build
+        run: cargo build --all-features --verbose
+      - name: Run expensive tests
+        id: expensive_tests
+        run: cargo test --workspace --features solc-backend --verbose -- --ignored
+      - name: Report
+        if: failure() && steps.expensive_tests.outcome == 'failure'
+        run: |
+          cat ./crates/tests/proptest-regressions/differential.txt
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build
         run: cargo build --all-features --verbose
       - name: Run tests
-        run: cargo test --workspace --features solc-backend --verbose -- --include-ignored
+        run: cargo test --workspace --features solc-backend --verbose
 
   wasm-test:
       runs-on: ubuntu-latest

--- a/crates/test-files/fixtures/differential/math_i8.sol
+++ b/crates/test-files/fixtures/differential/math_i8.sol
@@ -16,10 +16,6 @@ contract Foo {
     return val1 / val2;
   }
 
-  function pow(int8 val1, uint8 val2) public pure returns (int8) {
-    return int8(uint8(val1) ** val2);
-  }
-
   function modulo(int8 val1, int8 val2) public pure returns (int8){
     return val1 % val2;
   }

--- a/crates/tests/src/differential.rs
+++ b/crates/tests/src/differential.rs
@@ -1,150 +1,150 @@
 //! Tests that check for differences between Solidity and Fe implementations of similar contracts
-// #![cfg(feature = "solc-backend")]
-// use proptest::prelude::*;
-//
-// use fe_compiler_test_utils::*;
-// use fe_compiler_test_utils::{self as test_utils};
-//
-// struct DualHarness {
-//     fe_harness: ContractHarness,
-//     solidity_harness: ContractHarness,
-// }
-//
-// struct CaptureResult<'a> {
-//     fe_capture: evm::Capture<(evm::ExitReason, Vec<u8>), std::convert::Infallible>,
-//     solidity_capture: evm::Capture<(evm::ExitReason, Vec<u8>), std::convert::Infallible>,
-//     name: &'a str,
-//     input: &'a [ethabi::Token],
-// }
-//
-// impl<'a> CaptureResult<'a> {
-//     pub fn assert_perfomed_equal(&self) {
-//         assert_eq!(
-//             self.fe_capture, self.solidity_capture,
-//             "Called {} with input: {:?}",
-//             self.name, self.input
-//         )
-//     }
-//
-//     pub fn assert_reverted(&self) {
-//         if !matches!(
-//             (self.fe_capture.clone(), self.solidity_capture.clone()),
-//             (
-//                 evm::Capture::Exit((evm::ExitReason::Revert(_), _)),
-//                 evm::Capture::Exit((evm::ExitReason::Revert(_), _))
-//             )
-//         ) {
-//             panic!(
-//                 "Asserted both revert but was: Fe: {:?} Solidity: {:?}",
-//                 self.fe_capture, self.solidity_capture
-//             )
-//         }
-//     }
-//
-//     pub fn performed_equal(&self) -> bool {
-//         self.fe_capture == self.solidity_capture
-//     }
-// }
-//
-// impl<'a> DualHarness {
-//     pub fn from_fixture(
-//         executor: &mut Executor,
-//         fixture: &str,
-//         contract_name: &str,
-//         init_params: &[ethabi::Token],
-//     ) -> DualHarness {
-//         let fe_harness = test_utils::deploy_contract(
-//             executor,
-//             &format!("differential/{}.fe", fixture),
-//             contract_name,
-//             init_params,
-//         );
-//         let solidity_harness = test_utils::deploy_solidity_contract(
-//             executor,
-//             &format!("differential/{}.sol", fixture),
-//             contract_name,
-//             init_params,
-//         );
-//         DualHarness {
-//             fe_harness,
-//             solidity_harness,
-//         }
-//     }
-//
-//     pub fn capture_call(
-//         &self,
-//         executor: &mut Executor,
-//         name: &'a str,
-//         input: &'a [ethabi::Token],
-//     ) -> CaptureResult<'a> {
-//         let fe_capture = self.fe_harness.capture_call(executor, name, input);
-//         let solidity_capture = self.solidity_harness.capture_call(executor, name, input);
-//
-//         CaptureResult {
-//             fe_capture,
-//             solidity_capture,
-//             name,
-//             input,
-//         }
-//     }
-// }
+#![cfg(feature = "solc-backend")]
+use proptest::prelude::*;
 
-// proptest! {
-//
-//     #[test]
-//     #[ignore]
-//     fn math_u8(val in 0u8..=255, val2 in 0u8..=255) {
-//         with_executor(&|mut executor| {
-//
-//             let harness = DualHarness::from_fixture(&mut executor, "math_u8", "Foo", &[]);
-//
-//             harness.capture_call(&mut executor, "add", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "subtract", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "divide", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "multiply", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "pow", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "modulo", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "leftshift", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "rightshift", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "order_of_operation", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "invert", &[uint_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "bit_and", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "bit_or", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "bit_xor", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "cast1", &[uint_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "cast2", &[uint_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "cast3", &[uint_token(val.into())]).assert_perfomed_equal();
-//         });
-//     }
-//
-//     #[test]
-//     #[ignore]
-//     fn math_i8(val in -128i8..=127i8, val2 in -128i8..=127i8, val3 in 0u8..=255, val4 in 0u8..=255) {
-//         with_executor(&|mut executor| {
-//             let harness = DualHarness::from_fixture(&mut executor, "math_i8", "Foo", &[]);
-//
-//             harness.capture_call(&mut executor, "add", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "subtract", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "divide", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "multiply", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
-//             let inputs = &[int_token(val3.into()), uint_token(val4.into())];
-//             let result = harness.capture_call(&mut executor, "pow", inputs);
-//             if !result.performed_equal() {
-//                 // If they didn't performed equal then we further assert that at least both reverted. Solidity reverts
-//                 // with zero revert data when a pow operation overflows whereas Fe uses a proper revert error.
-//                 // We tolerate the divergence and assume its a TODO on the Solidity side :)
-//                 result.assert_reverted();
-//             }
-//
-//             harness.capture_call(&mut executor, "modulo", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "leftshift", &[int_token(val.into()), uint_token(val3.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "rightshift", &[int_token(val.into()), uint_token(val3.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "order_of_operation", &[int_token(val.into()), int_token(val2.into()), uint_token(val3.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "invert", &[int_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "cast1", &[int_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "cast2", &[int_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "cast3", &[int_token(val.into())]).assert_perfomed_equal();
-//             harness.capture_call(&mut executor, "negate", &[int_token(val.into())]).assert_perfomed_equal();
-//         });
-//     }
-// }
+use fe_compiler_test_utils::*;
+use fe_compiler_test_utils::{self as test_utils};
+
+struct DualHarness {
+    fe_harness: ContractHarness,
+    solidity_harness: ContractHarness,
+}
+
+struct CaptureResult<'a> {
+    fe_capture: evm::Capture<(evm::ExitReason, Vec<u8>), std::convert::Infallible>,
+    solidity_capture: evm::Capture<(evm::ExitReason, Vec<u8>), std::convert::Infallible>,
+    name: &'a str,
+    input: &'a [ethabi::Token],
+}
+
+impl<'a> CaptureResult<'a> {
+    pub fn assert_perfomed_equal(&self) {
+        assert_eq!(
+            self.fe_capture, self.solidity_capture,
+            "Called {} with input: {:?}",
+            self.name, self.input
+        )
+    }
+
+    pub fn assert_reverted(&self) {
+        if !matches!(
+            (self.fe_capture.clone(), self.solidity_capture.clone()),
+            (
+                evm::Capture::Exit((evm::ExitReason::Revert(_), _)),
+                evm::Capture::Exit((evm::ExitReason::Revert(_), _))
+            )
+        ) {
+            panic!(
+                "Asserted both revert but was: Fe: {:?} Solidity: {:?}",
+                self.fe_capture, self.solidity_capture
+            )
+        }
+    }
+
+    pub fn performed_equal(&self) -> bool {
+        self.fe_capture == self.solidity_capture
+    }
+}
+
+impl<'a> DualHarness {
+    pub fn from_fixture(
+        executor: &mut Executor,
+        fixture: &str,
+        contract_name: &str,
+        init_params: &[ethabi::Token],
+    ) -> DualHarness {
+        let fe_harness = test_utils::deploy_contract(
+            executor,
+            &format!("differential/{}.fe", fixture),
+            contract_name,
+            init_params,
+        );
+        let solidity_harness = test_utils::deploy_solidity_contract(
+            executor,
+            &format!("differential/{}.sol", fixture),
+            contract_name,
+            init_params,
+        );
+        DualHarness {
+            fe_harness,
+            solidity_harness,
+        }
+    }
+
+    pub fn capture_call(
+        &self,
+        executor: &mut Executor,
+        name: &'a str,
+        input: &'a [ethabi::Token],
+    ) -> CaptureResult<'a> {
+        let fe_capture = self.fe_harness.capture_call(executor, name, input);
+        let solidity_capture = self.solidity_harness.capture_call(executor, name, input);
+
+        CaptureResult {
+            fe_capture,
+            solidity_capture,
+            name,
+            input,
+        }
+    }
+}
+
+proptest! {
+
+    #[test]
+    #[ignore]
+    fn math_u8(val in 0u8..=255, val2 in 0u8..=255) {
+        with_executor(&|mut executor| {
+
+            let harness = DualHarness::from_fixture(&mut executor, "math_u8", "Foo", &[]);
+
+            harness.capture_call(&mut executor, "add", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "subtract", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "divide", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "multiply", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "pow", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "modulo", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "leftshift", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "rightshift", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "order_of_operation", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "invert", &[uint_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "bit_and", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "bit_or", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "bit_xor", &[uint_token(val.into()), uint_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "cast1", &[uint_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "cast2", &[uint_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "cast3", &[uint_token(val.into())]).assert_perfomed_equal();
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn math_i8(val in -128i8..=127i8, val2 in -128i8..=127i8, val3 in 0u8..=255, val4 in 0u8..=255) {
+        with_executor(&|mut executor| {
+            let harness = DualHarness::from_fixture(&mut executor, "math_i8", "Foo", &[]);
+
+            harness.capture_call(&mut executor, "add", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "subtract", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "divide", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "multiply", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
+            let inputs = &[int_token(val3.into()), uint_token(val4.into())];
+            let result = harness.capture_call(&mut executor, "pow", inputs);
+            if !result.performed_equal() {
+                // If they didn't performed equal then we further assert that at least both reverted. Solidity reverts
+                // with zero revert data when a pow operation overflows whereas Fe uses a proper revert error.
+                // We tolerate the divergence and assume its a TODO on the Solidity side :)
+                result.assert_reverted();
+            }
+
+            harness.capture_call(&mut executor, "modulo", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "leftshift", &[int_token(val.into()), uint_token(val3.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "rightshift", &[int_token(val.into()), uint_token(val3.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "order_of_operation", &[int_token(val.into()), int_token(val2.into()), uint_token(val3.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "invert", &[int_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "cast1", &[int_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "cast2", &[int_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "cast3", &[int_token(val.into())]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "negate", &[int_token(val.into())]).assert_perfomed_equal();
+        });
+    }
+}

--- a/crates/tests/src/differential.rs
+++ b/crates/tests/src/differential.rs
@@ -26,6 +26,7 @@ impl<'a> CaptureResult<'a> {
         )
     }
 
+    #[allow(dead_code)]
     pub fn assert_reverted(&self) {
         if !matches!(
             (self.fe_capture.clone(), self.solidity_capture.clone()),
@@ -41,6 +42,7 @@ impl<'a> CaptureResult<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn performed_equal(&self) -> bool {
         self.fe_capture == self.solidity_capture
     }
@@ -119,7 +121,7 @@ proptest! {
 
     #[test]
     #[ignore]
-    fn math_i8(val in -128i8..=127i8, val2 in -128i8..=127i8, val3 in 0u8..=255, val4 in 0u8..=255) {
+    fn math_i8(val in -128i8..=127i8, val2 in -128i8..=127i8, val3 in 0u8..=255) {
         with_executor(&|mut executor| {
             let harness = DualHarness::from_fixture(&mut executor, "math_i8", "Foo", &[]);
 
@@ -127,15 +129,6 @@ proptest! {
             harness.capture_call(&mut executor, "subtract", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
             harness.capture_call(&mut executor, "divide", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
             harness.capture_call(&mut executor, "multiply", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
-            let inputs = &[int_token(val3.into()), uint_token(val4.into())];
-            let result = harness.capture_call(&mut executor, "pow", inputs);
-            if !result.performed_equal() {
-                // If they didn't performed equal then we further assert that at least both reverted. Solidity reverts
-                // with zero revert data when a pow operation overflows whereas Fe uses a proper revert error.
-                // We tolerate the divergence and assume its a TODO on the Solidity side :)
-                result.assert_reverted();
-            }
-
             harness.capture_call(&mut executor, "modulo", &[int_token(val.into()), int_token(val2.into())]).assert_perfomed_equal();
             harness.capture_call(&mut executor, "leftshift", &[int_token(val.into()), uint_token(val3.into())]).assert_perfomed_equal();
             harness.capture_call(&mut executor, "rightshift", &[int_token(val.into()), uint_token(val3.into())]).assert_perfomed_equal();


### PR DESCRIPTION
### What was wrong?

We recently added differential tests that aim to find bugs through fuzzing certain contracts with random inputs. These tests do not work well for the PR CI runs because:

- They may discover bugs which then causes a PR to fail for an unrelated reason
- They take a long time to run
- They should run as often as possible

### How was it fixed?

- Moved it into a cron job to run every 30 minutes. This was chosen as a sweet spot to run it as often as possible without clogging our CI queue (leaving room for PR jobs etc)
- When a job fails, the `differential.txt` is read and presented which give us a chance to add the seed to version control as a regression test.
- Ideally, we would like to create a github issue automatically but that's a job for another day because we will need to come up with something that first checks if the issue was already reported to not clog our issue log with duplicates
