### PR TITLE
CI speedup

### DIFF
--- a/.github/workflows/expensive.yml
+++ b/.github/workflows/expensive.yml
@@ -2,7 +2,7 @@ name: Expensive
 
 on:
   schedule:
-    - cron:  '*/30 * * * *'
+    - cron:  '*/60 * * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,42 +10,29 @@ env:
 jobs:
   test:
     # Build & Test runs on all platforms
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
-      - name: Cache Rust dependencies
-        uses: actions/cache@v1.1.2
-        with:
-          # There's a problem with caching serde, hence we exclude it here
-          path: |
-            target
-            !target/**/*serde*
-          key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install Mac System dependencies
-        if: startsWith(matrix.os,'macOS')
+      - name: Install system dependencies
         run: |
-          brew install boost
-      - name: Install Linux dependencies
-        if: startsWith(matrix.os,'ubuntu')
-        run: |
-          "${GITHUB_WORKSPACE}/.github/install_deps.sh"
+          sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+
       - name: Build
-        run: cargo build --all-features --verbose
+        run: cargo test --workspace --all-features --no-run --locked -- --ignored
       - name: Run expensive tests
         id: expensive_tests
-        run: cargo test --workspace --features solc-backend --verbose -- --ignored
+        run: cargo test --workspace --all-features --verbose -- --ignored
       - name: Report
         if: failure() && steps.expensive_tests.outcome == 'failure'
         run: |
           cat ./crates/tests/proptest-regressions/differential.txt
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install system dependencies
         run: |
-          "${GITHUB_WORKSPACE}/.github/install_deps.sh"
+          sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
@@ -30,9 +30,12 @@ jobs:
           override: true
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
+      - name: install cargo-tarpaulin
+        run: |
+          cargo install cargo-quickinstall
+          cargo quickinstall cargo-tarpaulin
       - name: coverage with tarpaulin
         run: |
-          cargo install cargo-tarpaulin
           make coverage
           bash <(curl -s https://codecov.io/bash)
 
@@ -42,15 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install system dependencies
         run: |
-          "${GITHUB_WORKSPACE}/.github/install_deps.sh"
-      - name: Cache Rust dependencies
-        uses: actions/cache@v1.1.2
-        with:
-          # There's a problem with caching serde, hence we exclude it here
-          path: |
-            target
-            !target/**/*serde*
-          key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
+          sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
@@ -92,7 +87,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
-          "${GITHUB_WORKSPACE}/.github/install_deps.sh"
+          sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
@@ -117,6 +112,10 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+      - name: Build WASM tests
+        run: wasm-pack test --node crates/fe -- --workspace --no-run
       - name: Run WASM tests
         # wasm-pack needs a Cargo.toml with a 'package' field.
         # (see https://github.com/rustwasm/wasm-pack/issues/642)
@@ -142,7 +141,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
-          "${GITHUB_WORKSPACE}/.github/install_deps.sh"
+          sudo apt-get install -y libboost-all-dev
       - name: Install Mac System dependencies
         if: startsWith(matrix.os,'macOS')
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   coverage:
@@ -20,20 +22,14 @@ jobs:
       - name: Install system dependencies
         run: |
           "${GITHUB_WORKSPACE}/.github/install_deps.sh"
-      - name: Cache Rust dependencies
-        uses: actions/cache@v1.1.2
-        with:
-          # There's a problem with caching serde, hence we exclude it here
-          path: |
-            target
-            !target/**/*serde*
-          key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
       - name: coverage with tarpaulin
         run: |
           cargo install cargo-tarpaulin
@@ -62,6 +58,8 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
       - name: Validate doc examples
         run: ./docs/validate_doc_examples.py
       - name: Validate release notes entry
@@ -87,14 +85,6 @@ jobs:
           - os: macOS-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cache Rust dependencies
-        uses: actions/cache@v1.1.2
-        with:
-          # There's a problem with caching serde, hence we exclude it here
-          path: |
-            target
-            !target/**/*serde*
-          key: ${{ runner.OS }}-build-v2-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Mac System dependencies
         if: startsWith(matrix.os,'macOS')
         run: |
@@ -109,10 +99,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
       - name: Build
-        run: cargo build --all-features --verbose
+        run: cargo test --workspace --all-features --no-run --locked
       - name: Run tests
-        run: cargo test --workspace --features solc-backend --verbose
+        run: cargo test --workspace --all-features --verbose
 
   wasm-test:
       runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ members = ["crates/*"]
 
 [profile.dev.package.solc]
 opt-level = 3
+
+[profile.dev]
+# Speeds up the build. May need to diable for debugging.
+debug = 0

--- a/docs/validate_doc_examples.py
+++ b/docs/validate_doc_examples.py
@@ -73,7 +73,7 @@ def create_fe_file(snippet: CodeSnippet) -> pathlib.Path:
     return fe_snippet_path
 
 def run_snippet(path: pathlib.Path) -> 'subprocess.CompletedProcess[bytes]':
-    return subprocess.run(["cargo", "run", "--features", "solc-backend", str(path), '--overwrite'])
+    return subprocess.run(["cargo", "run", str(path), '--overwrite'])
 
 def validate_code_examples() -> None:
     TMP_SNIPPET_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
### What was wrong?

Github CI builds are slow.

### How was it fixed?

The rust-cache action is doing most of the work here, but I made a few other tweaks too. The test jobs now take 2-3 minutes instead of 20-25. Installing boost is about a third of this. I had been using an apt cache action, but then the coverage build failed mysteriously on a failure to find boost, so I scrapped that. I'll either revisit that someday, or maybe just install the few boost libs that solc actually uses.

The coverage job is still slow (~20min now instead of 35). I'm tempted to remove it from the PR workflow so that finishes quickly, and just let it run on merges to master or something. We aren't using coverage stats to judge the test cases of PRs anyway.

Oh, I bumped the proptest job to run every 60 minutes, just to reduce our resource consumption a bit. I'm not attached to this, it just felt like a reasonable thing to do. They are now running much more quickly overall (~6min iirc), thanks to the build speedup. We should, however, speed up the proptest code. Grant demonstrated that 95% of the time is spent building/deploying the contracts over and over again, so a 20x perf improvement should be possible with some refactoring of the test utils.