### PR TITLE
Lower `revert` argument

### DIFF
--- a/crates/lowering/src/mappers/functions.rs
+++ b/crates/lowering/src/mappers/functions.rs
@@ -221,7 +221,9 @@ fn func_stmt(context: &mut FnContext, stmt: Node<fe::FuncStmt>) -> Vec<Node<fe::
         fe::FuncStmt::Pass => vec![stmt.kind],
         fe::FuncStmt::Break => vec![stmt.kind],
         fe::FuncStmt::Continue => vec![stmt.kind],
-        fe::FuncStmt::Revert { .. } => vec![stmt.kind],
+        fe::FuncStmt::Revert { error } => vec![fe::FuncStmt::Revert {
+            error: error.map(|expr| expressions::expr(context, expr)),
+        }],
     };
     let span = stmt.span;
 

--- a/crates/lowering/tests/snapshots/lowering__module_const.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_const.snap
@@ -42,7 +42,7 @@ contract Foo:
                 return 3 * 10
             else:
                 if true:
-                    revert Bar(val=THREE)
+                    revert Bar(val=3)
 
 
 

--- a/crates/test-files/fixtures/crashes/revert_const.fe
+++ b/crates/test-files/fixtures/crashes/revert_const.fe
@@ -1,0 +1,7 @@
+const FOO: u256 = 0x101
+
+struct Error:
+  code: u256
+
+fn exit():
+  revert Error(code = FOO)

--- a/crates/tests/src/crashes.rs
+++ b/crates/tests/src/crashes.rs
@@ -18,3 +18,4 @@ macro_rules! test_file {
 
 test_file! { agroce531 }
 test_file! { agroce550 }
+test_file! { revert_const }

--- a/newsfragments/619.bugfix.md
+++ b/newsfragments/619.bugfix.md
@@ -1,0 +1,13 @@
+The argument to `revert` wasn't being lowered by the compiler,
+meaning that some `revert` calls would cause a compiler panic
+in later stages. For example:
+
+```
+const BAD_MOJO: u256 = 0xdeaddead
+
+struct Error:
+  code: u256
+
+fn fail():
+  revert Error(code = BAD_MOJO)
+```


### PR DESCRIPTION
### What was wrong?

The `revert` arg expr wasn't being lowered, leading to a panic for certain code (eg code that uses a `const`)

### How was it fixed?

:magic_wand:

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
