### PR TITLE
Use specific commit for solc-rust (solc 0.8.4) and yultsur (latest)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/solc-rust#fcb910596c2b22d607970b2ba64229fe02e98e54"
+source = "git+https://github.com/g-r-a-n-t/solc-rust?rev=fcb9105#fcb910596c2b22d607970b2ba64229fe02e98e54"
 dependencies = [
  "bindgen",
  "cmake",

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -19,7 +19,7 @@ test-files = {path = "../test-files", package = "fe-test-files" }
 hex = "0.4"
 primitive-types = {version = "0.9", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"
-solc = {git = "https://github.com/g-r-a-n-t/solc-rust", optional = true}
+solc = {git = "https://github.com/g-r-a-n-t/solc-rust", rev = "fcb9105", optional = true}
 yultsur = {git = "https://github.com/g-r-a-n-t/yultsur"}
 
 # used by ethabi, we need to force the js feature for wasm support

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4"
 primitive-types = {version = "0.9", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"
 solc = {git = "https://github.com/g-r-a-n-t/solc-rust", rev = "fcb9105", optional = true}
-yultsur = {git = "https://github.com/g-r-a-n-t/yultsur"}
+yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 
 # used by ethabi, we need to force the js feature for wasm support
 getrandom = { version = "0.2.3", features = ["js"] }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -26,7 +26,7 @@ primitive-types = {version = "0.9", default-features = false, features = ["rlp"]
 rand = "0.7.3"
 rstest = "0.6.4"
 # This fork contains the shorthand macros and some other necessary updates.
-yultsur = {git = "https://github.com/g-r-a-n-t/yultsur"}
+yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 insta = "1.7.1"
 pretty_assertions = "0.7.2"
 wasm-bindgen-test = "0.3.24"

--- a/crates/yulc/Cargo.toml
+++ b/crates/yulc/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/ethereum/fe"
 [dependencies]
 fe-yulgen = {path = "../yulgen", version = "^0.11.0-alpha"}
 # This fork supports concurrent compilation, which is required for Rust tests.
-solc = { git = "https://github.com/g-r-a-n-t/solc-rust", optional = true}
+solc = { git = "https://github.com/g-r-a-n-t/solc-rust", rev = "fcb9105", optional = true}
 serde_json = "1.0"
 indexmap = "1.6.2"
 

--- a/crates/yulgen/Cargo.toml
+++ b/crates/yulgen/Cargo.toml
@@ -18,7 +18,7 @@ num-bigint = "0.4.0"
 salsa = "0.16.1"
 
 # This fork contains the shorthand macros and some other necessary updates.
-yultsur = { git = "https://github.com/g-r-a-n-t/yultsur"}
+yultsur = { git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 smol_str = "0.1.21"
 
 [dev-dependencies]


### PR DESCRIPTION
### What was wrong?

The build of the latest solc-rust commit is broken on gh workflow's mac environment.

We should be using a specific git revision id for all git dependencies anyway, so that we have control of when exactly the changes to those repositories land in fe.

### How was it fixed?

Specified a git "rev" for the solc-rust and yultsur dependencies. solc-rust is set to the commit that uses solc 0.8.4 for now.

(See https://github.com/ethereum/solidity/pull/12408)