### PR TITLE
Update solc to 0.8.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/solc-rust#fcb910596c2b22d607970b2ba64229fe02e98e54"
+source = "git+https://github.com/sbillig/solc-rust#f899c2f9dafd5b735fb31cf5b9ae6f23a3800dc5"
 dependencies = [
  "bindgen",
  "cmake",

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -19,7 +19,7 @@ test-files = {path = "../test-files", package = "fe-test-files" }
 hex = "0.4"
 primitive-types = {version = "0.9", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"
-solc = {git = "https://github.com/g-r-a-n-t/solc-rust", optional = true}
+solc = {git = "https://github.com/sbillig/solc-rust", branch = "solc-0.8.10", optional = true}
 yultsur = {git = "https://github.com/g-r-a-n-t/yultsur"}
 
 # used by ethabi, we need to force the js feature for wasm support

--- a/crates/yulc/Cargo.toml
+++ b/crates/yulc/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ethereum/fe"
 [dependencies]
 fe-yulgen = {path = "../yulgen", version = "^0.11.0-alpha"}
 # This fork supports concurrent compilation, which is required for Rust tests.
-solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true}
+solc = { git = "https://github.com/sbillig/solc-rust", branch = "solc-0.8.10", optional = true}
 serde_json = "1.0"
 indexmap = "1.6.2"
 

--- a/crates/yulc/src/lib.rs
+++ b/crates/yulc/src/lib.rs
@@ -72,5 +72,7 @@ fn test_solc_sanity() {
         .to_string()
         .replace("\"", "");
 
-    assert_eq!(bytecode, "6000600055", "incorrect bytecode",);
+    // solc 0.8.4:  push1 0; push1 0; sstore  "6000600055"
+    // solc 0.8.10: push1 0; dup1; sstore     "60008055"
+    assert_eq!(bytecode, "60008055", "incorrect bytecode",);
 }


### PR DESCRIPTION
### What was wrong?

Closes #108

We were using solc 0.8.4, which doesn't support the (London) basefee opcode.

### How was it fixed?

Updated solc to 0.8.10

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
