### PR TITLE
Parser performance stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +192,15 @@ name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version 0.4.0",
+]
 
 [[package]]
 name = "cc"
@@ -286,12 +307,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -299,6 +391,28 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ctor"
@@ -345,6 +459,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encode_unicode"
@@ -504,6 +624,7 @@ dependencies = [
 name = "fe-analyzer"
 version = "0.11.0-alpha"
 dependencies = [
+ "criterion",
  "fe-common",
  "fe-parser",
  "fe-test-files",
@@ -622,6 +743,7 @@ dependencies = [
 name = "fe-parser"
 version = "0.11.0-alpha"
 dependencies = [
+ "criterion",
  "fe-common",
  "fe-test-files",
  "if_chain",
@@ -631,6 +753,7 @@ dependencies = [
  "pretty_assertions",
  "semver 1.0.0",
  "serde",
+ "smol_str",
  "unescape",
  "uuid",
  "vec1",
@@ -756,6 +879,12 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hash-db"
@@ -906,6 +1035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,9 +1051,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1015,6 +1153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,6 +1210,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1163,6 +1320,34 @@ checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1340,6 +1525,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1565,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1403,7 +1619,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.2.3",
  "syn",
 ]
 
@@ -1426,6 +1642,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver 1.0.0",
 ]
 
 [[package]]
@@ -1512,6 +1737,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1718,6 +1953,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,9 +2084,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1849,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1876,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1886,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1899,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -1929,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.50"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,7 +755,6 @@ dependencies = [
  "serde",
  "smol_str",
  "unescape",
- "uuid",
  "vec1",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -868,10 +867,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2034,9 +2031,6 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.2",
-]
 
 [[package]]
 name = "vec1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "fe-test-files",
  "fe-yulc",
  "fe-yulgen",
+ "getrandom 0.2.3",
  "hex",
  "primitive-types",
  "serde_json",
@@ -863,13 +864,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1501,7 +1504,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "salsa",
  "semver 1.0.0",
  "smallvec",
+ "smol_str",
  "strum",
  "vec1",
  "wasm-bindgen-test",

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -28,3 +28,8 @@ rstest = "0.6.4"
 test-files = {path = "../test-files", package = "fe-test-files" }
 wasm-bindgen-test = "0.3"
 pretty_assertions = "0.7.2"
+criterion = "0.3.5"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -21,6 +21,7 @@ indexmap = "1.6.2"
 if_chain = "1.0.1"
 smallvec = { version = "1.6.1", features = ["union"] }
 petgraph = "0.6.0"
+smol_str = "0.1.21"
 
 [dev-dependencies]
 insta = "1.7.1"

--- a/crates/analyzer/benches/bench.rs
+++ b/crates/analyzer/benches/bench.rs
@@ -11,7 +11,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let path = "demos/uniswap.fe";
     let src = test_files::fixture(path);
     let id = files.add_file(path, src);
-    let ast = match fe_parser::parse_file(id, &src) {
+    let ast = match fe_parser::parse_file(id, src) {
         Ok((module, _)) => module,
         Err(diags) => {
             print_diagnostics(&diags, &files);

--- a/crates/analyzer/benches/bench.rs
+++ b/crates/analyzer/benches/bench.rs
@@ -1,0 +1,44 @@
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use fe_analyzer::namespace::items::{Global, Module, ModuleContext, ModuleFileContent};
+use fe_analyzer::{AnalyzerDb, TestDb};
+use fe_common::diagnostics::print_diagnostics;
+use fe_common::files::FileStore;
+use std::rc::Rc;
+// use fe_parser::
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut files = FileStore::new();
+    let path = "demos/uniswap.fe";
+    let src = test_files::fixture(path);
+    let id = files.add_file(path, src);
+    let ast = match fe_parser::parse_file(id, &src) {
+        Ok((module, _)) => module,
+        Err(diags) => {
+            print_diagnostics(&diags, &files);
+            panic!("parsing failed");
+        }
+    };
+
+    c.bench_function("analyze uniswap", |b| {
+        b.iter_batched(
+            || {
+                let db = TestDb::default();
+                let global = Global::default();
+                let global_id = db.intern_global(Rc::new(global));
+                let module = Module {
+                    name: "test_module".into(),
+                    context: ModuleContext::Global(global_id),
+                    file_content: ModuleFileContent::File { file: id },
+                    ast: ast.clone(),
+                };
+                let module_id = db.intern_module(Rc::new(module));
+                (db, module_id)
+            },
+            |(db, module_id)| fe_analyzer::analyze_module(&db, module_id),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -8,10 +8,11 @@ pub use fe_common::diagnostics::Label;
 use fe_common::Span;
 use fe_parser::ast;
 use fe_parser::node::NodeId;
+
 use indexmap::{IndexMap, IndexSet};
+use smol_str::SmolStr;
 use std::collections::HashMap;
-use std::fmt;
-use std::fmt::{Debug, Display};
+use std::fmt::{self, Debug, Display};
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -195,7 +196,7 @@ impl Location {
 pub struct FunctionBody {
     pub expressions: IndexMap<NodeId, ExpressionAttributes>,
     pub emits: IndexMap<NodeId, EventId>,
-    pub string_literals: IndexSet<String>, // for yulgen
+    pub string_literals: IndexSet<SmolStr>, // for yulgen
 
     // This is the id of the VarDecl TypeDesc node
     pub var_decl_types: IndexMap<NodeId, FixedSize>,
@@ -307,17 +308,17 @@ impl CallType {
         }
     }
 
-    pub fn function_name(&self, db: &dyn AnalyzerDb) -> String {
+    pub fn function_name(&self, db: &dyn AnalyzerDb) -> SmolStr {
         match self {
-            CallType::BuiltinFunction(f) => f.as_ref().to_string(),
-            CallType::BuiltinValueMethod { method, .. } => method.as_ref().to_string(),
-            CallType::BuiltinAssociatedFunction { function, .. } => function.as_ref().to_string(),
+            CallType::BuiltinFunction(f) => f.as_ref().into(),
+            CallType::BuiltinValueMethod { method, .. } => method.as_ref().into(),
+            CallType::BuiltinAssociatedFunction { function, .. } => function.as_ref().into(),
 
             CallType::AssociatedFunction { function: id, .. }
             | CallType::ValueMethod { method: id, .. }
             | CallType::External { function: id, .. }
             | CallType::Pure(id) => id.name(db),
-            CallType::TypeConstructor(typ) => typ.to_string(),
+            CallType::TypeConstructor(typ) => typ.name(),
         }
     }
 

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -9,8 +9,8 @@ use fe_common::Span;
 use fe_parser::ast;
 use fe_parser::node::Node;
 use indexmap::map::IndexMap;
+use smol_str::SmolStr;
 use std::rc::Rc;
-
 mod queries;
 
 // from rust-analyzer {
@@ -64,7 +64,7 @@ pub trait AnalyzerDb {
     #[salsa::invoke(queries::module::module_all_items)]
     fn module_all_items(&self, module: ModuleId) -> Rc<Vec<Item>>;
     #[salsa::invoke(queries::module::module_item_map)]
-    fn module_item_map(&self, module: ModuleId) -> Analysis<Rc<IndexMap<String, Item>>>;
+    fn module_item_map(&self, module: ModuleId) -> Analysis<Rc<IndexMap<SmolStr, Item>>>;
     #[salsa::invoke(queries::module::module_contracts)]
     fn module_contracts(&self, module: ModuleId) -> Rc<Vec<ContractId>>;
     #[salsa::invoke(queries::module::module_structs)]
@@ -73,19 +73,19 @@ pub trait AnalyzerDb {
     fn module_used_item_map(
         &self,
         module: ModuleId,
-    ) -> Analysis<Rc<IndexMap<String, (Span, Item)>>>;
+    ) -> Analysis<Rc<IndexMap<SmolStr, (Span, Item)>>>;
     #[salsa::invoke(queries::module::module_resolve_use_tree)]
     fn module_resolve_use_tree(
         &self,
         module: ModuleId,
         tree: Node<ast::UseTree>,
-    ) -> Analysis<Rc<IndexMap<String, (Span, Item)>>>;
+    ) -> Analysis<Rc<IndexMap<SmolStr, (Span, Item)>>>;
     #[salsa::invoke(queries::module::module_parent_module)]
     fn module_parent_module(&self, module: ModuleId) -> Option<ModuleId>;
     #[salsa::invoke(queries::module::module_adjacent_modules)]
-    fn module_adjacent_modules(&self, module: ModuleId) -> Rc<IndexMap<String, ModuleId>>;
+    fn module_adjacent_modules(&self, module: ModuleId) -> Rc<IndexMap<SmolStr, ModuleId>>;
     #[salsa::invoke(queries::module::module_sub_modules)]
-    fn module_sub_modules(&self, module: ModuleId) -> Rc<IndexMap<String, ModuleId>>;
+    fn module_sub_modules(&self, module: ModuleId) -> Rc<IndexMap<SmolStr, ModuleId>>;
 
     // Module Constant
     #[salsa::invoke(queries::module::module_constant_type)]
@@ -98,22 +98,24 @@ pub trait AnalyzerDb {
     #[salsa::invoke(queries::contracts::contract_all_functions)]
     fn contract_all_functions(&self, id: ContractId) -> Rc<Vec<FunctionId>>;
     #[salsa::invoke(queries::contracts::contract_function_map)]
-    fn contract_function_map(&self, id: ContractId) -> Analysis<Rc<IndexMap<String, FunctionId>>>;
+    fn contract_function_map(&self, id: ContractId) -> Analysis<Rc<IndexMap<SmolStr, FunctionId>>>;
     #[salsa::invoke(queries::contracts::contract_public_function_map)]
-    fn contract_public_function_map(&self, id: ContractId) -> Rc<IndexMap<String, FunctionId>>;
+    fn contract_public_function_map(&self, id: ContractId) -> Rc<IndexMap<SmolStr, FunctionId>>;
     #[salsa::invoke(queries::contracts::contract_init_function)]
     fn contract_init_function(&self, id: ContractId) -> Analysis<Option<FunctionId>>;
 
     #[salsa::invoke(queries::contracts::contract_all_events)]
     fn contract_all_events(&self, id: ContractId) -> Rc<Vec<EventId>>;
     #[salsa::invoke(queries::contracts::contract_event_map)]
-    fn contract_event_map(&self, id: ContractId) -> Analysis<Rc<IndexMap<String, EventId>>>;
+    fn contract_event_map(&self, id: ContractId) -> Analysis<Rc<IndexMap<SmolStr, EventId>>>;
 
     #[salsa::invoke(queries::contracts::contract_all_fields)]
     fn contract_all_fields(&self, id: ContractId) -> Rc<Vec<ContractFieldId>>;
     #[salsa::invoke(queries::contracts::contract_field_map)]
-    fn contract_field_map(&self, id: ContractId)
-        -> Analysis<Rc<IndexMap<String, ContractFieldId>>>;
+    fn contract_field_map(
+        &self,
+        id: ContractId,
+    ) -> Analysis<Rc<IndexMap<SmolStr, ContractFieldId>>>;
     #[salsa::invoke(queries::contracts::contract_field_type)]
     fn contract_field_type(
         &self,
@@ -141,7 +143,7 @@ pub trait AnalyzerDb {
     #[salsa::invoke(queries::structs::struct_all_fields)]
     fn struct_all_fields(&self, id: StructId) -> Rc<Vec<StructFieldId>>;
     #[salsa::invoke(queries::structs::struct_field_map)]
-    fn struct_field_map(&self, id: StructId) -> Analysis<Rc<IndexMap<String, StructFieldId>>>;
+    fn struct_field_map(&self, id: StructId) -> Analysis<Rc<IndexMap<SmolStr, StructFieldId>>>;
     #[salsa::invoke(queries::structs::struct_field_type)]
     fn struct_field_type(
         &self,
@@ -150,7 +152,7 @@ pub trait AnalyzerDb {
     #[salsa::invoke(queries::structs::struct_all_functions)]
     fn struct_all_functions(&self, id: StructId) -> Rc<Vec<FunctionId>>;
     #[salsa::invoke(queries::structs::struct_function_map)]
-    fn struct_function_map(&self, id: StructId) -> Analysis<Rc<IndexMap<String, FunctionId>>>;
+    fn struct_function_map(&self, id: StructId) -> Analysis<Rc<IndexMap<SmolStr, FunctionId>>>;
     #[salsa::invoke(queries::structs::struct_dependency_graph)]
     fn struct_dependency_graph(&self, id: StructId) -> DepGraphWrapper;
 

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -11,6 +11,7 @@ use crate::traversal::types::type_desc;
 use fe_common::diagnostics::Label;
 use fe_parser::ast;
 use indexmap::map::{Entry, IndexMap};
+use smol_str::SmolStr;
 use std::rc::Rc;
 
 /// A `Vec` of every function defined in the contract, including duplicates and the init function.
@@ -36,9 +37,9 @@ pub fn contract_all_functions(db: &dyn AnalyzerDb, contract: ContractId) -> Rc<V
 pub fn contract_function_map(
     db: &dyn AnalyzerDb,
     contract: ContractId,
-) -> Analysis<Rc<IndexMap<String, FunctionId>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, FunctionId>>> {
     let mut scope = ItemScope::new(db, contract.module(db));
-    let mut map = IndexMap::<String, FunctionId>::new();
+    let mut map = IndexMap::<SmolStr, FunctionId>::new();
 
     for func in db.contract_all_functions(contract).iter() {
         let def = &func.data(db).ast;
@@ -69,7 +70,7 @@ pub fn contract_function_map(
             continue;
         }
 
-        match map.entry(def.name().to_string()) {
+        match map.entry(def.name().into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
                     &format!(
@@ -95,7 +96,7 @@ pub fn contract_function_map(
 pub fn contract_public_function_map(
     db: &dyn AnalyzerDb,
     contract: ContractId,
-) -> Rc<IndexMap<String, FunctionId>> {
+) -> Rc<IndexMap<SmolStr, FunctionId>> {
     Rc::new(
         contract
             .functions(db)
@@ -176,15 +177,15 @@ pub fn contract_all_events(db: &dyn AnalyzerDb, contract: ContractId) -> Rc<Vec<
 pub fn contract_event_map(
     db: &dyn AnalyzerDb,
     contract: ContractId,
-) -> Analysis<Rc<IndexMap<String, EventId>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, EventId>>> {
     let mut scope = ItemScope::new(db, contract.module(db));
-    let mut map = IndexMap::<String, EventId>::new();
+    let mut map = IndexMap::<SmolStr, EventId>::new();
 
     let contract_name = contract.name(db);
     for event in db.contract_all_events(contract).iter() {
         let node = &event.data(db).ast;
 
-        match map.entry(node.name().to_string()) {
+        match map.entry(node.name().into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
                     &format!("duplicate event names in `contract {}`", contract_name,),
@@ -226,15 +227,15 @@ pub fn contract_all_fields(db: &dyn AnalyzerDb, contract: ContractId) -> Rc<Vec<
 pub fn contract_field_map(
     db: &dyn AnalyzerDb,
     contract: ContractId,
-) -> Analysis<Rc<IndexMap<String, ContractFieldId>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, ContractFieldId>>> {
     let mut scope = ItemScope::new(db, contract.module(db));
-    let mut map = IndexMap::<String, ContractFieldId>::new();
+    let mut map = IndexMap::<SmolStr, ContractFieldId>::new();
 
     let contract_name = contract.name(db);
     for field in db.contract_all_fields(contract).iter() {
         let node = &field.data(db).ast;
 
-        match map.entry(node.name().to_string()) {
+        match map.entry(node.name().into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
                     &format!("duplicate field names in `contract {}`", contract_name,),

--- a/crates/analyzer/src/db/queries/ingots.rs
+++ b/crates/analyzer/src/db/queries/ingots.rs
@@ -21,7 +21,7 @@ pub fn ingot_all_modules(db: &dyn AnalyzerDb, ingot_id: IngotId) -> Rc<Vec<Modul
                     .expect("file does not have stem")
                     .to_str()
                     .expect("could not convert file stem to string")
-                    .to_string(),
+                    .into(),
                 ast: ast.clone(),
                 file_content: ModuleFileContent::File { file: file.id },
                 context: ModuleContext::Ingot(ingot_id),
@@ -49,14 +49,14 @@ pub fn ingot_all_modules(db: &dyn AnalyzerDb, ingot_id: IngotId) -> Rc<Vec<Modul
                     .expect("missing file name")
                     .to_str()
                     .expect("could not convert dir name to string")
-                    .to_string(),
+                    .into(),
                 ast: ast::Module { body: vec![] },
                 context: ModuleContext::Ingot(ingot_id),
                 file_content: ModuleFileContent::Dir {
                     dir_path: dir
                         .to_str()
                         .expect("could not convert dir path to string")
-                        .to_string(),
+                        .into(),
                 },
             };
 

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -15,6 +15,7 @@ use fe_parser::ast;
 use fe_parser::node::Node;
 use indexmap::indexmap;
 use indexmap::map::{Entry, IndexMap};
+use smol_str::SmolStr;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::path::Path;
@@ -22,27 +23,24 @@ use std::rc::Rc;
 use strum::IntoEnumIterator;
 
 // Placeholder; someday std::prelude will be a proper module.
-fn std_prelude_items() -> IndexMap<String, Item> {
+fn std_prelude_items() -> IndexMap<SmolStr, Item> {
     let mut items = indexmap! {
-        "bool".to_string() => Item::Type(TypeDef::Primitive(types::Base::Bool)),
-        "address".to_string() => Item::Type(TypeDef::Primitive(types::Base::Address)),
+        SmolStr::new("bool") => Item::Type(TypeDef::Primitive(types::Base::Bool)),
+        SmolStr::new("address") => Item::Type(TypeDef::Primitive(types::Base::Address)),
     };
     items.extend(types::Integer::iter().map(|typ| {
         (
-            typ.as_ref().to_string(),
+            typ.as_ref().into(),
             Item::Type(TypeDef::Primitive(types::Base::Numeric(typ))),
         )
     }));
-    items.extend(
-        types::GenericType::iter().map(|typ| (typ.name().to_string(), Item::GenericType(typ))),
-    );
+    items.extend(types::GenericType::iter().map(|typ| (typ.name(), Item::GenericType(typ))));
     items.extend(
         builtins::GlobalFunction::iter()
-            .map(|fun| (fun.as_ref().to_string(), Item::BuiltinFunction(fun))),
+            .map(|fun| (fun.as_ref().into(), Item::BuiltinFunction(fun))),
     );
-    items.extend(
-        builtins::GlobalObject::iter().map(|obj| (obj.as_ref().to_string(), Item::Object(obj))),
-    );
+    items
+        .extend(builtins::GlobalObject::iter().map(|obj| (obj.as_ref().into(), Item::Object(obj))));
     items
 }
 
@@ -60,7 +58,7 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> 
             ))),
             ast::ModuleStmt::Contract(node) => Some(Item::Type(TypeDef::Contract(
                 db.intern_contract(Rc::new(Contract {
-                    name: node.name().to_string(),
+                    name: node.name().into(),
                     ast: node.clone(),
                     module,
                 })),
@@ -94,7 +92,7 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> 
 pub fn module_item_map(
     db: &dyn AnalyzerDb,
     module: ModuleId,
-) -> Analysis<Rc<IndexMap<String, Item>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, Item>>> {
     let builtin_items = std_prelude_items();
     let sub_modules = module
         .sub_modules(db)
@@ -104,7 +102,7 @@ pub fn module_item_map(
     let used_items = db.module_used_item_map(module);
     let mut diagnostics = (*used_items.diagnostics).clone();
 
-    let mut map = IndexMap::<String, Item>::new();
+    let mut map = IndexMap::<SmolStr, Item>::new();
 
     for item in module.all_items(db).iter() {
         let item_name = item.name(db);
@@ -232,7 +230,7 @@ pub fn module_constant_type(
 pub fn module_used_item_map(
     db: &dyn AnalyzerDb,
     module: ModuleId,
-) -> Analysis<Rc<IndexMap<String, (Span, Item)>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, (Span, Item)>>> {
     let mut diagnostics = vec![];
 
     let ast::Module { body } = &module.data(db).ast;
@@ -296,7 +294,7 @@ pub fn module_resolve_use_tree(
     db: &dyn AnalyzerDb,
     module: ModuleId,
     tree: Node<ast::UseTree>,
-) -> Analysis<Rc<IndexMap<String, (Span, Item)>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, (Span, Item)>>> {
     let mut diagnostics = vec![];
 
     match &tree.kind {
@@ -421,7 +419,7 @@ pub fn module_parent_module(db: &dyn AnalyzerDb, module: ModuleId) -> Option<Mod
 pub fn module_adjacent_modules(
     db: &dyn AnalyzerDb,
     module: ModuleId,
-) -> Rc<IndexMap<String, ModuleId>> {
+) -> Rc<IndexMap<SmolStr, ModuleId>> {
     if let Some(parent) = module.parent_module(db) {
         parent.sub_modules(db)
     } else {
@@ -429,7 +427,10 @@ pub fn module_adjacent_modules(
     }
 }
 
-pub fn module_sub_modules(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<IndexMap<String, ModuleId>> {
+pub fn module_sub_modules(
+    db: &dyn AnalyzerDb,
+    module: ModuleId,
+) -> Rc<IndexMap<SmolStr, ModuleId>> {
     match module.context(db) {
         ModuleContext::Ingot(ingot) => {
             let all_modules = ingot.all_modules(db);
@@ -439,10 +440,10 @@ pub fn module_sub_modules(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<IndexMap<
                     let sub_modules = all_modules
                         .iter()
                         .filter(|module_id| {
-                            Path::new(&module_id.ingot_path(db))
+                            Path::new(module_id.ingot_path(db).as_str())
                                 .parent()
                                 .expect("module file in ingot does not have parent path")
-                                == Path::new(&dir_path)
+                                == Path::new(dir_path.as_str())
                         })
                         .map(|module_id| (module_id.name(db), *module_id))
                         .collect::<IndexMap<_, _>>();

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -12,6 +12,7 @@ use crate::traversal::types::type_desc;
 use crate::AnalyzerDb;
 use fe_parser::ast;
 use indexmap::map::{Entry, IndexMap};
+use smol_str::SmolStr;
 use std::rc::Rc;
 use std::str::FromStr;
 
@@ -43,15 +44,15 @@ pub fn struct_all_fields(db: &dyn AnalyzerDb, struct_: StructId) -> Rc<Vec<Struc
 pub fn struct_field_map(
     db: &dyn AnalyzerDb,
     struct_: StructId,
-) -> Analysis<Rc<IndexMap<String, StructFieldId>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, StructFieldId>>> {
     let mut scope = ItemScope::new(db, struct_.module(db));
-    let mut fields = IndexMap::<String, StructFieldId>::new();
+    let mut fields = IndexMap::<SmolStr, StructFieldId>::new();
 
     let struct_name = struct_.name(db);
     for field in db.struct_all_fields(struct_).iter() {
         let node = &field.data(db).ast;
 
-        match fields.entry(node.name().to_string()) {
+        match fields.entry(node.name().into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
                     &format!("duplicate field names in `struct {}`", struct_name,),
@@ -133,9 +134,9 @@ pub fn struct_all_functions(db: &dyn AnalyzerDb, struct_: StructId) -> Rc<Vec<Fu
 pub fn struct_function_map(
     db: &dyn AnalyzerDb,
     struct_: StructId,
-) -> Analysis<Rc<IndexMap<String, FunctionId>>> {
+) -> Analysis<Rc<IndexMap<SmolStr, FunctionId>>> {
     let mut scope = ItemScope::new(db, struct_.module(db));
-    let mut map = IndexMap::<String, FunctionId>::new();
+    let mut map = IndexMap::<SmolStr, FunctionId>::new();
 
     for func in db.struct_all_functions(struct_).iter() {
         let def = &func.data(db).ast;
@@ -167,7 +168,7 @@ pub fn struct_function_map(
             continue;
         }
 
-        match map.entry(def_name.to_string()) {
+        match map.entry(def_name.into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
                     &format!("duplicate function names in `struct {}`", struct_.name(db)),

--- a/crates/analyzer/src/traversal/call_args.rs
+++ b/crates/analyzer/src/traversal/call_args.rs
@@ -7,6 +7,7 @@ use fe_common::{diagnostics::Label, utils::humanize::pluralize_conditionally};
 use fe_common::{Span, Spanned};
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
+use smol_str::SmolStr;
 
 pub trait LabeledParameter {
     fn label(&self) -> Option<&str>;
@@ -40,7 +41,7 @@ impl LabeledParameter for EventField {
 //     }
 // }
 
-impl LabeledParameter for (String, Result<FixedSize, TypeError>) {
+impl LabeledParameter for (SmolStr, Result<FixedSize, TypeError>) {
     fn label(&self) -> Option<&str> {
         Some(&self.0)
     }

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -14,13 +14,12 @@ use crate::traversal::call_args::{validate_arg_count, validate_named_args, Label
 use crate::traversal::types::apply_generic_type_args;
 use crate::traversal::utils::{add_bin_operations_errors, types_to_fixed_sizes};
 use fe_common::diagnostics::Label;
-use fe_common::numeric;
-use fe_common::Span;
+use fe_common::{numeric, Span};
 use fe_parser::ast as fe;
-use fe_parser::ast;
 use fe_parser::ast::UnaryOperator;
 use fe_parser::node::Node;
 use num_bigint::BigInt;
+use smol_str::SmolStr;
 use std::convert::TryInto;
 use std::ops::RangeInclusive;
 use std::str::FromStr;
@@ -888,7 +887,7 @@ fn expr_call_name<T: std::fmt::Display>(
 
 fn expr_call_path<T: std::fmt::Display>(
     scope: &mut BlockScope,
-    path: &ast::Path,
+    path: &fe::Path,
     func: &Node<T>,
     generic_args: &Option<Node<Vec<fe::GenericArg>>>,
     args: &Node<Vec<Node<fe::CallArg>>>,
@@ -1304,7 +1303,7 @@ fn expr_call_struct_constructor(
 fn expr_call_method(
     scope: &mut BlockScope,
     target: &Node<fe::Expr>,
-    field: &Node<String>,
+    field: &Node<SmolStr>,
     generic_args: &Option<Node<Vec<fe::GenericArg>>>,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<(ExpressionAttributes, CallType), FatalError> {
@@ -1467,7 +1466,7 @@ fn expr_call_builtin_value_method(
     value_attrs: ExpressionAttributes,
     value: &Node<fe::Expr>,
     method: ValueMethod,
-    method_name: &Node<String>,
+    method_name: &Node<SmolStr>,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<(ExpressionAttributes, CallType), FatalError> {
     // for now all of these functions expect 0 arguments
@@ -1610,7 +1609,7 @@ fn expr_call_type_attribute(
     scope: &mut BlockScope,
     typ: Type,
     target_span: Span,
-    field: &Node<String>,
+    field: &Node<SmolStr>,
     generic_args: &Option<Node<Vec<fe::GenericArg>>>,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<(ExpressionAttributes, CallType), FatalError> {

--- a/crates/analyzer/src/traversal/pragma.rs
+++ b/crates/analyzer/src/traversal/pragma.rs
@@ -1,6 +1,5 @@
 use crate::errors;
-use fe_common::diagnostics::Diagnostic;
-use fe_common::diagnostics::Label;
+use fe_common::diagnostics::{Diagnostic, Label};
 use fe_parser::ast;
 use fe_parser::node::Node;
 use semver::{Version, VersionReq};

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -40,7 +40,7 @@ pub fn apply_generic_type_args(
 
     if let Some(diag) = validate_arg_count(
         context,
-        generic.name(),
+        &generic.name(),
         name_span,
         args,
         params.len(),

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -40,7 +40,7 @@ macro_rules! test_analysis {
             let global_id = db.intern_global(Rc::new(global));
 
             let module = Module {
-                name: "test_module".to_string(),
+                name: "test_module".into(),
                 context: ModuleContext::Global(global_id),
                 file_content: ModuleFileContent::File { file: id },
                 ast,
@@ -82,7 +82,7 @@ macro_rules! test_analysis_ingot {
             let global_id = db.intern_global(Rc::new(global));
 
             let ingot = Ingot {
-                name: "test_ingot".to_string(),
+                name: "test_ingot".into(),
                 global: global_id,
                 fe_files: files
                     .files

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -30,7 +30,7 @@ fn error_string(path: &str, src: &str) -> String {
     let global_id = db.intern_global(Rc::new(global));
 
     let module = items::Module {
-        name: path.to_string(),
+        name: path.into(),
         context: items::ModuleContext::Global(global_id),
         file_content: ModuleFileContent::File { file: id },
         ast,
@@ -53,7 +53,7 @@ fn error_string_ingot(path: &str) -> String {
     let global_id = db.intern_global(Rc::new(global));
 
     let ingot = items::Ingot {
-        name: path.to_string(),
+        name: path.into(),
         global: global_id,
         fe_files: files
             .files

--- a/crates/common/src/span.rs
+++ b/crates/common/src/span.rs
@@ -15,12 +15,6 @@ pub struct Span {
     pub end: usize,
 }
 
-impl Debug for Span {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", Range::from(*self))
-    }
-}
-
 impl Span {
     pub fn new(file_id: SourceFileId, start: usize, end: usize) -> Self {
         Span {
@@ -57,6 +51,12 @@ impl Span {
             start: start_span.start,
             end: end_span.end,
         }
+    }
+}
+
+impl Debug for Span {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", Range::from(*self))
     }
 }
 

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -57,7 +57,7 @@ pub fn compile_module(
             .file_stem()
             .expect("missing file name")
             .to_string_lossy()
-            .to_string(),
+            .into(),
         context: ModuleContext::Global(global_id),
         file_content: ModuleFileContent::File { file: file_id },
         ast,
@@ -161,7 +161,7 @@ pub fn compile_ingot(
     let global_id = db.intern_global(Rc::new(global));
 
     let ingot = Ingot {
-        name: name.to_string(),
+        name: name.into(),
         global: global_id,
         fe_files: file_ids
             .iter()

--- a/crates/lowering/src/ast_utils.rs
+++ b/crates/lowering/src/ast_utils.rs
@@ -455,14 +455,14 @@ pub fn ternary_to_if(
     } = &expr.kind
     {
         let mut stmts = vec![FuncStmt::VarDecl {
-            target: VarDeclTarget::Name(result_name.to_string()).into_node(),
+            target: VarDeclTarget::Name(result_name.into()).into_node(),
             typ: names::fixed_size_type_desc(&ternary_type).into_node(),
             value: None,
         }
         .into_node()];
 
         let if_branch = FuncStmt::Assign {
-            target: Expr::Name(result_name.to_string()).into_node(),
+            target: Expr::Name(result_name.into()).into_node(),
             value: if_expr
                 .kind
                 .clone()
@@ -471,7 +471,7 @@ pub fn ternary_to_if(
         .into_node();
 
         let else_branch = FuncStmt::Assign {
-            target: Expr::Name(result_name.to_string()).into_node(),
+            target: Expr::Name(result_name.into()).into_node(),
             value: else_expr
                 .kind
                 .clone()
@@ -512,13 +512,13 @@ pub fn boolean_expr_to_if(
                 //     res = right
 
                 let mut stmts = vec![FuncStmt::VarDecl {
-                    target: VarDeclTarget::Name(result_name.to_string()).into_node(),
+                    target: VarDeclTarget::Name(result_name.into()).into_node(),
                     typ: names::fixed_size_type_desc(&expr_type).into_node(),
                     value: Some(Expr::Bool(false).into_node()),
                 }
                 .into_node()];
                 let if_branch = FuncStmt::Assign {
-                    target: Expr::Name(result_name.to_string()).into_node(),
+                    target: Expr::Name(result_name.into()).into_node(),
                     value: right.kind.clone().into_traceable_node(right.original_id),
                 }
                 .into_node();
@@ -540,13 +540,13 @@ pub fn boolean_expr_to_if(
                 // if not left:
                 //     res = right
                 let mut stmts = vec![FuncStmt::VarDecl {
-                    target: VarDeclTarget::Name(result_name.to_string()).into_node(),
+                    target: VarDeclTarget::Name(result_name.into()).into_node(),
                     typ: names::fixed_size_type_desc(&expr_type).into_node(),
                     value: Some(Expr::Bool(true).into_node()),
                 }
                 .into_node()];
                 let if_branch = FuncStmt::Assign {
-                    target: Expr::Name(result_name.to_string()).into_node(),
+                    target: Expr::Name(result_name.into()).into_node(),
                     value: right.kind.clone().into_traceable_node(right.original_id),
                 }
                 .into_node();
@@ -644,7 +644,7 @@ pub fn replace_node_with_name_expression(
         .map(|node| {
             map_ast_node(node.clone().into(), &mut |val| match val {
                 StmtOrExpr::Expr(expr) if expr.original_id == node_id => {
-                    Expr::Name(name.to_string()).into_node().into()
+                    Expr::Name(name.into()).into_node().into()
                 }
                 _ => val,
             })
@@ -677,7 +677,7 @@ mod tests {
             source.push_str(&stmt.kind.to_string());
             source.push('\n');
         }
-        source.trim().to_string()
+        source.trim().into()
     }
 
     #[test]
@@ -689,7 +689,7 @@ mod tests {
             if let StmtOrExpr::Stmt(stmt) = stmt {
                 let node = match stmt.kind {
                     FuncStmt::Return { .. } => FuncStmt::Return {
-                        value: Some(Expr::Name("foo".to_string()).into_node()),
+                        value: Some(Expr::Name("foo".into()).into_node()),
                     },
                     _ => stmt.kind,
                 }
@@ -706,7 +706,7 @@ mod tests {
     #[test]
     fn transform_expr() {
         let stmt = FuncStmt::Return {
-            value: Some(Expr::Name("foo".to_string()).into_node()),
+            value: Some(Expr::Name("foo".into()).into_node()),
         }
         .into_node();
         assert_eq!(to_code(&[stmt.clone()]), "return foo");
@@ -714,7 +714,7 @@ mod tests {
         let mut transform_expr = |expr| {
             if let StmtOrExpr::Expr(expr) = expr {
                 let node = match expr.kind {
-                    Expr::Name(_) => Expr::Name("bar".to_string()),
+                    Expr::Name(_) => Expr::Name("bar".into()),
                     _ => expr.kind,
                 }
                 .into_node();
@@ -731,8 +731,8 @@ mod tests {
     #[test]
     fn count_expr() {
         let add_expr = Expr::BinOperation {
-            left: Expr::Num("1".to_string()).into_boxed_node(),
-            right: Expr::Num("2".to_string()).into_boxed_node(),
+            left: Expr::Num("1".into()).into_boxed_node(),
+            right: Expr::Num("2".into()).into_boxed_node(),
             op: BinOperator::Add.into_node(),
         };
         let stmt = FuncStmt::Return {
@@ -767,14 +767,14 @@ mod tests {
     fn inject_expression() {
         let nested_ternary = Expr::Ternary {
             test: Expr::Bool(true).into_boxed_node(),
-            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
-            else_expr: Expr::Num("2".to_string()).into_boxed_node(),
+            if_expr: Expr::Num("1".into()).into_boxed_node(),
+            else_expr: Expr::Num("2".into()).into_boxed_node(),
         }
         .into_boxed_node();
 
         let ternary = Expr::Ternary {
             test: Expr::Bool(true).into_boxed_node(),
-            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            if_expr: Expr::Num("1".into()).into_boxed_node(),
             else_expr: nested_ternary,
         }
         .into_node();
@@ -801,14 +801,14 @@ mod tests {
     fn inject_expression_nested() {
         let nested_ternary = Expr::Ternary {
             test: Expr::Bool(true).into_boxed_node(),
-            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
-            else_expr: Expr::Num("2".to_string()).into_boxed_node(),
+            if_expr: Expr::Num("1".into()).into_boxed_node(),
+            else_expr: Expr::Num("2".into()).into_boxed_node(),
         }
         .into_boxed_node();
 
         let ternary = Expr::Ternary {
             test: Expr::Bool(true).into_boxed_node(),
-            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            if_expr: Expr::Num("1".into()).into_boxed_node(),
             else_expr: nested_ternary,
         }
         .into_node();
@@ -850,20 +850,20 @@ else:
     fn lower_nested_ternary() {
         let nested_ternary = Expr::Ternary {
             test: Expr::Bool(true).into_boxed_node(),
-            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
-            else_expr: Expr::Num("2".to_string()).into_boxed_node(),
+            if_expr: Expr::Num("1".into()).into_boxed_node(),
+            else_expr: Expr::Num("2".into()).into_boxed_node(),
         }
         .into_boxed_node();
 
         let ternary = Expr::Ternary {
             test: Expr::Bool(true).into_boxed_node(),
-            if_expr: Expr::Num("1".to_string()).into_boxed_node(),
+            if_expr: Expr::Num("1".into()).into_boxed_node(),
             else_expr: nested_ternary.clone(),
         }
         .into_node();
 
         let call = Expr::Call {
-            func: Expr::Name("foo".to_string()).into_boxed_node(),
+            func: Expr::Name("foo".into()).into_boxed_node(),
             args: vec![CallArg {
                 value: ternary.clone(),
                 label: None,

--- a/crates/lowering/src/mappers/expressions.rs
+++ b/crates/lowering/src/mappers/expressions.rs
@@ -149,7 +149,7 @@ fn expr_tuple(context: &mut FnContext, exp: Node<fe::Expr>) -> fe::Expr {
                 let span = elt.span;
                 Node::new(
                     fe::CallArg {
-                        label: Some(Node::new(format!("item{}", index), span)),
+                        label: Some(Node::new(format!("item{}", index).into(), span)),
                         value: expr(context, elt),
                     },
                     span,

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -5,7 +5,7 @@ use crate::utils::ZeroSpanNode;
 use fe_analyzer::namespace::items::{Item, ModuleId, TypeDef};
 use fe_analyzer::namespace::types::{Array, Base, FixedSize, Tuple};
 use fe_analyzer::AnalyzerDb;
-use fe_parser::ast;
+use fe_parser::ast::{self, SmolStr};
 use fe_parser::node::Node;
 
 /// Lowers a module.
@@ -110,7 +110,7 @@ fn build_struct_field(name: String, type_desc: ast::TypeDesc) -> ast::Field {
     ast::Field {
         is_pub: false,
         is_const: false,
-        name: name.into_node(),
+        name: SmolStr::new(name).into_node(),
         typ: type_desc.into_node(),
         value: None,
     }
@@ -119,15 +119,13 @@ fn build_struct_field(name: String, type_desc: ast::TypeDesc) -> ast::Field {
 fn build_type_desc(typ: &FixedSize) -> ast::TypeDesc {
     match typ {
         FixedSize::Base(Base::Unit) => ast::TypeDesc::Unit,
-        FixedSize::Base(base) => ast::TypeDesc::Base {
-            base: names::base_type_name(base),
-        },
+        FixedSize::Base(base) => ast::TypeDesc::Base { base: base.name() },
         FixedSize::Array(array) => ast::TypeDesc::Generic {
-            base: "Array".to_string().into_node(),
+            base: SmolStr::new("Array").into_node(),
             args: vec![
                 ast::GenericArg::TypeDesc(
                     ast::TypeDesc::Base {
-                        base: array.inner.to_string(),
+                        base: array.inner.name(),
                     }
                     .into_node(),
                 ),
@@ -139,7 +137,7 @@ fn build_type_desc(typ: &FixedSize) -> ast::TypeDesc {
             base: names::tuple_struct_name(tuple),
         },
         FixedSize::String(string) => ast::TypeDesc::Generic {
-            base: "String".to_string().into_node(),
+            base: SmolStr::new("String").into_node(),
             args: vec![ast::GenericArg::Int(string.max_size.into_node())].into_node(),
         },
         FixedSize::Contract(contract) => ast::TypeDesc::Base {
@@ -156,7 +154,7 @@ fn list_expr_to_fn_def(array: &Array) -> ast::Function {
     let args = (0..array.size)
         .map(|index| {
             ast::FunctionArg::Regular(ast::RegularFunctionArg {
-                name: format!("val{}", index).into_node(),
+                name: SmolStr::new(format!("val{}", index)).into_node(),
                 typ: names::fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
             })
             .into_node()
@@ -166,7 +164,7 @@ fn list_expr_to_fn_def(array: &Array) -> ast::Function {
     // Build the AST node for the array declaration
     let var_decl_name = "generated_array";
     let var_decl = ast::FuncStmt::VarDecl {
-        target: ast::VarDeclTarget::Name(var_decl_name.to_string()).into_node(),
+        target: ast::VarDeclTarget::Name(var_decl_name.into()).into_node(),
         typ: names::fixed_size_type_desc(&FixedSize::Array(array.clone())).into_node(),
         value: None,
     }
@@ -177,11 +175,11 @@ fn list_expr_to_fn_def(array: &Array) -> ast::Function {
         .map(|index| {
             ast::FuncStmt::Assign {
                 target: ast::Expr::Subscript {
-                    value: ast::Expr::Name(var_decl_name.to_string()).into_boxed_node(),
-                    index: ast::Expr::Num(index.to_string()).into_boxed_node(),
+                    value: ast::Expr::Name(var_decl_name.into()).into_boxed_node(),
+                    index: ast::Expr::Num(index.to_string().into()).into_boxed_node(),
                 }
                 .into_node(),
-                value: ast::Expr::Name(format!("val{}", index)).into_node(),
+                value: ast::Expr::Name(format!("val{}", index).into()).into_node(),
             }
             .into_node()
         })
@@ -189,7 +187,7 @@ fn list_expr_to_fn_def(array: &Array) -> ast::Function {
 
     // Build the AST node for the return statement
     let return_stmt = ast::FuncStmt::Return {
-        value: Some(ast::Expr::Name(var_decl_name.to_string()).into_node()),
+        value: Some(ast::Expr::Name(var_decl_name.into()).into_node()),
     }
     .into_node();
 

--- a/crates/lowering/src/names.rs
+++ b/crates/lowering/src/names.rs
@@ -1,73 +1,48 @@
 use crate::names;
 use crate::utils::ZeroSpanNode;
-use fe_analyzer::namespace::types::{Array, Base, FixedSize, Integer, SafeNames, Tuple};
-use fe_parser::ast as fe;
+use fe_analyzer::namespace::types::{Array, Base, FixedSize, SafeNames, Tuple};
+use fe_parser::ast::{self, SmolStr};
 
 /// The name of a lowered list expression generator function.
-pub fn list_expr_generator_fn_name(list_expr_type: &Array) -> String {
-    format!("list_expr_{}", list_expr_type.lower_snake())
+pub fn list_expr_generator_fn_name(list_expr_type: &Array) -> SmolStr {
+    format!("list_expr_{}", list_expr_type.lower_snake()).into()
 }
 
 /// The name of a lowered tuple struct definition.
-pub fn tuple_struct_name(tuple: &Tuple) -> String {
-    format!("${}", tuple.lower_snake())
+pub fn tuple_struct_name(tuple: &Tuple) -> SmolStr {
+    format!("${}", tuple.lower_snake()).into()
 }
 
 /// Maps a FixedSize type to its type description.
-pub fn fixed_size_type_desc(typ: &FixedSize) -> fe::TypeDesc {
+pub fn fixed_size_type_desc(typ: &FixedSize) -> ast::TypeDesc {
     match typ {
-        FixedSize::Base(Base::Unit) => fe::TypeDesc::Unit,
-        FixedSize::Base(base) => fe::TypeDesc::Base {
-            base: names::base_type_name(base),
-        },
-        FixedSize::Array(array) => fe::TypeDesc::Generic {
-            base: "Array".to_string().into_node(),
+        FixedSize::Base(Base::Unit) => ast::TypeDesc::Unit,
+        FixedSize::Base(base) => ast::TypeDesc::Base { base: base.name() },
+        FixedSize::Array(array) => ast::TypeDesc::Generic {
+            base: SmolStr::new("Array").into_node(),
             args: vec![
-                fe::GenericArg::TypeDesc(
-                    fe::TypeDesc::Base {
-                        base: array.inner.to_string(),
+                ast::GenericArg::TypeDesc(
+                    ast::TypeDesc::Base {
+                        base: array.inner.name(),
                     }
                     .into_node(),
                 ),
-                fe::GenericArg::Int(array.size.into_node()),
+                ast::GenericArg::Int(array.size.into_node()),
             ]
             .into_node(),
         },
-        FixedSize::Tuple(tuple) => fe::TypeDesc::Base {
+        FixedSize::Tuple(tuple) => ast::TypeDesc::Base {
             base: names::tuple_struct_name(tuple),
         },
-        FixedSize::String(string) => fe::TypeDesc::Generic {
-            base: "String".to_string().into_node(),
-            args: vec![fe::GenericArg::Int(string.max_size.into_node())].into_node(),
+        FixedSize::String(string) => ast::TypeDesc::Generic {
+            base: SmolStr::new("String").into_node(),
+            args: vec![ast::GenericArg::Int(string.max_size.into_node())].into_node(),
         },
-        FixedSize::Contract(contract) => fe::TypeDesc::Base {
+        FixedSize::Contract(contract) => ast::TypeDesc::Base {
             base: contract.name.clone(),
         },
-        FixedSize::Struct(strukt) => fe::TypeDesc::Base {
+        FixedSize::Struct(strukt) => ast::TypeDesc::Base {
             base: strukt.name.clone(),
         },
     }
-}
-
-pub fn base_type_name(typ: &Base) -> String {
-    match typ {
-        Base::Numeric(number) => match number {
-            Integer::U256 => "u256",
-            Integer::U128 => "u128",
-            Integer::U64 => "u64",
-            Integer::U32 => "u32",
-            Integer::U16 => "u16",
-            Integer::U8 => "u8",
-            Integer::I256 => "i256",
-            Integer::I128 => "i128",
-            Integer::I64 => "i64",
-            Integer::I32 => "i32",
-            Integer::I16 => "i16",
-            Integer::I8 => "i8",
-        },
-        Base::Bool => "bool",
-        Base::Address => "address",
-        Base::Unit => "unit",
-    }
-    .to_string()
 }

--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -17,7 +17,7 @@ fn lower(src: &str, id: SourceFileId, files: &FileStore) -> fe::Module {
     let global_id = db.intern_global(Rc::new(global));
 
     let module = Module {
-        name: "test_module".to_string(),
+        name: "test_module".into(),
         context: ModuleContext::Global(global_id),
         file_content: ModuleFileContent::File { file: id },
         ast,

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -15,7 +15,6 @@ fe-common = {path = "../common", version = "^0.11.0-alpha"}
 logos = { version = "0.11.4", default-features = false, features = ["export_derive"] }
 serde = { version = "1", features = ["derive"] }
 unescape = "0.1.0"
-uuid = { version = "0.8", features = ["v4", "stdweb"] }
 vec1 = { version = "1.8.0", features = ["serde"] }
 if_chain = "1.0.1"
 semver = "1.0.0"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -20,6 +20,7 @@ vec1 = { version = "1.8.0", features = ["serde"] }
 if_chain = "1.0.1"
 semver = "1.0.0"
 indenter = "0.3"
+smol_str = "0.1.21"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
@@ -29,3 +30,8 @@ fe-test-files = {path = "../test-files", version = "^0.11.0-alpha"}
 insta = "1.7.1"
 wasm-bindgen-test = "0.3"
 pretty_assertions = "0.7.2"
+criterion = "0.3.5"
+
+[[bench]]
+name = "bench"
+harness = false

--- a/crates/parser/benches/bench.rs
+++ b/crates/parser/benches/bench.rs
@@ -1,0 +1,20 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use fe_common::files::FileStore;
+
+fn uniswap(c: &mut Criterion) {
+    let mut files = FileStore::new();
+    let path = "demos/uniswap.fe";
+    let src = fe_test_files::fixture(path);
+    let id = files.add_file(path, src);
+
+    c.bench_function("parse_uniswap", |b| {
+        b.iter(|| fe_parser::parse_file(id, &src))
+    });
+    c.bench_function("clone_ast", |b| {
+        let ast = fe_parser::parse_file(id, &src).unwrap();
+        b.iter(|| ast.clone())
+    });
+}
+
+criterion_group!(benches, uniswap);
+criterion_main!(benches);

--- a/crates/parser/benches/bench.rs
+++ b/crates/parser/benches/bench.rs
@@ -8,10 +8,10 @@ fn uniswap(c: &mut Criterion) {
     let id = files.add_file(path, src);
 
     c.bench_function("parse_uniswap", |b| {
-        b.iter(|| fe_parser::parse_file(id, &src))
+        b.iter(|| fe_parser::parse_file(id, src))
     });
     c.bench_function("clone_ast", |b| {
-        let ast = fe_parser::parse_file(id, &src).unwrap();
+        let ast = fe_parser::parse_file(id, src).unwrap();
         b.iter(|| ast.clone())
     });
 }

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -2,6 +2,7 @@ use crate::node::Node;
 use fe_common::{Span, Spanned};
 use indenter::indented;
 use serde::{Deserialize, Serialize};
+pub use smol_str::SmolStr;
 use std::fmt;
 use std::fmt::Formatter;
 use std::fmt::Write;
@@ -25,12 +26,12 @@ pub enum ModuleStmt {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Pragma {
-    pub version_requirement: Node<String>,
+    pub version_requirement: Node<SmolStr>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Path {
-    pub segments: Vec<Node<String>>,
+    pub segments: Vec<Node<SmolStr>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -49,33 +50,33 @@ pub enum UseTree {
     },
     Simple {
         path: Path,
-        rename: Option<Node<String>>,
+        rename: Option<Node<SmolStr>>,
     },
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct ConstantDecl {
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub typ: Node<TypeDesc>,
     pub value: Node<Expr>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct TypeAlias {
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub typ: Node<TypeDesc>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Contract {
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub fields: Vec<Node<Field>>,
     pub body: Vec<ContractStmt>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Struct {
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub fields: Vec<Node<Field>>,
     pub functions: Vec<Node<Function>>,
 }
@@ -83,9 +84,9 @@ pub struct Struct {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub enum TypeDesc {
     Unit,
-    // TODO: replace with `Name(String)`, or eliminate in favor of `Path`?
+    // TODO: replace with `Name(SmolStr)`, or eliminate in favor of `Path`?
     Base {
-        base: String,
+        base: SmolStr,
     },
     Path(Path),
     Tuple {
@@ -94,7 +95,7 @@ pub enum TypeDesc {
     Generic {
         // TODO: when we support user-defined generic types,
         // this will have to be a `Path`
-        base: Node<String>,
+        base: Node<SmolStr>,
         args: Node<Vec<GenericArg>>,
     },
 }
@@ -119,7 +120,7 @@ impl Spanned for GenericArg {
 pub struct Field {
     pub is_pub: bool,
     pub is_const: bool,
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub typ: Node<TypeDesc>,
     pub value: Option<Node<Expr>>,
 }
@@ -133,7 +134,7 @@ pub enum ContractStmt {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Event {
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub fields: Vec<Node<EventField>>,
 }
 
@@ -142,7 +143,7 @@ pub struct Function {
     // qualifier order: `pub unsafe fn`
     pub pub_: Option<Span>,
     pub unsafe_: Option<Span>,
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub args: Vec<Node<FunctionArg>>,
     pub return_type: Option<Node<TypeDesc>>,
     pub body: Vec<Node<FuncStmt>>,
@@ -151,13 +152,13 @@ pub struct Function {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct EventField {
     pub is_idx: bool,
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub typ: Node<TypeDesc>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct RegularFunctionArg {
-    pub name: Node<String>,
+    pub name: Node<SmolStr>,
     pub typ: Node<TypeDesc>,
 }
 
@@ -188,7 +189,7 @@ pub enum FuncStmt {
         value: Node<Expr>,
     },
     For {
-        target: Node<String>,
+        target: Node<SmolStr>,
         iter: Node<Expr>,
         body: Vec<Node<FuncStmt>>,
     },
@@ -206,7 +207,7 @@ pub enum FuncStmt {
         msg: Option<Node<Expr>>,
     },
     Emit {
-        name: Node<String>,
+        name: Node<SmolStr>,
         args: Node<Vec<Node<CallArg>>>,
     },
     Expr {
@@ -223,7 +224,7 @@ pub enum FuncStmt {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub enum VarDeclTarget {
-    Name(String),
+    Name(SmolStr),
     Tuple(Vec<Node<VarDeclTarget>>),
 }
 
@@ -255,7 +256,7 @@ pub enum Expr {
     },
     Attribute {
         value: Box<Node<Expr>>,
-        attr: Node<String>,
+        attr: Node<SmolStr>,
     },
     Subscript {
         value: Box<Node<Expr>>,
@@ -273,16 +274,16 @@ pub enum Expr {
         elts: Vec<Node<Expr>>,
     },
     Bool(bool),
-    Name(String),
+    Name(SmolStr),
     Path(Path),
-    Num(String),
-    Str(String),
+    Num(SmolStr),
+    Str(SmolStr),
     Unit,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CallArg {
-    pub label: Option<Node<String>>,
+    pub label: Option<Node<SmolStr>>,
     pub value: Node<Expr>,
 }
 
@@ -463,7 +464,7 @@ impl fmt::Display for Path {
         let joined_names = self
             .segments
             .iter()
-            .map(|name| name.kind.to_string())
+            .map(|name| name.kind.as_ref())
             .collect::<Vec<_>>()
             .join("::");
         write!(f, "{}", joined_names)?;

--- a/crates/parser/src/grammar/contracts.rs
+++ b/crates/parser/src/grammar/contracts.rs
@@ -106,7 +106,7 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<Contract>> {
     let span = header_span + fields.last() + defs.last();
     Ok(Node::new(
         Contract {
-            name: Node::new(contract_name.text.to_string(), contract_name.span),
+            name: Node::new(contract_name.text.into(), contract_name.span),
             fields,
             body: defs,
         },

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -355,12 +355,12 @@ fn atom(par: &mut Parser, tok: &Token) -> Node<Expr> {
     use TokenKind::*;
 
     let expr = match tok.kind {
-        Name | SelfValue => Expr::Name(tok.text.to_owned()),
-        Int | Hex | Octal | Binary => Expr::Num(tok.text.to_owned()),
+        Name | SelfValue => Expr::Name(tok.text.into()),
+        Int | Hex | Octal | Binary => Expr::Num(tok.text.into()),
         True | False => Expr::Bool(tok.kind == True),
         Text => {
             if let Some(string) = unescape_string(tok.text) {
-                Expr::Str(string)
+                Expr::Str(string.into())
             } else {
                 par.error(tok.span, "String contains an invalid escape sequence");
                 Expr::Str(tok.text.into())

--- a/crates/parser/src/grammar/functions.rs
+++ b/crates/parser/src/grammar/functions.rs
@@ -480,8 +480,13 @@ pub fn parse_emit_statement(par: &mut Parser) -> ParseResult<Node<FuncStmt>> {
         let args = parse_call_args(par)?;
         par.expect_newline("emit statement")?;
         let span = emit_tok.span + args.span;
-        let name = Node::new(event_name.text.to_string(), event_name.span);
-        return Ok(Node::new(FuncStmt::Emit { name, args }, span));
+        return Ok(Node::new(
+            FuncStmt::Emit {
+                name: event_name.into(),
+                args,
+            },
+            span,
+        ));
     } else {
         par.expect(
             TokenKind::ParenOpen,

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -199,12 +199,10 @@ pub fn parse_use_tree(par: &mut Parser) -> ParseResult<Node<UseTree>> {
         par.next()?;
 
         let rename_tok = par.expect(TokenKind::Name, "failed to parse `use` tree")?;
-        let rename = Some(Node::new(rename_tok.text.to_string(), rename_tok.span));
+        let span = path_span + rename_tok.span;
+        let rename = Some(rename_tok.into());
 
-        Ok(Node::new(
-            UseTree::Simple { path, rename },
-            path_span + rename_tok.span,
-        ))
+        Ok(Node::new(UseTree::Simple { path, rename }, span))
     } else {
         Ok(Node::new(UseTree::Simple { path, rename: None }, path_span))
     }
@@ -243,7 +241,7 @@ pub fn parse_pragma(par: &mut Parser) -> ParseResult<Node<Pragma>> {
     match VersionReq::parse(&version_string) {
         Ok(_) => Ok(Node::new(
             Pragma {
-                version_requirement: Node::new(version_string, version_requirement_span),
+                version_requirement: Node::new(version_string.into(), version_requirement_span),
             },
             tok.span + version_requirement_span,
         )),

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -6,6 +6,7 @@ use crate::Token;
 use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 use fe_common::diagnostics::Label;
 use if_chain::if_chain;
+use smol_str::SmolStr;
 use vec1::Vec1;
 
 /// Parse a [`ModuleStmt::Struct`].
@@ -148,7 +149,7 @@ pub fn parse_event_field(par: &mut Parser) -> ParseResult<Node<EventField>> {
     Ok(Node::new(
         EventField {
             is_idx: idx_qual.is_some(),
-            name: Node::new(name.text.into(), name.span),
+            name: name.into(),
             typ,
         },
         span,
@@ -202,7 +203,7 @@ pub fn parse_field(
         Field {
             is_pub: pub_qual.is_some(),
             is_const: const_qual.is_some(),
-            name: Node::new(name.text.into(), name.span),
+            name: name.into(),
             typ,
             value,
         },
@@ -299,7 +300,7 @@ pub fn parse_generic_args(par: &mut Parser) -> ParseResult<Node<Vec<GenericArg>>
 /// Returns path and trailing `::` token, if present.
 pub fn parse_path_tail<'a>(
     par: &mut Parser<'a>,
-    head: Node<String>,
+    head: Node<SmolStr>,
 ) -> (Path, Span, Option<Token<'a>>) {
     let mut span = head.span;
     let mut segments = vec![head];
@@ -436,7 +437,7 @@ pub fn parse_type_desc(par: &mut Parser) -> ParseResult<Node<TypeDesc>> {
                 );
                 typ = Node::new(
                     TypeDesc::Generic {
-                        base: Node::new("Array".to_string(), typ.span),
+                        base: Node::new("Array".into(), typ.span),
                         args: Node::new(vec![
                             GenericArg::TypeDesc(
                                 Node::new(typ.kind, typ.span)

--- a/crates/parser/src/lexer/token.rs
+++ b/crates/parser/src/lexer/token.rs
@@ -1,5 +1,7 @@
-use crate::node::{Node, Span};
+use crate::node::Node;
+use crate::node::Span;
 use logos::Logos;
+use smol_str::SmolStr;
 use std::ops::Add;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -9,8 +11,8 @@ pub struct Token<'a> {
     pub span: Span,
 }
 
-impl<'a> From<Token<'a>> for Node<String> {
-    fn from(tok: Token<'a>) -> Node<String> {
+impl<'a> From<Token<'a>> for Node<SmolStr> {
+    fn from(tok: Token<'a>) -> Node<SmolStr> {
         Node::new(tok.text.into(), tok.span)
     }
 }

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -1,13 +1,14 @@
 pub use fe_common::{Span, Spanned};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 #[derive(Debug, PartialEq, Copy, Clone, Hash, Eq, Default, PartialOrd, Ord)]
-pub struct NodeId(Uuid);
+pub struct NodeId(u32);
 
 impl NodeId {
     pub fn create() -> Self {
-        Self(Uuid::new_v4())
+        static NEXT_ID: AtomicU32 = AtomicU32::new(0);
+        Self(NEXT_ID.fetch_add(1, Ordering::Relaxed))
     }
 }
 

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -22,5 +22,8 @@ serde_json = "1.0.64"
 solc = {git = "https://github.com/g-r-a-n-t/solc-rust", optional = true}
 yultsur = {git = "https://github.com/g-r-a-n-t/yultsur"}
 
+# used by ethabi, we need to force the js feature for wasm support
+getrandom = { version = "0.2.3", features = ["js"] }
+
 [features]
 solc-backend = ["fe-yulc", "solc"]

--- a/crates/yulgen/src/db/queries/contracts.rs
+++ b/crates/yulgen/src/db/queries/contracts.rs
@@ -8,6 +8,7 @@ use fe_analyzer::namespace::items::{walk_local_dependencies, ContractId, DepGrap
 use fe_analyzer::namespace::types::FixedSize;
 use fe_common::utils::keccak;
 use indexmap::IndexSet;
+use smol_str::SmolStr;
 use std::convert::TryInto;
 use yultsur::*;
 
@@ -79,12 +80,7 @@ pub fn contract_abi_dispatcher(db: &dyn YulgenDb, contract: ContractId) -> Vec<y
             let bare_name = id.name(adb);
             let qualified_name = db.function_yul_name(*id);
             let (param_types, return_type) = db.function_sig_abi_types(*id);
-            (
-                bare_name,
-                qualified_name.to_string(),
-                param_types,
-                return_type,
-            )
+            (bare_name, qualified_name, param_types, return_type)
         })
         .collect::<Vec<_>>();
 
@@ -114,7 +110,7 @@ fn build_dependency_graph(
 ) -> (Vec<yul::Statement>, Vec<yul::Data>, Vec<yul::Object>) {
     let adb = db.upcast(); // AnalyzerDb
 
-    let mut string_literals = IndexSet::<String>::new();
+    let mut string_literals = IndexSet::<SmolStr>::new();
     let mut created_contracts = IndexSet::<ContractId>::new();
 
     // We need all of the "std" yul functions,
@@ -181,7 +177,7 @@ fn build_dependency_graph(
         .into_iter()
         .map(|string| yul::Data {
             name: keccak::full(string.as_bytes()),
-            value: string,
+            value: string.to_string(),
         })
         .collect();
 

--- a/crates/yulgen/src/db/queries/structs.rs
+++ b/crates/yulgen/src/db/queries/structs.rs
@@ -128,7 +128,7 @@ pub fn struct_api_fns(db: &dyn YulgenDb, struct_: StructId) -> Vec<yul::Statemen
         struct_
             .fields(db.upcast())
             .keys()
-            .map(|name| db.struct_getter_fn(struct_, name.into()))
+            .map(|name| db.struct_getter_fn(struct_, name.clone()))
             .collect(),
     ]
     .concat()

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -17,6 +17,7 @@ use fe_common::utils::keccak;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use num_bigint::BigInt;
+use smol_str::SmolStr;
 use std::convert::TryFrom;
 use std::str::FromStr;
 use yultsur::*;
@@ -354,7 +355,7 @@ pub fn expr_unary_operation(context: &mut FnContext, exp: &Node<fe::Expr>) -> yu
 }
 
 /// Retrieves the String value of a name expression.
-pub fn expr_name_string(exp: &Node<fe::Expr>) -> String {
+pub fn expr_name_string(exp: &Node<fe::Expr>) -> SmolStr {
     if let fe::Expr::Name(name) = &exp.kind {
         return name.to_owned();
     }

--- a/crates/yulgen/src/mappers/module.rs
+++ b/crates/yulgen/src/mappers/module.rs
@@ -13,7 +13,7 @@ pub fn module(db: &dyn YulgenDb, module: ModuleId) -> YulContracts {
             let yul_contract = db.contract_object(*id);
 
             if contracts
-                .insert(id.name(db.upcast()), yul_contract)
+                .insert(id.name(db.upcast()).to_string(), yul_contract)
                 .is_some()
             {
                 panic!("duplicate contract definition");

--- a/crates/yulgen/src/runtime/abi_dispatcher.rs
+++ b/crates/yulgen/src/runtime/abi_dispatcher.rs
@@ -2,11 +2,12 @@ use crate::names::abi as abi_names;
 use crate::operations::abi as abi_operations;
 use crate::types::{to_abi_selector_names, AbiDecodeLocation, AbiType};
 use fe_abi::utils as abi_utils;
+use smol_str::SmolStr;
 use yultsur::*;
 
 /// Builds a switch statement that dispatches calls to the contract.
 pub fn dispatcher(
-    functions: &[(String, String, impl AsRef<[AbiType]>, Option<AbiType>)],
+    functions: &[(SmolStr, SmolStr, impl AsRef<[AbiType]>, Option<AbiType>)],
 ) -> yul::Statement {
     let arms = functions
         .iter()

--- a/crates/yulgen/tests/yulgen.rs
+++ b/crates/yulgen/tests/yulgen.rs
@@ -5,6 +5,7 @@ use fe_yulgen::runtime::abi_dispatcher;
 use fe_yulgen::runtime::functions::{abi as abi_functions, revert as revert_functions};
 use fe_yulgen::types::{AbiDecodeLocation, AbiType};
 use insta::assert_display_snapshot;
+use smol_str::SmolStr;
 use wasm_bindgen_test::wasm_bindgen_test;
 use yultsur::*;
 
@@ -28,17 +29,17 @@ macro_rules! test_yulgen {
 // constructor
 test_yulgen! { constructor_no_init,  constructor::build() }
 
-fn functions() -> Vec<(String, String, Vec<AbiType>, Option<AbiType>)> {
+fn functions() -> Vec<(SmolStr, SmolStr, Vec<AbiType>, Option<AbiType>)> {
     vec![
         (
-            "hello_world".to_string(),
-            "$$somemod$hello_world".to_string(),
+            "hello_world".into(),
+            "$$somemod$hello_world".into(),
             vec![],
             Some(AbiType::String { max_size: 42 }),
         ),
         (
-            "add".to_string(),
-            "$$somemod$add".to_string(),
+            "add".into(),
+            "$$somemod$add".into(),
             vec![AbiType::Uint { size: 32 }, AbiType::Uint { size: 32 }],
             Some(AbiType::Uint { size: 32 }),
         ),


### PR DESCRIPTION
### What was wrong?

```
parse_uniswap           time:   [5.5317 ms 5.5724 ms 5.6175 ms]                          
clone_ast               time:   [146.20 us 147.06 us 148.00 us]                      
analyze uniswap         time:   [1.3687 ms 1.3788 ms 1.3894 ms]                             
```

### How was it fixed?

```
parse_uniswap           time:   [252.10 us 254.47 us 256.97 us]                          
                        change: [-95.455% -95.391% -95.324%] (p = 0.00 < 0.05)

clone_ast               time:   [78.725 us 79.315 us 79.954 us]                      
                        change: [-47.624% -46.448% -45.283%] (p = 0.00 < 0.05)

analyze uniswap         time:   [1.1384 ms 1.1481 ms 1.1590 ms]                             
                        change: [-18.654% -15.780% -12.782%] (p = 0.00 < 0.05)
```

Most of the parsing speedup came from changing `NodeId` from `Uuid::new_v4()` to a u32 (generated by incrementing a static atomic). 5.5ms -> 320us. Replacing Strings in the AST with SmolStr brought it down to 255us, and made AST cloning cheaper.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
