### PR TITLE
Attach file IDs to `Span`s

### DIFF
--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -71,7 +71,7 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> 
             )))),
             ast::ModuleStmt::Constant(node) => Some(Item::Constant(db.intern_module_const(
                 Rc::new(ModuleConstant {
-                    ast: node.clone(),
+                    ast: *node.clone(),
                     module,
                 }),
             ))),

--- a/crates/analyzer/src/traversal/call_args.rs
+++ b/crates/analyzer/src/traversal/call_args.rs
@@ -156,7 +156,7 @@ pub fn validate_arg_labels(
                         scope.fancy_error(
                             "missing argument label",
                             vec![Label::primary(
-                                Span::new(arg_val.span.start, arg_val.span.start),
+                                Span::new(arg_val.span.file_id, arg_val.span.start, arg_val.span.start),
                                 format!("add `{}=` here", expected_label),
                             )],
                             vec![format!(

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -10,10 +10,10 @@ fn error_string(path: &str, src: &str) -> String {
     let mut files = FileStore::new();
     let id = files.add_file(path, src);
 
-    let fe_module = match fe_parser::parse_file(src) {
+    let fe_module = match fe_parser::parse_file(id, src) {
         Ok((module, _)) => module,
         Err(diags) => {
-            print_diagnostics(&diags, id, &files);
+            print_diagnostics(&diags, &files);
             panic!("parsing failed");
         }
     };
@@ -21,7 +21,7 @@ fn error_string(path: &str, src: &str) -> String {
     let db = Db::default();
     match fe_analyzer::analyze(&db, fe_module) {
         Ok(_) => panic!("expected analysis to fail with an error"),
-        Err(diags) => diagnostics_string(&diags, id, &files),
+        Err(diags) => diagnostics_string(&diags, &files),
     }
 }
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/call_statement_with_args.fe\", &src, module, &db)"
+expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
@@ -115,14 +115,11 @@ note:
   ┌─ features/call_statement_with_args.fe:8:9
   │
 8 │         self.assign(100)
-  │         ^^^^^^^^^^^ attributes hash: 8420354620523897173
+  │         ^^^^^^^^^^^ attributes hash: 8522453005002335674
   │
   = SelfAttribute {
         func_name: "assign",
-        self_span: Span {
-            start: 137,
-            end: 141,
-        },
+        self_span: 137..141,
     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/call_statement_with_args_2.fe\", &src, module, &db)"
+expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
@@ -124,14 +124,11 @@ note:
   ┌─ features/call_statement_with_args_2.fe:9:9
   │
 9 │         self.assign(100)
-  │         ^^^^^^^^^^^ attributes hash: 511266823031776296
+  │         ^^^^^^^^^^^ attributes hash: 2997557065728909304
   │
   = SelfAttribute {
         func_name: "assign",
-        self_span: Span {
-            start: 164,
-            end: 168,
-        },
+        self_span: 164..168,
     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/call_statement_without_args.fe\", &src, module, &db)"
+expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
@@ -98,14 +98,11 @@ note:
   ┌─ features/call_statement_without_args.fe:8:9
   │
 8 │         self.assign()
-  │         ^^^^^^^^^^^ attributes hash: 17318279018058750260
+  │         ^^^^^^^^^^^ attributes hash: 1845414425399096131
   │
   = SelfAttribute {
         func_name: "assign",
-        self_span: Span {
-            start: 126,
-            end: 130,
-        },
+        self_span: 126..130,
     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"demos/erc20_token.fe\", &src, module, &db)"
+expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
@@ -1949,14 +1949,11 @@ note:
    ┌─ demos/erc20_token.fe:23:9
    │
 23 │         self._mint(msg.sender, 1000000000000000000000000)
-   │         ^^^^^^^^^^ attributes hash: 16096825613720258282
+   │         ^^^^^^^^^^ attributes hash: 3032414134331615192
    │
    = SelfAttribute {
          func_name: "_mint",
-         self_span: Span {
-             start: 542,
-             end: 546,
-         },
+         self_span: 542..546,
      }
 
 note: 
@@ -1979,84 +1976,66 @@ note:
    ┌─ demos/erc20_token.fe:41:9
    │
 41 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 11998329377771437848
+   │         ^^^^^^^^^^^^^^ attributes hash: 15399895119751945816
    │
    = SelfAttribute {
          func_name: "_transfer",
-         self_span: Span {
-             start: 1052,
-             end: 1056,
-         },
+         self_span: 1052..1056,
      }
 
 note: 
    ┌─ demos/erc20_token.fe:48:9
    │
 48 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 47467343444821621
+   │         ^^^^^^^^^^^^^ attributes hash: 10047856837296232623
    │
    = SelfAttribute {
          func_name: "_approve",
-         self_span: Span {
-             start: 1310,
-             end: 1314,
-         },
+         self_span: 1310..1314,
      }
 
 note: 
    ┌─ demos/erc20_token.fe:53:9
    │
 53 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 14187559596189701922
+   │         ^^^^^^^^^^^^^^ attributes hash: 13311941709994158162
    │
    = SelfAttribute {
          func_name: "_transfer",
-         self_span: Span {
-             start: 1531,
-             end: 1535,
-         },
+         self_span: 1531..1535,
      }
 
 note: 
    ┌─ demos/erc20_token.fe:54:9
    │
 54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^ attributes hash: 337359114556530356
+   │         ^^^^^^^^^^^^^ attributes hash: 5596759839039037729
    │
    = SelfAttribute {
          func_name: "_approve",
-         self_span: Span {
-             start: 1580,
-             end: 1584,
-         },
+         self_span: 1580..1584,
      }
 
 note: 
    ┌─ demos/erc20_token.fe:58:9
    │
 58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 10097494349759349093
+   │         ^^^^^^^^^^^^^ attributes hash: 10420458525874606876
    │
    = SelfAttribute {
          func_name: "_approve",
-         self_span: Span {
-             start: 1769,
-             end: 1773,
-         },
+         self_span: 1769..1773,
      }
 
 note: 
    ┌─ demos/erc20_token.fe:62:9
    │
 62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^ attributes hash: 9207024764946008481
+   │         ^^^^^^^^^^^^^ attributes hash: 1575892034280724253
    │
    = SelfAttribute {
          func_name: "_approve",
-         self_span: Span {
-             start: 1970,
-             end: 1974,
-         },
+         self_span: 1970..1974,
      }
 
 note: 

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/pure_fn_standalone.fe\", &src, module, &db)"
+expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
@@ -284,28 +284,22 @@ note:
    ┌─ features/pure_fn_standalone.fe:17:9
    │
 17 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^ attributes hash: 8626870049799486243
+   │         ^^^^^^^^^^^^^^^ attributes hash: 5094765954567266946
    │
    = SelfAttribute {
          func_name: "add_points",
-         self_span: Span {
-             start: 400,
-             end: 404,
-         },
+         self_span: 400..404,
      }
 
 note: 
    ┌─ features/pure_fn_standalone.fe:19:9
    │
 19 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^ attributes hash: 13248801714086080881
+   │         ^^^^^^^^^^^^^^^ attributes hash: 5317772279976617936
    │
    = SelfAttribute {
          func_name: "add_points",
-         self_span: Span {
-             start: 466,
-             end: 470,
-         },
+         self_span: 466..470,
      }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"demos/uniswap.fe\", &src, module, &db)"
+expression: "build_snapshot(files, module, &db)"
 
 ---
 note: 
@@ -5800,42 +5800,33 @@ note:
    ┌─ demos/uniswap.fe:95:9
    │
 95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ attributes hash: 10018161393539106403
+   │         ^^^^^^^^^^^^^ attributes hash: 14531113974490967627
    │
    = SelfAttribute {
          func_name: "_approve",
-         self_span: Span {
-             start: 2409,
-             end: 2413,
-         },
+         self_span: 2409..2413,
      }
 
 note: 
    ┌─ demos/uniswap.fe:99:9
    │
 99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^ attributes hash: 10093895704938982127
+   │         ^^^^^^^^^^^^^^ attributes hash: 7946469693452924957
    │
    = SelfAttribute {
          func_name: "_transfer",
-         self_span: Span {
-             start: 2541,
-             end: 2545,
-         },
+         self_span: 2541..2545,
      }
 
 note: 
     ┌─ demos/uniswap.fe:106:9
     │
 106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^ attributes hash: 12907935190801646102
+    │         ^^^^^^^^^^^^^^ attributes hash: 9013399514526062924
     │
     = SelfAttribute {
           func_name: "_transfer",
-          self_span: Span {
-              start: 2833,
-              end: 2837,
-          },
+          self_span: 2833..2837,
       }
 
 note: 
@@ -5903,14 +5894,11 @@ note:
     ┌─ demos/uniswap.fe:151:25
     │
 151 │                         self._mint(fee_to, liquidity)
-    │                         ^^^^^^^^^^ attributes hash: 5774063433734111386
+    │                         ^^^^^^^^^^ attributes hash: 12418659184498534900
     │
     = SelfAttribute {
           func_name: "_mint",
-          self_span: Span {
-              start: 5111,
-              end: 5115,
-          },
+          self_span: 5111..5115,
       }
 
 note: 
@@ -5967,14 +5955,11 @@ note:
     ┌─ demos/uniswap.fe:167:28
     │
 167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ attributes hash: 5706709587227470482
+    │                            ^^^^^^^^^^^^^^ attributes hash: 16080475652312567395
     │
     = SelfAttribute {
           func_name: "_mint_fee",
-          self_span: Span {
-              start: 5772,
-              end: 5776,
-          },
+          self_span: 5772..5776,
       }
 
 note: 
@@ -5993,14 +5978,11 @@ note:
     ┌─ demos/uniswap.fe:172:13
     │
 172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^ attributes hash: 1138819520748010179
+    │             ^^^^^^^^^^ attributes hash: 7856352234549907196
     │
     = SelfAttribute {
           func_name: "_mint",
-          self_span: Span {
-              start: 6077,
-              end: 6081,
-          },
+          self_span: 6077..6081,
       }
 
 note: 
@@ -6031,28 +6013,22 @@ note:
     ┌─ demos/uniswap.fe:178:9
     │
 178 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^ attributes hash: 11733924240468847297
+    │         ^^^^^^^^^^ attributes hash: 15101716191511699734
     │
     = SelfAttribute {
           func_name: "_mint",
-          self_span: Span {
-              start: 6372,
-              end: 6376,
-          },
+          self_span: 6372..6376,
       }
 
 note: 
     ┌─ demos/uniswap.fe:179:9
     │
 179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 13255950405190274570
+    │         ^^^^^^^^^^^^ attributes hash: 3915756169872662167
     │
     = SelfAttribute {
           func_name: "_update",
-          self_span: Span {
-              start: 6406,
-              end: 6410,
-          },
+          self_span: 6406..6410,
       }
 
 note: 
@@ -6109,28 +6085,22 @@ note:
     ┌─ demos/uniswap.fe:197:28
     │
 197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ attributes hash: 5536339678205451361
+    │                            ^^^^^^^^^^^^^^ attributes hash: 9805941357832028794
     │
     = SelfAttribute {
           func_name: "_mint_fee",
-          self_span: Span {
-              start: 7186,
-              end: 7190,
-          },
+          self_span: 7186..7190,
       }
 
 note: 
     ┌─ demos/uniswap.fe:202:9
     │
 202 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^ attributes hash: 4813635634628659472
+    │         ^^^^^^^^^^ attributes hash: 11916723560899393221
     │
     = SelfAttribute {
           func_name: "_burn",
-          self_span: Span {
-              start: 7671,
-              end: 7675,
-          },
+          self_span: 7671..7675,
       }
 
 note: 
@@ -6169,14 +6139,11 @@ note:
     ┌─ demos/uniswap.fe:208:9
     │
 208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 15351211589753982846
+    │         ^^^^^^^^^^^^ attributes hash: 2808373337661029670
     │
     = SelfAttribute {
           func_name: "_update",
-          self_span: Span {
-              start: 7890,
-              end: 7894,
-          },
+          self_span: 7890..7894,
       }
 
 note: 
@@ -6273,14 +6240,11 @@ note:
     ┌─ demos/uniswap.fe:252:9
     │
 252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 5918725660327764465
+    │         ^^^^^^^^^^^^ attributes hash: 2670672044438645764
     │
     = SelfAttribute {
           func_name: "_update",
-          self_span: Span {
-              start: 10100,
-              end: 10104,
-          },
+          self_span: 10100..10104,
       }
 
 note: 
@@ -6387,14 +6351,11 @@ note:
     ┌─ demos/uniswap.fe:267:9
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^ attributes hash: 15796683777521125666
+    │         ^^^^^^^^^^^^ attributes hash: 11941105680565576248
     │
     = SelfAttribute {
           func_name: "_update",
-          self_span: Span {
-              start: 10760,
-              end: 10764,
-          },
+          self_span: 10760..10764,
       }
 
 note: 

--- a/crates/common/src/files.rs
+++ b/crates/common/src/files.rs
@@ -15,7 +15,7 @@ pub struct SourceFile {
     line_starts: Vec<usize>,
 }
 
-#[derive(PartialEq, Copy, Clone, Eq, Hash, Debug)]
+#[derive(PartialEq, Copy, Clone, Eq, Hash, Debug, Default)]
 pub struct SourceFileId(pub u128);
 
 impl SourceFile {
@@ -42,7 +42,7 @@ impl SourceFile {
         } else {
             *self.line_starts.get(line_index + 1)?
         };
-        Some(Span::new(*self.line_starts.get(line_index)?, end))
+        Some(Span::new(self.id, *self.line_starts.get(line_index)?, end))
     }
 }
 

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -1,5 +1,6 @@
 use fe_analyzer::Db;
 use fe_common::diagnostics::Diagnostic;
+use fe_common::files::SourceFileId;
 use fe_parser::parse_file;
 #[cfg(feature = "solc-backend")]
 use serde_json::Value;
@@ -28,6 +29,7 @@ pub struct CompileError(pub Vec<Diagnostic>);
 /// If `with_bytecode` is set to false, the compiler will skip the final Yul ->
 /// Bytecode pass. This is useful when debugging invalid Yul code.
 pub fn compile(
+    file_id: SourceFileId,
     src: &str,
     _with_bytecode: bool,
     _optimize: bool,
@@ -36,7 +38,7 @@ pub fn compile(
 
     let mut errors = vec![];
 
-    let (fe_module, parser_diagnostics) = parse_file(src).map_err(CompileError)?;
+    let (fe_module, parser_diagnostics) = parse_file(file_id, src).map_err(CompileError)?;
     errors.extend(parser_diagnostics.into_iter());
 
     let src_ast = format!("{:#?}", &fe_module);

--- a/crates/lowering/src/utils.rs
+++ b/crates/lowering/src/utils.rs
@@ -1,3 +1,4 @@
+use fe_common::files::SourceFileId;
 use fe_common::Span;
 use fe_parser::node::Node;
 
@@ -5,7 +6,7 @@ use fe_parser::node::Node;
 pub trait ZeroSpanNode: Sized {
     /// Wrap the value in a `Node` with a span of zero.
     fn into_node(self) -> Node<Self> {
-        Node::new(self, Span::zero())
+        Node::new(self, Span::zero(SourceFileId::default()))
     }
 
     /// Wrap the value in a boxed `Node` with a span of zero

--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -8,26 +8,26 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 fn lower(src: &str, id: SourceFileId, files: &FileStore) -> fe::Module {
     let fe_module = parse_file(src, id, files);
-    let (db, module_id) = analyze(fe_module, id, files);
+    let (db, module_id) = analyze(fe_module, files);
     fe_lowering::lower(&db, module_id)
 }
 
-fn analyze(module: fe::Module, id: SourceFileId, files: &FileStore) -> (Db, ModuleId) {
+fn analyze(module: fe::Module, files: &FileStore) -> (Db, ModuleId) {
     let db = Db::default();
     match fe_analyzer::analyze(&db, module) {
         Ok(id) => (db, id),
         Err(diagnostics) => {
-            print_diagnostics(&diagnostics, id, files);
+            print_diagnostics(&diagnostics, files);
             panic!("analysis failed");
         }
     }
 }
 
 fn parse_file(src: &str, id: SourceFileId, files: &FileStore) -> fe::Module {
-    match fe_parser::parse_file(src) {
+    match fe_parser::parse_file(id, src) {
         Ok((module, diags)) if diags.is_empty() => module,
         Ok((_, diags)) | Err(diags) => {
-            print_diagnostics(&diags, id, files);
+            print_diagnostics(&diags, files);
             panic!("failed to parse file");
         }
     }

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -18,7 +18,7 @@ pub enum ModuleStmt {
     Use(Node<Use>),
     TypeAlias(Node<TypeAlias>),
     Contract(Node<Contract>),
-    Constant(Node<ConstantDecl>),
+    Constant(Box<Node<ConstantDecl>>),
     Struct(Node<Struct>),
     Function(Node<Function>),
 }

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -25,7 +25,7 @@ pub fn parse_module(par: &mut Parser) -> ParseResult<Node<Module>> {
             }
         }
     }
-    let span = Span::zero() + body.first() + body.last();
+    let span = Span::zero(par.file_id) + body.first() + body.last();
     Ok(Node::new(Module { body }, span))
 }
 
@@ -37,7 +37,7 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
         TokenKind::Contract => ModuleStmt::Contract(parse_contract_def(par)?),
         TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par)?),
         TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par)?),
-        TokenKind::Const => ModuleStmt::Constant(parse_constant(par)?),
+        TokenKind::Const => ModuleStmt::Constant(Box::new(parse_constant(par)?)),
 
         // Let these be parse errors for now:
         // TokenKind::Event => todo!("module-level event def"),

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -8,6 +8,7 @@ pub mod node;
 
 use ast::Module;
 use fe_common::diagnostics::Diagnostic;
+use fe_common::files::SourceFileId;
 
 /// Parse a [`Module`] from the file content string.
 ///
@@ -20,8 +21,11 @@ use fe_common::diagnostics::Diagnostic;
 ///
 /// A [`SourceFileId`] is required to associate any diagnostics with the
 /// underlying file.
-pub fn parse_file(src: &str) -> Result<(Module, Vec<Diagnostic>), Vec<Diagnostic>> {
-    let mut parser = Parser::new(src);
+pub fn parse_file(
+    file_id: SourceFileId,
+    src: &str,
+) -> Result<(Module, Vec<Diagnostic>), Vec<Diagnostic>> {
+    let mut parser = Parser::new(file_id, src);
     match crate::grammar::module::parse_module(&mut parser) {
         Err(_) => Err(parser.diagnostics),
         Ok(node) => Ok((node.kind, parser.diagnostics)),
@@ -37,11 +41,11 @@ where
 {
     let mut files = fe_common::files::FileStore::new();
     let id = files.add_file("parse_code_chunk test snippet", src);
-    let mut parser = Parser::new(src);
+    let mut parser = Parser::new(id, src);
     if let Ok(node) = parse_fn(&mut parser) {
         Ok(node)
     } else {
-        fe_common::diagnostics::print_diagnostics(&parser.diagnostics, id, &files);
+        fe_common::diagnostics::print_diagnostics(&parser.diagnostics, &files);
         Err(ParseFailed)
     }
 }

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -10,10 +10,10 @@ where
 {
     let mut files = fe_common::files::FileStore::new();
     let id = files.add_file(test_name, src);
-    let mut parser = Parser::new(src);
+    let mut parser = Parser::new(id, src);
 
     let parse_failed = parse_fn(&mut parser).is_err();
-    let diag = diagnostics_string(&parser.diagnostics, id, &files);
+    let diag = diagnostics_string(&parser.diagnostics, &files);
     if parse_failed != should_fail {
         panic!(
             "expected parsing to {}fail. Diagnostics:\n{}",

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -13,11 +13,11 @@ where
 {
     let mut files = fe_common::files::FileStore::new();
     let id = files.add_file(test_name, src);
-    let mut parser = Parser::new(src);
+    let mut parser = Parser::new(id, src);
 
     if let Ok(ast) = parse_fn(&mut parser) {
         if !parser.diagnostics.is_empty() {
-            print_diagnostics(&parser.diagnostics, id, &files);
+            print_diagnostics(&parser.diagnostics, &files);
             panic!("parse error");
         }
         to_ron_string_pretty(&ast).unwrap()
@@ -30,12 +30,12 @@ where
                     tok.span,
                     "this is the next token at time of parsing failure",
                 );
-                print_diagnostics(&parser.diagnostics, id, &files);
+                print_diagnostics(&parser.diagnostics, &files);
             } else {
                 eprintln!("parser is at end of file");
             }
         } else {
-            print_diagnostics(&parser.diagnostics, id, &files);
+            print_diagnostics(&parser.diagnostics, &files);
         }
         panic!("parse failed");
     }

--- a/crates/parser/tests/cases/print_ast.rs
+++ b/crates/parser/tests/cases/print_ast.rs
@@ -1,9 +1,11 @@
+use fe_common::files::SourceFileId;
 use fe_parser::parse_file;
 use fe_test_files::fixture;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 fn parse_and_print(src: &str) -> String {
-    let (module, _) = parse_file(src).expect("failed to parse source file");
+    let (module, _) =
+        parse_file(SourceFileId::default(), src).expect("failed to parse source file");
     format!("{}", module)
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -245,10 +245,10 @@ pub fn deploy_contract(
     let mut files = FileStore::new();
     let id = files.add_file(fixture, src);
 
-    let compiled_module = match driver::compile(src, true, true) {
+    let compiled_module = match driver::compile(id, src, true, true) {
         Ok(module) => module,
         Err(error) => {
-            fe_common::diagnostics::print_diagnostics(&error.0, id, &files);
+            fe_common::diagnostics::print_diagnostics(&error.0, &files);
             panic!("failed to compile module: {}", fixture)
         }
     };
@@ -448,10 +448,10 @@ pub fn load_contract(address: H160, fixture: &str, contract_name: &str) -> Contr
     let mut files = FileStore::new();
     let src = test_files::fixture(fixture);
     let id = files.add_file(fixture, src);
-    let compiled_module = match driver::compile(src, true, true) {
+    let compiled_module = match driver::compile(id, src, true, true) {
         Ok(module) => module,
         Err(err) => {
-            print_diagnostics(&err.0, id, &files);
+            print_diagnostics(&err.0, &files);
             panic!("failed to compile fixture: {}", fixture);
         }
     };

--- a/crates/tests/src/crashes.rs
+++ b/crates/tests/src/crashes.rs
@@ -1,3 +1,4 @@
+use fe_common::files::SourceFileId;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 macro_rules! test_file {
@@ -7,7 +8,7 @@ macro_rules! test_file {
         fn $name() {
             let path = concat!("crashes/", stringify!($name), ".fe");
             let src = test_files::fixture(path);
-            fe_driver::compile(src, true, true).ok();
+            fe_driver::compile(SourceFileId::default(), src, true, true).ok();
         }
     };
 }

--- a/newsfragments/587.internal.md
+++ b/newsfragments/587.internal.md
@@ -1,0 +1,1 @@
+File IDs are now attached to `Span`s.


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/fe/blob/bfeffe82b4f8623330c1ebb1950ca981449c9e86/crates/common/src/diagnostics.rs#L8-L11

We also can't get a list of diagnostics with labels pointing to different source files.

### How was it fixed?

Refactored things.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
