### PR TITLE
Properly resolve generic type desc

### DIFF
--- a/crates/lowering/src/names.rs
+++ b/crates/lowering/src/names.rs
@@ -22,10 +22,7 @@ pub fn fixed_size_type_desc(typ: &FixedSize) -> ast::TypeDesc {
             base: SmolStr::new("Array").into_node(),
             args: vec![
                 ast::GenericArg::TypeDesc(
-                    ast::TypeDesc::Base {
-                        base: array.inner.name(),
-                    }
-                    .into_node(),
+                    fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
                 ),
                 ast::GenericArg::Int(array.size.into_node()),
             ]

--- a/crates/lowering/tests/snapshots/lowering__list_expressions.snap
+++ b/crates/lowering/tests/snapshots/lowering__list_expressions.snap
@@ -10,7 +10,12 @@ fn list_expr_array_u256_3(val0: u256, val1: u256, val2: u256) -> Array<u256, 3>:
     generated_array[2] = val2
     return generated_array
 
+fn list_expr_array_unit_0() -> Array<(), 0>:
+    let generated_array: Array<(), 0>
+    return generated_array
+
 contract Foo:
     pub fn foo() -> ():
         let x: Array<u256, 3> = list_expr_array_u256_3(10, 20, 30)
+        list_expr_array_unit_0()
         return ()

--- a/crates/test-files/fixtures/crashes/agroce623.fe
+++ b/crates/test-files/fixtures/crashes/agroce623.fe
@@ -1,0 +1,3 @@
+contract r:
+ pub fn t():
+  []

--- a/crates/test-files/fixtures/lowering/list_expressions.fe
+++ b/crates/test-files/fixtures/lowering/list_expressions.fe
@@ -1,3 +1,4 @@
 contract Foo:
     pub fn foo():
         let x: Array<u256, 3> = [10, 20, 30]
+        []

--- a/crates/tests/src/crashes.rs
+++ b/crates/tests/src/crashes.rs
@@ -18,4 +18,5 @@ macro_rules! test_file {
 
 test_file! { agroce531 }
 test_file! { agroce550 }
+test_file! { agroce623 }
 test_file! { revert_const }

--- a/newsfragments/623.bugfix.md
+++ b/newsfragments/623.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a regression where an empty list expression (`[]`) would lead to a compiler crash.


### PR DESCRIPTION
### What was wrong?

Empty list expressions lead to an ICE

### How was it fixed?

Lowering code produced wrong `TypeDesc` for generic arrays.
