### PR TITLE
private struct fields

### DIFF
--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -82,16 +82,13 @@ pub fn struct_field_type(
     let mut scope = ItemScope::new(db, field_data.parent.module(db));
 
     let ast::Field {
-        is_pub,
+        is_pub: _,
         is_const,
         name: _,
         typ,
         value,
     } = &field_data.ast.kind;
 
-    if *is_pub {
-        scope.not_yet_implemented("struct `pub` fields", field_data.ast.span);
-    }
     if *is_const {
         scope.not_yet_implemented("struct `const` fields", field_data.ast.span);
     }

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -2,6 +2,7 @@
 
 use crate::context::{AnalyzerContext, CallType, ExpressionAttributes, FunctionBody, NamedThing};
 use crate::errors::{AlreadyDefined, TypeError};
+use crate::namespace::items::Item;
 use crate::namespace::items::{Class, EventId, FunctionId, ModuleId};
 use crate::namespace::types::FixedSize;
 use crate::AnalyzerDb;
@@ -338,6 +339,11 @@ impl<'a, 'b> BlockScope<'a, 'b> {
     /// Return true if the scope or any of its parents is of the given type
     pub fn inherits_type(&self, typ: BlockScopeType) -> bool {
         self.typ == typ || self.parent.map_or(false, |scope| scope.inherits_type(typ))
+    }
+
+    /// Return the root item of the block scope
+    pub fn root_item(&self) -> Item {
+        self.root.function.parent(self.db())
     }
 }
 

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -280,6 +280,7 @@ test_file! { needs_mem_copy }
 test_file! { not_callable }
 test_file! { not_in_scope }
 test_file! { not_in_scope_2 }
+test_file! { private_struct_field }
 test_file! { return_addition_with_mixed_types }
 test_file! { return_call_to_fn_with_param_type_mismatch }
 test_file! { return_call_to_fn_without_return }
@@ -290,6 +291,7 @@ test_file! { return_type_not_fixedsize }
 test_file! { undefined_type_param }
 
 test_file! { strict_boolean_if_else }
+test_file! { struct_private_constructor }
 test_file! { struct_call_bad_args }
 test_file! { struct_call_without_kw_args }
 test_file! { non_pub_init }

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -6,14 +6,14 @@ expression: "build_snapshot(&files, module_id, &db)"
 note: 
   ┌─ stress/abi_encoding_stress.fe:2:5
   │
-2 │     my_num: u256
-  │     ^^^^^^^^^^^^ u256
-3 │     my_num2: u8
-  │     ^^^^^^^^^^^ u8
-4 │     my_bool: bool
-  │     ^^^^^^^^^^^^^ bool
-5 │     my_addr: address
-  │     ^^^^^^^^^^^^^^^^ address
+2 │     pub my_num: u256
+  │     ^^^^^^^^^^^^^^^^ u256
+3 │     pub my_num2: u8
+  │     ^^^^^^^^^^^^^^^ u8
+4 │     pub my_bool: bool
+  │     ^^^^^^^^^^^^^^^^^ bool
+5 │     pub my_addr: address
+  │     ^^^^^^^^^^^^^^^^^^^^ address
 
 note: 
    ┌─ stress/abi_encoding_stress.fe:8:5

--- a/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(\"features/associated_fns.fe\", &src, module, &db)"
+expression: "build_snapshot(&files, module_id, &db)"
 
 ---
 note: 
@@ -50,8 +50,8 @@ note:
 note: 
   ┌─ features/associated_fns.fe:7:3
   │
-7 │   x: u256
-  │   ^^^^^^^ u256
+7 │   pub x: u256
+  │   ^^^^^^^^^^^ u256
 
 note: 
   ┌─ features/associated_fns.fe:8:3

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -4,14 +4,21 @@ expression: snapshot
 
 ---
 note: 
+  ┌─ ingots/basic_ingot/src/ding/dang.fe:1:1
+  │
+1 │ type Dang = Array<u256, 42>
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
+
+
+note: 
   ┌─ ingots/basic_ingot/src/ding/dong.fe:4:3
   │
-4 │   my_address: address
-  │   ^^^^^^^^^^^^^^^^^^^ address
-5 │   my_u256: u256
-  │   ^^^^^^^^^^^^^ u256
-6 │   my_i8: i8
-  │   ^^^^^^^^^ i8
+4 │   pub my_address: address
+  │   ^^^^^^^^^^^^^^^^^^^^^^^ address
+5 │   pub my_u256: u256
+  │   ^^^^^^^^^^^^^^^^^ u256
+6 │   pub my_i8: i8
+  │   ^^^^^^^^^^^^^ i8
 
 note: 
   ┌─ ingots/basic_ingot/src/ding/dong.fe:8:1
@@ -65,105 +72,6 @@ note:
   │
 9 │     return Bing(my_address=address(0))
   │            ^^^^ TypeConstructor(Struct(Struct { name: "Bing", id: StructId(4), field_count: 1 }))
-
-
-note: 
-  ┌─ ingots/basic_ingot/src/ding/dang.fe:1:1
-  │
-1 │ type Dang = Array<u256, 42>
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
-
-
-note: 
-  ┌─ ingots/basic_ingot/src/bing.fe:6:5
-  │
-6 │     my_address: address
-  │     ^^^^^^^^^^^^^^^^^^^ address
-
-note: 
-  ┌─ ingots/basic_ingot/src/bing.fe:8:1
-  │  
-8 │ ╭ fn get_42_backend() -> u256:
-9 │ │     return std::get_42()
-  │ ╰────────────────────────^ attributes hash: 17979516652885443340
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
-
-note: 
-  ┌─ ingots/basic_ingot/src/bing.fe:9:12
-  │
-9 │     return std::get_42()
-  │            ^^^^^^^^^^^^^ u256: Value
-
-note: 
-  ┌─ ingots/basic_ingot/src/bing.fe:9:12
-  │
-9 │     return std::get_42()
-  │            ^^^^^^^^^^^ Pure(FunctionId(1))
-
-note: 
-   ┌─ ingots/basic_ingot/src/bing.fe:12:4
-   │  
-12 │ ╭    pub fn add(x: u256, y: u256) -> u256:
-13 │ │        return x + y
-   │ ╰───────────────────^ attributes hash: 4022593831796629401
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [
-             FunctionParam {
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 name: "y",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
-
-note: 
-   ┌─ ingots/basic_ingot/src/bing.fe:13:15
-   │
-13 │        return x + y
-   │               ^   ^ u256: Value
-   │               │    
-   │               u256: Value
-
-note: 
-   ┌─ ingots/basic_ingot/src/bing.fe:13:15
-   │
-13 │        return x + y
-   │               ^^^^^ u256: Value
 
 
 note: 
@@ -451,16 +359,108 @@ note:
 28 │         let bing_contract: BingContract = BingContract.create(0)
    │                                           ^^^^^^^^^^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(0), function: Create }
 29 │         return bing_contract.add(40, 50)
-   │                ^^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(4) }
+   │                ^^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(10) }
 
 
 note: 
   ┌─ ingots/basic_ingot/src/bar/baz.fe:2:5
   │
-2 │     my_bool: bool
-  │     ^^^^^^^^^^^^^ bool
-3 │     my_u256: u256
-  │     ^^^^^^^^^^^^^ u256
+2 │     pub my_bool: bool
+  │     ^^^^^^^^^^^^^^^^^ bool
+3 │     pub my_u256: u256
+  │     ^^^^^^^^^^^^^^^^^ u256
+
+
+note: 
+  ┌─ ingots/basic_ingot/src/bing.fe:6:5
+  │
+6 │     pub my_address: address
+  │     ^^^^^^^^^^^^^^^^^^^^^^^ address
+
+note: 
+  ┌─ ingots/basic_ingot/src/bing.fe:8:1
+  │  
+8 │ ╭ fn get_42_backend() -> u256:
+9 │ │     return std::get_42()
+  │ ╰────────────────────────^ attributes hash: 17979516652885443340
+  │  
+  = FunctionSignature {
+        self_decl: None,
+        params: [],
+        return_type: Ok(
+            Base(
+                Numeric(
+                    U256,
+                ),
+            ),
+        ),
+    }
+
+note: 
+  ┌─ ingots/basic_ingot/src/bing.fe:9:12
+  │
+9 │     return std::get_42()
+  │            ^^^^^^^^^^^^^ u256: Value
+
+note: 
+  ┌─ ingots/basic_ingot/src/bing.fe:9:12
+  │
+9 │     return std::get_42()
+  │            ^^^^^^^^^^^ Pure(FunctionId(1))
+
+note: 
+   ┌─ ingots/basic_ingot/src/bing.fe:12:4
+   │  
+12 │ ╭    pub fn add(x: u256, y: u256) -> u256:
+13 │ │        return x + y
+   │ ╰───────────────────^ attributes hash: 4022593831796629401
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [
+             FunctionParam {
+                 name: "x",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+             FunctionParam {
+                 name: "y",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ ingots/basic_ingot/src/bing.fe:13:15
+   │
+13 │        return x + y
+   │               ^   ^ u256: Value
+   │               │    
+   │               u256: Value
+
+note: 
+   ┌─ ingots/basic_ingot/src/bing.fe:13:15
+   │
+13 │        return x + y
+   │               ^^^^^ u256: Value
 
 
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -6,18 +6,18 @@ expression: "build_snapshot(&files, module_id, &db)"
 note: 
   ┌─ features/revert.fe:2:5
   │
-2 │     msg: u256
-  │     ^^^^^^^^^ u256
-3 │     val: bool
-  │     ^^^^^^^^^ bool
+2 │     pub msg: u256
+  │     ^^^^^^^^^^^^^ u256
+3 │     pub val: bool
+  │     ^^^^^^^^^^^^^ bool
 
 note: 
   ┌─ features/revert.fe:6:5
   │
-6 │     msg: u256
-  │     ^^^^^^^^^ u256
-7 │     val: bool
-  │     ^^^^^^^^^ bool
+6 │     pub msg: u256
+  │     ^^^^^^^^^^^^^ u256
+7 │     pub val: bool
+  │     ^^^^^^^^^^^^^ bool
 
 note: 
    ┌─ features/revert.fe:10:5

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -1,15 +1,15 @@
 ---
 source: crates/analyzer/tests/analysis.rs
-expression: "build_snapshot(&files, module, &db)"
+expression: "build_snapshot(&files, module_id, &db)"
 
 ---
 note: 
   ┌─ features/struct_fns.fe:2:3
   │
-2 │   x: u64
-  │   ^^^^^^ u64
-3 │   y: u64
-  │   ^^^^^^ u64
+2 │   pub x: u64
+  │   ^^^^^^^^^^ u64
+3 │   pub y: u64
+  │   ^^^^^^^^^^ u64
 
 note: 
   ┌─ features/struct_fns.fe:5:3

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -6,62 +6,124 @@ expression: "build_snapshot(&files, module_id, &db)"
 note: 
   ┌─ features/structs.fe:2:5
   │
-2 │     price: u256
-  │     ^^^^^^^^^^^ u256
-3 │     size: u256
-  │     ^^^^^^^^^^ u256
-4 │     rooms: u8
-  │     ^^^^^^^^^ u8
-5 │     vacant: bool
-  │     ^^^^^^^^^^^^ bool
+2 │     pub foo: u256
+  │     ^^^^^^^^^^^^^ u256
+3 │     bar: bool
+  │     ^^^^^^^^^ bool
 
 note: 
-  ┌─ features/structs.fe:7:5
+  ┌─ features/structs.fe:5:5
   │  
-7 │ ╭     pub fn encode(self) -> Array<u8, 128>:
-8 │ │         return self.abi_encode()
-  │ ╰────────────────────────────────^ attributes hash: 17909223604408730591
+5 │ ╭     pub fn new(val: u256) -> Mixed:
+6 │ │         return Mixed(foo=val, bar=false)
+  │ ╰────────────────────────────────────────^ attributes hash: 1457966546801734592
   │  
   = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        params: [],
-        return_type: Ok(
-            Array(
-                Array {
-                    size: 128,
-                    inner: Numeric(
-                        U8,
+        self_decl: None,
+        params: [
+            FunctionParam {
+                name: "val",
+                typ: Ok(
+                    Base(
+                        Numeric(
+                            U256,
+                        ),
                     ),
+                ),
+            },
+        ],
+        return_type: Ok(
+            Struct(
+                Struct {
+                    name: "Mixed",
+                    id: StructId(
+                        0,
+                    ),
+                    field_count: 2,
                 },
             ),
         ),
     }
 
 note: 
-  ┌─ features/structs.fe:8:16
+  ┌─ features/structs.fe:6:26
   │
-8 │         return self.abi_encode()
-  │                ^^^^ House: Memory
+6 │         return Mixed(foo=val, bar=false)
+  │                          ^^^      ^^^^^ bool: Value
+  │                          │         
+  │                          u256: Value
 
 note: 
-  ┌─ features/structs.fe:8:16
+  ┌─ features/structs.fe:6:16
   │
-8 │         return self.abi_encode()
-  │                ^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory
+6 │         return Mixed(foo=val, bar=false)
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^ Mixed: Memory
 
 note: 
-  ┌─ features/structs.fe:8:16
+  ┌─ features/structs.fe:6:16
   │
-8 │         return self.abi_encode()
-  │                ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Struct(Struct { name: "House", id: StructId(0), field_count: 4 }) }
+6 │         return Mixed(foo=val, bar=false)
+  │                ^^^^^ TypeConstructor(Struct(Struct { name: "Mixed", id: StructId(0), field_count: 2 }))
 
 note: 
-   ┌─ features/structs.fe:10:5
+   ┌─ features/structs.fe:9:5
+   │
+ 9 │     pub price: u256
+   │     ^^^^^^^^^^^^^^^ u256
+10 │     pub size: u256
+   │     ^^^^^^^^^^^^^^ u256
+11 │     pub rooms: u8
+   │     ^^^^^^^^^^^^^ u8
+12 │     pub vacant: bool
+   │     ^^^^^^^^^^^^^^^^ bool
+
+note: 
+   ┌─ features/structs.fe:14:5
    │  
-10 │ ╭     pub fn hash(self) -> u256:
-11 │ │         return keccak256(self.encode())
+14 │ ╭     pub fn encode(self) -> Array<u8, 128>:
+15 │ │         return self.abi_encode()
+   │ ╰────────────────────────────────^ attributes hash: 17909223604408730591
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Array(
+                 Array {
+                     size: 128,
+                     inner: Numeric(
+                         U8,
+                     ),
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:15:16
+   │
+15 │         return self.abi_encode()
+   │                ^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:15:16
+   │
+15 │         return self.abi_encode()
+   │                ^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory
+
+note: 
+   ┌─ features/structs.fe:15:16
+   │
+15 │         return self.abi_encode()
+   │                ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Struct(Struct { name: "House", id: StructId(1), field_count: 4 }) }
+
+note: 
+   ┌─ features/structs.fe:17:5
+   │  
+17 │ ╭     pub fn hash(self) -> u256:
+18 │ │         return keccak256(self.encode())
    │ ╰───────────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
@@ -79,40 +141,40 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:11:26
+   ┌─ features/structs.fe:18:26
    │
-11 │         return keccak256(self.encode())
+18 │         return keccak256(self.encode())
    │                          ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:11:26
+   ┌─ features/structs.fe:18:26
    │
-11 │         return keccak256(self.encode())
+18 │         return keccak256(self.encode())
    │                          ^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-   ┌─ features/structs.fe:11:16
+   ┌─ features/structs.fe:18:16
    │
-11 │         return keccak256(self.encode())
+18 │         return keccak256(self.encode())
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ features/structs.fe:11:26
+   ┌─ features/structs.fe:18:26
    │
-11 │         return keccak256(self.encode())
-   │                          ^^^^^^^^^^^ ValueMethod { is_self: true, class: Struct(StructId(0)), method: FunctionId(0) }
+18 │         return keccak256(self.encode())
+   │                          ^^^^^^^^^^^ ValueMethod { is_self: true, class: Struct(StructId(1)), method: FunctionId(1) }
 
 note: 
-   ┌─ features/structs.fe:11:16
+   ┌─ features/structs.fe:18:16
    │
-11 │         return keccak256(self.encode())
+18 │         return keccak256(self.encode())
    │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 note: 
-   ┌─ features/structs.fe:13:5
+   ┌─ features/structs.fe:20:5
    │  
-13 │ ╭     pub fn price_per_sqft(self) -> u256:
-14 │ │         return self.price / self.size
+20 │ ╭     pub fn price_per_sqft(self) -> u256:
+21 │ │         return self.price / self.size
    │ ╰─────────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
@@ -130,37 +192,37 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:14:16
+   ┌─ features/structs.fe:21:16
    │
-14 │         return self.price / self.size
+21 │         return self.price / self.size
    │                ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:14:16
+   ┌─ features/structs.fe:21:16
    │
-14 │         return self.price / self.size
+21 │         return self.price / self.size
    │                ^^^^^^^^^^   ^^^^ House: Memory
    │                │             
    │                u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:14:29
+   ┌─ features/structs.fe:21:29
    │
-14 │         return self.price / self.size
+21 │         return self.price / self.size
    │                             ^^^^^^^^^ u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:14:16
+   ┌─ features/structs.fe:21:16
    │
-14 │         return self.price / self.size
+21 │         return self.price / self.size
    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ features/structs.fe:16:5
+   ┌─ features/structs.fe:23:5
    │  
-16 │ ╭     pub fn expand(self):
-17 │ │         self.rooms += 1
-18 │ │         self.size += 100
+23 │ ╭     pub fn expand(self):
+24 │ │         self.rooms += 1
+25 │ │         self.size += 100
    │ ╰────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
@@ -176,41 +238,95 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:17:9
+   ┌─ features/structs.fe:24:9
    │
-17 │         self.rooms += 1
+24 │         self.rooms += 1
    │         ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:17:9
+   ┌─ features/structs.fe:24:9
    │
-17 │         self.rooms += 1
+24 │         self.rooms += 1
    │         ^^^^^^^^^^    ^ u8: Value
    │         │              
    │         u8: Memory
-18 │         self.size += 100
+25 │         self.size += 100
    │         ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:18:9
+   ┌─ features/structs.fe:25:9
    │
-18 │         self.size += 100
+25 │         self.size += 100
    │         ^^^^^^^^^    ^^^ u256: Value
    │         │             
    │         u256: Memory
 
 note: 
-   ┌─ features/structs.fe:21:5
+   ┌─ features/structs.fe:28:5
    │
-21 │     my_house: House
+28 │     my_house: House
    │     ^^^^^^^^^^^^^^^ House
 
 note: 
-   ┌─ features/structs.fe:23:5
+   ┌─ features/structs.fe:30:5
    │  
-23 │ ╭     pub fn set_house(self, data: House):
-24 │ │         self.my_house = data
-   │ ╰────────────────────────────^ attributes hash: 12541815911505045945
+30 │ ╭     pub fn create_mixed(self) -> u256:
+31 │ │         let mixed: Mixed = Mixed.new(1)
+32 │ │         return mixed.foo
+   │ ╰────────────────────────^ attributes hash: 2875164910451995213
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             Base(
+                 Numeric(
+                     U256,
+                 ),
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:31:20
+   │
+31 │         let mixed: Mixed = Mixed.new(1)
+   │                    ^^^^^ Mixed
+
+note: 
+   ┌─ features/structs.fe:31:38
+   │
+31 │         let mixed: Mixed = Mixed.new(1)
+   │                                      ^ u256: Value
+
+note: 
+   ┌─ features/structs.fe:31:28
+   │
+31 │         let mixed: Mixed = Mixed.new(1)
+   │                            ^^^^^^^^^^^^ Mixed: Memory
+32 │         return mixed.foo
+   │                ^^^^^ Mixed: Memory
+
+note: 
+   ┌─ features/structs.fe:32:16
+   │
+32 │         return mixed.foo
+   │                ^^^^^^^^^ u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:31:28
+   │
+31 │         let mixed: Mixed = Mixed.new(1)
+   │                            ^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(0) }
+
+note: 
+   ┌─ features/structs.fe:34:5
+   │  
+34 │ ╭     pub fn set_house(self, data: House):
+35 │ │         self.my_house = data
+   │ ╰────────────────────────────^ attributes hash: 9345407860387613771
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -224,7 +340,7 @@ note:
                          Struct {
                              name: "House",
                              id: StructId(
-                                 0,
+                                 1,
                              ),
                              field_count: 4,
                          },
@@ -240,25 +356,25 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:24:9
+   ┌─ features/structs.fe:35:9
    │
-24 │         self.my_house = data
+35 │         self.my_house = data
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:24:9
+   ┌─ features/structs.fe:35:9
    │
-24 │         self.my_house = data
+35 │         self.my_house = data
    │         ^^^^^^^^^^^^^   ^^^^ House: Memory
    │         │                
    │         House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:26:5
+   ┌─ features/structs.fe:37:5
    │  
-26 │ ╭     pub fn get_house(self) -> House:
-27 │ │         return self.my_house.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 15995799457870358812
+37 │ ╭     pub fn get_house(self) -> House:
+38 │ │         return self.my_house.to_mem()
+   │ ╰─────────────────────────────────────^ attributes hash: 3213903632176759353
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -270,7 +386,7 @@ note:
                  Struct {
                      name: "House",
                      id: StructId(
-                         0,
+                         1,
                      ),
                      field_count: 4,
                  },
@@ -279,39 +395,39 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:27:16
+   ┌─ features/structs.fe:38:16
    │
-27 │         return self.my_house.to_mem()
+38 │         return self.my_house.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:27:16
+   ┌─ features/structs.fe:38:16
    │
-27 │         return self.my_house.to_mem()
+38 │         return self.my_house.to_mem()
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:27:16
+   ┌─ features/structs.fe:38:16
    │
-27 │         return self.my_house.to_mem()
+38 │         return self.my_house.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ features/structs.fe:27:16
+   ┌─ features/structs.fe:38:16
    │
-27 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "House", id: StructId(0), field_count: 4 }) }
+38 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "House", id: StructId(1), field_count: 4 }) }
 
 note: 
-   ┌─ features/structs.fe:29:5
+   ┌─ features/structs.fe:40:5
    │  
-29 │ ╭     pub fn create_house(self):
-30 │ │         self.my_house = House(
-31 │ │             price=1,
-32 │ │             size=2,
+40 │ ╭     pub fn create_house(self):
+41 │ │         self.my_house = House(
+42 │ │             price=1,
+43 │ │             size=2,
    · │
-60 │ │         assert self.my_house.rooms == u8(100)
-61 │ │         assert self.my_house.vacant
+71 │ │         assert self.my_house.rooms == u8(100)
+72 │ │         assert self.my_house.vacant
    │ ╰───────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
@@ -327,418 +443,197 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:30:9
+   ┌─ features/structs.fe:41:9
    │
-30 │         self.my_house = House(
+41 │         self.my_house = House(
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:30:9
+   ┌─ features/structs.fe:41:9
    │
-30 │         self.my_house = House(
+41 │         self.my_house = House(
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-31 │             price=1,
+42 │             price=1,
    │                   ^ u256: Value
-32 │             size=2,
+43 │             size=2,
    │                  ^ u256: Value
-33 │             rooms=u8(5),
+44 │             rooms=u8(5),
    │                      ^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:33:19
+   ┌─ features/structs.fe:44:19
    │
-33 │             rooms=u8(5),
+44 │             rooms=u8(5),
    │                   ^^^^^ u8: Value
-34 │             vacant=false
+45 │             vacant=false
    │                    ^^^^^ bool: Value
 
 note: 
-   ┌─ features/structs.fe:30:25
+   ┌─ features/structs.fe:41:25
    │  
-30 │           self.my_house = House(
+41 │           self.my_house = House(
    │ ╭─────────────────────────^
-31 │ │             price=1,
-32 │ │             size=2,
-33 │ │             rooms=u8(5),
-34 │ │             vacant=false
-35 │ │         )
+42 │ │             price=1,
+43 │ │             size=2,
+44 │ │             rooms=u8(5),
+45 │ │             vacant=false
+46 │ │         )
    │ ╰─────────^ House: Memory
-36 │           assert self.my_house.price == 1
+47 │           assert self.my_house.price == 1
    │                  ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:36:16
+   ┌─ features/structs.fe:47:16
    │
-36 │         assert self.my_house.price == 1
+47 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:36:16
+   ┌─ features/structs.fe:47:16
    │
-36 │         assert self.my_house.price == 1
+47 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                       
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:36:16
+   ┌─ features/structs.fe:47:16
    │
-36 │         assert self.my_house.price == 1
+47 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-37 │         assert self.my_house.size == 2
+48 │         assert self.my_house.size == 2
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:37:16
+   ┌─ features/structs.fe:48:16
    │
-37 │         assert self.my_house.size == 2
+48 │         assert self.my_house.size == 2
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:37:16
+   ┌─ features/structs.fe:48:16
    │
-37 │         assert self.my_house.size == 2
+48 │         assert self.my_house.size == 2
    │                ^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                      
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:37:16
+   ┌─ features/structs.fe:48:16
    │
-37 │         assert self.my_house.size == 2
+48 │         assert self.my_house.size == 2
    │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-38 │         assert self.my_house.rooms == u8(5)
+49 │         assert self.my_house.rooms == u8(5)
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:49:16
    │
-38 │         assert self.my_house.rooms == u8(5)
+49 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:49:16
    │
-38 │         assert self.my_house.rooms == u8(5)
+49 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
    │                │                          
    │                u8: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:38:39
+   ┌─ features/structs.fe:49:39
    │
-38 │         assert self.my_house.rooms == u8(5)
+49 │         assert self.my_house.rooms == u8(5)
    │                                       ^^^^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:49:16
    │
-38 │         assert self.my_house.rooms == u8(5)
+49 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-39 │         assert self.my_house.vacant == false
+50 │         assert self.my_house.vacant == false
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:39:16
+   ┌─ features/structs.fe:50:16
    │
-39 │         assert self.my_house.vacant == false
+50 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:39:16
+   ┌─ features/structs.fe:50:16
    │
-39 │         assert self.my_house.vacant == false
+50 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
    │                │                        
    │                bool: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:39:16
+   ┌─ features/structs.fe:50:16
    │
-39 │         assert self.my_house.vacant == false
+50 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-40 │         # We change only the size and check other fields are unchanged
-41 │         self.my_house.size = 50
+51 │         # We change only the size and check other fields are unchanged
+52 │         self.my_house.size = 50
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:41:9
+   ┌─ features/structs.fe:52:9
    │
-41 │         self.my_house.size = 50
+52 │         self.my_house.size = 50
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:41:9
+   ┌─ features/structs.fe:52:9
    │
-41 │         self.my_house.size = 50
+52 │         self.my_house.size = 50
    │         ^^^^^^^^^^^^^^^^^^   ^^ u256: Value
    │         │                     
    │         u256: Storage { nonce: Some(0) }
-42 │         assert self.my_house.size == 50
+53 │         assert self.my_house.size == 50
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:42:16
+   ┌─ features/structs.fe:53:16
    │
-42 │         assert self.my_house.size == 50
+53 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:42:16
+   ┌─ features/structs.fe:53:16
    │
-42 │         assert self.my_house.size == 50
+53 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
    │                │                      
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:42:16
+   ┌─ features/structs.fe:53:16
    │
-42 │         assert self.my_house.size == 50
+53 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-43 │         assert self.my_house.price == 1
+54 │         assert self.my_house.price == 1
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:43:16
+   ┌─ features/structs.fe:54:16
    │
-43 │         assert self.my_house.price == 1
+54 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:43:16
+   ┌─ features/structs.fe:54:16
    │
-43 │         assert self.my_house.price == 1
+54 │         assert self.my_house.price == 1
    │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                       
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:43:16
-   │
-43 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-44 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:44:16
-   │
-44 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:44:16
-   │
-44 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:44:39
-   │
-44 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:44:16
-   │
-44 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-45 │         assert self.my_house.vacant == false
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:45:16
-   │
-45 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:45:16
-   │
-45 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:45:16
-   │
-45 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-46 │         # We change only the price and check other fields are unchanged
-47 │         self.my_house.price = 1000
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:47:9
-   │
-47 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:47:9
-   │
-47 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
-   │         │                      
-   │         u256: Storage { nonce: Some(0) }
-48 │         assert self.my_house.size == 50
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
-48 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
-48 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
-48 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-49 │         assert self.my_house.price == 1000
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:49:16
-   │
-49 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:49:16
-   │
-49 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:49:16
-   │
-49 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-50 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:50:16
-   │
-50 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:50:16
-   │
-50 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:50:39
-   │
-50 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:50:16
-   │
-50 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-51 │         assert self.my_house.vacant == false
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:51:16
-   │
-51 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:51:16
-   │
-51 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:51:16
-   │
-51 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-52 │         self.my_house.vacant = true
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:52:9
-   │
-52 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:52:9
-   │
-52 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value
-   │         │                       
-   │         bool: Storage { nonce: Some(0) }
-53 │         assert self.my_house.size == 50
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-54 │         assert self.my_house.price == 1000
-   │                ^^^^ Foo: Value
-
-note: 
    ┌─ features/structs.fe:54:16
    │
-54 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:54:16
-   │
-54 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:54:16
-   │
-54 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+54 │         assert self.my_house.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 55 │         assert self.my_house.rooms == u8(5)
    │                ^^^^ Foo: Value
 
@@ -767,383 +662,478 @@ note:
    │
 55 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-56 │         assert self.my_house.vacant
+56 │         assert self.my_house.vacant == false
    │                ^^^^ Foo: Value
 
 note: 
    ┌─ features/structs.fe:56:16
    │
-56 │         assert self.my_house.vacant
+56 │         assert self.my_house.vacant == false
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
    ┌─ features/structs.fe:56:16
    │
-56 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
-57 │         self.my_house.rooms = u8(100)
+56 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:56:16
+   │
+56 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+57 │         # We change only the price and check other fields are unchanged
+58 │         self.my_house.price = 1000
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:57:9
+   ┌─ features/structs.fe:58:9
    │
-57 │         self.my_house.rooms = u8(100)
+58 │         self.my_house.price = 1000
    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:57:9
+   ┌─ features/structs.fe:58:9
    │
-57 │         self.my_house.rooms = u8(100)
-   │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value
-   │         │                         
-   │         u8: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:57:31
-   │
-57 │         self.my_house.rooms = u8(100)
-   │                               ^^^^^^^ u8: Value
-58 │         assert self.my_house.size == 50
+58 │         self.my_house.price = 1000
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
+   │         │                      
+   │         u256: Storage { nonce: Some(0) }
+59 │         assert self.my_house.size == 50
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:58:16
+   ┌─ features/structs.fe:59:16
    │
-58 │         assert self.my_house.size == 50
+59 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:58:16
+   ┌─ features/structs.fe:59:16
    │
-58 │         assert self.my_house.size == 50
+59 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
    │                │                      
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:58:16
+   ┌─ features/structs.fe:59:16
    │
-58 │         assert self.my_house.size == 50
+59 │         assert self.my_house.size == 50
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-59 │         assert self.my_house.price == 1000
+60 │         assert self.my_house.price == 1000
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:59:16
+   ┌─ features/structs.fe:60:16
    │
-59 │         assert self.my_house.price == 1000
+60 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:59:16
+   ┌─ features/structs.fe:60:16
    │
-59 │         assert self.my_house.price == 1000
+60 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
    │                │                       
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:59:16
+   ┌─ features/structs.fe:60:16
    │
-59 │         assert self.my_house.price == 1000
+60 │         assert self.my_house.price == 1000
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-60 │         assert self.my_house.rooms == u8(100)
+61 │         assert self.my_house.rooms == u8(5)
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:60:16
+   ┌─ features/structs.fe:61:16
    │
-60 │         assert self.my_house.rooms == u8(100)
+61 │         assert self.my_house.rooms == u8(5)
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:60:16
+   ┌─ features/structs.fe:61:16
    │
-60 │         assert self.my_house.rooms == u8(100)
+61 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:61:39
+   │
+61 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^^^^ u8: Value
+
+note: 
+   ┌─ features/structs.fe:61:16
+   │
+61 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+62 │         assert self.my_house.vacant == false
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:62:16
+   │
+62 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:62:16
+   │
+62 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+   │                │                        
+   │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:62:16
+   │
+62 │         assert self.my_house.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+63 │         self.my_house.vacant = true
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:63:9
+   │
+63 │         self.my_house.vacant = true
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:63:9
+   │
+63 │         self.my_house.vacant = true
+   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value
+   │         │                       
+   │         bool: Storage { nonce: Some(0) }
+64 │         assert self.my_house.size == 50
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:64:16
+   │
+64 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:64:16
+   │
+64 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:64:16
+   │
+64 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+65 │         assert self.my_house.price == 1000
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:65:16
+   │
+65 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:65:16
+   │
+65 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:65:16
+   │
+65 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+66 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:66:16
+   │
+66 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:66:16
+   │
+66 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+   │                │                          
+   │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:66:39
+   │
+66 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^^^^ u8: Value
+
+note: 
+   ┌─ features/structs.fe:66:16
+   │
+66 │         assert self.my_house.rooms == u8(5)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+67 │         assert self.my_house.vacant
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:67:16
+   │
+67 │         assert self.my_house.vacant
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:67:16
+   │
+67 │         assert self.my_house.vacant
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
+68 │         self.my_house.rooms = u8(100)
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:68:9
+   │
+68 │         self.my_house.rooms = u8(100)
+   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:68:9
+   │
+68 │         self.my_house.rooms = u8(100)
+   │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value
+   │         │                         
+   │         u8: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:68:31
+   │
+68 │         self.my_house.rooms = u8(100)
+   │                               ^^^^^^^ u8: Value
+69 │         assert self.my_house.size == 50
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                      
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert self.my_house.size == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+70 │         assert self.my_house.price == 1000
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+   │                │                       
+   │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert self.my_house.price == 1000
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+71 │         assert self.my_house.rooms == u8(100)
+   │                ^^^^ Foo: Value
+
+note: 
+   ┌─ features/structs.fe:71:16
+   │
+71 │         assert self.my_house.rooms == u8(100)
+   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ features/structs.fe:71:16
+   │
+71 │         assert self.my_house.rooms == u8(100)
    │                ^^^^^^^^^^^^^^^^^^^       ^^^ u8: Value
    │                │                          
    │                u8: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:60:39
+   ┌─ features/structs.fe:71:39
    │
-60 │         assert self.my_house.rooms == u8(100)
+71 │         assert self.my_house.rooms == u8(100)
    │                                       ^^^^^^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:60:16
+   ┌─ features/structs.fe:71:16
    │
-60 │         assert self.my_house.rooms == u8(100)
+71 │         assert self.my_house.rooms == u8(100)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-61 │         assert self.my_house.vacant
+72 │         assert self.my_house.vacant
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:61:16
+   ┌─ features/structs.fe:72:16
    │
-61 │         assert self.my_house.vacant
+72 │         assert self.my_house.vacant
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:61:16
+   ┌─ features/structs.fe:72:16
    │
-61 │         assert self.my_house.vacant
+72 │         assert self.my_house.vacant
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ features/structs.fe:33:19
+   ┌─ features/structs.fe:44:19
    │
-33 │             rooms=u8(5),
+44 │             rooms=u8(5),
    │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-   ┌─ features/structs.fe:30:25
+   ┌─ features/structs.fe:41:25
    │
-30 │         self.my_house = House(
-   │                         ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+41 │         self.my_house = House(
+   │                         ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
    ·
-38 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-44 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-50 │         assert self.my_house.rooms == u8(5)
+49 │         assert self.my_house.rooms == u8(5)
    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
    ·
 55 │         assert self.my_house.rooms == u8(5)
    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-56 │         assert self.my_house.vacant
-57 │         self.my_house.rooms = u8(100)
+   ·
+61 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+   ·
+66 │         assert self.my_house.rooms == u8(5)
+   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+67 │         assert self.my_house.vacant
+68 │         self.my_house.rooms = u8(100)
    │                               ^^ TypeConstructor(Base(Numeric(U8)))
    ·
-60 │         assert self.my_house.rooms == u8(100)
+71 │         assert self.my_house.rooms == u8(100)
    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-   ┌─ features/structs.fe:63:5
-   │  
-63 │ ╭     pub fn bar() -> u256:
-64 │ │         let building: House = House(
-65 │ │             price=300,
-66 │ │             size=500,
-   · │
-88 │ │ 
-89 │ │         return building.size
-   │ ╰────────────────────────────^ attributes hash: 17979516652885443340
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+    ┌─ features/structs.fe:74:5
+    │  
+ 74 │ ╭     pub fn bar() -> u256:
+ 75 │ │         let building: House = House(
+ 76 │ │             price=300,
+ 77 │ │             size=500,
+    · │
+ 99 │ │ 
+100 │ │         return building.size
+    │ ╰────────────────────────────^ attributes hash: 17979516652885443340
+    │  
+    = FunctionSignature {
+          self_decl: None,
+          params: [],
+          return_type: Ok(
+              Base(
+                  Numeric(
+                      U256,
+                  ),
+              ),
+          ),
+      }
 
 note: 
-   ┌─ features/structs.fe:64:23
+   ┌─ features/structs.fe:75:23
    │
-64 │         let building: House = House(
+75 │         let building: House = House(
    │                       ^^^^^ House
 
 note: 
-   ┌─ features/structs.fe:65:19
+   ┌─ features/structs.fe:76:19
    │
-65 │             price=300,
+76 │             price=300,
    │                   ^^^ u256: Value
-66 │             size=500,
+77 │             size=500,
    │                  ^^^ u256: Value
-67 │             rooms=u8(20),
+78 │             rooms=u8(20),
    │                      ^^ u8: Value
 
 note: 
-   ┌─ features/structs.fe:67:19
+   ┌─ features/structs.fe:78:19
    │
-67 │             rooms=u8(20),
+78 │             rooms=u8(20),
    │                   ^^^^^^ u8: Value
-68 │             vacant=true
+79 │             vacant=true
    │                    ^^^^ bool: Value
 
 note: 
-   ┌─ features/structs.fe:64:31
+   ┌─ features/structs.fe:75:31
    │  
-64 │           let building: House = House(
+75 │           let building: House = House(
    │ ╭───────────────────────────────^
-65 │ │             price=300,
-66 │ │             size=500,
-67 │ │             rooms=u8(20),
-68 │ │             vacant=true
-69 │ │         )
+76 │ │             price=300,
+77 │ │             size=500,
+78 │ │             rooms=u8(20),
+79 │ │             vacant=true
+80 │ │         )
    │ ╰─────────^ House: Memory
-70 │           assert building.size == 500
+81 │           assert building.size == 500
    │                  ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:70:16
+   ┌─ features/structs.fe:81:16
    │
-70 │         assert building.size == 500
+81 │         assert building.size == 500
    │                ^^^^^^^^^^^^^    ^^^ u256: Value
    │                │                 
    │                u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:70:16
+   ┌─ features/structs.fe:81:16
    │
-70 │         assert building.size == 500
+81 │         assert building.size == 500
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-71 │         assert building.price == 300
+82 │         assert building.price == 300
    │                ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:71:16
+   ┌─ features/structs.fe:82:16
    │
-71 │         assert building.price == 300
+82 │         assert building.price == 300
    │                ^^^^^^^^^^^^^^    ^^^ u256: Value
    │                │                  
    │                u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:71:16
+   ┌─ features/structs.fe:82:16
    │
-71 │         assert building.price == 300
+82 │         assert building.price == 300
    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-72 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:72:16
-   │
-72 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^       ^^ u8: Value
-   │                │                     
-   │                u8: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:72:34
-   │
-72 │         assert building.rooms == u8(20)
-   │                                  ^^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:72:16
-   │
-72 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-73 │         assert building.vacant
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:73:16
-   │
-73 │         assert building.vacant
-   │                ^^^^^^^^^^^^^^^ bool: Memory => Value
-74 │ 
-75 │         building.vacant = false
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:75:9
-   │
-75 │         building.vacant = false
-   │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value
-   │         │                  
-   │         bool: Memory
-76 │         building.price = 1
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:76:9
-   │
-76 │         building.price = 1
-   │         ^^^^^^^^^^^^^^   ^ u256: Value
-   │         │                 
-   │         u256: Memory
-77 │         building.size = 2
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:77:9
-   │
-77 │         building.size = 2
-   │         ^^^^^^^^^^^^^   ^ u256: Value
-   │         │                
-   │         u256: Memory
-78 │         building.rooms = u8(10)
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:78:9
-   │
-78 │         building.rooms = u8(10)
-   │         ^^^^^^^^^^^^^^      ^^ u8: Value
-   │         │                    
-   │         u8: Memory
-
-note: 
-   ┌─ features/structs.fe:78:26
-   │
-78 │         building.rooms = u8(10)
-   │                          ^^^^^^ u8: Value
-79 │ 
-80 │         assert building.vacant == false
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:80:16
-   │
-80 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                   
-   │                bool: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:80:16
-   │
-80 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-81 │         assert building.price == 1
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:81:16
-   │
-81 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^    ^ u256: Value
-   │                │                  
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:81:16
-   │
-81 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
-82 │         assert building.size == 2
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:82:16
-   │
-82 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^    ^ u256: Value
-   │                │                 
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:82:16
-   │
-82 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^^^^^^ bool: Value
-83 │         assert building.rooms == u8(10)
+83 │         assert building.rooms == u8(20)
    │                ^^^^^^^^ House: Memory
 
 note: 
    ┌─ features/structs.fe:83:16
    │
-83 │         assert building.rooms == u8(10)
+83 │         assert building.rooms == u8(20)
    │                ^^^^^^^^^^^^^^       ^^ u8: Value
    │                │                     
    │                u8: Memory => Value
@@ -1151,185 +1141,311 @@ note:
 note: 
    ┌─ features/structs.fe:83:34
    │
-83 │         assert building.rooms == u8(10)
+83 │         assert building.rooms == u8(20)
    │                                  ^^^^^^ u8: Value
 
 note: 
    ┌─ features/structs.fe:83:16
    │
-83 │         assert building.rooms == u8(10)
+83 │         assert building.rooms == u8(20)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-84 │ 
-85 │         building.expand()
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:85:9
-   │
-85 │         building.expand()
-   │         ^^^^^^^^^^^^^^^^^ (): Value
-86 │         assert building.size == 102
+84 │         assert building.vacant
    │                ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:86:16
+   ┌─ features/structs.fe:84:16
    │
-86 │         assert building.size == 102
+84 │         assert building.vacant
+   │                ^^^^^^^^^^^^^^^ bool: Memory => Value
+85 │ 
+86 │         building.vacant = false
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:86:9
+   │
+86 │         building.vacant = false
+   │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value
+   │         │                  
+   │         bool: Memory
+87 │         building.price = 1
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:87:9
+   │
+87 │         building.price = 1
+   │         ^^^^^^^^^^^^^^   ^ u256: Value
+   │         │                 
+   │         u256: Memory
+88 │         building.size = 2
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:88:9
+   │
+88 │         building.size = 2
+   │         ^^^^^^^^^^^^^   ^ u256: Value
+   │         │                
+   │         u256: Memory
+89 │         building.rooms = u8(10)
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:89:9
+   │
+89 │         building.rooms = u8(10)
+   │         ^^^^^^^^^^^^^^      ^^ u8: Value
+   │         │                    
+   │         u8: Memory
+
+note: 
+   ┌─ features/structs.fe:89:26
+   │
+89 │         building.rooms = u8(10)
+   │                          ^^^^^^ u8: Value
+90 │ 
+91 │         assert building.vacant == false
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:91:16
+   │
+91 │         assert building.vacant == false
+   │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+   │                │                   
+   │                bool: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:91:16
+   │
+91 │         assert building.vacant == false
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+92 │         assert building.price == 1
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:92:16
+   │
+92 │         assert building.price == 1
+   │                ^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:92:16
+   │
+92 │         assert building.price == 1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+93 │         assert building.size == 2
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:93:16
+   │
+93 │         assert building.size == 2
+   │                ^^^^^^^^^^^^^    ^ u256: Value
+   │                │                 
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:93:16
+   │
+93 │         assert building.size == 2
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value
+94 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:94:16
+   │
+94 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^^^^^^^       ^^ u8: Value
+   │                │                     
+   │                u8: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:94:34
+   │
+94 │         assert building.rooms == u8(10)
+   │                                  ^^^^^^ u8: Value
+
+note: 
+   ┌─ features/structs.fe:94:16
+   │
+94 │         assert building.rooms == u8(10)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+95 │ 
+96 │         building.expand()
+   │         ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:96:9
+   │
+96 │         building.expand()
+   │         ^^^^^^^^^^^^^^^^^ (): Value
+97 │         assert building.size == 102
+   │                ^^^^^^^^ House: Memory
+
+note: 
+   ┌─ features/structs.fe:97:16
+   │
+97 │         assert building.size == 102
    │                ^^^^^^^^^^^^^    ^^^ u256: Value
    │                │                 
    │                u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:86:16
+   ┌─ features/structs.fe:97:16
    │
-86 │         assert building.size == 102
+97 │         assert building.size == 102
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-87 │         assert building.rooms == 11
+98 │         assert building.rooms == 11
    │                ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:87:16
+   ┌─ features/structs.fe:98:16
    │
-87 │         assert building.rooms == 11
+98 │         assert building.rooms == 11
    │                ^^^^^^^^^^^^^^    ^^ u8: Value
    │                │                  
    │                u8: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:87:16
-   │
-87 │         assert building.rooms == 11
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-88 │ 
-89 │         return building.size
-   │                ^^^^^^^^ House: Memory
+    ┌─ features/structs.fe:98:16
+    │
+ 98 │         assert building.rooms == 11
+    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+ 99 │ 
+100 │         return building.size
+    │                ^^^^^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:89:16
-   │
-89 │         return building.size
-   │                ^^^^^^^^^^^^^ u256: Memory => Value
+    ┌─ features/structs.fe:100:16
+    │
+100 │         return building.size
+    │                ^^^^^^^^^^^^^ u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:67:19
+   ┌─ features/structs.fe:78:19
    │
-67 │             rooms=u8(20),
+78 │             rooms=u8(20),
    │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-   ┌─ features/structs.fe:64:31
+   ┌─ features/structs.fe:75:31
    │
-64 │         let building: House = House(
-   │                               ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+75 │         let building: House = House(
+   │                               ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
    ·
-72 │         assert building.rooms == u8(20)
+83 │         assert building.rooms == u8(20)
    │                                  ^^ TypeConstructor(Base(Numeric(U8)))
    ·
-78 │         building.rooms = u8(10)
+89 │         building.rooms = u8(10)
    │                          ^^ TypeConstructor(Base(Numeric(U8)))
    ·
-83 │         assert building.rooms == u8(10)
+94 │         assert building.rooms == u8(10)
    │                                  ^^ TypeConstructor(Base(Numeric(U8)))
-84 │ 
-85 │         building.expand()
-   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(3) }
+95 │ 
+96 │         building.expand()
+   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(1)), method: FunctionId(4) }
 
 note: 
-   ┌─ features/structs.fe:91:5
-   │  
-91 │ ╭     pub fn encode_house() -> Array<u8, 128>:
-92 │ │         let house: House = House(
-93 │ │             price=300,
-94 │ │             size=500,
-   · │
-97 │ │         )
-98 │ │         return house.encode()
-   │ ╰─────────────────────────────^ attributes hash: 6092146250611764360
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 128,
-                     inner: Numeric(
-                         U8,
-                     ),
-                 },
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:92:20
-   │
-92 │         let house: House = House(
-   │                    ^^^^^ House
-
-note: 
-   ┌─ features/structs.fe:93:19
-   │
-93 │             price=300,
-   │                   ^^^ u256: Value
-94 │             size=500,
-   │                  ^^^ u256: Value
-95 │             rooms=u8(20),
-   │                      ^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:95:19
-   │
-95 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value
-96 │             vacant=true
-   │                    ^^^^ bool: Value
-
-note: 
-   ┌─ features/structs.fe:92:28
-   │  
-92 │           let house: House = House(
-   │ ╭────────────────────────────^
-93 │ │             price=300,
-94 │ │             size=500,
-95 │ │             rooms=u8(20),
-96 │ │             vacant=true
-97 │ │         )
-   │ ╰─────────^ House: Memory
-98 │           return house.encode()
-   │                  ^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:98:16
-   │
-98 │         return house.encode()
-   │                ^^^^^^^^^^^^^^ Array<u8, 128>: Memory
-
-note: 
-   ┌─ features/structs.fe:95:19
-   │
-95 │             rooms=u8(20),
-   │                   ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-   ┌─ features/structs.fe:92:28
-   │
-92 │         let house: House = House(
-   │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
-   ·
-98 │         return house.encode()
-   │                ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(0) }
-
-note: 
-    ┌─ features/structs.fe:100:5
+    ┌─ features/structs.fe:102:5
     │  
-100 │ ╭     pub fn hashed_house() -> u256:
-101 │ │         let house: House = House(
-102 │ │             price=300,
-103 │ │             size=500,
+102 │ ╭     pub fn encode_house() -> Array<u8, 128>:
+103 │ │         let house: House = House(
+104 │ │             price=300,
+105 │ │             size=500,
     · │
-106 │ │         )
-107 │ │         return house.hash()
+108 │ │         )
+109 │ │         return house.encode()
+    │ ╰─────────────────────────────^ attributes hash: 6092146250611764360
+    │  
+    = FunctionSignature {
+          self_decl: None,
+          params: [],
+          return_type: Ok(
+              Array(
+                  Array {
+                      size: 128,
+                      inner: Numeric(
+                          U8,
+                      ),
+                  },
+              ),
+          ),
+      }
+
+note: 
+    ┌─ features/structs.fe:103:20
+    │
+103 │         let house: House = House(
+    │                    ^^^^^ House
+
+note: 
+    ┌─ features/structs.fe:104:19
+    │
+104 │             price=300,
+    │                   ^^^ u256: Value
+105 │             size=500,
+    │                  ^^^ u256: Value
+106 │             rooms=u8(20),
+    │                      ^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:106:19
+    │
+106 │             rooms=u8(20),
+    │                   ^^^^^^ u8: Value
+107 │             vacant=true
+    │                    ^^^^ bool: Value
+
+note: 
+    ┌─ features/structs.fe:103:28
+    │  
+103 │           let house: House = House(
+    │ ╭────────────────────────────^
+104 │ │             price=300,
+105 │ │             size=500,
+106 │ │             rooms=u8(20),
+107 │ │             vacant=true
+108 │ │         )
+    │ ╰─────────^ House: Memory
+109 │           return house.encode()
+    │                  ^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:109:16
+    │
+109 │         return house.encode()
+    │                ^^^^^^^^^^^^^^ Array<u8, 128>: Memory
+
+note: 
+    ┌─ features/structs.fe:106:19
+    │
+106 │             rooms=u8(20),
+    │                   ^^ TypeConstructor(Base(Numeric(U8)))
+
+note: 
+    ┌─ features/structs.fe:103:28
+    │
+103 │         let house: House = House(
+    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
+    ·
+109 │         return house.encode()
+    │                ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(1)), method: FunctionId(1) }
+
+note: 
+    ┌─ features/structs.fe:111:5
+    │  
+111 │ ╭     pub fn hashed_house() -> u256:
+112 │ │         let house: House = House(
+113 │ │             price=300,
+114 │ │             size=500,
+    · │
+117 │ │         )
+118 │ │         return house.hash()
     │ ╰───────────────────────────^ attributes hash: 17979516652885443340
     │  
     = FunctionSignature {
@@ -1345,62 +1461,62 @@ note:
       }
 
 note: 
-    ┌─ features/structs.fe:101:20
+    ┌─ features/structs.fe:112:20
     │
-101 │         let house: House = House(
+112 │         let house: House = House(
     │                    ^^^^^ House
 
 note: 
-    ┌─ features/structs.fe:102:19
+    ┌─ features/structs.fe:113:19
     │
-102 │             price=300,
+113 │             price=300,
     │                   ^^^ u256: Value
-103 │             size=500,
+114 │             size=500,
     │                  ^^^ u256: Value
-104 │             rooms=u8(20),
+115 │             rooms=u8(20),
     │                      ^^ u8: Value
 
 note: 
-    ┌─ features/structs.fe:104:19
+    ┌─ features/structs.fe:115:19
     │
-104 │             rooms=u8(20),
+115 │             rooms=u8(20),
     │                   ^^^^^^ u8: Value
-105 │             vacant=true
+116 │             vacant=true
     │                    ^^^^ bool: Value
 
 note: 
-    ┌─ features/structs.fe:101:28
+    ┌─ features/structs.fe:112:28
     │  
-101 │           let house: House = House(
+112 │           let house: House = House(
     │ ╭────────────────────────────^
-102 │ │             price=300,
-103 │ │             size=500,
-104 │ │             rooms=u8(20),
-105 │ │             vacant=true
-106 │ │         )
+113 │ │             price=300,
+114 │ │             size=500,
+115 │ │             rooms=u8(20),
+116 │ │             vacant=true
+117 │ │         )
     │ ╰─────────^ House: Memory
-107 │           return house.hash()
+118 │           return house.hash()
     │                  ^^^^^ House: Memory
 
 note: 
-    ┌─ features/structs.fe:107:16
+    ┌─ features/structs.fe:118:16
     │
-107 │         return house.hash()
+118 │         return house.hash()
     │                ^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ features/structs.fe:104:19
+    ┌─ features/structs.fe:115:19
     │
-104 │             rooms=u8(20),
+115 │             rooms=u8(20),
     │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-    ┌─ features/structs.fe:101:28
+    ┌─ features/structs.fe:112:28
     │
-101 │         let house: House = House(
-    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(0), field_count: 4 }))
+112 │         let house: House = House(
+    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
     ·
-107 │         return house.hash()
-    │                ^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(1) }
+118 │         return house.hash()
+    │                ^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(1)), method: FunctionId(2) }
 
 

--- a/crates/analyzer/tests/snapshots/errors__private_struct_field.snap
+++ b/crates/analyzer/tests/snapshots/errors__private_struct_field.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Can not access private field `id` on struct `Bar`
+  ┌─ compile_errors/private_struct_field.fe:8:14
+  │
+8 │     self.val.id
+  │              ^^ private field
+
+

--- a/crates/analyzer/tests/snapshots/errors__struct_private_constructor.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_private_constructor.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: Can not call private constructor of struct `House` 
+  ┌─ compile_errors/struct_private_constructor.fe:2:5
+  │
+2 │     vacant: bool
+  │     ^^^^^^^^^^^^ Field `vacant` is private
+  │
+  = Suggestion: implement a method `new(...)` on struct `House` to call the constructor and return the struct
+
+

--- a/crates/analyzer/tests/snapshots/errors__undefined_type_param.snap
+++ b/crates/analyzer/tests/snapshots/errors__undefined_type_param.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, &src)"
 
 ---
 error: undefined type
-  ┌─ compile_errors/undefined_type_param.fe:4:8
+  ┌─ compile_errors/undefined_type_param.fe:4:12
   │
-4 │     x: MysteryType
-  │        ^^^^^^^^^^^ `MysteryType` has not been defined
+4 │     pub x: MysteryType
+  │            ^^^^^^^^^^^ `MysteryType` has not been defined
 
 error: undefined type
   ┌─ compile_errors/undefined_type_param.fe:8:19

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -110,7 +110,7 @@ fn build_tuple_struct(tuple: &Tuple) -> ast::Struct {
 
 fn build_struct_field(name: String, type_desc: ast::TypeDesc) -> ast::Field {
     ast::Field {
-        is_pub: false,
+        is_pub: true,
         is_const: false,
         name: SmolStr::new(name).into_node(),
         typ: type_desc.into_node(),

--- a/crates/lowering/tests/snapshots/lowering__and_or.snap
+++ b/crates/lowering/tests/snapshots/lowering__and_or.snap
@@ -4,8 +4,8 @@ expression: lowered_code
 
 ---
 struct $tuple_bool_bool_:
-    item0: bool
-    item1: bool
+    pub item0: bool
+    pub item1: bool
 
 contract Foo:
     pub fn bar() -> ():

--- a/crates/lowering/tests/snapshots/lowering__base_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__base_tuple.snap
@@ -4,33 +4,33 @@ expression: lowered_code
 
 ---
 struct $tuple_bool_address_:
-    item0: bool
-    item1: address
+    pub item0: bool
+    pub item1: address
 
 struct $tuple_bool_bool_:
-    item0: bool
-    item1: bool
+    pub item0: bool
+    pub item1: bool
 
 struct $tuple_address_address_:
-    item0: address
-    item1: address
+    pub item0: address
+    pub item1: address
 
 struct $tuple_u256_bool_:
-    item0: u256
-    item1: bool
+    pub item0: u256
+    pub item1: bool
 
 struct $tuple_u256_bool_u8_address_:
-    item0: u256
-    item1: bool
-    item2: u8
-    item3: address
+    pub item0: u256
+    pub item1: bool
+    pub item2: u8
+    pub item3: address
 
 struct $tuple_address_address_u16_i32_bool_:
-    item0: address
-    item1: address
-    item2: u16
-    item3: i32
-    item4: bool
+    pub item0: address
+    pub item1: address
+    pub item2: u16
+    pub item3: i32
+    pub item4: bool
 
 contract Foo:
     my_tuple_field: $tuple_bool_address_

--- a/crates/lowering/tests/snapshots/lowering__map_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__map_tuple.snap
@@ -4,12 +4,12 @@ expression: lowered_code
 
 ---
 struct $tuple_u256_u8_:
-    item0: u256
-    item1: u8
+    pub item0: u256
+    pub item1: u8
 
 struct $tuple_address_tuple_u256_u8__:
-    item0: address
-    item1: $tuple_u256_u8_
+    pub item0: address
+    pub item1: $tuple_u256_u8_
 
 contract Foo:
     tuples: Map<u256, $tuple_address_tuple_u256_u8__>

--- a/crates/lowering/tests/snapshots/lowering__module_const.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_const.snap
@@ -4,8 +4,8 @@ expression: lowered_code
 
 ---
 struct $tuple_u256_u256_:
-    item0: u256
-    item1: u256
+    pub item0: u256
+    pub item1: u256
 
 fn list_expr_array_u256_2(val0: u256, val1: u256) -> Array<u256, 2>:
     let generated_array: Array<u256, 2>

--- a/crates/lowering/tests/snapshots/lowering__module_fn.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_fn.snap
@@ -4,12 +4,12 @@ expression: lowered_code
 
 ---
 struct $tuple_u256_u8_:
-    item0: u256
-    item1: u8
+    pub item0: u256
+    pub item1: u8
 
 struct $tuple_address_tuple_u256_u8__:
-    item0: address
-    item1: $tuple_u256_u8_
+    pub item0: address
+    pub item1: $tuple_u256_u8_
 
 fn list_expr_array_u8_3(val0: u8, val1: u8, val2: u8) -> Array<u8, 3>:
     let generated_array: Array<u8, 3>

--- a/crates/lowering/tests/snapshots/lowering__nested_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__nested_tuple.snap
@@ -4,21 +4,21 @@ expression: lowered_code
 
 ---
 struct $tuple_u8_bool_:
-    item0: u8
-    item1: bool
+    pub item0: u8
+    pub item1: bool
 
 struct $tuple_u8_u8_:
-    item0: u8
-    item1: u8
+    pub item0: u8
+    pub item1: u8
 
 struct $tuple_address_tuple_u8_u8__:
-    item0: address
-    item1: $tuple_u8_u8_
+    pub item0: address
+    pub item1: $tuple_u8_u8_
 
 struct $tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___:
-    item0: u256
-    item1: $tuple_u8_bool_
-    item2: $tuple_address_tuple_u8_u8__
+    pub item0: u256
+    pub item1: $tuple_u8_bool_
+    pub item2: $tuple_address_tuple_u8_u8__
 
 contract Foo:
     tup: $tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___

--- a/crates/lowering/tests/snapshots/lowering__ternary.snap
+++ b/crates/lowering/tests/snapshots/lowering__ternary.snap
@@ -4,8 +4,8 @@ expression: lowered_code
 
 ---
 struct $tuple_u256_u256_:
-    item0: u256
-    item1: u256
+    pub item0: u256
+    pub item1: u256
 
 contract Foo:
     pub fn bar() -> ():

--- a/crates/lowering/tests/snapshots/lowering__tuple_destruct.snap
+++ b/crates/lowering/tests/snapshots/lowering__tuple_destruct.snap
@@ -4,14 +4,14 @@ expression: lowered_code
 
 ---
 struct $tuple_bool_bool_address_u8_:
-    item0: bool
-    item1: bool
-    item2: address
-    item3: u8
+    pub item0: bool
+    pub item1: bool
+    pub item2: address
+    pub item3: u8
 
 struct $tuple_u256_bool_:
-    item0: u256
-    item1: bool
+    pub item0: u256
+    pub item1: bool
 
 contract Foo:
     my_sto_tuple: $tuple_bool_bool_address_u8_

--- a/crates/lowering/tests/snapshots/lowering__type_alias_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__type_alias_tuple.snap
@@ -4,8 +4,8 @@ expression: lowered_code
 
 ---
 struct $tuple_u8_address_:
-    item0: u8
-    item1: address
+    pub item0: u8
+    pub item1: address
 
 type Tup = $tuple_u8_address_
 

--- a/crates/test-files/fixtures/compile_errors/bad_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_ingot/src/foo.fe
@@ -3,7 +3,7 @@ use ingot::bing::Tong
 use ingot::bing as std
 
 struct Foo:
-    my_num: u256
+    pub my_num: u256
 
 struct Bar:
     pass

--- a/crates/test-files/fixtures/compile_errors/call_undefined_function_on_memory_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/call_undefined_function_on_memory_struct.fe
@@ -1,5 +1,5 @@
 struct Something:
-  val: u8
+  pub val: u8
 
 contract Bar:
   pub fn test():

--- a/crates/test-files/fixtures/compile_errors/private_struct_field.fe
+++ b/crates/test-files/fixtures/compile_errors/private_struct_field.fe
@@ -1,0 +1,8 @@
+struct Bar:
+  id: u256
+
+contract Foo:
+  val: Bar
+
+  pub fn foo(self):
+    self.val.id

--- a/crates/test-files/fixtures/compile_errors/self_misuse.fe
+++ b/crates/test-files/fixtures/compile_errors/self_misuse.fe
@@ -9,7 +9,7 @@ fn bar(c: C):
   pass
 
 struct S:
-  x: u8
+  pub x: u8
 
   fn f(self):
     self()

--- a/crates/test-files/fixtures/compile_errors/struct_call_bad_args.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_call_bad_args.fe
@@ -1,6 +1,6 @@
 struct House:
-    vacant: bool
-    price: u256
+    pub vacant: bool
+    pub price: u256
 
 contract Foo:
 

--- a/crates/test-files/fixtures/compile_errors/struct_call_without_kw_args.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_call_without_kw_args.fe
@@ -1,6 +1,6 @@
 struct House:
-    vacant: bool
-    price: u256
+    pub vacant: bool
+    pub price: u256
 
 contract Foo:
 

--- a/crates/test-files/fixtures/compile_errors/struct_private_constructor.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_private_constructor.fe
@@ -1,0 +1,8 @@
+struct House:
+    vacant: bool
+    pub price: u256
+
+contract Foo:
+
+    pub fn bar():
+        let my_house: House = House(vacant=true, price=1000000)

--- a/crates/test-files/fixtures/compile_errors/undefined_type_param.fe
+++ b/crates/test-files/fixtures/compile_errors/undefined_type_param.fe
@@ -1,7 +1,7 @@
 # https://github.com/ethereum/fe/issues/530
 
 struct BadField:
-    x: MysteryType
+    pub x: MysteryType
 
 contract Foo:
     # case 1: using arg with undefined type within the fn body

--- a/crates/test-files/fixtures/features/associated_fns.fe
+++ b/crates/test-files/fixtures/features/associated_fns.fe
@@ -4,7 +4,7 @@ struct Lib: # This can't be a contract, yet
     return x * x
 
 struct MyStruct:
-  x: u256
+  pub x: u256
   pub fn new(x: u256) -> MyStruct:
     return MyStruct(x)
 

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -1,10 +1,10 @@
 struct Error:
-    msg: u256
-    val: bool
+    pub msg: u256
+    pub val: bool
 
 struct OtherError:
-    msg: u256
-    val: bool
+    pub msg: u256
+    pub val: bool
 
 contract Foo:
     my_other_error: OtherError

--- a/crates/test-files/fixtures/features/struct_fns.fe
+++ b/crates/test-files/fixtures/features/struct_fns.fe
@@ -1,6 +1,6 @@
 struct Point:
-  x: u64
-  y: u64
+  pub x: u64
+  pub y: u64
 
   pub fn new(x: u64, y: u64) -> Point:
     return Point(x, y)

--- a/crates/test-files/fixtures/features/structs.fe
+++ b/crates/test-files/fixtures/features/structs.fe
@@ -1,8 +1,15 @@
+struct Mixed:
+    pub foo: u256
+    bar: bool
+
+    pub fn new(val: u256) -> Mixed:
+        return Mixed(foo=val, bar=false)
+
 struct House:
-    price: u256
-    size: u256
-    rooms: u8
-    vacant: bool
+    pub price: u256
+    pub size: u256
+    pub rooms: u8
+    pub vacant: bool
 
     pub fn encode(self) -> Array<u8, 128>:
         return self.abi_encode()
@@ -19,6 +26,10 @@ struct House:
 
 contract Foo:
     my_house: House
+
+    pub fn create_mixed(self) -> u256:
+        let mixed: Mixed = Mixed.new(1)
+        return mixed.foo
 
     pub fn set_house(self, data: House):
         self.my_house = data

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/bar/baz.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/bar/baz.fe
@@ -1,3 +1,3 @@
 struct Baz:
-    my_bool: bool
-    my_u256: u256
+    pub my_bool: bool
+    pub my_u256: u256

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/bing.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/bing.fe
@@ -3,7 +3,7 @@ use std::bar::bar::Bar
 #
 # simply defining an item causes a cycle
 struct Bing:
-    my_address: address
+    pub my_address: address
 
 fn get_42_backend() -> u256:
     return std::get_42()

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dong.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dong.fe
@@ -1,9 +1,9 @@
 use ingot::bing::Bing
 
 struct Dyng:
-  my_address: address
-  my_u256: u256
-  my_i8: i8
+  pub my_address: address
+  pub my_u256: u256
+  pub my_i8: i8
 
 fn get_bing() -> Bing:
     return Bing(my_address=address(0))

--- a/crates/test-files/fixtures/stress/abi_encoding_stress.fe
+++ b/crates/test-files/fixtures/stress/abi_encoding_stress.fe
@@ -1,8 +1,8 @@
 struct MyStruct:
-    my_num: u256
-    my_num2: u8
-    my_bool: bool
-    my_addr: address
+    pub my_num: u256
+    pub my_num2: u8
+    pub my_bool: bool
+    pub my_addr: address
 
 contract Foo:
     my_addrs: Array<address, 5>

--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -1,5 +1,5 @@
 struct SomeError:
-    code: u256
+    pub code: u256
 
 contract Foo:
     my_tuple: (u256, address)

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -1227,6 +1227,8 @@ fn structs() {
                 "46276961562062403346660092841258592376337652487249021183958956662511039738107",
             )),
         );
+
+        harness.test_function(&mut executor, "create_mixed", &[], Some(&uint_token(1)))
     });
 }
 

--- a/docs/src/spec/expr_attribute.md
+++ b/docs/src/spec/expr_attribute.md
@@ -13,8 +13,8 @@ Examples:
 
 ```python
 struct Point:
-    x: u256
-    y: u256
+    pub x: u256
+    pub y: u256
 
 contract Foo:
     some_point: Point

--- a/newsfragments/214.feature.md
+++ b/newsfragments/214.feature.md
@@ -1,0 +1,25 @@
+Support private fields on structs
+
+Public fields now need to be declared with the `pub` modifier, otherwise they default to private fields.
+If a struct contains private fields it can not be constructed directly except from within the
+struct itself. The recommended way is to implement a method `new(...)` as demonstrated in the
+following example.
+
+```
+struct House:
+    pub price: u256
+    pub size: u256
+    vacant: bool
+
+    pub fn new(price: u256, size: u256) -> House
+      return House(price=price, size=size, vacant=true)
+
+contract Manager:
+
+  house: House
+
+  pub fn create_house(price: u256, size: u256):
+    self.house = House::new(price, size)
+    let can_access_price: u256 = self.house.price
+    # can not access `self.house.vacant` because the field is private
+```


### PR DESCRIPTION
### What was wrong?

As described in #236 we need support for private fields in structs.

### How was it fixed?

Public fields now need to be declared with the `pub` modifier, otherwise they default to private fields.
If a struct contains private fields it can not be constructed directly except from within the
struct itself. The recommended way is to implement a method `new(...)` as demonstrated in the
following example.

```
struct House:
    pub price: u256
    pub size: u256
    vacant: bool

    pub fn new(price: u256, size: u256) -> House
      return House(price=price, size=size, vacant=true)

contract Manager:

  house: House

  pub fn create_house(price: u256, size: u256):
    self.house = House::new(price, size)
    let can_access_price: u256 = self.house.price
    # can not access `self.house.vacant` because the field is private
```
