### PR TITLE
Intrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "fe-lowering",
  "fe-parser",
  "fe-test-files",
+ "if_chain",
  "indexmap",
  "insta",
  "maplit",

--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -1,3 +1,4 @@
+use crate::namespace::types::Base;
 use strum::{AsRefStr, EnumIter, EnumString};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EnumString, AsRefStr)]
@@ -80,4 +81,125 @@ pub enum TxField {
 #[strum(serialize_all = "snake_case")]
 pub enum ContractSelfField {
     Address,
+}
+
+/// The evm functions exposed by yul.
+#[allow(non_camel_case_types)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, EnumString, AsRefStr, EnumIter,
+)]
+pub enum Intrinsic {
+    __stop,           // () -> ()
+    __add,            // (x, y)
+    __sub,            // (x, y)
+    __mul,            // (x, y)
+    __div,            // (x, y)
+    __sdiv,           // (x, y)
+    __mod,            // (x, y)
+    __smod,           // (x, y)
+    __exp,            // (x, y)
+    __not,            // (x)
+    __lt,             // (x, y)
+    __gt,             // (x, y)
+    __slt,            // (x, y)
+    __sgt,            // (x, y)
+    __eq,             // (x, y)
+    __iszero,         // (x)
+    __and,            // (x, y)
+    __or,             // (x, y)
+    __xor,            // (x, y)
+    __byte,           // (n, x)
+    __shl,            // (x, y)
+    __shr,            // (x, y)
+    __sar,            // (x, y)
+    __addmod,         // (x, y, m)
+    __mulmod,         // (x, y, m)
+    __signextend,     // (i, x)
+    __keccak256,      // (p, n)
+    __pc,             // ()
+    __pop,            // (x) -> ()
+    __mload,          // (p)
+    __mstore,         // (p, v) -> ()
+    __mstore8,        // (p, v) -> ()
+    __sload,          // (p)
+    __sstore,         // (p, v) -> ()
+    __msize,          // ()
+    __gas,            // ()
+    __address,        // ()
+    __balance,        // (a)
+    __selfbalance,    // ()
+    __caller,         // ()
+    __callvalue,      // ()
+    __calldataload,   // (p)
+    __calldatasize,   // ()
+    __calldatacopy,   // (t, f, s) -> ()
+    __codesize,       // ()
+    __codecopy,       // (t, f, s) -> ()
+    __extcodesize,    // (a)
+    __extcodecopy,    // (a, t, f, s) -> ()
+    __returndatasize, // ()
+    __returndatacopy, // (t, f, s) -> ()
+    __extcodehash,    // (a)
+    __create,         // (v, p, n)
+    __create2,        // (v, p, n, s)
+    __call,           // (g, a, v, in, insize, out, outsize)
+    __callcode,       // (g, a, v, in, insize, out, outsize)
+    __delegatecall,   // (g, a, in, insize, out, outsize)
+    __staticcall,     // (g, a, in, insize, out, outsize)
+    __return,         // (p, s) -> ()
+    __revert,         // (p, s) -> ()
+    __selfdestruct,   // (a) -> ()
+    __invalid,        // () -> ()
+    __log0,           // (p, s) -> ()
+    __log1,           // (p, s, t1) -> ()
+    __log2,           // (p, s, t1, t2) -> ()
+    __log3,           // (p, s, t1, t2, t3) -> ()
+    __log4,           // (p, s, t1, t2, t3, t4) -> ()
+    __chainid,        // ()
+    __basefee,        // ()
+    __origin,         // ()
+    __gasprice,       // ()
+    __blockhash,      // (b)
+    __coinbase,       // ()
+    __timestamp,      // ()
+    __number,         // ()
+    __difficulty,     // ()
+    __gaslimit,       // ()
+}
+
+impl Intrinsic {
+    pub fn arg_count(&self) -> usize {
+        use Intrinsic::*;
+        match self {
+            __stop | __basefee | __origin | __gasprice | __coinbase | __timestamp | __number
+            | __difficulty | __gaslimit | __pc | __msize | __gas | __address | __selfbalance
+            | __caller | __callvalue | __calldatasize | __codesize | __returndatasize
+            | __invalid | __chainid => 0,
+
+            __not | __iszero | __pop | __mload | __balance | __sload | __calldataload
+            | __extcodesize | __extcodehash | __selfdestruct | __blockhash => 1,
+
+            __add | __sub | __mul | __div | __sdiv | __mod | __smod | __exp | __lt | __gt
+            | __slt | __sgt | __eq | __and | __or | __xor | __byte | __shl | __shr | __sar
+            | __signextend | __keccak256 | __mstore | __mstore8 | __sstore | __return
+            | __revert | __log0 => 2,
+
+            __addmod | __mulmod | __calldatacopy | __codecopy | __returndatacopy | __create
+            | __log1 => 3,
+            __extcodecopy | __create2 | __log2 => 4,
+            __log3 => 5,
+            __delegatecall | __staticcall | __log4 => 6,
+            __call | __callcode => 7,
+        }
+    }
+
+    pub fn return_type(&self) -> Base {
+        use Intrinsic::*;
+        match self {
+            __stop | __pop | __calldatacopy | __codecopy | __extcodecopy | __returndatacopy
+            | __return | __revert | __selfdestruct | __invalid | __log0 | __log1 | __log2
+            | __log3 | __log4 => Base::Unit,
+            _ => Base::u256(),
+        }
+    }
 }

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -123,11 +123,14 @@ impl<'a> FunctionScope<'a> {
             .expect_none("declaration attributes already exist");
     }
     /// Attribute contextual information to a call expression node.
+    /// NOTE: `node` here is actually the `func` node of the `Expr::Call`.
     ///
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
     pub fn add_call(&self, node: &Node<ast::Expr>, call_type: CallType) {
+        // TODO: should probably take the Expr::Call node, rather than the function node
+
         self.add_node(node);
         self.body
             .borrow_mut()

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -74,6 +74,9 @@ impl Base {
             Base::Unit => "()".into(),
         }
     }
+    pub fn u256() -> Base {
+        Base::Numeric(Integer::U256)
+    }
 }
 
 #[derive(

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -282,6 +282,7 @@ fn build_snapshot(file_store: &FileStore, module: items::ModuleId, db: &dyn Anal
             | Item::Type(TypeDef::Primitive(_))
             | Item::GenericType(_)
             | Item::BuiltinFunction(_)
+            | Item::Intrinsic(_)
             | Item::Ingot(_)
             | Item::Module(_)
             | Item::Object(_) => vec![],

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -58,7 +58,9 @@ pub fn module(db: &dyn AnalyzerDb, module: ModuleId) -> ast::Module {
 
         Item::GenericType(_) => todo!("generic types can't be defined in fe yet"),
         Item::Event(_) => todo!("events can't be defined at the module level yet"),
-        Item::BuiltinFunction(_) | Item::Object(_) => unreachable!("special built-in stuff"),
+        Item::BuiltinFunction(_) | Item::Intrinsic(_) | Item::Object(_) => {
+            unreachable!("special built-in stuff")
+        }
 
         // All name expressions referring to constants are handled at the time of lowering,
         // which causes the constants to no longer serve a purpose.

--- a/crates/test-files/fixtures/features/intrinsics.fe
+++ b/crates/test-files/fixtures/features/intrinsics.fe
@@ -1,0 +1,95 @@
+
+contract Intrinsics:
+
+  pub fn add(x: u256, y: u256) -> u256:
+    unsafe:
+      return __add(x, y)
+
+  pub fn gas() -> u256:
+    unsafe:
+      return __gas()
+
+  pub fn addr() -> address:
+    unsafe:
+      return address(__address())
+
+  pub fn self_balance() -> u256:
+    unsafe:
+      return __selfbalance()
+
+  pub fn other_balance(a: u256) -> u256:
+    unsafe:
+      return __balance(a)
+
+  pub fn caller() -> address:
+    unsafe:
+      return address(__caller())
+
+  pub fn callvalue() -> u256:
+    unsafe:
+      return __callvalue()
+
+  pub fn calldataload(offset: u256) -> u256:
+    unsafe:
+      return __calldataload(offset)
+
+  pub fn calldatasize() -> u256:
+    unsafe:
+      return __calldatasize()
+
+  pub fn calldatacopy(offset: u256, len: u256) -> u256:
+    unsafe:
+      __calldatacopy(0, offset, len)
+      return __mload(0)
+
+  pub fn codesize() -> u256:
+    unsafe:
+      return __codesize()
+
+  pub fn extcodesize(addr: u256) -> u256:
+    unsafe:
+      return __extcodesize(addr)
+
+  pub fn extcodehash(addr: u256) -> u256:
+    unsafe:
+      return __extcodehash(addr)
+
+  pub fn chainid() -> u256:
+    unsafe:
+      return __chainid()
+
+  pub fn basefee() -> u256:
+    unsafe:
+      return __basefee()
+
+  pub fn origin() -> u256:
+    unsafe:
+      return __origin()
+
+  pub fn gasprice() -> u256:
+    unsafe:
+      return __gasprice()
+
+  pub fn blockhash(n: u256) -> u256:
+    unsafe:
+      return __blockhash(n)
+
+  pub fn coinbase() -> u256:
+    unsafe:
+      return __coinbase()
+
+  pub fn timestamp() -> u256:
+    unsafe:
+      return __timestamp()
+
+  pub fn number() -> u256:
+    unsafe:
+      return __number()
+
+  pub fn difficulty() -> u256:
+    unsafe:
+      return __difficulty()
+
+  pub fn gaslimit() -> u256:
+    unsafe:
+      return __gaslimit()

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -1731,3 +1731,40 @@ fn abi_decode_checks() {
         }
     });
 }
+
+#[test]
+fn intrinsics() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "intrinsics.fe", "Intrinsics", &[]);
+
+        executor
+            .state_mut()
+            .deposit(harness.address, U256::from(123));
+
+        harness.test_function(
+            &mut executor,
+            "add",
+            &[uint_token(10), uint_token(100)],
+            Some(&uint_token(110)),
+        );
+        harness.test_function(&mut executor, "self_balance", &[], Some(&uint_token(123)));
+        harness.test_function(&mut executor, "calldatasize", &[], Some(&uint_token(4)));
+        harness.test_function(
+            &mut executor,
+            "calldatacopy",
+            &[uint_token(36), uint_token(32)],
+            Some(&uint_token(32)),
+        );
+        harness.test_function(&mut executor, "callvalue", &[], Some(&uint_token(0)));
+
+        // TODO: need an evm update for the basefee opcode
+        // harness.test_function(&mut executor, "basefee", &[], Some(&uint_token(0)));
+
+        harness.test_function(
+            &mut executor,
+            "caller",
+            &[],
+            Some(&ethabi::Token::Address(harness.caller)),
+        );
+    });
+}

--- a/crates/yulgen/Cargo.toml
+++ b/crates/yulgen/Cargo.toml
@@ -20,6 +20,7 @@ salsa = "0.16.1"
 # This fork contains the shorthand macros and some other necessary updates.
 yultsur = { git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 smol_str = "0.1.21"
+if_chain = "1.0.2"
 
 [dev-dependencies]
 insta = "1.7.1"

--- a/crates/yulgen/src/context.rs
+++ b/crates/yulgen/src/context.rs
@@ -21,25 +21,36 @@ impl<'a> FnContext<'a> {
     }
 
     /// Get information that has been attributed to an expression node.
-    pub fn expression_attributes(&self, expr: &Node<ast::Expr>) -> Option<&ExpressionAttributes> {
-        self.fn_body.expressions.get(&expr.id)
+    pub fn expression_attributes(&self, expr: &Node<ast::Expr>) -> &ExpressionAttributes {
+        self.fn_body
+            .expressions
+            .get(&expr.id)
+            .expect("missing expression attributes")
     }
 
     /// Get the type of a variable declaration.
-    pub fn declaration_type(&self, typ: &Node<ast::TypeDesc>) -> Option<&FixedSize> {
-        self.fn_body.var_decl_types.get(&typ.id)
+    pub fn declaration_type(&self, typ: &Node<ast::TypeDesc>) -> &FixedSize {
+        self.fn_body
+            .var_decl_types
+            .get(&typ.id)
+            .expect("missing declaration type")
     }
 
     /// Get information that has been attributed to a call expression node.
-    pub fn call_type(&self, expr: &Node<ast::Expr>) -> Option<CallType> {
-        self.fn_body.calls.get(&expr.id).cloned()
+    pub fn call_type(&self, expr: &Node<ast::Expr>) -> CallType {
+        self.fn_body
+            .calls
+            .get(&expr.id)
+            .cloned()
+            .expect("missing call type")
     }
 
     /// Get information that has been attributed to an emit statement node.
-    pub fn emitted_event(&self, emit_stmt: &Node<ast::FuncStmt>) -> Option<Rc<Event>> {
+    pub fn emitted_event(&self, emit_stmt: &Node<ast::FuncStmt>) -> Rc<Event> {
         self.fn_body
             .emits
             .get(&emit_stmt.id)
-            .map(|event| event.typ(self.adb))
+            .expect("missing emit event type")
+            .typ(self.adb)
     }
 }

--- a/crates/yulgen/src/mappers/assignments.rs
+++ b/crates/yulgen/src/mappers/assignments.rs
@@ -17,12 +17,8 @@ pub fn assign(context: &mut FnContext, stmt: &Node<fe::FuncStmt>) -> yul::Statem
         let target = expressions::expr(context, target_node);
         let value = expressions::expr(context, value_node);
 
-        let target_attributes = context
-            .expression_attributes(target_node)
-            .expect("missing attributes");
-        let value_attributes = context
-            .expression_attributes(value_node)
-            .expect("missing attributes");
+        let target_attributes = context.expression_attributes(target_node);
+        let value_attributes = context.expression_attributes(value_node);
 
         let typ =
             FixedSize::try_from(target_attributes.typ.to_owned()).expect("invalid attributes");

--- a/crates/yulgen/src/mappers/declarations.rs
+++ b/crates/yulgen/src/mappers/declarations.rs
@@ -10,9 +10,7 @@ use yultsur::*;
 /// Builds a Yul statement from a Fe variable declaration
 pub fn var_decl(context: &mut FnContext, stmt: &Node<fe::FuncStmt>) -> yul::Statement {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
-        let decl_type = context
-            .declaration_type(typ)
-            .expect("missing declaration type");
+        let decl_type = context.declaration_type(typ);
 
         let target = names::var_name(var_decl_name(&target.kind));
 

--- a/newsfragments/603.feature.md
+++ b/newsfragments/603.feature.md
@@ -1,0 +1,20 @@
+Added unsafe low-level "intrinsic" functions, that perform raw evm operations.
+For example:
+
+```
+fn foo():
+  unsafe:
+    __mtore(0, 5000)
+    assert __mload(0) == 5000
+```
+
+The functions available are exactly those defined in yul's "evm dialect":
+https://docs.soliditylang.org/en/v0.8.11/yul.html#evm-dialect
+but with a double-underscore prefix. Eg `selfdestruct` -> `__selfdestruct`.
+
+These are intended to be used for implementing basic standard library functionality,
+and shouldn't typically be needed in normal contract code.
+
+Note: some intrinsic functions don't return a value (eg `__log0`); using these
+functions in a context that assumes a return value of unit type (eg `let x: () = __log0(a, b)`)
+will currently result in a compiler panic in the yul compilation phase.


### PR DESCRIPTION
This adds yul's evm functions (with an added double-underscore prefix) as `unsafe` global functions. https://docs.soliditylang.org/en/latest/yul.html#evm-dialect
eg `mload` -> `__mload`


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
