### PR TITLE
analyze lowered code in lowering tests

### DIFF
--- a/crates/lowering/tests/lowering.rs
+++ b/crates/lowering/tests/lowering.rs
@@ -24,7 +24,9 @@ fn lower(src: &str, id: SourceFileId, files: &FileStore) -> fe::Module {
     };
     let module_id = db.intern_module(Rc::new(module));
 
-    fe_lowering::lower_module(&db, module_id).ast(&db)
+    let lowered_module = fe_lowering::lower_module(&db, module_id);
+    fe_analyzer::analyze_module(&db, lowered_module).expect("failed to analyze lowered AST");
+    lowered_module.ast(&db)
 }
 
 fn parse_file(src: &str, id: SourceFileId, files: &FileStore) -> fe::Module {


### PR DESCRIPTION
### What was wrong?

The lowering tests do not analyze the lowered code which has let a regression slip through (#623)

### How was it fixed?

Analyze lowered module.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
