### PR TITLE
Allow address-to-u256 cast

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1281,6 +1281,15 @@ fn expr_call_type_constructor(
                             scope.error("Casting between numeric values can change the sign or size but not both at once", arg.span, &format!("can not cast from `{}` to `{}` in a single step", arg_exp.typ, typ));
                         }
                     }
+                    Type::Base(Base::Address) => {
+                        if *integer != Integer::U256 {
+                            scope.error(
+                                &format!("can't cast `address` to `{}`", integer),
+                                name_span,
+                                "try `u256` here",
+                            );
+                        }
+                    }
                     _ => {
                         scope.error(
                             "type mismatch",

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -127,6 +127,7 @@ test_stmt! { call_keccak_without_parameter, "keccak256()" }
 test_stmt! { call_keccak_with_wrong_type, "keccak256(true)" }
 test_stmt! { call_keccak_with_2_args, "keccak256(1, 2)" }
 test_stmt! { call_keccak_with_generic_args, "keccak256<10>(1)" }
+test_stmt! { cast_address_to_u64, "u64(address(0))" }
 
 test_stmt! { call_balance_of_without_parameter, "balance_of()" }
 test_stmt! { call_balance_of_with_wrong_type, "balance_of(true)" }

--- a/crates/analyzer/tests/snapshots/errors__cast_address_to_u64.snap
+++ b/crates/analyzer/tests/snapshots/errors__cast_address_to_u64.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(\"[snippet]\", &src)"
+
+---
+error: can't cast `address` to `u64`
+  ┌─ [snippet]:3:3
+  │
+3 │   u64(address(0))
+  │   ^^^ try `u256` here
+
+

--- a/crates/test-files/fixtures/features/cast_address_to_u256.fe
+++ b/crates/test-files/fixtures/features/cast_address_to_u256.fe
@@ -1,0 +1,4 @@
+contract Foo:
+  pub fn bar(a: address) -> address:
+    let x: u256 = u256(a)
+    return address(x)

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -10,6 +10,8 @@ use fe_common::utils::keccak;
 use fe_compiler_test_utils::*;
 use fe_compiler_test_utils::{self as test_utils};
 
+const SOME_ADDRESS: &str = "2012301230123012301230123012301230123002";
+
 pub fn deploy_contract(
     executor: &mut Executor,
     fixture: &str,
@@ -428,6 +430,7 @@ fn test_arrays() {
     case::int_literal_coercion("int_literal_coercion.fe", &[], uint_token(300)),
     case::associated_fns("associated_fns.fe", &[uint_token(12)], uint_token(144)),
     case::struct_fns("struct_fns.fe", &[uint_token(10), uint_token(20)], uint_token(100)),
+    case::cast_address_to_u256("cast_address_to_u256.fe", &[address_token(SOME_ADDRESS)], address_token(SOME_ADDRESS)),
 )]
 fn test_method_return(fixture_file: &str, input: &[ethabi::Token], expected: ethabi::Token) {
     with_executor(&|mut executor| {

--- a/newsfragments/621.feature.md
+++ b/newsfragments/621.feature.md
@@ -1,0 +1,6 @@
+Addresses can now be explicitly cast to u256. For example:
+
+```
+fn f(addr: address) -> u256:
+  return u256(addr)
+```


### PR DESCRIPTION
### What was wrong?

#614

### How was it fixed?

Tiny change to the analyzer to make this cast not an error anymore.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
