### PR TITLE
Lower ternary and boolean expressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets --all-features -- -D warnings
+          args: --workspace --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms -A clippy::large-enum-variant
 
   test:
     # Build & Test runs on all platforms

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ coverage:
 
 .PHONY: clippy
 clippy:
-	cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms
+	cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms -A clippy::large-enum-variant
 
 .PHONY: rustfmt
 rustfmt:

--- a/crates/common/src/numeric.rs
+++ b/crates/common/src/numeric.rs
@@ -26,8 +26,6 @@ pub struct Literal<'a> {
     num: &'a str,
     /// The radix of the literal.
     radix: Radix,
-    /// The radix part of the string.
-    prefix: Option<&'a str>,
 }
 
 impl<'a> Literal<'a> {
@@ -48,7 +46,6 @@ impl<'a> Literal<'a> {
         Self {
             num: &src[prefix.map_or(0, |pref| pref.len())..],
             radix,
-            prefix,
         }
     }
 

--- a/crates/common/src/panic.rs
+++ b/crates/common/src/panic.rs
@@ -5,7 +5,7 @@ const BUG_REPORT_URL: &str = "https://github.com/ethereum/fe/issues/new";
 static DEFAULT_PANIC_HOOK: Lazy<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> =
     Lazy::new(|| {
         let hook = panic::take_hook();
-        panic::set_hook(Box::new(|info| report_ice(info)));
+        panic::set_hook(Box::new(report_ice));
         hook
     });
 

--- a/crates/lowering/src/ast_utils.rs
+++ b/crates/lowering/src/ast_utils.rs
@@ -1,0 +1,858 @@
+use fe_analyzer::namespace::types::FixedSize;
+use fe_parser::ast::{CallArg, Expr, FuncStmt, VarDeclTarget};
+use fe_parser::node::{Node, NodeId};
+
+use crate::names;
+use crate::utils::ZeroSpanNode;
+
+#[derive(Debug)]
+pub enum StmtOrExpr {
+    Stmt(Node<FuncStmt>),
+    Expr(Node<Expr>),
+}
+
+impl From<Node<FuncStmt>> for StmtOrExpr {
+    fn from(stmt: Node<FuncStmt>) -> Self {
+        StmtOrExpr::Stmt(stmt)
+    }
+}
+
+impl From<Node<Expr>> for StmtOrExpr {
+    fn from(expr: Node<Expr>) -> Self {
+        StmtOrExpr::Expr(expr)
+    }
+}
+
+impl StmtOrExpr {
+    pub fn as_stmt(&self) -> Node<FuncStmt> {
+        match self {
+            StmtOrExpr::Stmt(stmt) => stmt.clone(),
+            _ => panic!("not a statement"),
+        }
+    }
+
+    pub fn as_expr(&self) -> Node<Expr> {
+        match self {
+            StmtOrExpr::Expr(expr) => expr.clone(),
+            _ => panic!("not an expression"),
+        }
+    }
+}
+
+/// Recursively map the given `node` by applying the given `map_fn`
+pub fn map_ast_node<M>(node: StmtOrExpr, map_fn: &mut M) -> StmtOrExpr
+where
+    M: FnMut(StmtOrExpr) -> StmtOrExpr,
+{
+    match node {
+        StmtOrExpr::Stmt(stmt) => {
+            let node = match stmt.kind {
+                FuncStmt::Assert { test, msg } => FuncStmt::Assert {
+                    test: map_ast_node(test.into(), map_fn).as_expr(),
+                    msg: msg.map(|val| map_ast_node(val.into(), map_fn).as_expr()),
+                },
+                FuncStmt::Assign { target, value } => FuncStmt::Assign {
+                    target: map_ast_node(target.into(), map_fn).as_expr(),
+                    value: map_ast_node(value.into(), map_fn).as_expr(),
+                },
+                FuncStmt::AugAssign { target, op, value } => FuncStmt::AugAssign {
+                    target: map_ast_node(target.into(), map_fn).as_expr(),
+                    value: map_ast_node(value.into(), map_fn).as_expr(),
+                    op,
+                },
+                FuncStmt::Emit { name, args } => FuncStmt::Emit {
+                    name,
+                    args: map_call_args(args, map_fn),
+                },
+                FuncStmt::Expr { value } => FuncStmt::Expr {
+                    value: map_ast_node(value.into(), map_fn).as_expr(),
+                },
+                FuncStmt::For { target, iter, body } => FuncStmt::For {
+                    target,
+                    iter: map_ast_node(iter.into(), map_fn).as_expr(),
+                    body: map_body(body, map_fn),
+                },
+                FuncStmt::If {
+                    body,
+                    test,
+                    or_else,
+                } => FuncStmt::If {
+                    body: map_body(body, map_fn),
+                    or_else: map_body(or_else, map_fn),
+                    test: map_ast_node(test.into(), map_fn).as_expr(),
+                },
+
+                FuncStmt::Return { value } => FuncStmt::Return {
+                    value: value.map(|val| map_ast_node(val.into(), map_fn).as_expr()),
+                },
+                FuncStmt::Revert { error } => FuncStmt::Revert {
+                    error: error.map(|val| map_ast_node(val.into(), map_fn).as_expr()),
+                },
+                FuncStmt::Unsafe(body) => FuncStmt::Unsafe(map_body(body, map_fn)),
+                FuncStmt::VarDecl { target, typ, value } => FuncStmt::VarDecl {
+                    target,
+                    typ,
+                    value: value.map(|val| map_ast_node(val.into(), map_fn).as_expr()),
+                },
+                FuncStmt::While { test, body } => FuncStmt::While {
+                    test: map_ast_node(test.into(), map_fn).as_expr(),
+                    body: map_body(body, map_fn),
+                },
+                // See comment below for why no catch all should be used here
+                FuncStmt::Pass | FuncStmt::Break | FuncStmt::Continue => stmt.kind,
+            }
+            .into_traceable_node(stmt.original_id);
+
+            map_fn(node.into())
+        }
+        StmtOrExpr::Expr(expr) => {
+            let expr = match expr.kind {
+                Expr::Attribute { value, attr } => Expr::Attribute {
+                    value: Box::new(map_ast_node((*value).into(), map_fn).as_expr()),
+                    attr,
+                },
+                Expr::BinOperation { left, op, right } => Expr::BinOperation {
+                    left: Box::new(map_ast_node((*left).into(), map_fn).as_expr()),
+                    right: Box::new(map_ast_node((*right).into(), map_fn).as_expr()),
+                    op,
+                },
+                Expr::BoolOperation { left, op, right } => Expr::BoolOperation {
+                    left: Box::new(map_ast_node((*left).into(), map_fn).as_expr()),
+                    right: Box::new(map_ast_node((*right).into(), map_fn).as_expr()),
+                    op,
+                },
+                Expr::Call {
+                    args,
+                    func,
+                    generic_args,
+                } => Expr::Call {
+                    args: map_call_args(args, map_fn),
+                    func: Box::new(map_ast_node((*func).into(), map_fn).as_expr()),
+                    generic_args,
+                },
+                Expr::CompOperation { left, op, right } => Expr::CompOperation {
+                    left: Box::new(map_ast_node((*left).into(), map_fn).as_expr()),
+                    right: Box::new(map_ast_node((*right).into(), map_fn).as_expr()),
+                    op,
+                },
+                Expr::List { elts } => Expr::List {
+                    elts: elts
+                        .into_iter()
+                        .map(|val| map_ast_node(val.into(), map_fn).as_expr())
+                        .collect(),
+                },
+                Expr::Subscript { value, index } => Expr::Subscript {
+                    value: Box::new(map_ast_node((*value).into(), map_fn).as_expr()),
+                    index: Box::new(map_ast_node((*index).into(), map_fn).as_expr()),
+                },
+                Expr::Ternary {
+                    if_expr,
+                    test,
+                    else_expr,
+                } => Expr::Ternary {
+                    if_expr: Box::new(map_ast_node((*if_expr).into(), map_fn).as_expr()),
+                    test: Box::new(map_ast_node((*test).into(), map_fn).as_expr()),
+                    else_expr: Box::new(map_ast_node((*else_expr).into(), map_fn).as_expr()),
+                },
+                Expr::Tuple { elts } => Expr::Tuple {
+                    elts: elts
+                        .into_iter()
+                        .map(|val| map_ast_node(val.into(), map_fn).as_expr())
+                        .collect(),
+                },
+                Expr::UnaryOperation { op, operand } => Expr::UnaryOperation {
+                    op,
+                    operand: Box::new(map_ast_node((*operand).into(), map_fn).as_expr()),
+                },
+                // The following *could* be covered via catch all. However, that would turn into a footgun if we add
+                // more expressions in the future that need to be walked. It's better to not use a catch all here.
+                Expr::Bool(_)
+                | Expr::Name(_)
+                | Expr::Num(_)
+                | Expr::Path(_)
+                | Expr::Str(_)
+                | Expr::Unit => expr.kind,
+            }
+            .into_traceable_node(expr.original_id);
+
+            map_fn(expr.into())
+        }
+    }
+}
+
+fn map_call_args<M>(args: Node<Vec<Node<CallArg>>>, map_fn: &mut M) -> Node<Vec<Node<CallArg>>>
+where
+    M: FnMut(StmtOrExpr) -> StmtOrExpr,
+{
+    args.kind
+        .into_iter()
+        .map(|call_arg| {
+            CallArg {
+                label: call_arg.kind.label,
+                value: map_ast_node(call_arg.kind.value.into(), map_fn).as_expr(),
+            }
+            .into_traceable_node(call_arg.original_id)
+        })
+        .collect::<Vec<_>>()
+        .into_traceable_node(args.original_id)
+}
+
+fn map_body<M>(body: Vec<Node<FuncStmt>>, map_fn: &mut M) -> Vec<Node<FuncStmt>>
+where
+    M: FnMut(StmtOrExpr) -> StmtOrExpr,
+{
+    body.into_iter()
+        .map(|val| map_ast_node(val.into(), map_fn).as_stmt())
+        .collect()
+}
+
+/// Returns `true` if the `node_id` matches the `orignal_id` of `node` or any of its children.
+pub fn contains_node(node: &Node<Expr>, node_id: NodeId) -> bool {
+    let mut success = false;
+    let wrapper = FuncStmt::Expr {
+        value: node.clone(),
+    }
+    .into_node();
+    map_ast_node(wrapper.into(), &mut |val| {
+        match val {
+            StmtOrExpr::Expr(ref expr) if expr.original_id == node_id => {
+                success = true;
+            }
+            StmtOrExpr::Stmt(ref stmt) if stmt.original_id == node_id => {
+                success = true;
+            }
+            _ => {}
+        }
+
+        val
+    });
+
+    success
+}
+
+/// Takes a mutable `body` of statements and inserts an `injection` of statements if any of the
+/// `test_nodes` or their children contain the given `target_nodeid`.
+pub fn inject_if_contains_target(
+    body: &mut Vec<Node<FuncStmt>>,
+    injection: &[Node<FuncStmt>],
+    test_nodes: &[&Node<Expr>],
+    target_nodeid: NodeId,
+) -> bool {
+    if test_nodes
+        .iter()
+        .any(|val| contains_node(val, target_nodeid))
+    {
+        for item in injection {
+            body.push(item.clone())
+        }
+        return true;
+    }
+    false
+}
+
+/// Like `inject_if_contains_target` but appends a `fallback` statement to the body if otherwise
+/// no injection would take place.
+pub fn inject_or_add_current(
+    body: &mut Vec<Node<FuncStmt>>,
+    injection: &[Node<FuncStmt>],
+    test: &[&Node<Expr>],
+    target: NodeId,
+    fallback: &Node<FuncStmt>,
+) {
+    if !inject_if_contains_target(body, injection, test, target) {
+        body.push(fallback.clone());
+    }
+}
+
+/// Inject a series of statements within a body of existing statements right before
+/// a given `expression` occures but not any earlier.
+pub fn inject_before_expression(
+    body: &[Node<FuncStmt>],
+    expression: NodeId,
+    injection: &[Node<FuncStmt>],
+) -> Vec<Node<FuncStmt>> {
+    let mut transformed_body = vec![];
+
+    for stmt in body {
+        let injection_and_current_stmt = &[injection, &[stmt.clone()]].concat();
+        match stmt.kind.clone() {
+            FuncStmt::If {
+                body,
+                test,
+                or_else,
+            } => {
+                if !inject_if_contains_target(
+                    &mut transformed_body,
+                    injection_and_current_stmt,
+                    &[&test],
+                    expression,
+                ) {
+                    transformed_body.push(
+                        FuncStmt::If {
+                            body: inject_before_expression(&body, expression, injection),
+                            or_else: inject_before_expression(&or_else, expression, injection),
+                            test,
+                        }
+                        .into_traceable_node(stmt.original_id),
+                    );
+                }
+            }
+            FuncStmt::For { target, iter, body } => {
+                if !inject_if_contains_target(
+                    &mut transformed_body,
+                    injection_and_current_stmt,
+                    &[&iter],
+                    expression,
+                ) {
+                    transformed_body.push(
+                        FuncStmt::For {
+                            target,
+                            iter,
+                            body: inject_before_expression(&body, expression, injection),
+                        }
+                        .into_traceable_node(stmt.original_id),
+                    );
+                }
+            }
+            FuncStmt::While { test, body } => {
+                if !inject_if_contains_target(
+                    &mut transformed_body,
+                    injection_and_current_stmt,
+                    &[&test],
+                    expression,
+                ) {
+                    transformed_body.push(
+                        FuncStmt::While {
+                            test,
+                            body: inject_before_expression(&body, expression, injection),
+                        }
+                        .into_traceable_node(stmt.original_id),
+                    )
+                }
+            }
+            FuncStmt::Unsafe(body) => transformed_body.push(
+                FuncStmt::Unsafe(inject_before_expression(&body, expression, injection))
+                    .into_traceable_node(stmt.original_id),
+            ),
+            // The following statements contain no further sub statements, only expressions.
+            // At this point it doesn't matter how deeply nested our expression is found because
+            // expressions can not contain statements.
+            // If we find it somewhere in the expression tree, we will inject the code right before it.
+            FuncStmt::Expr { value } => {
+                inject_or_add_current(
+                    &mut transformed_body,
+                    injection_and_current_stmt,
+                    &[&value],
+                    expression,
+                    stmt,
+                );
+            }
+            FuncStmt::Assign { target, value } => {
+                inject_or_add_current(
+                    &mut transformed_body,
+                    injection_and_current_stmt,
+                    &[&value, &target],
+                    expression,
+                    stmt,
+                );
+            }
+            FuncStmt::Return { value } => {
+                if let Some(val) = value {
+                    inject_or_add_current(
+                        &mut transformed_body,
+                        injection_and_current_stmt,
+                        &[&val],
+                        expression,
+                        stmt,
+                    );
+                } else {
+                    transformed_body.push(stmt.clone())
+                }
+            }
+            FuncStmt::VarDecl { value, .. } => {
+                if let Some(val) = value {
+                    inject_or_add_current(
+                        &mut transformed_body,
+                        injection_and_current_stmt,
+                        &[&val],
+                        expression,
+                        stmt,
+                    );
+                } else {
+                    transformed_body.push(stmt.clone())
+                }
+            }
+            FuncStmt::Assert { test, msg } => {
+                if let Some(msg) = msg {
+                    inject_or_add_current(
+                        &mut transformed_body,
+                        injection_and_current_stmt,
+                        &[&test, &msg],
+                        expression,
+                        stmt,
+                    );
+                } else {
+                    inject_or_add_current(
+                        &mut transformed_body,
+                        injection_and_current_stmt,
+                        &[&test],
+                        expression,
+                        stmt,
+                    );
+                }
+            }
+            FuncStmt::AugAssign { target, value, .. } => {
+                inject_or_add_current(
+                    &mut transformed_body,
+                    injection_and_current_stmt,
+                    &[&target, &value],
+                    expression,
+                    stmt,
+                );
+            }
+            FuncStmt::Emit { args, .. } => {
+                if args
+                    .kind
+                    .iter()
+                    .any(|val| contains_node(&val.kind.value, expression))
+                {
+                    transformed_body = [&transformed_body, injection].concat();
+                }
+                transformed_body.push(stmt.clone());
+            }
+            FuncStmt::Revert { error } => {
+                if let Some(error) = error {
+                    inject_or_add_current(
+                        &mut transformed_body,
+                        injection_and_current_stmt,
+                        &[&error],
+                        expression,
+                        stmt,
+                    )
+                } else {
+                    transformed_body.push(stmt.clone())
+                }
+            }
+            FuncStmt::Break | FuncStmt::Continue | FuncStmt::Pass => {
+                transformed_body.push(stmt.clone())
+            }
+        }
+    }
+    transformed_body
+}
+
+/// Turns a ternary expression into a set of statements resembling an if/else block with equal
+/// functionality. Expects the type and variable result name to be provided as parameters.
+pub fn ternary_to_if(
+    ternary_type: FixedSize,
+    expr: &Node<Expr>,
+    result_name: &str,
+) -> Vec<Node<FuncStmt>> {
+    if let Expr::Ternary {
+        if_expr,
+        test,
+        else_expr,
+    } = &expr.kind
+    {
+        let mut stmts = vec![FuncStmt::VarDecl {
+            target: VarDeclTarget::Name(result_name.to_string()).into_node(),
+            typ: names::fixed_size_type_desc(&ternary_type).into_node(),
+            value: None,
+        }
+        .into_node()];
+
+        let if_branch = FuncStmt::Assign {
+            target: Expr::Name(result_name.to_string()).into_node(),
+            value: if_expr
+                .kind
+                .clone()
+                .into_traceable_node(if_expr.original_id),
+        }
+        .into_node();
+
+        let else_branch = FuncStmt::Assign {
+            target: Expr::Name(result_name.to_string()).into_node(),
+            value: else_expr
+                .kind
+                .clone()
+                .into_traceable_node(else_expr.original_id),
+        }
+        .into_node();
+
+        stmts.push(
+            FuncStmt::If {
+                test: test.kind.clone().into_node(),
+                body: vec![if_branch],
+                or_else: vec![else_branch],
+            }
+            .into_node(),
+        );
+
+        return stmts;
+    }
+
+    unreachable!()
+}
+
+/// Returns a vector of expressions with all ternary expressions that are
+/// contained within the given function statement. The last expression
+/// in the list is the outermost ternary expression found in the statement.
+pub fn get_all_ternary_expressions(node: &Node<FuncStmt>) -> Vec<Node<Expr>> {
+    let mut terns = vec![];
+    map_ast_node(node.clone().into(), &mut |exp| {
+        if let StmtOrExpr::Expr(expr) = &exp {
+            if let Expr::Ternary { .. } = expr.kind {
+                terns.push(expr.clone())
+            }
+        }
+
+        exp
+    });
+
+    terns
+}
+
+/// For a given set of nodes returns the first set of ternary expressions that can be found.
+/// The last expression in the list is the outermost ternary expression found in the statement.
+pub fn get_first_ternary_expressions(nodes: &[Node<FuncStmt>]) -> Vec<Node<Expr>> {
+    for node in nodes {
+        let result = get_all_ternary_expressions(node);
+        if !result.is_empty() {
+            return result;
+        }
+    }
+    vec![]
+}
+
+/// In a given set of `nodes replaces a node that matches the `node_id` with a name expression node.
+pub fn replace_node_with_name_expression(
+    nodes: &[Node<FuncStmt>],
+    node_id: NodeId,
+    name: &str,
+) -> Vec<Node<FuncStmt>> {
+    nodes
+        .iter()
+        .map(|node| {
+            map_ast_node(node.clone().into(), &mut |val| match val {
+                StmtOrExpr::Expr(expr) if expr.original_id == node_id => {
+                    Expr::Name(name.to_string()).into_node().into()
+                }
+                _ => val,
+            })
+            .as_stmt()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::ast_utils::get_first_ternary_expressions;
+    use crate::ast_utils::inject_before_expression;
+    use crate::ast_utils::map_ast_node;
+    use crate::ast_utils::replace_node_with_name_expression;
+    use crate::ast_utils::ternary_to_if;
+    use crate::ast_utils::StmtOrExpr;
+    use crate::utils::ZeroSpanNode;
+    use fe_analyzer::namespace::types::FixedSize;
+    use fe_parser::ast::BinOperator;
+    use fe_parser::ast::CallArg;
+    use fe_parser::ast::Expr;
+    use fe_parser::ast::FuncStmt;
+    use fe_parser::node::Node;
+    use std::vec;
+
+    fn to_code(body: &[Node<FuncStmt>]) -> String {
+        let mut source = String::new();
+        for stmt in body {
+            source.push_str(&stmt.kind.to_string());
+            source.push('\n');
+        }
+        source.trim().to_string()
+    }
+
+    #[test]
+    fn transform_statement() {
+        let stmt = FuncStmt::Return { value: None }.into_node();
+        assert_eq!(to_code(&[stmt.clone()]), "return");
+
+        let transformed_stmt = map_ast_node(stmt.into(), &mut |stmt| {
+            if let StmtOrExpr::Stmt(stmt) = stmt {
+                let node = match stmt.kind {
+                    FuncStmt::Return { .. } => FuncStmt::Return {
+                        value: Some(Expr::Name("foo".to_string()).into_node()),
+                    },
+                    _ => stmt.kind,
+                }
+                .into_node();
+                return node.into();
+            }
+            stmt
+        })
+        .as_stmt();
+
+        assert_eq!(to_code(&[transformed_stmt]), "return foo");
+    }
+
+    #[test]
+    fn transform_expr() {
+        let stmt = FuncStmt::Return {
+            value: Some(Expr::Name("foo".to_string()).into_node()),
+        }
+        .into_node();
+        assert_eq!(to_code(&[stmt.clone()]), "return foo");
+
+        let mut transform_expr = |expr| {
+            if let StmtOrExpr::Expr(expr) = expr {
+                let node = match expr.kind {
+                    Expr::Name(_) => Expr::Name("bar".to_string()),
+                    _ => expr.kind,
+                }
+                .into_node();
+                return node.into();
+            }
+            expr
+        };
+
+        let transformed_stmt = map_ast_node(stmt.into(), &mut transform_expr).as_stmt();
+
+        assert_eq!(to_code(&[transformed_stmt]), "return bar");
+    }
+
+    #[test]
+    fn count_expr() {
+        let add_expr = Expr::BinOperation {
+            left: Expr::Num("1".to_string()).into_boxed_node(),
+            right: Expr::Num("2".to_string()).into_boxed_node(),
+            op: BinOperator::Add.into_node(),
+        };
+        let stmt = FuncStmt::Return {
+            value: Some(add_expr.into_node()),
+        }
+        .into_node();
+
+        let mut counter = 0;
+
+        let mut transform_expr = |expr| {
+            if let StmtOrExpr::Expr(expr) = expr {
+                let node = match expr.kind.clone() {
+                    Expr::Num(_) => {
+                        counter += 1;
+                        expr.kind
+                    }
+                    _ => expr.kind,
+                }
+                .into_node();
+                return node.into();
+            }
+
+            expr
+        };
+
+        map_ast_node(stmt.into(), &mut transform_expr);
+
+        assert_eq!(counter, 2)
+    }
+
+    #[test]
+    fn inject_expression() {
+        let nested_ternary = Expr::Ternary {
+            test: Expr::Bool(true).into_boxed_node(),
+            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            else_expr: Expr::Num("2".to_string()).into_boxed_node(),
+        }
+        .into_boxed_node();
+
+        let ternary = Expr::Ternary {
+            test: Expr::Bool(true).into_boxed_node(),
+            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            else_expr: nested_ternary,
+        }
+        .into_node();
+
+        let replacement = vec![FuncStmt::Return { value: None }.into_node()];
+
+        let stmt = FuncStmt::Expr {
+            value: ternary.clone(),
+        }
+        .into_node();
+
+        let original_body = vec![stmt];
+        assert_eq!(to_code(&original_body), "1 if true else 1 if true else 2");
+        let body = inject_before_expression(&original_body, ternary.original_id, &replacement);
+
+        assert_eq!(
+            to_code(&body),
+            "return
+1 if true else 1 if true else 2"
+        );
+    }
+
+    #[test]
+    fn inject_expression_nested() {
+        let nested_ternary = Expr::Ternary {
+            test: Expr::Bool(true).into_boxed_node(),
+            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            else_expr: Expr::Num("2".to_string()).into_boxed_node(),
+        }
+        .into_boxed_node();
+
+        let ternary = Expr::Ternary {
+            test: Expr::Bool(true).into_boxed_node(),
+            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            else_expr: nested_ternary,
+        }
+        .into_node();
+
+        let if_else = FuncStmt::If {
+            test: Expr::Bool(true).into_node(),
+            body: vec![],
+            or_else: vec![FuncStmt::Expr {
+                value: ternary.clone(),
+            }
+            .into_node()],
+        }
+        .into_node();
+
+        let replacement = vec![FuncStmt::Return { value: None }.into_node()];
+
+        let original_body = vec![if_else];
+        assert_eq!(
+            to_code(&original_body),
+            "if true:
+
+else:
+    1 if true else 1 if true else 2"
+        );
+
+        let body = inject_before_expression(&original_body, ternary.original_id, &replacement);
+
+        assert_eq!(
+            to_code(&body),
+            "if true:
+
+else:
+    return
+    1 if true else 1 if true else 2"
+        );
+    }
+
+    #[test]
+    fn lower_nested_ternary() {
+        let nested_ternary = Expr::Ternary {
+            test: Expr::Bool(true).into_boxed_node(),
+            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            else_expr: Expr::Num("2".to_string()).into_boxed_node(),
+        }
+        .into_boxed_node();
+
+        let ternary = Expr::Ternary {
+            test: Expr::Bool(true).into_boxed_node(),
+            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            else_expr: nested_ternary.clone(),
+        }
+        .into_node();
+
+        let call = Expr::Call {
+            func: Expr::Name("foo".to_string()).into_boxed_node(),
+            args: vec![CallArg {
+                value: ternary.clone(),
+                label: None,
+            }
+            .into_node()]
+            .into_node(),
+            generic_args: None,
+        }
+        .into_node();
+
+        let stmt = FuncStmt::Expr { value: call }.into_node();
+
+        let original_body = vec![stmt];
+
+        assert_eq!(
+            to_code(&original_body),
+            "foo(1 if true else 1 if true else 2)"
+        );
+
+        let all_ternary = get_first_ternary_expressions(&original_body);
+
+        assert_eq!(all_ternary.len(), 2);
+
+        // They are collected inside-out which means the lowest level is at the end of the vec.
+        let first_ternary = all_ternary.get(0).unwrap();
+        assert_eq!(first_ternary.original_id, nested_ternary.original_id);
+        let second_ternary = all_ternary.get(1).unwrap();
+        assert_eq!(second_ternary.original_id, ternary.original_id);
+
+        let ternary_type = FixedSize::u256();
+
+        let transformed_outer = ternary_to_if(ternary_type.clone(), second_ternary, "outer");
+
+        assert_eq!(
+            to_code(&transformed_outer),
+            "let outer: u256
+if true:
+    outer = 1
+else:
+    outer = 1 if true else 2"
+        );
+
+        let new_body = inject_before_expression(
+            &original_body,
+            second_ternary.original_id,
+            &transformed_outer,
+        );
+
+        assert_eq!(
+            to_code(&new_body),
+            "let outer: u256
+if true:
+    outer = 1
+else:
+    outer = 1 if true else 2
+
+foo(1 if true else 1 if true else 2)"
+        );
+
+        let new_body =
+            replace_node_with_name_expression(&new_body, second_ternary.original_id, "outer");
+
+        assert_eq!(
+            to_code(&new_body),
+            "let outer: u256
+if true:
+    outer = 1
+else:
+    outer = 1 if true else 2
+
+foo(outer)"
+        );
+
+        let remaining_terns = get_first_ternary_expressions(&new_body);
+        let last_ternary = remaining_terns.last().unwrap();
+        let transformed_inner = ternary_to_if(ternary_type, last_ternary, "inner");
+
+        let new_body =
+            inject_before_expression(&new_body, last_ternary.original_id, &transformed_inner);
+
+        let new_body =
+            replace_node_with_name_expression(&new_body, last_ternary.original_id, "inner");
+
+        assert_eq!(
+            to_code(&new_body),
+            r#"let outer: u256
+if true:
+    outer = 1
+else:
+    let inner: u256
+    if true:
+        inner = 1
+    else:
+        inner = 2
+
+    outer = inner
+
+foo(outer)"#
+        )
+    }
+}

--- a/crates/lowering/src/context.rs
+++ b/crates/lowering/src/context.rs
@@ -2,8 +2,7 @@ use fe_analyzer::context::{ExpressionAttributes, FunctionBody};
 use fe_analyzer::namespace::items::{FunctionId, ModuleId};
 use fe_analyzer::namespace::types::{Array, FixedSize, Tuple};
 use fe_analyzer::AnalyzerDb;
-use fe_parser::ast;
-use fe_parser::node::Node;
+use fe_parser::node::NodeId;
 use indexmap::IndexSet;
 use std::rc::Rc;
 
@@ -59,11 +58,14 @@ impl<'a, 'db> FnContext<'a, 'db> {
         self.module.db
     }
 
-    pub fn expression_attributes(&self, node: &Node<ast::Expr>) -> Option<&ExpressionAttributes> {
-        self.body.expressions.get(&node.id)
+    pub fn expression_attributes<T: Into<NodeId>>(
+        &self,
+        node_id: T,
+    ) -> Option<&ExpressionAttributes> {
+        self.body.expressions.get(&node_id.into())
     }
-    pub fn var_decl_type(&self, node: &Node<ast::TypeDesc>) -> Option<&FixedSize> {
-        self.body.var_decl_types.get(&node.id)
+    pub fn var_decl_type<T: Into<NodeId>>(&self, node_id: T) -> Option<&FixedSize> {
+        self.body.var_decl_types.get(&node_id.into())
     }
 }
 

--- a/crates/lowering/src/lib.rs
+++ b/crates/lowering/src/lib.rs
@@ -2,6 +2,7 @@
 
 use fe_analyzer::namespace::items::{IngotId, ModuleId};
 
+mod ast_utils;
 mod context;
 pub mod db;
 mod mappers;

--- a/crates/lowering/src/mappers/expressions.rs
+++ b/crates/lowering/src/mappers/expressions.rs
@@ -8,6 +8,7 @@ use fe_parser::node::Node;
 
 /// Lowers an expression and all sub expressions.
 pub fn expr(context: &mut FnContext, exp: Node<fe::Expr>) -> Node<fe::Expr> {
+    let original_exp = exp.clone();
     let span = exp.span;
 
     let lowered_kind = match exp.kind {
@@ -66,7 +67,7 @@ pub fn expr(context: &mut FnContext, exp: Node<fe::Expr>) -> Node<fe::Expr> {
         fe::Expr::Unit => exp.kind,
     };
 
-    Node::new(lowered_kind, span)
+    Node::with_original_id(lowered_kind, span, original_exp.original_id)
 }
 
 /// Lowers and optional expression.

--- a/crates/lowering/src/mappers/functions.rs
+++ b/crates/lowering/src/mappers/functions.rs
@@ -71,7 +71,7 @@ pub fn func_def(context: &mut ModuleContext, function: FunctionId) -> Node<fe::F
             if let fe::FunctionArg::Regular(regular) = &pnode.kind {
                 fe::FunctionArg::Regular(RegularFunctionArg {
                     name: regular.name.clone(),
-                    typ: types::type_desc(&mut fn_ctx.module, regular.typ.clone(), &ptype),
+                    typ: types::type_desc(fn_ctx.module, regular.typ.clone(), &ptype),
                 })
                 .into_node()
             } else {
@@ -84,9 +84,7 @@ pub fn func_def(context: &mut ModuleContext, function: FunctionId) -> Node<fe::F
     // The return type is lowered if it exists. If there is no return type, we set it to the unit type.
     let lowered_return_type = return_type_node
         .clone()
-        .map(|type_desc| {
-            types::type_desc(&mut fn_ctx.module, type_desc, &return_type.clone().into())
-        })
+        .map(|type_desc| types::type_desc(fn_ctx.module, type_desc, &return_type.clone().into()))
         .unwrap_or_else(|| fe::TypeDesc::Unit.into_node());
 
     let lowered_function = fe::Function {
@@ -255,7 +253,7 @@ fn lower_tuple_destructuring(
     let tmp_tuple = context.make_unique_name("tmp_tuple");
     stmts.push(fe::FuncStmt::VarDecl {
         target: Node::new(fe::VarDeclTarget::Name(tmp_tuple.clone()), span),
-        typ: types::type_desc(&mut context.module, type_desc.clone(), typ),
+        typ: types::type_desc(context.module, type_desc.clone(), typ),
         value: expressions::optional_expr(context, value),
     });
 
@@ -293,7 +291,7 @@ fn declare_tuple_items(
 
             stmts.push(fe::FuncStmt::VarDecl {
                 target,
-                typ: types::type_desc(&mut context.module, type_desc, typ),
+                typ: types::type_desc(context.module, type_desc, typ),
                 value: expressions::optional_expr(context, Some(value)),
             });
         }

--- a/crates/lowering/src/utils.rs
+++ b/crates/lowering/src/utils.rs
@@ -1,12 +1,16 @@
 use fe_common::files::SourceFileId;
 use fe_common::Span;
-use fe_parser::node::Node;
+use fe_parser::node::{Node, NodeId};
 
 /// A trait to turn any sized type into a `Node` with a span of zero.
 pub trait ZeroSpanNode: Sized {
     /// Wrap the value in a `Node` with a span of zero.
     fn into_node(self) -> Node<Self> {
         Node::new(self, Span::zero(SourceFileId::default()))
+    }
+
+    fn into_traceable_node(self, original_id: NodeId) -> Node<Self> {
+        Node::with_original_id(self, Span::zero(SourceFileId::default()), original_id)
     }
 
     /// Wrap the value in a boxed `Node` with a span of zero

--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -75,5 +75,6 @@ test_file! { module_const, "lowering/module_const.fe" }
 test_file! { module_fn, "lowering/module_fn.fe" }
 test_file! { struct_fn, "lowering/struct_fn.fe" }
 test_file! { ternary, "lowering/ternary.fe" }
+test_file! { and_or, "lowering/and_or.fe" }
 // TODO: the analyzer rejects lowered nested tuples.
 // test_file!(array_tuple, "lowering/array_tuple.fe");

--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -74,5 +74,6 @@ test_file! { tuple_destruct, "lowering/tuple_destruct.fe" }
 test_file! { module_const, "lowering/module_const.fe" }
 test_file! { module_fn, "lowering/module_fn.fe" }
 test_file! { struct_fn, "lowering/struct_fn.fe" }
+test_file! { ternary, "lowering/ternary.fe" }
 // TODO: the analyzer rejects lowered nested tuples.
 // test_file!(array_tuple, "lowering/array_tuple.fe");

--- a/crates/lowering/tests/snapshots/lowering__and_or.snap
+++ b/crates/lowering/tests/snapshots/lowering__and_or.snap
@@ -1,0 +1,182 @@
+---
+source: crates/lowering/tests/lowering.rs
+expression: lowered_code
+
+---
+struct $tuple_bool_bool_:
+    item0: bool
+    item1: bool
+
+contract Foo:
+    pub fn bar() -> ():
+        let $boolean_expr_result_0: bool = true
+        if not false:
+            $boolean_expr_result_0 = true
+
+        return baz($boolean_expr_result_0)
+
+    pub fn nested() -> ():
+        if true:
+            let a: bool = true
+            let b: bool = false
+            let x: bool = true
+            let y: bool = false
+            let $boolean_expr_result_0: bool = true
+            if not x:
+                $boolean_expr_result_0 = y
+
+            let $boolean_expr_result_1: bool = false
+            if a:
+                $boolean_expr_result_1 = b
+
+            return double_baz($boolean_expr_result_1, $boolean_expr_result_0)
+
+        return ()
+
+    pub fn nested_ternary() -> ():
+        let a: bool = true
+        let b: bool = false
+        let x: bool = true
+        let y: bool = false
+        let $boolean_expr_result_0: bool = false
+        let $boolean_expr_result_1: bool = false
+        if a:
+            $boolean_expr_result_1 = b
+
+        if baz($boolean_expr_result_1):
+            let $boolean_expr_result_2: bool = false
+            if x:
+                $boolean_expr_result_2 = y
+
+            $boolean_expr_result_0 = $boolean_expr_result_2
+
+        return $boolean_expr_result_0
+
+    pub fn in_dec() -> ():
+        let a: bool = true
+        let b: bool = false
+        let x: bool = true
+        let y: bool = false
+        let $boolean_expr_result_0: bool = true
+        if not x:
+            $boolean_expr_result_0 = y
+
+        let $boolean_expr_result_1: bool = false
+        if a:
+            $boolean_expr_result_1 = b
+
+        let z: $tuple_bool_bool_ = $tuple_bool_bool_(item0=$boolean_expr_result_1, item1=$boolean_expr_result_0)
+        return ()
+
+    pub fn short_or(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = true
+        let $boolean_expr_result_1: bool = true
+        let $boolean_expr_result_2: bool = true
+        if not first:
+            $boolean_expr_result_2 = second
+
+        if not $boolean_expr_result_2:
+            $boolean_expr_result_1 = third
+
+        if not $boolean_expr_result_1:
+            $boolean_expr_result_0 = fourth
+
+        return $boolean_expr_result_0
+
+    pub fn short_or2(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = true
+        let $boolean_expr_result_1: bool = true
+        if not first:
+            $boolean_expr_result_1 = second
+
+        if not $boolean_expr_result_1:
+            let $boolean_expr_result_2: bool = true
+            if not third:
+                $boolean_expr_result_2 = fourth
+
+            $boolean_expr_result_0 = $boolean_expr_result_2
+
+        return $boolean_expr_result_0
+
+    pub fn short_or3(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = true
+        let $boolean_expr_result_1: bool = true
+        let $boolean_expr_result_2: bool = true
+        if not first:
+            $boolean_expr_result_2 = second
+
+        if not $boolean_expr_result_2:
+            $boolean_expr_result_1 = third
+
+        if not $boolean_expr_result_1:
+            $boolean_expr_result_0 = fourth
+
+        return $boolean_expr_result_0
+
+    pub fn short_and(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = false
+        let $boolean_expr_result_1: bool = false
+        let $boolean_expr_result_2: bool = false
+        if first:
+            $boolean_expr_result_2 = second
+
+        if $boolean_expr_result_2:
+            $boolean_expr_result_1 = third
+
+        if $boolean_expr_result_1:
+            $boolean_expr_result_0 = fourth
+
+        return $boolean_expr_result_0
+
+    pub fn short_and2(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = false
+        let $boolean_expr_result_1: bool = false
+        if first:
+            $boolean_expr_result_1 = second
+
+        if $boolean_expr_result_1:
+            let $boolean_expr_result_2: bool = false
+            if third:
+                $boolean_expr_result_2 = fourth
+
+            $boolean_expr_result_0 = $boolean_expr_result_2
+
+        return $boolean_expr_result_0
+
+    pub fn short_and3(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = false
+        let $boolean_expr_result_1: bool = false
+        let $boolean_expr_result_2: bool = false
+        if first:
+            $boolean_expr_result_2 = second
+
+        if $boolean_expr_result_2:
+            $boolean_expr_result_1 = third
+
+        if $boolean_expr_result_1:
+            $boolean_expr_result_0 = fourth
+
+        return $boolean_expr_result_0
+
+    pub fn short_mixed(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        let $boolean_expr_result_0: bool = true
+        let $boolean_expr_result_1: bool = false
+        let $boolean_expr_result_2: bool = true
+        if not first:
+            $boolean_expr_result_2 = second
+
+        if $boolean_expr_result_2:
+            $boolean_expr_result_1 = third
+
+        if not $boolean_expr_result_1:
+            $boolean_expr_result_0 = fourth
+
+        return $boolean_expr_result_0
+
+    pub fn baz(val: bool) -> ():
+        pass
+        return ()
+
+    pub fn double_baz(val: bool, val2: bool) -> ():
+        pass
+        return ()

--- a/crates/lowering/tests/snapshots/lowering__ternary.snap
+++ b/crates/lowering/tests/snapshots/lowering__ternary.snap
@@ -1,0 +1,87 @@
+---
+source: crates/lowering/tests/lowering.rs
+expression: lowered_code
+
+---
+struct $tuple_u256_u256_:
+    item0: u256
+    item1: u256
+
+contract Foo:
+    pub fn bar() -> ():
+        let $ternary_result_0: u256
+        if true:
+            $ternary_result_0 = 1
+        else:
+            $ternary_result_0 = 0
+
+        return baz($ternary_result_0)
+
+    pub fn nested() -> ():
+        if true:
+            let a: u256 = 10
+            let b: u256 = 20
+            let x: u256 = 10
+            let y: u256 = 20
+            let $ternary_result_0: u256
+            if true:
+                $ternary_result_0 = x
+            else:
+                $ternary_result_0 = y
+
+            let $ternary_result_1: u256
+            if true:
+                $ternary_result_1 = a
+            else:
+                $ternary_result_1 = b
+
+            return double_baz($ternary_result_1, $ternary_result_0)
+
+        return ()
+
+    pub fn nested_ternary() -> ():
+        let a: u256 = 10
+        let b: u256 = 20
+        let x: u256 = 10
+        let y: u256 = 20
+        let $ternary_result_0: u256
+        if true:
+            $ternary_result_0 = a
+        else:
+            let $ternary_result_1: u256
+            if true:
+                $ternary_result_1 = x
+            else:
+                $ternary_result_1 = y
+
+            $ternary_result_0 = $ternary_result_1
+
+        return baz($ternary_result_0)
+
+    pub fn in_dec() -> ():
+        let a: u256 = 10
+        let b: u256 = 20
+        let x: u256 = 10
+        let y: u256 = 20
+        let $ternary_result_0: u256
+        if true:
+            $ternary_result_0 = x
+        else:
+            $ternary_result_0 = y
+
+        let $ternary_result_1: u256
+        if true:
+            $ternary_result_1 = a
+        else:
+            $ternary_result_1 = b
+
+        let z: $tuple_u256_u256_ = $tuple_u256_u256_(item0=$ternary_result_1, item1=$ternary_result_0)
+        return ()
+
+    pub fn baz(val: u256) -> ():
+        pass
+        return ()
+
+    pub fn double_baz(val1: u256, val2: u256) -> ():
+        pass
+        return ()

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -16,22 +16,30 @@ pub struct Node<T> {
     pub kind: T,
     #[serde(skip_serializing, skip_deserializing)]
     pub id: NodeId,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub original_id: NodeId,
     pub span: Span,
 }
 
 impl<T> Node<T> {
     pub fn new(kind: T, span: Span) -> Self {
+        let id = NodeId::create();
         Self {
             kind,
-            id: NodeId::create(),
+            id,
+            original_id: id,
             span,
         }
     }
 
-    /// Sets a new node ID.
-    pub fn new_id(mut self) -> Self {
-        self.id = NodeId::create();
-        self
+    pub fn with_original_id(kind: T, span: Span, original_id: NodeId) -> Self {
+        let id = NodeId::create();
+        Self {
+            kind,
+            id,
+            original_id,
+            span,
+        }
     }
 }
 

--- a/crates/test-files/fixtures/features/short_circuit.fe
+++ b/crates/test-files/fixtures/features/short_circuit.fe
@@ -1,0 +1,18 @@
+contract Foo:
+
+    pub fn bar(input: u256) -> u256:
+        return 1 if input > 5 else revert_u256()
+
+    fn revert_u256() -> u256:
+        revert
+        return 0
+
+    fn revert_bool() -> bool:
+        revert
+        return true
+
+    pub fn short_circuit_and(let_through: bool) -> bool:
+        return let_through and revert_bool()
+
+    pub fn short_circuit_or(break_early: bool) -> bool:
+        return break_early or revert_bool()

--- a/crates/test-files/fixtures/features/ternary_expression_with_revert.fe
+++ b/crates/test-files/fixtures/features/ternary_expression_with_revert.fe
@@ -1,8 +1,0 @@
-contract Foo:
-
-    pub fn bar(input: u256) -> u256:
-        return 1 if input > 5 else revert_me()
-
-    fn revert_me() -> u256:
-        revert
-        return 0

--- a/crates/test-files/fixtures/features/ternary_expression_with_revert.fe
+++ b/crates/test-files/fixtures/features/ternary_expression_with_revert.fe
@@ -1,0 +1,8 @@
+contract Foo:
+
+    pub fn bar(input: u256) -> u256:
+        return 1 if input > 5 else revert_me()
+
+    fn revert_me() -> u256:
+        revert
+        return 0

--- a/crates/test-files/fixtures/lowering/and_or.fe
+++ b/crates/test-files/fixtures/lowering/and_or.fe
@@ -1,0 +1,55 @@
+contract Foo:
+
+    pub fn bar():
+        return baz(false or true)
+
+    pub fn nested():
+        if true:
+            let a: bool = true
+            let b: bool = false
+            let x: bool = true
+            let y: bool = false
+            return double_baz(a and b, x or y)
+
+    pub fn nested_ternary():
+        let a: bool = true
+        let b: bool = false
+        let x: bool = true
+        let y: bool = false
+        return baz(a and b) and (x and y)
+
+    pub fn in_dec():
+        let a: bool = true
+        let b: bool = false
+        let x: bool = true
+        let y: bool = false
+
+        let z: (bool, bool) = (a and b, x or y)
+
+    pub fn short_or(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return first or second or third or fourth
+
+    pub fn short_or2(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return (first or second) or (third or fourth)
+
+    pub fn short_or3(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return (first or second) or third or fourth
+
+    pub fn short_and(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return first and second and third and fourth
+
+    pub fn short_and2(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return (first and second) and (third and fourth)
+
+    pub fn short_and3(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return (first and second) and third and fourth
+
+    pub fn short_mixed(first: bool, second: bool, third: bool, fourth: bool) -> bool:
+        return (first or second) and third or fourth
+
+    pub fn baz(val: bool):
+        pass
+
+    pub fn double_baz(val: bool, val2: bool):
+        pass
+

--- a/crates/test-files/fixtures/lowering/ternary.fe
+++ b/crates/test-files/fixtures/lowering/ternary.fe
@@ -31,3 +31,4 @@ contract Foo:
 
     pub fn double_baz(val1: u256, val2: u256):
         pass
+

--- a/crates/test-files/fixtures/lowering/ternary.fe
+++ b/crates/test-files/fixtures/lowering/ternary.fe
@@ -1,0 +1,33 @@
+contract Foo:
+
+    pub fn bar():
+        return baz(1 if true else 0)
+
+    pub fn nested():
+        if true:
+            let a: u256 = 10
+            let b: u256 = 20
+            let x: u256 = 10
+            let y: u256 = 20
+            return double_baz(a if true else b, x if true else y)
+
+    pub fn nested_ternary():
+        let a: u256 = 10
+        let b: u256 = 20
+        let x: u256 = 10
+        let y: u256 = 20
+        return baz(a if true else (x if true else y))
+
+    pub fn in_dec():
+        let a: u256 = 10
+        let b: u256 = 20
+        let x: u256 = 10
+        let y: u256 = 20
+        
+        let z: (u256, u256) = (a if true else b, x if true else y) 
+
+    pub fn baz(val: u256):
+        pass
+
+    pub fn double_baz(val1: u256, val2: u256):
+        pass

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -1244,6 +1244,21 @@ fn keccak() {
 }
 
 #[test]
+fn ternary() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(
+            &mut executor,
+            "ternary_expression_with_revert.fe",
+            "Foo",
+            &[],
+        );
+        harness.test_function(&mut executor, "bar", &[uint_token(6)], Some(&uint_token(1)));
+
+        harness.test_function_reverts(&mut executor, "bar", &[uint_token(1)], &[]);
+    });
+}
+
+#[test]
 fn math() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "math.fe", "Math", &[]);

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -1244,17 +1244,28 @@ fn keccak() {
 }
 
 #[test]
-fn ternary() {
+fn short_circuit() {
     with_executor(&|mut executor| {
-        let harness = deploy_contract(
-            &mut executor,
-            "ternary_expression_with_revert.fe",
-            "Foo",
-            &[],
-        );
+        let harness = deploy_contract(&mut executor, "short_circuit.fe", "Foo", &[]);
         harness.test_function(&mut executor, "bar", &[uint_token(6)], Some(&uint_token(1)));
 
         harness.test_function_reverts(&mut executor, "bar", &[uint_token(1)], &[]);
+
+        harness.test_function(
+            &mut executor,
+            "short_circuit_and",
+            &[bool_token(false)],
+            Some(&bool_token(false)),
+        );
+        harness.test_function_reverts(&mut executor, "short_circuit_and", &[bool_token(true)], &[]);
+
+        harness.test_function(
+            &mut executor,
+            "short_circuit_or",
+            &[bool_token(true)],
+            Some(&bool_token(true)),
+        );
+        harness.test_function_reverts(&mut executor, "short_circuit_or", &[bool_token(false)], &[]);
     });
 }
 

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -31,7 +31,7 @@ pub fn expr(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
         fe::Expr::Subscript { .. } => expr_subscript(context, exp),
         fe::Expr::Attribute { .. } => expr_attribute(context, exp),
         fe::Expr::Ternary { .. } => panic!("ternary expressions should be lowered"),
-        fe::Expr::BoolOperation { .. } => expr_bool_operation(context, exp),
+        fe::Expr::BoolOperation { .. } => panic!("bool operation expressions should be lowered"),
         fe::Expr::BinOperation { .. } => expr_bin_operation(context, exp),
         fe::Expr::UnaryOperation { .. } => expr_unary_operation(context, exp),
         fe::Expr::CompOperation { .. } => expr_comp_operation(context, exp),
@@ -507,18 +507,4 @@ pub fn nonce_to_ptr(nonce: usize) -> yul::Expression {
     // set the last byte to `0x00` to ensure our pointer sits at the start of a word
     let ptr = keccak::partial_right_padded(nonce.to_string().as_bytes(), 31);
     literal_expression! { (ptr) }
-}
-
-fn expr_bool_operation(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
-    if let fe::Expr::BoolOperation { left, op, right } = &exp.kind {
-        let yul_left = expr(context, left);
-        let yul_right = expr(context, right);
-
-        return match op.kind {
-            fe::BoolOperator::And => expression! {and([yul_left], [yul_right])},
-            fe::BoolOperator::Or => expression! {or([yul_left], [yul_right])},
-        };
-    }
-
-    unreachable!()
 }

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -30,7 +30,7 @@ pub fn expr(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
         fe::Expr::Bool(_) => expr_bool(exp),
         fe::Expr::Subscript { .. } => expr_subscript(context, exp),
         fe::Expr::Attribute { .. } => expr_attribute(context, exp),
-        fe::Expr::Ternary { .. } => expr_ternary(context, exp),
+        fe::Expr::Ternary { .. } => panic!("ternary expressions should be lowered"),
         fe::Expr::BoolOperation { .. } => expr_bool_operation(context, exp),
         fe::Expr::BinOperation { .. } => expr_bin_operation(context, exp),
         fe::Expr::UnaryOperation { .. } => expr_unary_operation(context, exp),
@@ -507,22 +507,6 @@ pub fn nonce_to_ptr(nonce: usize) -> yul::Expression {
     // set the last byte to `0x00` to ensure our pointer sits at the start of a word
     let ptr = keccak::partial_right_padded(nonce.to_string().as_bytes(), 31);
     literal_expression! { (ptr) }
-}
-
-fn expr_ternary(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
-    if let fe::Expr::Ternary {
-        if_expr,
-        test,
-        else_expr,
-    } = &exp.kind
-    {
-        let yul_test_expr = expr(context, test);
-        let yul_if_expr = expr(context, if_expr);
-        let yul_else_expr = expr(context, else_expr);
-
-        return expression! {ternary([yul_test_expr], [yul_if_expr], [yul_else_expr])};
-    }
-    unreachable!()
 }
 
 fn expr_bool_operation(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {

--- a/newsfragments/488.bugfix.md
+++ b/newsfragments/488.bugfix.md
@@ -17,3 +17,5 @@ Previous to this change, the code above would **always** revert no matter
 which branch of the ternary expressions it would resolve to. That is because
 both sides were evaluated and then one side was discarded. With this change,
 only the branch that doesn't get picked won't get evaluated at all.
+
+The same is true for the boolean operations `and` and `or`.

--- a/newsfragments/488.bugfix.md
+++ b/newsfragments/488.bugfix.md
@@ -1,0 +1,19 @@
+Ensure ternary expression short circuit.
+
+Example:
+
+```
+contract Foo:
+
+    pub fn bar(input: u256) -> u256:
+        return 1 if input > 5 else revert_me()
+
+    fn revert_me() -> u256:
+        revert
+        return 0
+```
+
+Previous to this change, the code above would **always** revert no matter
+which branch of the ternary expressions it would resolve to. That is because
+both sides were evaluated and then one side was discarded. With this change,
+only the branch that doesn't get picked won't get evaluated at all.


### PR DESCRIPTION
### What was wrong?

As described in #488 our current ternary expression doesn't short circuit but instead evaluates both branches and then discards one side of it.

### How was it fixed?

1. Create some helpers to manipulate parts of the AST better
2. Used these helpers to lower ternary expressions in a way that maps them to an if/else followed by a simple name expression
