### PR TITLE
Module Item Visibility

### DIFF
--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -25,6 +25,7 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
     let ast::Event {
         name: event_name,
         fields: field_nodes,
+        pub_qual: pub_qual
     } = &event.data(db).ast.kind;
 
     let mut names = HashMap::new();

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -25,7 +25,7 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
     let ast::Event {
         name: event_name,
         fields: field_nodes,
-        pub_qual: pub_qual
+        pub_qual: _,
     } = &event.data(db).ast.kind;
 
     let mut names = HashMap::new();

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -86,6 +86,7 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<Vec<Item>> 
             }
             ast::ModuleStmt::Pragma(_) => None,
             ast::ModuleStmt::Use(_) => None,
+            ast::ModuleStmt::Event(_) => todo!(),
         })
         .collect();
     Rc::new(items)

--- a/crates/lowering/src/mappers/contracts.rs
+++ b/crates/lowering/src/mappers/contracts.rs
@@ -38,6 +38,7 @@ pub fn contract_def(context: &mut ModuleContext, contract: ContractId) -> Node<a
             name: node.kind.name.clone(),
             fields,
             body: [events, functions].concat(),
+            pub_qual: None,
         },
         node.span,
     )

--- a/crates/lowering/src/mappers/contracts.rs
+++ b/crates/lowering/src/mappers/contracts.rs
@@ -90,6 +90,7 @@ fn event_def(context: &mut ModuleContext, event: EventId) -> Node<ast::Event> {
         ast::Event {
             name: node.kind.name.clone(),
             fields,
+            pub_qual: None,
         },
         node.span,
     )

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -37,6 +37,7 @@ pub fn module(db: &dyn AnalyzerDb, module: ModuleId) -> ast::Module {
                             node.kind.typ.clone(),
                             &id.typ(db).expect("type alias error"),
                         ),
+                        pub_qual: None,
                     },
                     id.span(db),
                 )))

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -103,6 +103,7 @@ fn build_tuple_struct(tuple: &Tuple) -> ast::Struct {
         name: names::tuple_struct_name(tuple).into_node(),
         fields,
         functions: vec![],
+        pub_qual: None,
     }
 }
 

--- a/crates/lowering/src/mappers/structs.rs
+++ b/crates/lowering/src/mappers/structs.rs
@@ -25,6 +25,7 @@ pub fn struct_def(context: &mut ModuleContext, struct_: StructId) -> Node<ast::S
             name: node.kind.name.clone(),
             fields,
             functions,
+            pub_qual: None,
         },
         node.span,
     )

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -78,6 +78,7 @@ pub struct Struct {
     pub name: Node<String>,
     pub fields: Vec<Node<Field>>,
     pub functions: Vec<Node<Function>>,
+    pub pub_qual: Option<Span>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -21,6 +21,7 @@ pub enum ModuleStmt {
     Constant(Box<Node<ConstantDecl>>),
     Struct(Node<Struct>),
     Function(Node<Function>),
+    Event(Node<Event>),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -138,6 +139,7 @@ pub enum ContractStmt {
 pub struct Event {
     pub name: Node<String>,
     pub fields: Vec<Node<EventField>>,
+    pub pub_qual: Option<Span>
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -398,6 +400,7 @@ impl Spanned for ModuleStmt {
             ModuleStmt::Constant(inner) => inner.span,
             ModuleStmt::Struct(inner) => inner.span,
             ModuleStmt::Function(inner) => inner.span,
+            ModuleStmt::Event(inner) => inner.span,
         }
     }
 }
@@ -427,6 +430,7 @@ impl fmt::Display for ModuleStmt {
             ModuleStmt::Constant(node) => write!(f, "{}", node.kind),
             ModuleStmt::Struct(node) => write!(f, "{}", node.kind),
             ModuleStmt::Function(node) => write!(f, "{}", node.kind),
+            ModuleStmt::Event(node) => write!(f, "{}", node.kind),
         }
     }
 }

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -64,6 +64,7 @@ pub struct ConstantDecl {
 pub struct TypeAlias {
     pub name: Node<String>,
     pub typ: Node<TypeDesc>,
+    pub pub_qual: Option<Span>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -71,6 +72,7 @@ pub struct Contract {
     pub name: Node<String>,
     pub fields: Vec<Node<Field>>,
     pub body: Vec<ContractStmt>,
+    pub pub_qual: Option<Span>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -139,7 +139,7 @@ pub enum ContractStmt {
 pub struct Event {
     pub name: Node<String>,
     pub fields: Vec<Node<EventField>>,
-    pub pub_qual: Option<Span>
+    pub pub_qual: Option<Span>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]

--- a/crates/parser/src/grammar/contracts.rs
+++ b/crates/parser/src/grammar/contracts.rs
@@ -73,7 +73,7 @@ pub fn parse_contract_def(par: &mut Parser, contract_pub_qual: Option<Span>) -> 
             }
             Some(TokenKind::Event) => {
                 if let Some(span) = pub_qual {
-                    par.error(span, "`pub` qualifier can't be used with event definitions");
+                    par.error(span, "`pub` qualifier can't be used with contract-level event definitions");
                 }
                 if let Some(span) = const_qual {
                     par.error(
@@ -81,7 +81,7 @@ pub fn parse_contract_def(par: &mut Parser, contract_pub_qual: Option<Span>) -> 
                         "`const` qualifier can't be used with event definitions",
                     );
                 }
-                defs.push(ContractStmt::Event(parse_event_def(par)?));
+                defs.push(ContractStmt::Event(parse_event_def(par, None)?));
             }
             Some(TokenKind::Pass) => {
                 parse_single_word_stmt(par)?;

--- a/crates/parser/src/grammar/contracts.rs
+++ b/crates/parser/src/grammar/contracts.rs
@@ -16,6 +16,7 @@ use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 /// # Panics
 /// Panics if the next token isn't `contract`.
 pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<Contract>> {
+    let pub_qual = par.optional(TokenKind::Pub).map(|tok| tok.span);
     let contract_tok = par.assert(TokenKind::Contract);
 
     // contract Foo:
@@ -103,12 +104,13 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<Contract>> {
         };
     }
 
-    let span = header_span + fields.last() + defs.last();
+    let span = header_span + pub_qual + fields.last() + defs.last();
     Ok(Node::new(
         Contract {
             name: Node::new(contract_name.text.to_string(), contract_name.span),
             fields,
             body: defs,
+            pub_qual,
         },
         span,
     ))

--- a/crates/parser/src/grammar/contracts.rs
+++ b/crates/parser/src/grammar/contracts.rs
@@ -3,7 +3,7 @@ use super::types::{parse_event_def, parse_field, parse_opt_qualifier};
 
 use crate::ast::{Contract, ContractStmt};
 use crate::grammar::functions::parse_single_word_stmt;
-use crate::node::Node;
+use crate::node::{Node, Span};
 use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 
 // Rule: all "statement" level parse functions consume their trailing
@@ -15,8 +15,7 @@ use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 /// Parse a contract definition.
 /// # Panics
 /// Panics if the next token isn't `contract`.
-pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<Contract>> {
-    let pub_qual = par.optional(TokenKind::Pub).map(|tok| tok.span);
+pub fn parse_contract_def(par: &mut Parser, contract_pub_qual: Option<Span>) -> ParseResult<Node<Contract>> {
     let contract_tok = par.assert(TokenKind::Contract);
 
     // contract Foo:
@@ -104,13 +103,13 @@ pub fn parse_contract_def(par: &mut Parser) -> ParseResult<Node<Contract>> {
         };
     }
 
-    let span = header_span + pub_qual + fields.last() + defs.last();
+    let span = header_span + contract_pub_qual + fields.last() + defs.last();
     Ok(Node::new(
         Contract {
             name: Node::new(contract_name.text.to_string(), contract_name.span),
             fields,
             body: defs,
-            pub_qual,
+            pub_qual: contract_pub_qual,
         },
         span,
     ))

--- a/crates/parser/src/grammar/contracts.rs
+++ b/crates/parser/src/grammar/contracts.rs
@@ -15,7 +15,10 @@ use crate::{ParseFailed, ParseResult, Parser, TokenKind};
 /// Parse a contract definition.
 /// # Panics
 /// Panics if the next token isn't `contract`.
-pub fn parse_contract_def(par: &mut Parser, contract_pub_qual: Option<Span>) -> ParseResult<Node<Contract>> {
+pub fn parse_contract_def(
+    par: &mut Parser,
+    contract_pub_qual: Option<Span>,
+) -> ParseResult<Node<Contract>> {
     let contract_tok = par.assert(TokenKind::Contract);
 
     // contract Foo:
@@ -73,7 +76,10 @@ pub fn parse_contract_def(par: &mut Parser, contract_pub_qual: Option<Span>) -> 
             }
             Some(TokenKind::Event) => {
                 if let Some(span) = pub_qual {
-                    par.error(span, "`pub` qualifier can't be used with contract-level event definitions");
+                    par.error(
+                        span,
+                        "`pub` qualifier can't be used with contract-level event definitions",
+                    );
                 }
                 if let Some(span) = const_qual {
                     par.error(

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -1,7 +1,7 @@
 use super::contracts::parse_contract_def;
 use super::expressions::parse_expr;
 use super::functions::parse_fn_def;
-use super::types::{parse_path_tail, parse_struct_def, parse_type_alias, parse_type_desc};
+use super::types::{parse_path_tail, parse_struct_def, parse_type_alias, parse_type_desc, parse_event_def};
 use crate::ast::{ConstantDecl, Module, ModuleStmt, Pragma, Use, UseTree};
 use crate::node::{Node, Span};
 use crate::{Label, ParseFailed, ParseResult, Parser, TokenKind};
@@ -40,11 +40,14 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
         TokenKind::Const => ModuleStmt::Constant(Box::new(parse_constant(par)?)),
 
         // Let these be parse errors for now:
-        // TokenKind::Event => todo!("module-level event def"),
+         TokenKind::Event => ModuleStmt::Event(parse_event_def(par, None)?),
         // TokenKind::Name if par.peeked_text() == "from" => parse_from_import(par),
         TokenKind::Pub => {
             let pub_span = par.next()?.span;
             match par.peek_or_err()? {
+                TokenKind::Event => {
+                    ModuleStmt::Event(parse_event_def(par, Some(pub_span))?)
+                },
                 TokenKind::Fn | TokenKind::Unsafe => {
                     ModuleStmt::Function(parse_fn_def(par, Some(pub_span))?)
                 },

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -35,7 +35,7 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
         TokenKind::Pragma => ModuleStmt::Pragma(parse_pragma(par)?),
         TokenKind::Use => ModuleStmt::Use(parse_use(par)?),
         TokenKind::Contract => ModuleStmt::Contract(parse_contract_def(par)?),
-        TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par)?),
+        TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par, None)?),
         TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par)?),
         TokenKind::Const => ModuleStmt::Constant(Box::new(parse_constant(par)?)),
 
@@ -47,6 +47,9 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
             match par.peek_or_err()? {
                 TokenKind::Fn | TokenKind::Unsafe => {
                     ModuleStmt::Function(parse_fn_def(par, Some(pub_span))?)
+                },
+                TokenKind::Struct => {
+                    ModuleStmt::Struct(parse_struct_def(par, Some(pub_span))?)
                 }
                 _ => {
                     let tok = par.next()?;

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -1,7 +1,9 @@
 use super::contracts::parse_contract_def;
 use super::expressions::parse_expr;
 use super::functions::parse_fn_def;
-use super::types::{parse_path_tail, parse_struct_def, parse_type_alias, parse_type_desc, parse_event_def};
+use super::types::{
+    parse_event_def, parse_path_tail, parse_struct_def, parse_type_alias, parse_type_desc,
+};
 use crate::ast::{ConstantDecl, Module, ModuleStmt, Pragma, Use, UseTree};
 use crate::node::{Node, Span};
 use crate::{Label, ParseFailed, ParseResult, Parser, TokenKind};
@@ -40,26 +42,20 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
         TokenKind::Const => ModuleStmt::Constant(Box::new(parse_constant(par)?)),
 
         // Let these be parse errors for now:
-         TokenKind::Event => ModuleStmt::Event(parse_event_def(par, None)?),
+        TokenKind::Event => ModuleStmt::Event(parse_event_def(par, None)?),
         // TokenKind::Name if par.peeked_text() == "from" => parse_from_import(par),
         TokenKind::Pub => {
             let pub_span = par.next()?.span;
             match par.peek_or_err()? {
-                TokenKind::Event => {
-                    ModuleStmt::Event(parse_event_def(par, Some(pub_span))?)
-                },
+                TokenKind::Event => ModuleStmt::Event(parse_event_def(par, Some(pub_span))?),
                 TokenKind::Fn | TokenKind::Unsafe => {
                     ModuleStmt::Function(parse_fn_def(par, Some(pub_span))?)
-                },
-                TokenKind::Struct => {
-                    ModuleStmt::Struct(parse_struct_def(par, Some(pub_span))?)
-                },
-                TokenKind::Type => {
-                    ModuleStmt::TypeAlias(parse_type_alias(par, Some(pub_span))?)
-                },
+                }
+                TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par, Some(pub_span))?),
+                TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par, Some(pub_span))?),
                 TokenKind::Contract => {
                     ModuleStmt::Contract(parse_contract_def(par, Some(pub_span))?)
-                },
+                }
                 _ => {
                     let tok = par.next()?;
                     par.unexpected_token_error(

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -34,9 +34,9 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
     let stmt = match par.peek_or_err()? {
         TokenKind::Pragma => ModuleStmt::Pragma(parse_pragma(par)?),
         TokenKind::Use => ModuleStmt::Use(parse_use(par)?),
-        TokenKind::Contract => ModuleStmt::Contract(parse_contract_def(par)?),
+        TokenKind::Contract => ModuleStmt::Contract(parse_contract_def(par, None)?),
         TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par, None)?),
-        TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par)?),
+        TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par, None)?),
         TokenKind::Const => ModuleStmt::Constant(Box::new(parse_constant(par)?)),
 
         // Let these be parse errors for now:
@@ -52,10 +52,10 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
                     ModuleStmt::Struct(parse_struct_def(par, Some(pub_span))?)
                 },
                 TokenKind::Type => {
-                    ModuleStmt::TypeAlias(parse_type_alias(par)?)
+                    ModuleStmt::TypeAlias(parse_type_alias(par, Some(pub_span))?)
                 },
                 TokenKind::Contract => {
-                    ModuleStmt::Contract(parse_contract_def(par)?)
+                    ModuleStmt::Contract(parse_contract_def(par, Some(pub_span))?)
                 },
                 _ => {
                     let tok = par.next()?;

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -50,7 +50,13 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
                 },
                 TokenKind::Struct => {
                     ModuleStmt::Struct(parse_struct_def(par, Some(pub_span))?)
-                }
+                },
+                TokenKind::Type => {
+                    ModuleStmt::TypeAlias(parse_type_alias(par)?)
+                },
+                TokenKind::Contract => {
+                    ModuleStmt::Contract(parse_contract_def(par)?)
+                },
                 _ => {
                     let tok = par.next()?;
                     par.unexpected_token_error(

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -11,7 +11,7 @@ use vec1::Vec1;
 /// Parse a [`ModuleStmt::Struct`].
 /// # Panics
 /// Panics if the next token isn't `struct`.
-pub fn parse_struct_def(par: &mut Parser, mut pub_qual: Option<Span>) -> ParseResult<Node<ast::Struct>> {
+pub fn parse_struct_def(par: &mut Parser, struct_pub_qual: Option<Span>) -> ParseResult<Node<ast::Struct>> {
     let struct_tok = par.assert(TokenKind::Struct);
     let name = par.expect_with_notes(TokenKind::Name, "failed to parse struct definition", |_| {
         vec!["Note: a struct name must start with a letter or underscore, and contain letters, numbers, or underscores".into()]
@@ -51,13 +51,13 @@ pub fn parse_struct_def(par: &mut Parser, mut pub_qual: Option<Span>) -> ParseRe
             }
         }
     }
-    let span = struct_tok.span + pub_qual + name.span + fields.last();
+    let span = struct_tok.span + struct_pub_qual + name.span + fields.last();
     Ok(Node::new(
         ast::Struct {
             name: name.into(),
             fields,
             functions,
-            pub_qual
+            pub_qual: struct_pub_qual
         },
         span,
     ))
@@ -66,8 +66,8 @@ pub fn parse_struct_def(par: &mut Parser, mut pub_qual: Option<Span>) -> ParseRe
 /// Parse a type alias definition, e.g. `type MyMap = Map<u8, address>`.
 /// # Panics
 /// Panics if the next token isn't `type`.
-pub fn parse_type_alias(par: &mut Parser) -> ParseResult<Node<TypeAlias>> {
-    let pub_qual = par.optional(TokenKind::Pub).map(|tok| tok.span);
+pub fn parse_type_alias(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<TypeAlias>> {
+    
     let type_tok = par.assert(TokenKind::Type);
     let name = par.expect(TokenKind::Name, "failed to parse type declaration")?;
     par.expect_with_notes(TokenKind::Eq, "failed to parse type declaration", |_| {

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -67,6 +67,7 @@ pub fn parse_struct_def(par: &mut Parser, mut pub_qual: Option<Span>) -> ParseRe
 /// # Panics
 /// Panics if the next token isn't `type`.
 pub fn parse_type_alias(par: &mut Parser) -> ParseResult<Node<TypeAlias>> {
+    let pub_qual = par.optional(TokenKind::Pub).map(|tok| tok.span);
     let type_tok = par.assert(TokenKind::Type);
     let name = par.expect(TokenKind::Name, "failed to parse type declaration")?;
     par.expect_with_notes(TokenKind::Eq, "failed to parse type declaration", |_| {
@@ -77,11 +78,12 @@ pub fn parse_type_alias(par: &mut Parser) -> ParseResult<Node<TypeAlias>> {
         ]
     })?;
     let typ = parse_type_desc(par)?;
-    let span = type_tok.span + typ.span;
+    let span = type_tok.span + pub_qual + typ.span;
     Ok(Node::new(
         TypeAlias {
             name: name.into(),
             typ,
+            pub_qual,
         },
         span,
     ))

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -92,7 +92,7 @@ pub fn parse_type_alias(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult
 /// Parse an event definition.
 /// # Panics
 /// Panics if the next token isn't `event`.
-pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<ast::Event>> {
+pub fn parse_event_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<ast::Event>> {
     use TokenKind::*;
 
     let event_tok = par.assert(Event);
@@ -120,11 +120,12 @@ pub fn parse_event_def(par: &mut Parser) -> ParseResult<Node<ast::Event>> {
             }
         }
     }
-    let span = event_tok.span + name.span + fields.last();
+    let span = event_tok.span + pub_qual + name.span + fields.last();
     Ok(Node::new(
         ast::Event {
             name: name.into(),
             fields,
+            pub_qual
         },
         span,
     ))

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -11,7 +11,10 @@ use vec1::Vec1;
 /// Parse a [`ModuleStmt::Struct`].
 /// # Panics
 /// Panics if the next token isn't `struct`.
-pub fn parse_struct_def(par: &mut Parser, struct_pub_qual: Option<Span>) -> ParseResult<Node<ast::Struct>> {
+pub fn parse_struct_def(
+    par: &mut Parser,
+    struct_pub_qual: Option<Span>,
+) -> ParseResult<Node<ast::Struct>> {
     let struct_tok = par.assert(TokenKind::Struct);
     let name = par.expect_with_notes(TokenKind::Name, "failed to parse struct definition", |_| {
         vec!["Note: a struct name must start with a letter or underscore, and contain letters, numbers, or underscores".into()]
@@ -57,7 +60,7 @@ pub fn parse_struct_def(par: &mut Parser, struct_pub_qual: Option<Span>) -> Pars
             name: name.into(),
             fields,
             functions,
-            pub_qual: struct_pub_qual
+            pub_qual: struct_pub_qual,
         },
         span,
     ))
@@ -67,7 +70,6 @@ pub fn parse_struct_def(par: &mut Parser, struct_pub_qual: Option<Span>) -> Pars
 /// # Panics
 /// Panics if the next token isn't `type`.
 pub fn parse_type_alias(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<Node<TypeAlias>> {
-    
     let type_tok = par.assert(TokenKind::Type);
     let name = par.expect(TokenKind::Name, "failed to parse type declaration")?;
     par.expect_with_notes(TokenKind::Eq, "failed to parse type declaration", |_| {
@@ -125,7 +127,7 @@ pub fn parse_event_def(par: &mut Parser, pub_qual: Option<Span>) -> ParseResult<
         ast::Event {
             name: name.into(),
             fields,
-            pub_qual
+            pub_qual,
         },
         span,
     ))

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -11,7 +11,7 @@ use vec1::Vec1;
 /// Parse a [`ModuleStmt::Struct`].
 /// # Panics
 /// Panics if the next token isn't `struct`.
-pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ast::Struct>> {
+pub fn parse_struct_def(par: &mut Parser, mut pub_qual: Option<Span>) -> ParseResult<Node<ast::Struct>> {
     let struct_tok = par.assert(TokenKind::Struct);
     let name = par.expect_with_notes(TokenKind::Name, "failed to parse struct definition", |_| {
         vec!["Note: a struct name must start with a letter or underscore, and contain letters, numbers, or underscores".into()]
@@ -51,12 +51,13 @@ pub fn parse_struct_def(par: &mut Parser) -> ParseResult<Node<ast::Struct>> {
             }
         }
     }
-    let span = struct_tok.span + name.span + fields.last();
+    let span = struct_tok.span + pub_qual + name.span + fields.last();
     Ok(Node::new(
         ast::Struct {
             name: name.into(),
             fields,
             functions,
+            pub_qual
         },
         span,
     ))

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -1,5 +1,5 @@
 use fe_common::diagnostics::diagnostics_string;
-use fe_parser::grammar::{contracts, expressions, functions, module, types};
+use fe_parser::grammar::{expressions, functions, module};
 use fe_parser::{ParseResult, Parser};
 use insta::assert_snapshot;
 

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -76,6 +76,7 @@ contract C:
 }
 
 test_parse_err! { type_desc_path_number, module::parse_module, true, "type Foo = some::mod::Foo::5000" }
+test_parse_err! { module_pub_event, module::parse_module, false, "pub event E:\n  x: u8" }
 test_parse_err! { contract_pub_event, module::parse_module, false, "contract C:\n pub event E:\n  x: u8" }
 test_parse_err! { contract_const_pub, module::parse_module, false, "contract C:\n const pub x: u8" }
 test_parse_err! { contract_const_fn, module::parse_module, false, "contract C:\n const fn f():\n  pass" }

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -65,7 +65,7 @@ contract C:
 "#
 }
 
-test_parse_err! { contract_bad_name, contracts::parse_contract_def, true, "contract 1X:\n x: u8" }
+test_parse_err! { contract_bad_name, module::parse_module, true, "contract 1X:\n x: u8" }
 test_parse_err! { contract_empty_body, module::parse_module, true, "contract X:\n \n \ncontract Y:\n x: u8" }
 test_parse_err! { contract_field_after_def, module::parse_module, false, r#"
 contract C:
@@ -76,9 +76,9 @@ contract C:
 }
 
 test_parse_err! { type_desc_path_number, module::parse_module, true, "type Foo = some::mod::Foo::5000" }
-test_parse_err! { contract_pub_event, contracts::parse_contract_def, false, "contract C:\n pub event E:\n  x: u8" }
-test_parse_err! { contract_const_pub, contracts::parse_contract_def, false, "contract C:\n const pub x: u8" }
-test_parse_err! { contract_const_fn, contracts::parse_contract_def, false, "contract C:\n const fn f():\n  pass" }
+test_parse_err! { contract_pub_event, module::parse_module, false, "contract C:\n pub event E:\n  x: u8" }
+test_parse_err! { contract_const_pub, module::parse_module, false, "contract C:\n const pub x: u8" }
+test_parse_err! { contract_const_fn, module::parse_module, false, "contract C:\n const fn f():\n  pass" }
 test_parse_err! { emit_no_args, functions::parse_stmt, true, "emit x" }
 test_parse_err! { emit_expr, functions::parse_stmt, true, "emit x + 1" }
 test_parse_err! { emit_bad_call, functions::parse_stmt, true, "emit MyEvent(1)()" }
@@ -89,7 +89,7 @@ test_parse_err! { expr_dotted_number, expressions::parse_expr, true, "3.14" }
 test_parse_err! { for_no_in, functions::parse_stmt, true, "for x:\n pass" }
 test_parse_err! { fn_no_args, module::parse_module, false, "fn f:\n  return 5" }
 test_parse_err! { fn_unsafe_pub, module::parse_module, false, "unsafe pub fn f():\n  return 5" }
-test_parse_err! { fn_def_kw, contracts::parse_contract_def, true, "contract C:\n pub def f(x: u8):\n  return x" }
+test_parse_err! { fn_def_kw, module::parse_module, true, "contract C:\n pub def f(x: u8):\n  return x" }
 test_parse_err! { if_no_body, functions::parse_stmt, true, "if x:\nelse:\n x" }
 test_parse_err! { use_bad_name, module::parse_use, true, "use x as 123" }
 test_parse_err! { module_bad_stmt, module::parse_module, true, "if x:\n y" }

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -94,7 +94,7 @@ test_parse_err! { if_no_body, functions::parse_stmt, true, "if x:\nelse:\n x" }
 test_parse_err! { use_bad_name, module::parse_use, true, "use x as 123" }
 test_parse_err! { module_bad_stmt, module::parse_module, true, "if x:\n y" }
 test_parse_err! { module_nonsense, module::parse_module, true, "))" }
-test_parse_err! { struct_bad_field_name, types::parse_struct_def, true, "struct f:\n pub event" }
+test_parse_err! { struct_bad_field_name, module::parse_module, true, "struct f:\n pub event" }
 test_parse_err! { stmt_vardecl_attr, functions::parse_stmt, true, "f.s : u" }
 test_parse_err! { stmt_vardecl_tuple, functions::parse_stmt, true, "(a, x+1) : u256" }
 test_parse_err! { stmt_vardecl_tuple_empty, functions::parse_stmt, true, "(a, ()) : u256" }

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -168,7 +168,7 @@ test_parse! { empty_struct_def, module::parse_module, r#"struct S:
   pass
 "# }
 
-test_parse! { contract_def, contracts::parse_contract_def, r#"contract Foo:
+test_parse! { contract_def, module::parse_module, r#"contract Foo:
   x: address
   pub y: u8
   pub const z: Map<u8, address>
@@ -178,11 +178,11 @@ test_parse! { contract_def, contracts::parse_contract_def, r#"contract Foo:
     idx from: address
 "# }
 
-test_parse! { empty_contract_def, contracts::parse_contract_def, r#"contract Foo:
+test_parse! { empty_contract_def, module::parse_module, r#"contract Foo:
     pass
 "# }
 
-test_parse! { pub_contract_def, contracts::parse_contract_def, r#"pub contract Foo:
+test_parse! { pub_contract_def, module::parse_module, r#"pub contract Foo:
     pub fn foo() -> u8:
       return 10
 "# }

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -1,6 +1,6 @@
 use fe_common::diagnostics::print_diagnostics;
 use fe_common::utils::ron::to_ron_string_pretty;
-use fe_parser::grammar::{contracts, expressions, functions, module, types};
+use fe_parser::grammar::{expressions, functions, module, types};
 use fe_parser::{ParseResult, Parser};
 use insta::assert_snapshot;
 use serde::Serialize;

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -136,9 +136,9 @@ test_parse! { fn_def, module::parse_module, "fn foo21(x: bool, y: address,) -> b
 test_parse! { fn_def_pub, module::parse_module, "pub fn foo21(x: bool, y: address,) -> bool:\n x"}
 test_parse! { fn_def_unsafe, module::parse_module, "unsafe fn foo21(x: bool, y: address,) -> bool:\n x"}
 test_parse! { fn_def_pub_unsafe, module::parse_module, "pub unsafe fn foo21(x: bool, y: address,) -> bool:\n x"}
-test_parse! { event_def, types::parse_event_def, "event Foo:\n  x: address\n  idx y: u8" }
-test_parse! { empty_event_def, types::parse_event_def, "event Foo:\n  pass" }
-
+test_parse! { event_def, module::parse_module, "event Foo:\n  x: address\n  idx y: u8" }
+test_parse! { empty_event_def, module::parse_module, "event Foo:\n  pass" }
+test_parse! { pub_event_def, module::parse_module, "event Foo:\n  x: address\n  idx y: u8" }
 test_parse! { pragma1, module::parse_pragma, "pragma 0.1.0" }
 test_parse! { pragma2, module::parse_pragma, "pragma 0.1.0-alpha" }
 test_parse! { pragma3, module::parse_pragma, "pragma >= 1.2, < 1.5" }

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -153,7 +153,7 @@ test_parse! { use_nested2, module::parse_use, r#"use std::bar::{
     evm as mve
 }"#
 }
-test_parse! { struct_def, types::parse_struct_def, r#"struct S:
+test_parse! { struct_def, module::parse_module, r#"struct S:
   x: address
   pub y: u8
   z: u8
@@ -164,7 +164,7 @@ test_parse! { struct_def, types::parse_struct_def, r#"struct S:
   unsafe fn bar():
     pass
 "# }
-test_parse! { empty_struct_def, types::parse_struct_def, r#"struct S:
+test_parse! { empty_struct_def, module::parse_module, r#"struct S:
   pass
 "# }
 

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -117,8 +117,8 @@ test_parse! { stmt_for, functions::parse_stmt, "for a in b[0]:\n pass" }
 test_parse! { stmt_var_decl_name, functions::parse_stmt, "let foo: u256 = 1" }
 test_parse! { stmt_var_decl_tuple, functions::parse_stmt, "let (foo, bar): (u256, u256) = (10, 10)" }
 test_parse! { stmt_var_decl_tuples, functions::parse_stmt, "let (a, (b, (c, d))): x" }
-
-test_parse! { type_def, types::parse_type_alias, "type X = Map<address, u256>" }
+test_parse! { type_def, module::parse_module, "type X = Map<address, u256>" }
+test_parse! { pub_type_def, module::parse_module, "pub type X = Map<address, u256>" }
 test_parse! { type_name, types::parse_type_desc, "MyType" }
 test_parse! { type_array, types::parse_type_desc, "Array<address, 25>" }
 test_parse! { type_3d, types::parse_type_desc, "Array<Array<Array<u256, 4>, 4>, 4>" }
@@ -180,6 +180,11 @@ test_parse! { contract_def, contracts::parse_contract_def, r#"contract Foo:
 
 test_parse! { empty_contract_def, contracts::parse_contract_def, r#"contract Foo:
     pass
+"# }
+
+test_parse! { pub_contract_def, contracts::parse_contract_def, r#"pub contract Foo:
+    pub fn foo() -> u8:
+      return 10
 "# }
 
 test_parse! { module_stmts, module::parse_module, r#"

--- a/crates/parser/tests/cases/snapshots/cases__errors__contract_pub_event.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__contract_pub_event.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/parser/tests/cases/errors.rs
-expression: "err_string(stringify!(contract_pub_event), contracts::parse_contract_def,\n           false, \"contract C:\\n pub event E:\\n  x: u8\")"
+expression: "err_string(stringify!(contract_pub_event), module::parse_module, false,\n           \"contract C:\\n pub event E:\\n  x: u8\")"
 
 ---
-error: `pub` qualifier can't be used with event definitions
+error: `pub` qualifier can't be used with contract-level event definitions
   ┌─ contract_pub_event:2:2
   │
 2 │  pub event E:

--- a/crates/parser/tests/cases/snapshots/cases__errors__module_pub_event.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__module_pub_event.snap
@@ -1,0 +1,6 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(module_pub_event), module::parse_module, false,\n           \"pub event E:\\n  x: u8\")"
+
+---
+

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -214,6 +214,7 @@ Node(
                     ),
                   ),
                 ],
+                pub_qual: None,
               ),
               span: Span(
                 start: 109,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -1,198 +1,30 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(contract_def), contracts::parse_contract_def,\n           r#\"contract Foo:\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n  pub fn foo() -> u8:\n    return 10\n  event Bar:\n    idx from: address\n\"#)"
+expression: "ast_string(stringify!(contract_def), module::parse_module,\n           r#\"contract Foo:\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n  pub fn foo() -> u8:\n    return 10\n  event Bar:\n    idx from: address\n\"#)"
 
 ---
 Node(
-  kind: Contract(
-    name: Node(
-      kind: "Foo",
-      span: Span(
-        start: 9,
-        end: 12,
-      ),
-    ),
-    fields: [
-      Node(
-        kind: Field(
-          is_pub: false,
-          is_const: false,
-          name: Node(
-            kind: "x",
-            span: Span(
-              start: 16,
-              end: 17,
-            ),
-          ),
-          typ: Node(
-            kind: Base(
-              base: "address",
-            ),
-            span: Span(
-              start: 19,
-              end: 26,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 16,
-          end: 26,
-        ),
-      ),
-      Node(
-        kind: Field(
-          is_pub: true,
-          is_const: false,
-          name: Node(
-            kind: "y",
-            span: Span(
-              start: 33,
-              end: 34,
-            ),
-          ),
-          typ: Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 36,
-              end: 38,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 29,
-          end: 38,
-        ),
-      ),
-      Node(
-        kind: Field(
-          is_pub: true,
-          is_const: true,
-          name: Node(
-            kind: "z",
-            span: Span(
-              start: 51,
-              end: 52,
-            ),
-          ),
-          typ: Node(
-            kind: Generic(
-              base: Node(
-                kind: "Map",
-                span: Span(
-                  start: 54,
-                  end: 57,
-                ),
-              ),
-              args: Node(
-                kind: [
-                  TypeDesc(Node(
-                    kind: Base(
-                      base: "u8",
-                    ),
-                    span: Span(
-                      start: 58,
-                      end: 60,
-                    ),
-                  )),
-                  TypeDesc(Node(
-                    kind: Base(
-                      base: "address",
-                    ),
-                    span: Span(
-                      start: 62,
-                      end: 69,
-                    ),
-                  )),
-                ],
-                span: Span(
-                  start: 57,
-                  end: 70,
-                ),
-              ),
-            ),
-            span: Span(
-              start: 54,
-              end: 70,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 41,
-          end: 70,
-        ),
-      ),
-    ],
+  kind: Module(
     body: [
-      Function(Node(
-        kind: Function(
-          pub_: Some(Span(
-            start: 73,
-            end: 76,
-          )),
-          unsafe_: None,
+      Contract(Node(
+        kind: Contract(
           name: Node(
-            kind: "foo",
+            kind: "Foo",
             span: Span(
-              start: 80,
-              end: 83,
-            ),
-          ),
-          args: [],
-          return_type: Some(Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 89,
-              end: 91,
-            ),
-          )),
-          body: [
-            Node(
-              kind: Return(
-                value: Some(Node(
-                  kind: Num("10"),
-                  span: Span(
-                    start: 104,
-                    end: 106,
-                  ),
-                )),
-              ),
-              span: Span(
-                start: 97,
-                end: 106,
-              ),
-            ),
-          ],
-        ),
-        span: Span(
-          start: 73,
-          end: 106,
-        ),
-      )),
-      Event(Node(
-        kind: Event(
-          name: Node(
-            kind: "Bar",
-            span: Span(
-              start: 115,
-              end: 118,
+              start: 9,
+              end: 12,
             ),
           ),
           fields: [
             Node(
-              kind: EventField(
-                is_idx: true,
+              kind: Field(
+                is_pub: false,
+                is_const: false,
                 name: Node(
-                  kind: "from",
+                  kind: "x",
                   span: Span(
-                    start: 128,
-                    end: 132,
+                    start: 16,
+                    end: 17,
                   ),
                 ),
                 typ: Node(
@@ -200,25 +32,203 @@ Node(
                     base: "address",
                   ),
                   span: Span(
-                    start: 134,
-                    end: 141,
+                    start: 19,
+                    end: 26,
                   ),
                 ),
+                value: None,
               ),
               span: Span(
-                start: 124,
-                end: 141,
+                start: 16,
+                end: 26,
+              ),
+            ),
+            Node(
+              kind: Field(
+                is_pub: true,
+                is_const: false,
+                name: Node(
+                  kind: "y",
+                  span: Span(
+                    start: 33,
+                    end: 34,
+                  ),
+                ),
+                typ: Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 36,
+                    end: 38,
+                  ),
+                ),
+                value: None,
+              ),
+              span: Span(
+                start: 29,
+                end: 38,
+              ),
+            ),
+            Node(
+              kind: Field(
+                is_pub: true,
+                is_const: true,
+                name: Node(
+                  kind: "z",
+                  span: Span(
+                    start: 51,
+                    end: 52,
+                  ),
+                ),
+                typ: Node(
+                  kind: Generic(
+                    base: Node(
+                      kind: "Map",
+                      span: Span(
+                        start: 54,
+                        end: 57,
+                      ),
+                    ),
+                    args: Node(
+                      kind: [
+                        TypeDesc(Node(
+                          kind: Base(
+                            base: "u8",
+                          ),
+                          span: Span(
+                            start: 58,
+                            end: 60,
+                          ),
+                        )),
+                        TypeDesc(Node(
+                          kind: Base(
+                            base: "address",
+                          ),
+                          span: Span(
+                            start: 62,
+                            end: 69,
+                          ),
+                        )),
+                      ],
+                      span: Span(
+                        start: 57,
+                        end: 70,
+                      ),
+                    ),
+                  ),
+                  span: Span(
+                    start: 54,
+                    end: 70,
+                  ),
+                ),
+                value: None,
+              ),
+              span: Span(
+                start: 41,
+                end: 70,
               ),
             ),
           ],
+          body: [
+            Function(Node(
+              kind: Function(
+                pub_: Some(Span(
+                  start: 73,
+                  end: 76,
+                )),
+                unsafe_: None,
+                name: Node(
+                  kind: "foo",
+                  span: Span(
+                    start: 80,
+                    end: 83,
+                  ),
+                ),
+                args: [],
+                return_type: Some(Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 89,
+                    end: 91,
+                  ),
+                )),
+                body: [
+                  Node(
+                    kind: Return(
+                      value: Some(Node(
+                        kind: Num("10"),
+                        span: Span(
+                          start: 104,
+                          end: 106,
+                        ),
+                      )),
+                    ),
+                    span: Span(
+                      start: 97,
+                      end: 106,
+                    ),
+                  ),
+                ],
+              ),
+              span: Span(
+                start: 73,
+                end: 106,
+              ),
+            )),
+            Event(Node(
+              kind: Event(
+                name: Node(
+                  kind: "Bar",
+                  span: Span(
+                    start: 115,
+                    end: 118,
+                  ),
+                ),
+                fields: [
+                  Node(
+                    kind: EventField(
+                      is_idx: true,
+                      name: Node(
+                        kind: "from",
+                        span: Span(
+                          start: 128,
+                          end: 132,
+                        ),
+                      ),
+                      typ: Node(
+                        kind: Base(
+                          base: "address",
+                        ),
+                        span: Span(
+                          start: 134,
+                          end: 141,
+                        ),
+                      ),
+                    ),
+                    span: Span(
+                      start: 124,
+                      end: 141,
+                    ),
+                  ),
+                ],
+              ),
+              span: Span(
+                start: 109,
+                end: 141,
+              ),
+            )),
+          ],
+          pub_qual: None,
         ),
         span: Span(
-          start: 109,
+          start: 0,
           end: 141,
         ),
       )),
     ],
-    pub_qual: None,
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -218,6 +218,7 @@ Node(
         ),
       )),
     ],
+    pub_qual: None,
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_contract_def.snap
@@ -14,6 +14,7 @@ Node(
     ),
     fields: [],
     body: [],
+    pub_qual: None,
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_contract_def.snap
@@ -1,20 +1,30 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(empty_contract_def), contracts::parse_contract_def,\n           r#\"contract Foo:\n    pass\n\"#)"
+expression: "ast_string(stringify!(empty_contract_def), module::parse_module,\n           r#\"contract Foo:\n    pass\n\"#)"
 
 ---
 Node(
-  kind: Contract(
-    name: Node(
-      kind: "Foo",
-      span: Span(
-        start: 9,
-        end: 12,
-      ),
-    ),
-    fields: [],
-    body: [],
-    pub_qual: None,
+  kind: Module(
+    body: [
+      Contract(Node(
+        kind: Contract(
+          name: Node(
+            kind: "Foo",
+            span: Span(
+              start: 9,
+              end: 12,
+            ),
+          ),
+          fields: [],
+          body: [],
+          pub_qual: None,
+        ),
+        span: Span(
+          start: 0,
+          end: 12,
+        ),
+      )),
+    ],
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_event_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_event_def.snap
@@ -1,18 +1,29 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(empty_event_def), types::parse_event_def,\n           \"event Foo:\\n  pass\")"
+expression: "ast_string(stringify!(empty_event_def), module::parse_module,\n           \"event Foo:\\n  pass\")"
 
 ---
 Node(
-  kind: Event(
-    name: Node(
-      kind: "Foo",
-      span: Span(
-        start: 6,
-        end: 9,
-      ),
-    ),
-    fields: [],
+  kind: Module(
+    body: [
+      Event(Node(
+        kind: Event(
+          name: Node(
+            kind: "Foo",
+            span: Span(
+              start: 6,
+              end: 9,
+            ),
+          ),
+          fields: [],
+          pub_qual: None,
+        ),
+        span: Span(
+          start: 0,
+          end: 9,
+        ),
+      )),
+    ],
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_struct_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__empty_struct_def.snap
@@ -1,19 +1,30 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(empty_struct_def), types::parse_struct_def,\n           r#\"struct S:\n  pass\n\"#)"
+expression: "ast_string(stringify!(empty_struct_def), module::parse_module,\n           r#\"struct S:\n  pass\n\"#)"
 
 ---
 Node(
-  kind: Struct(
-    name: Node(
-      kind: "S",
-      span: Span(
-        start: 7,
-        end: 8,
-      ),
-    ),
-    fields: [],
-    functions: [],
+  kind: Module(
+    body: [
+      Struct(Node(
+        kind: Struct(
+          name: Node(
+            kind: "S",
+            span: Span(
+              start: 7,
+              end: 8,
+            ),
+          ),
+          fields: [],
+          functions: [],
+          pub_qual: None,
+        ),
+        span: Span(
+          start: 0,
+          end: 8,
+        ),
+      )),
+    ],
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -168,6 +168,7 @@ Node(
                     ),
                   ),
                 ],
+                pub_qual: None,
               ),
               span: Span(
                 start: 102,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -54,6 +54,7 @@ Node(
               end: 33,
             ),
           ),
+          pub_qual: None,
         ),
         span: Span(
           start: 1,
@@ -451,6 +452,7 @@ Node(
               ),
             )),
           ],
+          pub_qual: None,
         ),
         span: Span(
           start: 35,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -152,6 +152,7 @@ Node(
               end: 85,
             ),
           ),
+          pub_qual: None,
         ),
         span: Span(
           start: 64,
@@ -341,6 +342,7 @@ Node(
             ),
           ],
           body: [],
+          pub_qual: None,
         ),
         span: Span(
           start: 171,
@@ -386,6 +388,7 @@ Node(
             ),
           ],
           body: [],
+          pub_qual: None,
         ),
         span: Span(
           start: 211,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
@@ -1,71 +1,81 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(pub_contract_def), contracts::parse_contract_def,\n           r#\"pub contract Foo:\n    pub fn foo() -> u8:\n      return 10\n\"#)"
+expression: "ast_string(stringify!(pub_contract_def), module::parse_module,\n           r#\"pub contract Foo:\n    pub fn foo() -> u8:\n      return 10\n\"#)"
 
 ---
 Node(
-  kind: Contract(
-    name: Node(
-      kind: "Foo",
-      span: Span(
-        start: 13,
-        end: 16,
-      ),
-    ),
-    fields: [],
+  kind: Module(
     body: [
-      Function(Node(
-        kind: Function(
-          pub_: Some(Span(
-            start: 22,
-            end: 25,
-          )),
-          unsafe_: None,
+      Contract(Node(
+        kind: Contract(
           name: Node(
-            kind: "foo",
+            kind: "Foo",
             span: Span(
-              start: 29,
-              end: 32,
+              start: 13,
+              end: 16,
             ),
           ),
-          args: [],
-          return_type: Some(Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 38,
-              end: 40,
-            ),
-          )),
+          fields: [],
           body: [
-            Node(
-              kind: Return(
-                value: Some(Node(
-                  kind: Num("10"),
+            Function(Node(
+              kind: Function(
+                pub_: Some(Span(
+                  start: 22,
+                  end: 25,
+                )),
+                unsafe_: None,
+                name: Node(
+                  kind: "foo",
                   span: Span(
-                    start: 55,
-                    end: 57,
+                    start: 29,
+                    end: 32,
+                  ),
+                ),
+                args: [],
+                return_type: Some(Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 38,
+                    end: 40,
                   ),
                 )),
+                body: [
+                  Node(
+                    kind: Return(
+                      value: Some(Node(
+                        kind: Num("10"),
+                        span: Span(
+                          start: 55,
+                          end: 57,
+                        ),
+                      )),
+                    ),
+                    span: Span(
+                      start: 48,
+                      end: 57,
+                    ),
+                  ),
+                ],
               ),
               span: Span(
-                start: 48,
+                start: 22,
                 end: 57,
               ),
-            ),
+            )),
           ],
+          pub_qual: Some(Span(
+            start: 0,
+            end: 3,
+          )),
         ),
         span: Span(
-          start: 22,
+          start: 0,
           end: 57,
         ),
       )),
     ],
-    pub_qual: Some(Span(
-      start: 0,
-      end: 3,
-    )),
   ),
   span: Span(
     start: 0,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
@@ -1,0 +1,74 @@
+---
+source: crates/parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(pub_contract_def), contracts::parse_contract_def,\n           r#\"pub contract Foo:\n    pub fn foo() -> u8:\n      return 10\n\"#)"
+
+---
+Node(
+  kind: Contract(
+    name: Node(
+      kind: "Foo",
+      span: Span(
+        start: 13,
+        end: 16,
+      ),
+    ),
+    fields: [],
+    body: [
+      Function(Node(
+        kind: Function(
+          pub_: Some(Span(
+            start: 22,
+            end: 25,
+          )),
+          unsafe_: None,
+          name: Node(
+            kind: "foo",
+            span: Span(
+              start: 29,
+              end: 32,
+            ),
+          ),
+          args: [],
+          return_type: Some(Node(
+            kind: Base(
+              base: "u8",
+            ),
+            span: Span(
+              start: 38,
+              end: 40,
+            ),
+          )),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: Num("10"),
+                  span: Span(
+                    start: 55,
+                    end: 57,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 48,
+                end: 57,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 22,
+          end: 57,
+        ),
+      )),
+    ],
+    pub_qual: Some(Span(
+      start: 0,
+      end: 3,
+    )),
+  ),
+  span: Span(
+    start: 0,
+    end: 57,
+  ),
+)

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_event_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_event_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(event_def), module::parse_module,\n           \"event Foo:\\n  x: address\\n  idx y: u8\")"
+expression: "ast_string(stringify!(pub_event_def), module::parse_module,\n           \"event Foo:\\n  x: address\\n  idx y: u8\")"
 
 ---
 Node(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_type_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_type_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(type_def), module::parse_module,\n           \"type X = Map<address, u256>\")"
+expression: "ast_string(stringify!(pub_type_def), module::parse_module,\n           \"pub type X = Map<address, u256>\")"
 
 ---
 Node(
@@ -11,8 +11,8 @@ Node(
           name: Node(
             kind: "X",
             span: Span(
-              start: 5,
-              end: 6,
+              start: 9,
+              end: 10,
             ),
           ),
           typ: Node(
@@ -20,8 +20,8 @@ Node(
               base: Node(
                 kind: "Map",
                 span: Span(
-                  start: 9,
-                  end: 12,
+                  start: 13,
+                  end: 16,
                 ),
               ),
               args: Node(
@@ -31,8 +31,8 @@ Node(
                       base: "address",
                     ),
                     span: Span(
-                      start: 13,
-                      end: 20,
+                      start: 17,
+                      end: 24,
                     ),
                   )),
                   TypeDesc(Node(
@@ -40,33 +40,33 @@ Node(
                       base: "u256",
                     ),
                     span: Span(
-                      start: 22,
-                      end: 26,
+                      start: 26,
+                      end: 30,
                     ),
                   )),
                 ],
                 span: Span(
-                  start: 12,
-                  end: 27,
+                  start: 16,
+                  end: 31,
                 ),
               ),
             ),
             span: Span(
-              start: 9,
-              end: 27,
+              start: 13,
+              end: 31,
             ),
           ),
           pub_qual: None,
         ),
         span: Span(
-          start: 0,
-          end: 27,
+          start: 4,
+          end: 31,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 27,
+    end: 31,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_type_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_type_def.snap
@@ -56,10 +56,13 @@ Node(
               end: 31,
             ),
           ),
-          pub_qual: None,
+          pub_qual: Some(Span(
+            start: 0,
+            end: 3,
+          )),
         ),
         span: Span(
-          start: 4,
+          start: 0,
           end: 31,
         ),
       )),

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
@@ -1,298 +1,309 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(struct_def), types::parse_struct_def,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8:\n    return self.z + self.y\n  unsafe fn bar():\n    pass\n\"#)"
+expression: "ast_string(stringify!(struct_def), module::parse_module,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8:\n    return self.z + self.y\n  unsafe fn bar():\n    pass\n\"#)"
 
 ---
 Node(
-  kind: Struct(
-    name: Node(
-      kind: "S",
-      span: Span(
-        start: 7,
-        end: 8,
-      ),
-    ),
-    fields: [
-      Node(
-        kind: Field(
-          is_pub: false,
-          is_const: false,
+  kind: Module(
+    body: [
+      Struct(Node(
+        kind: Struct(
           name: Node(
-            kind: "x",
+            kind: "S",
             span: Span(
-              start: 12,
-              end: 13,
+              start: 7,
+              end: 8,
             ),
           ),
-          typ: Node(
-            kind: Base(
-              base: "address",
-            ),
-            span: Span(
-              start: 15,
-              end: 22,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 12,
-          end: 22,
-        ),
-      ),
-      Node(
-        kind: Field(
-          is_pub: true,
-          is_const: false,
-          name: Node(
-            kind: "y",
-            span: Span(
-              start: 29,
-              end: 30,
-            ),
-          ),
-          typ: Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 32,
-              end: 34,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 25,
-          end: 34,
-        ),
-      ),
-      Node(
-        kind: Field(
-          is_pub: false,
-          is_const: false,
-          name: Node(
-            kind: "z",
-            span: Span(
-              start: 37,
-              end: 38,
-            ),
-          ),
-          typ: Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 40,
-              end: 42,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 37,
-          end: 42,
-        ),
-      ),
-      Node(
-        kind: Field(
-          is_pub: true,
-          is_const: false,
-          name: Node(
-            kind: "a",
-            span: Span(
-              start: 49,
-              end: 50,
-            ),
-          ),
-          typ: Node(
-            kind: Generic(
-              base: Node(
-                kind: "Map",
-                span: Span(
-                  start: 52,
-                  end: 55,
-                ),
-              ),
-              args: Node(
-                kind: [
-                  TypeDesc(Node(
-                    kind: Base(
-                      base: "u8",
-                    ),
-                    span: Span(
-                      start: 56,
-                      end: 58,
-                    ),
-                  )),
-                  TypeDesc(Node(
-                    kind: Base(
-                      base: "foo",
-                    ),
-                    span: Span(
-                      start: 60,
-                      end: 63,
-                    ),
-                  )),
-                ],
-                span: Span(
-                  start: 55,
-                  end: 64,
-                ),
-              ),
-            ),
-            span: Span(
-              start: 52,
-              end: 64,
-            ),
-          ),
-          value: None,
-        ),
-        span: Span(
-          start: 45,
-          end: 64,
-        ),
-      ),
-    ],
-    functions: [
-      Node(
-        kind: Function(
-          pub_: Some(Span(
-            start: 68,
-            end: 71,
-          )),
-          unsafe_: None,
-          name: Node(
-            kind: "foo",
-            span: Span(
-              start: 75,
-              end: 78,
-            ),
-          ),
-          args: [
+          fields: [
             Node(
-              kind: Zelf,
+              kind: Field(
+                is_pub: false,
+                is_const: false,
+                name: Node(
+                  kind: "x",
+                  span: Span(
+                    start: 12,
+                    end: 13,
+                  ),
+                ),
+                typ: Node(
+                  kind: Base(
+                    base: "address",
+                  ),
+                  span: Span(
+                    start: 15,
+                    end: 22,
+                  ),
+                ),
+                value: None,
+              ),
               span: Span(
-                start: 79,
-                end: 83,
+                start: 12,
+                end: 22,
               ),
             ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 88,
-              end: 90,
-            ),
-          )),
-          body: [
             Node(
-              kind: Return(
-                value: Some(Node(
-                  kind: BinOperation(
-                    left: Node(
-                      kind: Attribute(
-                        value: Node(
-                          kind: Name("self"),
-                          span: Span(
-                            start: 103,
-                            end: 107,
-                          ),
-                        ),
-                        attr: Node(
-                          kind: "z",
-                          span: Span(
-                            start: 108,
-                            end: 109,
-                          ),
-                        ),
-                      ),
+              kind: Field(
+                is_pub: true,
+                is_const: false,
+                name: Node(
+                  kind: "y",
+                  span: Span(
+                    start: 29,
+                    end: 30,
+                  ),
+                ),
+                typ: Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 32,
+                    end: 34,
+                  ),
+                ),
+                value: None,
+              ),
+              span: Span(
+                start: 25,
+                end: 34,
+              ),
+            ),
+            Node(
+              kind: Field(
+                is_pub: false,
+                is_const: false,
+                name: Node(
+                  kind: "z",
+                  span: Span(
+                    start: 37,
+                    end: 38,
+                  ),
+                ),
+                typ: Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 40,
+                    end: 42,
+                  ),
+                ),
+                value: None,
+              ),
+              span: Span(
+                start: 37,
+                end: 42,
+              ),
+            ),
+            Node(
+              kind: Field(
+                is_pub: true,
+                is_const: false,
+                name: Node(
+                  kind: "a",
+                  span: Span(
+                    start: 49,
+                    end: 50,
+                  ),
+                ),
+                typ: Node(
+                  kind: Generic(
+                    base: Node(
+                      kind: "Map",
                       span: Span(
-                        start: 103,
-                        end: 109,
+                        start: 52,
+                        end: 55,
                       ),
                     ),
-                    op: Node(
-                      kind: Add,
-                      span: Span(
-                        start: 110,
-                        end: 111,
-                      ),
-                    ),
-                    right: Node(
-                      kind: Attribute(
-                        value: Node(
-                          kind: Name("self"),
-                          span: Span(
-                            start: 112,
-                            end: 116,
+                    args: Node(
+                      kind: [
+                        TypeDesc(Node(
+                          kind: Base(
+                            base: "u8",
                           ),
-                        ),
-                        attr: Node(
-                          kind: "y",
                           span: Span(
-                            start: 117,
-                            end: 118,
+                            start: 56,
+                            end: 58,
                           ),
-                        ),
-                      ),
+                        )),
+                        TypeDesc(Node(
+                          kind: Base(
+                            base: "foo",
+                          ),
+                          span: Span(
+                            start: 60,
+                            end: 63,
+                          ),
+                        )),
+                      ],
                       span: Span(
-                        start: 112,
-                        end: 118,
+                        start: 55,
+                        end: 64,
                       ),
                     ),
                   ),
                   span: Span(
-                    start: 103,
-                    end: 118,
+                    start: 52,
+                    end: 64,
                   ),
-                )),
+                ),
+                value: None,
               ),
               span: Span(
-                start: 96,
-                end: 118,
+                start: 45,
+                end: 64,
               ),
             ),
           ],
-        ),
-        span: Span(
-          start: 68,
-          end: 118,
-        ),
-      ),
-      Node(
-        kind: Function(
-          pub_: None,
-          unsafe_: Some(Span(
-            start: 121,
-            end: 127,
-          )),
-          name: Node(
-            kind: "bar",
-            span: Span(
-              start: 131,
-              end: 134,
-            ),
-          ),
-          args: [],
-          return_type: None,
-          body: [
+          functions: [
             Node(
-              kind: Pass,
+              kind: Function(
+                pub_: Some(Span(
+                  start: 68,
+                  end: 71,
+                )),
+                unsafe_: None,
+                name: Node(
+                  kind: "foo",
+                  span: Span(
+                    start: 75,
+                    end: 78,
+                  ),
+                ),
+                args: [
+                  Node(
+                    kind: Zelf,
+                    span: Span(
+                      start: 79,
+                      end: 83,
+                    ),
+                  ),
+                ],
+                return_type: Some(Node(
+                  kind: Base(
+                    base: "u8",
+                  ),
+                  span: Span(
+                    start: 88,
+                    end: 90,
+                  ),
+                )),
+                body: [
+                  Node(
+                    kind: Return(
+                      value: Some(Node(
+                        kind: BinOperation(
+                          left: Node(
+                            kind: Attribute(
+                              value: Node(
+                                kind: Name("self"),
+                                span: Span(
+                                  start: 103,
+                                  end: 107,
+                                ),
+                              ),
+                              attr: Node(
+                                kind: "z",
+                                span: Span(
+                                  start: 108,
+                                  end: 109,
+                                ),
+                              ),
+                            ),
+                            span: Span(
+                              start: 103,
+                              end: 109,
+                            ),
+                          ),
+                          op: Node(
+                            kind: Add,
+                            span: Span(
+                              start: 110,
+                              end: 111,
+                            ),
+                          ),
+                          right: Node(
+                            kind: Attribute(
+                              value: Node(
+                                kind: Name("self"),
+                                span: Span(
+                                  start: 112,
+                                  end: 116,
+                                ),
+                              ),
+                              attr: Node(
+                                kind: "y",
+                                span: Span(
+                                  start: 117,
+                                  end: 118,
+                                ),
+                              ),
+                            ),
+                            span: Span(
+                              start: 112,
+                              end: 118,
+                            ),
+                          ),
+                        ),
+                        span: Span(
+                          start: 103,
+                          end: 118,
+                        ),
+                      )),
+                    ),
+                    span: Span(
+                      start: 96,
+                      end: 118,
+                    ),
+                  ),
+                ],
+              ),
               span: Span(
-                start: 142,
+                start: 68,
+                end: 118,
+              ),
+            ),
+            Node(
+              kind: Function(
+                pub_: None,
+                unsafe_: Some(Span(
+                  start: 121,
+                  end: 127,
+                )),
+                name: Node(
+                  kind: "bar",
+                  span: Span(
+                    start: 131,
+                    end: 134,
+                  ),
+                ),
+                args: [],
+                return_type: None,
+                body: [
+                  Node(
+                    kind: Pass,
+                    span: Span(
+                      start: 142,
+                      end: 146,
+                    ),
+                  ),
+                ],
+              ),
+              span: Span(
+                start: 121,
                 end: 146,
               ),
             ),
           ],
+          pub_qual: None,
         ),
         span: Span(
-          start: 121,
-          end: 146,
+          start: 0,
+          end: 64,
         ),
-      ),
+      )),
     ],
   ),
   span: Span(

--- a/crates/test-files/fixtures/ingots/private_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/private_ingot/src/foo.fe
@@ -1,0 +1,5 @@
+pub struct Foo:
+    my_address: address
+
+struct Bar:
+    my_u256: u256

--- a/crates/test-files/fixtures/ingots/private_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/private_ingot/src/foo.fe
@@ -1,5 +1,0 @@
-pub struct Foo:
-    my_address: address
-
-struct Bar:
-    my_u256: u256

--- a/crates/test-files/fixtures/ingots/private_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/private_ingot/src/main.fe
@@ -1,8 +1,0 @@
-use foo::Foo
-use foo::Bar
-
-contract FooBar:
-    pub fn get_bar() -> Bar:
-        return Bar(
-            my_u256=24
-        )

--- a/crates/test-files/fixtures/ingots/private_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/private_ingot/src/main.fe
@@ -1,0 +1,8 @@
+use foo::Foo
+use foo::Bar
+
+contract FooBar:
+    pub fn get_bar() -> Bar:
+        return Bar(
+            my_u256=24
+        )

--- a/crates/test-files/fixtures/ingots/pub_contract_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/pub_contract_ingot/src/foo.fe
@@ -1,0 +1,9 @@
+pub struct Foo:
+    my_address: address
+
+struct Bar:
+    my_u256: u256
+
+pub contract FooBar:
+   pub fn add(x: u256, y: u256) -> u256:
+       return x + y

--- a/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
@@ -1,0 +1,11 @@
+use foo::{Foo, Bar, FooBar}
+
+contract FooBarBing:
+    pub fn get_bar() -> Bar:
+        return Bar(
+            my_u256=24
+        )
+
+    pub fn create_foobar_contract() -> u256:
+        let foo_bar: FooBar = FooBar.create(0)
+        return foo_bar.add(40, 50)

--- a/crates/test-files/fixtures/ingots/visibility_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/visibility_ingot/src/foo.fe
@@ -1,0 +1,11 @@
+pub struct Bing:
+    my_address: address
+
+fn get_42_backend() -> u256:
+    return 42
+
+pub type Precision = u256
+
+contract BingContract:
+    pub fn add(x: u256, y: u256) -> u256:
+        return x + y

--- a/crates/test-files/fixtures/ingots/visibility_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/visibility_ingot/src/main.fe
@@ -1,0 +1,8 @@
+use foo::{get_42_backend, Precision, Bing}
+
+contract Foo:
+    pub fn get_addr() -> Bing:
+        return Bing(my_address=address(24))
+
+    pub fn get_precision() -> Precision:
+        return 18

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -18,15 +18,15 @@ pub fn deploy_ingot(
 
 #[test]
 fn test_ingot_with_visibility() {
-    _with_executor(&|mut executor| {
-        let harness = deploy_ingot(&mut executor, "pub_contract_ingot", "FooBarBing", &[]);
+    with_executor(&|mut executor| {
+        let _harness = deploy_ingot(&mut executor, "pub_contract_ingot", "FooBarBing", &[]);
     })
 }
 
 #[test]
 fn test_ingot_pub_contract() {
-    _with_executor(&|mut executor| {
-        let harness = deploy_ingot(&mut executor, "visibility_ingot", "Foo", &[]);
+    with_executor(&|mut executor| {
+        let _harness = deploy_ingot(&mut executor, "visibility_ingot", "Foo", &[]);
     })
 }
 #[test]

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -20,7 +20,6 @@ pub fn deploy_ingot(
 fn test_ingot_with_visibility() {
     with_executor(&|mut executor| {
         let harness = deploy_ingot(&mut executor, "pub_contract_ingot", "FooBarBing", &[]);
-        
     })
 }
 
@@ -28,7 +27,6 @@ fn test_ingot_with_visibility() {
 fn test_ingot_pub_contract() {
     with_executor(&|mut executor| {
         let harness = deploy_ingot(&mut executor, "visibility_ingot", "Foo", &[]);
-        
     })
 }
 #[test]

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -18,14 +18,14 @@ pub fn deploy_ingot(
 
 #[test]
 fn test_ingot_with_visibility() {
-    with_executor(&|mut executor| {
+    _with_executor(&|mut executor| {
         let harness = deploy_ingot(&mut executor, "pub_contract_ingot", "FooBarBing", &[]);
     })
 }
 
 #[test]
 fn test_ingot_pub_contract() {
-    with_executor(&|mut executor| {
+    _with_executor(&|mut executor| {
         let harness = deploy_ingot(&mut executor, "visibility_ingot", "Foo", &[]);
     })
 }

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -17,6 +17,14 @@ pub fn deploy_ingot(
 }
 
 #[test]
+fn test_ingot_with_visibility() {
+    with_executor(&|mut executor| {
+        let harness = deploy_ingot(&mut executor, "private_ingot", "FooBar", &[]);
+        
+    })
+}
+
+#[test]
 fn test_basic_ingot() {
     with_executor(&|mut executor| {
         let harness = deploy_ingot(&mut executor, "basic_ingot", "Foo", &[]);

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -19,11 +19,18 @@ pub fn deploy_ingot(
 #[test]
 fn test_ingot_with_visibility() {
     with_executor(&|mut executor| {
-        let harness = deploy_ingot(&mut executor, "private_ingot", "FooBar", &[]);
+        let harness = deploy_ingot(&mut executor, "pub_contract_ingot", "FooBarBing", &[]);
         
     })
 }
 
+#[test]
+fn test_ingot_pub_contract() {
+    with_executor(&|mut executor| {
+        let harness = deploy_ingot(&mut executor, "visibility_ingot", "Foo", &[]);
+        
+    })
+}
 #[test]
 fn test_basic_ingot() {
     with_executor(&|mut executor| {

--- a/docs/src/spec/visibility_and_privacy.md
+++ b/docs/src/spec/visibility_and_privacy.md
@@ -14,3 +14,39 @@ For example, this is a function that can be called externally from a transaction
 pub fn answer_to_life_the_universe_and_everything() -> u256:
     return 42
 ```
+
+Top-level definitions in a Fe source file can also be specified as `pub` if the file exists within the context of an Ingot. Declaring a definition as `pub` enables other modules within an Ingot to `use` the definition.
+
+For example, given an Ingot with the following structure:
+
+```
+example_ingot
+└── src
+    ├── ding
+    │   └── dong.fe
+    └── main.fe
+```
+
+With `ding/dong.fe` having the following contents:
+
+```python
+pub struct Dyng:
+  my_address: address
+  my_u256: u256
+  my_i8: i8
+```
+
+
+Then `main.fe` can use the `Dyng` struct since it is `pub`-qualified:
+
+```python
+use ding::{dong::Dyng}
+
+contract Foo:
+ pub fn get_my_dyng() -> Dyng:
+        return Dyng(
+            my_address=address(8),
+            my_u256=42,
+            my_i8=-1
+        )
+```

--- a/docs/validate_doc_examples.py
+++ b/docs/validate_doc_examples.py
@@ -29,7 +29,10 @@ SKIP_LIST = [
     'stack.md_0.fe',
     'functions.md_0.fe',
     'first_contract.md_0.fe',
-    'first_contract.md_2.fe'
+    'first_contract.md_2.fe',
+    'visibility_and_privacy.md_1.fe',
+    'visibility_and_privacy.md_2.fe',
+    'visibility_and_privacy.md_3.fe'
 ]
 
 class CodeSnippet(NamedTuple):


### PR DESCRIPTION
# What was wrong?

`pub` qualifiers for modules could not be parsed for events, structs, contracts, and type aliases

# How was it fixed?

Added parsing logic to handle when any of the above-listed types were preceded by `pub` keyword.
# To-Do

- [x] OPTIONAL: Update Spec if applicable
- [ ] Add entry to the release notes (may forgo for trivial changes)
- [ ]  Clean up commit history