### PR TITLE
Fix feature flags in test & test-utils

### DIFF
--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -26,4 +26,4 @@ yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 getrandom = { version = "0.2.3", features = ["js"] }
 
 [features]
-solc-backend = ["fe-yulc", "solc"]
+solc-backend = ["fe-yulc", "solc", "fe-driver/solc-backend"]

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -32,7 +32,7 @@ pretty_assertions = "0.7.2"
 wasm-bindgen-test = "0.3.24"
 
 [features]
-solc-backend = ["fe-yulc/solc-backend"]
+solc-backend = ["fe-yulc/solc-backend", "fe-compiler-test-utils/solc-backend"]
 
 [dev-dependencies.proptest]
 version = "1.0.0"


### PR DESCRIPTION


### What was wrong?
Running only the `fe-compiler-tests` with `cargo test -p fe-compiler-tests --features solc-backend` fails because the `solc-backend` feature did not enable that feature in `test-utils`. Further, `test-utils` depends on `solc-backend` being enabled in `fe-driver` in the situation that `test-utils/solc-backend` is enabled. 


### How was it fixed?
Added relevant features in `tests` and `test-utils` crate to enable the same conditional features in appropriate dependencies. 

