### PR TITLE
Output ast as json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "fe-common",
  "fe-driver",
  "fe-parser",
+ "serde_json",
 ]
 
 [[package]]
@@ -1492,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",

--- a/crates/fe/Cargo.toml
+++ b/crates/fe/Cargo.toml
@@ -18,3 +18,4 @@ clap = "2.33.3"
 fe-common = {path = "../common", version = "^0.10.0-alpha"}
 fe-driver = {path = "../driver", version = "^0.10.0-alpha"}
 fe-parser = {path = "../parser", version = "^0.10.0-alpha"}
+serde_json = "1.0.69"

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -134,11 +134,17 @@ fn write_compiled_module(
     fs::create_dir_all(output_dir).map_err(ioerr_to_string)?;
 
     if targets.contains(&CompilationTarget::Ast) {
-        write_output(&output_dir.join("module.ast"), &module.src_ast)?;
+        write_output(
+            &output_dir.join("module.ast.json"),
+            &serde_json::to_string_pretty(&module.src_ast).expect("json encoding failed"),
+        )?;
     }
 
     if targets.contains(&CompilationTarget::LoweredAst) {
-        write_output(&output_dir.join("lowered_module.ast"), &module.lowered_ast)?;
+        write_output(
+            &output_dir.join("lowered_module.ast.json"),
+            &serde_json::to_string_pretty(&module.lowered_ast).expect("json encoding failed"),
+        )?;
     }
 
     if targets.contains(&CompilationTarget::Tokens) {


### PR DESCRIPTION
### What was wrong?

#593 

### How was it fixed?

This is just a quick swap of the default `Debug` encoding of the ast with `serde_json::to_string_pretty`. Anyone have any feelings about what the ast output should look like? Should json be a separate cli option, with `Debug` (or RON?) the default? I have no preference. I also have no attachment to this PR (it was like 30 seconds of effort), so if someone wants to do other things with our cli options and outputs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
