### PR TITLE
Fix typo in expressions.rs

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -167,7 +167,7 @@ pub fn value_expr(
 
 /// Gather context information for expressions and check for type errors.
 ///
-/// Also ensures that the expression is in the type's assigment location.
+/// Also ensures that the expression is in the type's assignment location.
 pub fn assignable_expr(
     scope: &mut BlockScope,
     exp: &Node<fe::Expr>,


### PR DESCRIPTION


### What was wrong?

comment typo

### How was it fixed?


assigment -> assignment