### PR TITLE
Add out of bound check for array element access

### DIFF
--- a/crates/test-files/fixtures/features/arrays.fe
+++ b/crates/test-files/fixtures/features/arrays.fe
@@ -1,0 +1,5 @@
+contract Foo:
+  data: u256[10]
+
+  pub fn get_item(self, index: u256) -> u256:
+    return self.data[index]

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -132,6 +132,19 @@ fn test_revert() {
 }
 
 #[test]
+fn test_arrays() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "arrays.fe", "Foo", &[]);
+
+
+        validate_revert(
+            harness.capture_call(&mut executor, "get_item", &[uint_token(20)]),
+             &[] // TODO pick the right panic code
+        );
+    })
+}
+
+#[test]
 fn test_balances() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "balances.fe", "Foo", &[]);


### PR DESCRIPTION
### What was wrong?

Another thing found by the differential contract fuzzing is that we are missing *out of bounds* checks for when we access array elements.

### How was it fixed?

Not yet, just reporting.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
