### PR TITLE
Remove ternary runtime function

### DIFF
--- a/crates/tests/src/runtime.rs
+++ b/crates/tests/src/runtime.rs
@@ -217,22 +217,6 @@ fn test_runtime_ceil32() {
 }
 
 #[test]
-fn test_runtime_ternary() {
-    with_executor(&|mut executor| {
-        Runtime::default()
-            .with_test_statements(statements! {
-                (let a := ternary(0, 42, 26))
-                (let b := ternary(1, 42, 26))
-
-                [assert_eq!(a, 26)]
-                [assert_eq!(b, 42)]
-            })
-            .execute(&mut executor)
-            .expect_success();
-    })
-}
-
-#[test]
 fn test_runtime_abi_unpack() {
     with_executor(&|mut executor| {
         Runtime::default()

--- a/crates/yulgen/src/runtime/functions/data.rs
+++ b/crates/yulgen/src/runtime/functions/data.rs
@@ -26,7 +26,6 @@ pub fn all() -> Vec<yul::Statement> {
         set_zero(),
         sloadn(),
         sstoren(),
-        ternary(),
     ]
 }
 
@@ -352,19 +351,6 @@ pub fn map_value_ptr() -> yul::Statement {
             (mstore((add(ptr, 32)), b))
             (let hash := keccak256(ptr, 64))
             (return_val := set_zero(248, 256, hash))
-        }
-    }
-}
-
-/// Evaluates the ternary expression and returns the result.
-pub fn ternary() -> yul::Statement {
-    function_definition! {
-        function ternary(test, if_expr, else_expr) -> result {
-            ([switch! {
-                switch test
-                (case 1 {(result := if_expr)})
-                (case 0 {(result := else_expr)})
-            }])
         }
     }
 }


### PR DESCRIPTION
### What was wrong?

The `ternary` runtime function should have been deleted in the PR that lowers ternary expressions to `if`/ `else` statements but it wasn't.

### How was it fixed?

Deleted dead code