### PR TITLE
std::evm lib, port send_value to fe

### DIFF
--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -16,8 +16,6 @@ pub enum ValueMethod {
 pub enum GlobalFunction {
     Keccak256,
     SendValue,
-    Balance,
-    BalanceOf,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, AsRefStr)]
@@ -196,9 +194,9 @@ impl Intrinsic {
     pub fn return_type(&self) -> Base {
         use Intrinsic::*;
         match self {
-            __stop | __pop | __calldatacopy | __codecopy | __extcodecopy | __returndatacopy
-            | __return | __revert | __selfdestruct | __invalid | __log0 | __log1 | __log2
-            | __log3 | __log4 => Base::Unit,
+            __stop | __pop | __mstore | __mstore8 | __sstore | __calldatacopy | __codecopy
+            | __extcodecopy | __returndatacopy | __return | __revert | __selfdestruct
+            | __invalid | __log0 | __log1 | __log2 | __log3 | __log4 => Base::Unit,
             _ => Base::u256(),
         }
     }

--- a/crates/analyzer/src/builtins.rs
+++ b/crates/analyzer/src/builtins.rs
@@ -15,7 +15,6 @@ pub enum ValueMethod {
 #[strum(serialize_all = "snake_case")]
 pub enum GlobalFunction {
     Keccak256,
-    SendValue,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, EnumString, AsRefStr)]

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -117,7 +117,7 @@ pub struct Tuple {
     pub items: Vec1<FixedSize>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Struct {
     pub name: SmolStr,
     pub id: StructId,
@@ -133,7 +133,7 @@ impl Struct {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Contract {
     pub name: SmolStr,
     pub id: ContractId,
@@ -797,10 +797,25 @@ impl fmt::Display for Contract {
         write!(f, "{}", self.name)
     }
 }
+impl fmt::Debug for Contract {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Contract")
+            .field("name", &self.name)
+            .finish()
+    }
+}
 
 impl fmt::Display for Struct {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)
+    }
+}
+impl fmt::Debug for Struct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Struct")
+            .field("name", &self.name)
+            .field("field_count", &self.field_count)
+            .finish()
     }
 }
 

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1106,32 +1106,6 @@ fn expr_call_builtin_function(
             };
             ExpressionAttributes::new(Type::Base(U256), Location::Value)
         }
-        GlobalFunction::Balance => {
-            validate_arg_count(context, function.as_ref(), name_span, args, 0, "argument");
-            ExpressionAttributes::new(Type::Base(U256), Location::Value)
-        }
-        GlobalFunction::BalanceOf => {
-            validate_arg_count(context, function.as_ref(), name_span, args, 1, "argument");
-            expect_no_label_on_arg(context, args, 0);
-
-            if let Some(arg_typ) = argument_attributes.first().map(|attr| &attr.typ) {
-                if !matches!(arg_typ, Type::Base(Base::Address)) {
-                    context.fancy_error(
-                        &format!(
-                            "`{}` can not be used as an argument to `{}`",
-                            arg_typ,
-                            function.as_ref(),
-                        ),
-                        vec![Label::primary(args.span, "wrong type")],
-                        vec![format!(
-                            "Note: `{}` expects an address argument",
-                            function.as_ref()
-                        )],
-                    );
-                }
-            };
-            ExpressionAttributes::new(Type::Base(U256), Location::Value)
-        }
         GlobalFunction::SendValue => {
             validate_arg_count(context, function.as_ref(), name_span, args, 2, "argument");
             // There's no label support for builtin functions today. That problem disappears

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1106,55 +1106,6 @@ fn expr_call_builtin_function(
             };
             ExpressionAttributes::new(Type::Base(U256), Location::Value)
         }
-        GlobalFunction::SendValue => {
-            validate_arg_count(context, function.as_ref(), name_span, args, 2, "argument");
-            // There's no label support for builtin functions today. That problem disappears
-            // as soon as they are written in Fe
-            expect_no_label_on_arg(context, args, 0);
-            expect_no_label_on_arg(context, args, 1);
-
-            let argument_info = argument_attributes
-                .iter()
-                .map(|attr| &attr.typ)
-                .zip(args.kind.iter().map(|arg| arg.span))
-                .collect::<Vec<_>>();
-
-            if let Some((arg_typ, span)) = argument_info.get(0) {
-                if !matches!(arg_typ, Type::Base(Base::Address)) {
-                    context.fancy_error(
-                        &format!(
-                            "`{}` can not be used as an argument to `{}`",
-                            arg_typ,
-                            function.as_ref(),
-                        ),
-                        vec![Label::primary(*span, "wrong type")],
-                        vec![format!(
-                            "Note: `{}` expects an `address` as first argument",
-                            function.as_ref()
-                        )],
-                    );
-                }
-            }
-
-            if let Some((arg_typ, span)) = argument_info.get(1) {
-                if !matches!(arg_typ, Type::Base(U256)) {
-                    context.fancy_error(
-                        &format!(
-                            "`{}` can not be used as an argument to `{}`",
-                            arg_typ,
-                            function.as_ref(),
-                        ),
-                        vec![Label::primary(*span, "wrong type")],
-                        vec![format!(
-                            "Note: `{}` expects an `u256` as second argument",
-                            function.as_ref()
-                        )],
-                    );
-                }
-            }
-
-            ExpressionAttributes::new(Type::unit(), Location::Value)
-        }
     };
     Ok((attrs, CallType::BuiltinFunction(function)))
 }

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -430,8 +430,10 @@ fn function_diagnostics(fun: items::FunctionId, db: &dyn AnalyzerDb) -> Vec<Diag
                 .map(|(span, eventid)| (span, eventid.typ(db)))
                 .collect::<Vec<(Span, Rc<Event>)>>(),
         ),
-        // calls
-        label_in_non_overlapping_groups(&lookup_spans(&body.calls, &body.spans)),
+        // CallType includes FunctionId,ContractId,StructId, so the debug output
+        // may change when we add something to the std lib.
+        // Disabling until we come up with a better label to use here.
+        // label_in_non_overlapping_groups(&lookup_spans(&body.calls, &body.spans)),
     ]
     .concat()
 }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -124,12 +124,10 @@ test_stmt! { call_keccak_with_2_args, "keccak256(1, 2)" }
 test_stmt! { call_keccak_with_generic_args, "keccak256<10>(1)" }
 test_stmt! { cast_address_to_u64, "u64(address(0))" }
 
-test_stmt! { call_balance_of_without_parameter, "balance_of()" }
-test_stmt! { call_balance_of_with_wrong_type, "balance_of(true)" }
-test_stmt! { call_balance_of_with_2_args, "balance_of(address(0), 2)" }
-test_stmt! { call_balance_of_with_generic_args, "balance_of<10>(address(0))" }
-test_stmt! { call_balance_with_arg, "balance(address(0))" }
-test_stmt! { call_balance_with_generic_args, "balance<10>()" }
+test_stmt! { call_balance_of_without_parameter, "std::evm::balance_of()" }
+test_stmt! { call_balance_of_with_wrong_type, "std::evm::balance_of(true)" }
+test_stmt! { call_balance_of_with_2_args, "std::evm::balance_of(address(0), 2)" }
+test_stmt! { call_balance_with_arg, "std::evm::balance(address(0))" }
 test_stmt! { call_send_value_without_parameter, "send_value()" }
 test_stmt! { call_send_value_with_1_arg, "send_value(address(0))" }
 test_stmt! { call_send_value_with_3_args, "send_value(address(0), 0, 0)" }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -128,12 +128,11 @@ test_stmt! { call_balance_of_without_parameter, "std::evm::balance_of()" }
 test_stmt! { call_balance_of_with_wrong_type, "std::evm::balance_of(true)" }
 test_stmt! { call_balance_of_with_2_args, "std::evm::balance_of(address(0), 2)" }
 test_stmt! { call_balance_with_arg, "std::evm::balance(address(0))" }
-test_stmt! { call_send_value_without_parameter, "send_value()" }
-test_stmt! { call_send_value_with_1_arg, "send_value(address(0))" }
-test_stmt! { call_send_value_with_3_args, "send_value(address(0), 0, 0)" }
-test_stmt! { call_send_value_with_wrong_type, "send_value(true, 0)" }
-test_stmt! { call_send_value_with_wrong_type2, "send_value(address(0), true)" }
-test_stmt! { call_send_value_with_generic_args, "send_value<10>(address(0), 1)" }
+test_stmt! { call_send_value_without_parameter, "std::send_value()" }
+test_stmt! { call_send_value_with_1_arg, "std::send_value(address(0))" }
+test_stmt! { call_send_value_with_3_args, "std::send_value(address(0), 0, 0)" }
+test_stmt! { call_send_value_with_wrong_type, "std::send_value(true, 0)" }
+test_stmt! { call_send_value_with_wrong_type2, "std::send_value(address(0), true)" }
 test_stmt! { clone_arg_count, "let x: Array<u256, 2> = [5, 6]\nlet y: Array<u256, 2> = x.clone(y)" }
 test_stmt! { continue_without_loop, "continue" }
 test_stmt! { continue_without_loop_2, "if true:\n  continue" }

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -133,12 +133,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:27:16
-   │
-27 │         return self.my_addrs.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 5, inner: Address }) }
-
-note: 
    ┌─ abi_encoding_stress.fe:29:5
    │  
 29 │ ╭     pub fn set_my_u128(self, my_u128: u128):
@@ -299,12 +293,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:39:16
-   │
-39 │         return self.my_string.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 10 }) }
-
-note: 
    ┌─ abi_encoding_stress.fe:41:5
    │  
 41 │ ╭     pub fn set_my_u16s(self, my_u16s: Array<u16, 255>):
@@ -392,12 +380,6 @@ note:
    │
 45 │         return self.my_u16s.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Memory
-
-note: 
-   ┌─ abi_encoding_stress.fe:45:16
-   │
-45 │         return self.my_u16s.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 255, inner: Numeric(U16) }) }
 
 note: 
    ┌─ abi_encoding_stress.fe:47:5
@@ -562,12 +544,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:57:16
-   │
-57 │         return self.my_bytes.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 100, inner: Numeric(U8) }) }
-
-note: 
    ┌─ abi_encoding_stress.fe:59:5
    │  
 59 │ ╭     pub fn get_my_struct() -> MyStruct:
@@ -577,7 +553,7 @@ note:
 63 │ │             my_bool: true,
 64 │ │             my_addr: address(123456)
 65 │ │         )
-   │ ╰─────────^ attributes hash: 12792745713144811261
+   │ ╰─────────^ attributes hash: 7607838094635872645
    │  
    = FunctionSignature {
          self_decl: None,
@@ -586,9 +562,6 @@ note:
              Struct(
                  Struct {
                      name: "MyStruct",
-                     id: StructId(
-                         0,
-                     ),
                      field_count: 4,
                  },
              ),
@@ -632,21 +605,6 @@ note:
    │ ╰─────────^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:62:22
-   │
-62 │             my_num2: u8(26),
-   │                      ^^ TypeConstructor(Base(Numeric(U8)))
-63 │             my_bool: true,
-64 │             my_addr: address(123456)
-   │                      ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-   ┌─ abi_encoding_stress.fe:60:16
-   │
-60 │         return MyStruct(
-   │                ^^^^^^^^ TypeConstructor(Struct(Struct { name: "MyStruct", id: StructId(0), field_count: 4 }))
-
-note: 
    ┌─ abi_encoding_stress.fe:67:5
    │  
 67 │ ╭     pub fn mod_my_struct(my_struct: MyStruct) -> MyStruct:
@@ -655,7 +613,7 @@ note:
 70 │ │         my_struct.my_bool = false
 71 │ │         my_struct.my_addr = address(9999)
 72 │ │         return my_struct
-   │ ╰────────────────────────^ attributes hash: 6786804746141497115
+   │ ╰────────────────────────^ attributes hash: 1170189699425425788
    │  
    = FunctionSignature {
          self_decl: None,
@@ -666,9 +624,6 @@ note:
                      Struct(
                          Struct {
                              name: "MyStruct",
-                             id: StructId(
-                                 0,
-                             ),
                              field_count: 4,
                          },
                      ),
@@ -679,9 +634,6 @@ note:
              Struct(
                  Struct {
                      name: "MyStruct",
-                     id: StructId(
-                         0,
-                     ),
                      field_count: 4,
                  },
              ),
@@ -745,15 +697,6 @@ note:
    │                             ^^^^^^^^^^^^^ address: Value
 72 │         return my_struct
    │                ^^^^^^^^^ MyStruct: Memory
-
-note: 
-   ┌─ abi_encoding_stress.fe:69:29
-   │
-69 │         my_struct.my_num2 = u8(42)
-   │                             ^^ TypeConstructor(Base(Numeric(U8)))
-70 │         my_struct.my_bool = false
-71 │         my_struct.my_addr = address(9999)
-   │                             ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ abi_encoding_stress.fe:74:5
@@ -943,19 +886,5 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ abi_encoding_stress.fe:76:23
-   │
-76 │             my_addrs: self.my_addrs.to_mem(),
-   │                       ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 5, inner: Address }) }
-77 │             my_u128: self.my_u128,
-78 │             my_string: self.my_string.to_mem(),
-   │                        ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 10 }) }
-79 │             my_u16s: self.my_u16s.to_mem(),
-   │                      ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 255, inner: Numeric(U16) }) }
-80 │             my_bool: self.my_bool,
-81 │             my_bytes: self.my_bytes.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 100, inner: Numeric(U8) }) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
@@ -69,12 +69,6 @@ note:
   │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 10>: Storage { nonce: None } => Memory
 
 note: 
-  ┌─ address_bytes10_map.fe:5:16
-  │
-5 │         return self.bar[key].to_mem()
-  │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 10, inner: Numeric(U8) }) }
-
-note: 
   ┌─ address_bytes10_map.fe:7:5
   │  
 7 │ ╭     pub fn write_bar(self, key: address, value: Array<u8, 10>):

--- a/crates/analyzer/tests/snapshots/analysis__assert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__assert.snap
@@ -243,10 +243,4 @@ note:
 20 │         assert false, self.my_string.to_mem()
    │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<5>: Storage { nonce: Some(1) } => Memory
 
-note: 
-   ┌─ assert.fe:20:23
-   │
-20 │         assert false, self.my_string.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 5 }) }
-
 

--- a/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
@@ -58,7 +58,7 @@ note:
   │  
 8 │ ╭   pub fn new(x: u256) -> MyStruct:
 9 │ │     return MyStruct(x)
-  │ ╰──────────────────────^ attributes hash: 12320534675640633934
+  │ ╰──────────────────────^ attributes hash: 13527498813317104922
   │  
   = FunctionSignature {
         self_decl: None,
@@ -78,9 +78,6 @@ note:
             Struct(
                 Struct {
                     name: "MyStruct",
-                    id: StructId(
-                        1,
-                    ),
                     field_count: 1,
                 },
             ),
@@ -98,12 +95,6 @@ note:
   │
 9 │     return MyStruct(x)
   │            ^^^^^^^^^^^ MyStruct: Memory
-
-note: 
-  ┌─ associated_fns.fe:9:12
-  │
-9 │     return MyStruct(x)
-  │            ^^^^^^^^ TypeConstructor(Struct(Struct { name: "MyStruct", id: StructId(1), field_count: 1 }))
 
 note: 
    ┌─ associated_fns.fe:12:3
@@ -183,13 +174,5 @@ note:
    │
 16 │     return Lib.square(self.my_struct.x)
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-
-note: 
-   ┌─ associated_fns.fe:15:22
-   │
-15 │     self.my_struct = MyStruct.new(val)
-   │                      ^^^^^^^^^^^^ AssociatedFunction { class: Struct(StructId(1)), function: FunctionId(1) }
-16 │     return Lib.square(self.my_struct.x)
-   │            ^^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(0) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__balances.snap
+++ b/crates/analyzer/tests/snapshots/analysis__balances.snap
@@ -4,10 +4,10 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ balances.fe:2:5
+  ┌─ balances.fe:4:5
   │  
-2 │ ╭     pub fn my_balance(self) -> u256:
-3 │ │         return balance()
+4 │ ╭     pub fn my_balance(self) -> u256:
+5 │ │         return balance()
   │ ╰────────────────────────^ attributes hash: 2875164910451995213
   │  
   = FunctionSignature {
@@ -25,16 +25,16 @@ note:
     }
 
 note: 
-  ┌─ balances.fe:3:16
+  ┌─ balances.fe:5:16
   │
-3 │         return balance()
+5 │         return balance()
   │                ^^^^^^^^^ u256: Value
 
 note: 
-  ┌─ balances.fe:5:5
+  ┌─ balances.fe:7:5
   │  
-5 │ ╭     pub fn other_balance(self, someone: address) -> u256:
-6 │ │         return balance_of(someone)
+7 │ ╭     pub fn other_balance(self, someone: address) -> u256:
+8 │ │         return balance_of(someone)
   │ ╰──────────────────────────────────^ attributes hash: 4973462877553265717
   │  
   = FunctionSignature {
@@ -61,15 +61,15 @@ note:
     }
 
 note: 
-  ┌─ balances.fe:6:27
+  ┌─ balances.fe:8:27
   │
-6 │         return balance_of(someone)
+8 │         return balance_of(someone)
   │                           ^^^^^^^ address: Value
 
 note: 
-  ┌─ balances.fe:6:16
+  ┌─ balances.fe:8:16
   │
-6 │         return balance_of(someone)
+8 │         return balance_of(someone)
   │                ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__balances.snap
+++ b/crates/analyzer/tests/snapshots/analysis__balances.snap
@@ -31,12 +31,6 @@ note:
   │                ^^^^^^^^^ u256: Value
 
 note: 
-  ┌─ balances.fe:3:16
-  │
-3 │         return balance()
-  │                ^^^^^^^ BuiltinFunction(Balance)
-
-note: 
   ┌─ balances.fe:5:5
   │  
 5 │ ╭     pub fn other_balance(self, someone: address) -> u256:
@@ -77,11 +71,5 @@ note:
   │
 6 │         return balance_of(someone)
   │                ^^^^^^^^^^^^^^^^^^^ u256: Value
-
-note: 
-  ┌─ balances.fe:6:16
-  │
-6 │         return balance_of(someone)
-  │                ^^^^^^^^^^ BuiltinFunction(BalanceOf)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -9,7 +9,7 @@ note:
  9 │ ╭     pub fn get_my_baz() -> Baz:
 10 │ │         assert file_items_work()
 11 │ │         return Baz(my_bool: true, my_u256: 26)
-   │ ╰──────────────────────────────────────────────^ attributes hash: 12324314335460528585
+   │ ╰──────────────────────────────────────────────^ attributes hash: 3745766174546896441
    │  
    = FunctionSignature {
          self_decl: None,
@@ -18,9 +18,6 @@ note:
              Struct(
                  Struct {
                      name: "Baz",
-                     id: StructId(
-                         4,
-                     ),
                      field_count: 2,
                  },
              ),
@@ -44,19 +41,11 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Baz: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:10:16
-   │
-10 │         assert file_items_work()
-   │                ^^^^^^^^^^^^^^^ Pure(FunctionId(0))
-11 │         return Baz(my_bool: true, my_u256: 26)
-   │                ^^^ TypeConstructor(Struct(Struct { name: "Baz", id: StructId(4), field_count: 2 }))
-
-note: 
    ┌─ ingots/basic_ingot/src/main.fe:13:5
    │  
 13 │ ╭     pub fn get_my_bing() -> Bong:
 14 │ │         return Bong(my_address: address(42))
-   │ ╰────────────────────────────────────────────^ attributes hash: 13981777418891958772
+   │ ╰────────────────────────────────────────────^ attributes hash: 10768881633044219748
    │  
    = FunctionSignature {
          self_decl: None,
@@ -65,9 +54,6 @@ note:
              Struct(
                  Struct {
                      name: "Bing",
-                     id: StructId(
-                         3,
-                     ),
                      field_count: 1,
                  },
              ),
@@ -91,18 +77,6 @@ note:
    │
 14 │         return Bong(my_address: address(42))
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:14:33
-   │
-14 │         return Bong(my_address: address(42))
-   │                                 ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:14:16
-   │
-14 │         return Bong(my_address: address(42))
-   │                ^^^^ TypeConstructor(Struct(Struct { name: "Bing", id: StructId(3), field_count: 1 }))
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:16:5
@@ -130,12 +104,6 @@ note:
    │                ^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:17:16
-   │
-17 │         return get_42_backend()
-   │                ^^^^^^^^^^^^^^ Pure(FunctionId(4))
-
-note: 
    ┌─ ingots/basic_ingot/src/main.fe:19:5
    │  
 19 │ ╭     pub fn get_26() -> u256:
@@ -161,12 +129,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:20:16
-   │
-20 │         return std::bar::bar::get_26()
-   │                ^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(3))
-
-note: 
    ┌─ ingots/basic_ingot/src/main.fe:22:5
    │  
 22 │ ╭     pub fn get_my_dyng() -> dong::Dyng:
@@ -175,7 +137,7 @@ note:
 25 │ │             my_u256: 42,
 26 │ │             my_i8: -1
 27 │ │         )
-   │ ╰─────────^ attributes hash: 8107142401187261877
+   │ ╰─────────^ attributes hash: 10106010945633631125
    │  
    = FunctionSignature {
          self_decl: None,
@@ -184,9 +146,6 @@ note:
              Struct(
                  Struct {
                      name: "Dyng",
-                     id: StructId(
-                         5,
-                     ),
                      field_count: 3,
                  },
              ),
@@ -225,18 +184,6 @@ note:
 26 │ │             my_i8: -1
 27 │ │         )
    │ ╰─────────^ Dyng: Memory
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:24:25
-   │
-24 │             my_address: address(8),
-   │                         ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:23:16
-   │
-23 │         return dong::Dyng(
-   │                ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "Dyng", id: StructId(5), field_count: 3 }))
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:29:5
@@ -286,14 +233,6 @@ note:
    │
 31 │         return bing_contract.add(40, 50)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:30:43
-   │
-30 │         let bing_contract: BingContract = BingContract.create(0)
-   │                                           ^^^^^^^^^^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(0), function: Create }
-31 │         return bing_contract.add(40, 50)
-   │                ^^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(5) }
 
 
 note: 
@@ -350,12 +289,6 @@ note:
   │
 9 │     return std::get_42()
   │            ^^^^^^^^^^^^^ u256: Value
-
-note: 
-  ┌─ ingots/basic_ingot/src/bing.fe:9:12
-  │
-9 │     return std::get_42()
-  │            ^^^^^^^^^^^ Pure(FunctionId(1))
 
 note: 
    ┌─ ingots/basic_ingot/src/bing.fe:12:4
@@ -444,7 +377,7 @@ note:
   │  
 8 │ ╭ fn get_bing() -> Bing:
 9 │ │     return Bing(my_address: address(0))
-  │ ╰───────────────────────────────────────^ attributes hash: 13981777418891958772
+  │ ╰───────────────────────────────────────^ attributes hash: 10768881633044219748
   │  
   = FunctionSignature {
         self_decl: None,
@@ -453,9 +386,6 @@ note:
             Struct(
                 Struct {
                     name: "Bing",
-                    id: StructId(
-                        3,
-                    ),
                     field_count: 1,
                 },
             ),
@@ -479,17 +409,5 @@ note:
   │
 9 │     return Bing(my_address: address(0))
   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
-
-note: 
-  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:29
-  │
-9 │     return Bing(my_address: address(0))
-  │                             ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:12
-  │
-9 │     return Bing(my_address: address(0))
-  │            ^^^^ TypeConstructor(Struct(Struct { name: "Bing", id: StructId(3), field_count: 1 }))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
@@ -113,10 +113,4 @@ note:
 9 │         return self.baz[0]
   │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
-note: 
-  ┌─ call_statement_with_args.fe:8:9
-  │
-8 │         self.assign(100)
-  │         ^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(0) }
-
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
@@ -118,10 +118,4 @@ note:
 10 │         return self.baz[0]
    │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
-note: 
-  ┌─ call_statement_with_args_2.fe:9:9
-  │
-9 │         self.assign(100)
-  │         ^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(0) }
-
 

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
@@ -100,10 +100,4 @@ note:
 9 │         return self.baz[0]
   │                ^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
-note: 
-  ┌─ call_statement_without_args.fe:8:9
-  │
-8 │         self.assign()
-  │         ^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(0) }
-
 

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -75,12 +75,4 @@ note:
 9 │         return address(foo)
   │                ^^^^^^^^^^^^ address: Value
 
-note: 
-  ┌─ create2_contract.fe:8:24
-  │
-8 │         let foo: Foo = Foo.create2(0, 52)
-  │                        ^^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(0), function: Create2 }
-9 │         return address(foo)
-  │                ^^^^^^^ TypeConstructor(Base(Address))
-
 

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -72,12 +72,4 @@ note:
 8 │         return address(foo)
   │                ^^^^^^^^^^^^ address: Value
 
-note: 
-  ┌─ create_contract.fe:7:24
-  │
-7 │         let foo: Foo = Foo.create(0)
-  │                        ^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(0), function: Create }
-8 │         return address(foo)
-  │                ^^^^^^^ TypeConstructor(Base(Address))
-
 

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -503,12 +503,6 @@ note:
    │                ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Memory
 
 note: 
-   ┌─ data_copying_stress.fe:52:16
-   │
-52 │         return my_array.clone()
-   │                ^^^^^^^^^^^^^^ BuiltinValueMethod { method: Clone, typ: Array(Array { size: 10, inner: Numeric(U256) }) }
-
-note: 
    ┌─ data_copying_stress.fe:54:5
    │  
 54 │ ╭     pub fn clone_mutate_and_return(my_array: Array<u256, 10>) -> Array<u256, 10>:
@@ -568,12 +562,6 @@ note:
    │         u256: Memory
 56 │         return my_array
    │                ^^^^^^^^ Array<u256, 10>: Memory
-
-note: 
-   ┌─ data_copying_stress.fe:55:9
-   │
-55 │         my_array.clone()[3] = 5
-   │         ^^^^^^^^^^^^^^ BuiltinValueMethod { method: Clone, typ: Array(Array { size: 10, inner: Numeric(U256) }) }
 
 note: 
    ┌─ data_copying_stress.fe:58:5
@@ -723,12 +711,6 @@ note:
    │                ^^^^^^^^^^^ Array<u256, 5>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:65:23
-   │
-65 │         my_nums_mem = self.my_nums.to_mem()
-   │                       ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 5, inner: Numeric(U256) }) }
-
-note: 
    ┌─ data_copying_stress.fe:68:5
    │  
 68 │ ╭     pub fn emit_my_event(self):
@@ -790,20 +772,6 @@ note:
 71 │ │             self.my_u256.to_mem()
 72 │ │         )
    │ ╰─────────^ (): Value
-
-note: 
-   ┌─ data_copying_stress.fe:70:13
-   │
-70 │             self.my_string.to_mem(),
-   │             ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 42 }) }
-71 │             self.my_u256.to_mem()
-   │             ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Base(Numeric(U256)) }
-
-note: 
-   ┌─ data_copying_stress.fe:69:9
-   │
-69 │         emit_my_event_internal(
-   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(8))
 
 note: 
    ┌─ data_copying_stress.fe:74:5

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -79,12 +79,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => Memory
 
 note: 
-   ┌─ erc20_token.fe:26:16
-   │
-26 │         return self._name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 100 }) }
-
-note: 
    ┌─ erc20_token.fe:28:5
    │  
 28 │ ╭     pub fn symbol(self) -> String<100>:
@@ -122,12 +116,6 @@ note:
    │
 29 │         return self._symbol.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => Memory
-
-note: 
-   ┌─ erc20_token.fe:29:16
-   │
-29 │         return self._symbol.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 100 }) }
 
 note: 
    ┌─ erc20_token.fe:31:5
@@ -303,12 +291,6 @@ note:
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:41:9
-   │
-41 │         self._transfer(msg.sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(12) }
-
-note: 
    ┌─ erc20_token.fe:44:5
    │  
 44 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256:
@@ -430,12 +412,6 @@ note:
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 49 │         return true
    │                ^^^^ bool: Value
-
-note: 
-   ┌─ erc20_token.fe:48:9
-   │
-48 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
 
 note: 
    ┌─ erc20_token.fe:51:5
@@ -579,14 +555,6 @@ note:
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:53:9
-   │
-53 │         self._transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(12) }
-54 │         self._approve(sender, msg.sender, self._allowances[sender][msg.sender] - value)
-   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
-
-note: 
    ┌─ erc20_token.fe:57:5
    │  
 57 │ ╭     pub fn increaseAllowance(self, spender: address, addedValue: u256) -> bool:
@@ -674,12 +642,6 @@ note:
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:58:9
-   │
-58 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] + addedValue)
-   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
-
-note: 
    ┌─ erc20_token.fe:61:5
    │  
 61 │ ╭     pub fn decreaseAllowance(self, spender: address, subtractedValue: u256) -> bool:
@@ -765,12 +727,6 @@ note:
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 63 │         return true
    │                ^^^^ bool: Value
-
-note: 
-   ┌─ erc20_token.fe:62:9
-   │
-62 │         self._approve(msg.sender, spender, self._allowances[msg.sender][spender] - subtractedValue)
-   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(15) }
 
 note: 
    ┌─ erc20_token.fe:65:5
@@ -997,16 +953,6 @@ note:
      }
 
 note: 
-   ┌─ erc20_token.fe:66:26
-   │
-66 │         assert sender != address(0)
-   │                          ^^^^^^^ TypeConstructor(Base(Address))
-67 │         assert recipient != address(0)
-   │                             ^^^^^^^ TypeConstructor(Base(Address))
-68 │         _before_token_transfer(sender, recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
-
-note: 
    ┌─ erc20_token.fe:73:5
    │  
 73 │ ╭     fn _mint(self, account: address, value: u256):
@@ -1200,23 +1146,6 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ erc20_token.fe:74:27
-   │
-74 │         assert account != address(0)
-   │                           ^^^^^^^ TypeConstructor(Base(Address))
-75 │         _before_token_transfer(address(0), account, value)
-   │                                ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-   ┌─ erc20_token.fe:75:9
-   │
-75 │         _before_token_transfer(address(0), account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
-   ·
-78 │         emit Transfer(from: address(0), to: account, value)
-   │                             ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ erc20_token.fe:80:5
@@ -1416,23 +1345,6 @@ note:
      }
 
 note: 
-   ┌─ erc20_token.fe:81:27
-   │
-81 │         assert account != address(0)
-   │                           ^^^^^^^ TypeConstructor(Base(Address))
-82 │         _before_token_transfer(account, address(0), value)
-   │                                         ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-   ┌─ erc20_token.fe:82:9
-   │
-82 │         _before_token_transfer(account, address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
-   ·
-85 │         emit Transfer(from: account, to: address(0), value)
-   │                                          ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
    ┌─ erc20_token.fe:87:5
    │  
 87 │ ╭     fn _approve(self, owner: address, spender: address, value: u256):
@@ -1588,14 +1500,6 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ erc20_token.fe:88:25
-   │
-88 │         assert owner != address(0)
-   │                         ^^^^^^^ TypeConstructor(Base(Address))
-89 │         assert spender != address(0)
-   │                           ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ erc20_token.fe:93:5

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -312,14 +312,6 @@ note:
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ external_contract.fe:24:24
-   │
-24 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^ TypeConstructor(Contract(Contract { name: "Foo", id: ContractId(0) }))
-25 │         foo.emit_event(my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-
-note: 
    ┌─ external_contract.fe:27:5
    │  
 27 │ ╭     pub fn call_build_array(
@@ -403,13 +395,5 @@ note:
    │
 33 │         return foo.build_array(a, b)
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 3>: Memory
-
-note: 
-   ┌─ external_contract.fe:32:24
-   │
-32 │         let foo: Foo = Foo(foo_address)
-   │                        ^^^ TypeConstructor(Contract(Contract { name: "Foo", id: ContractId(0) }))
-33 │         return foo.build_array(a, b)
-   │                ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -155,10 +155,4 @@ note:
 21 │         return self.messages[addr].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => Memory
 
-note: 
-   ┌─ guest_book.fe:21:16
-   │
-21 │         return self.messages[addr].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 100 }) }
-
 

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -49,12 +49,6 @@ note:
   │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
-  ┌─ keccak.fe:4:16
-  │
-4 │         return keccak256(val)
-  │                ^^^^^^^^^ BuiltinFunction(Keccak256)
-
-note: 
   ┌─ keccak.fe:6:5
   │  
 6 │ ╭     pub fn return_hash_from_foo(val: Array<u8, 3>) -> u256:
@@ -100,12 +94,6 @@ note:
   │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
-  ┌─ keccak.fe:7:16
-  │
-7 │         return keccak256(val)
-  │                ^^^^^^^^^ BuiltinFunction(Keccak256)
-
-note: 
    ┌─ keccak.fe:9:5
    │  
  9 │ ╭     pub fn return_hash_from_u256(val: Array<u8, 32>) -> u256:
@@ -149,11 +137,5 @@ note:
    │
 10 │         return keccak256(val)
    │                ^^^^^^^^^^^^^^ u256: Value
-
-note: 
-   ┌─ keccak.fe:10:16
-   │
-10 │         return keccak256(val)
-   │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 

--- a/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
@@ -35,12 +35,6 @@ note:
   │                ^^^^^ u8: Value
 
 note: 
-  ┌─ numeric_sizes.fe:4:16
-  │
-4 │         return u8(0)
-  │                ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
   ┌─ numeric_sizes.fe:6:5
   │  
 6 │ ╭     pub fn get_u16_min() -> u16:
@@ -70,12 +64,6 @@ note:
   │
 7 │         return u16(0)
   │                ^^^^^^ u16: Value
-
-note: 
-  ┌─ numeric_sizes.fe:7:16
-  │
-7 │         return u16(0)
-  │                ^^^ TypeConstructor(Base(Numeric(U16)))
 
 note: 
    ┌─ numeric_sizes.fe:9:5
@@ -109,12 +97,6 @@ note:
    │                ^^^^^^ u32: Value
 
 note: 
-   ┌─ numeric_sizes.fe:10:16
-   │
-10 │         return u32(0)
-   │                ^^^ TypeConstructor(Base(Numeric(U32)))
-
-note: 
    ┌─ numeric_sizes.fe:12:5
    │  
 12 │ ╭     pub fn get_u64_min() -> u64:
@@ -144,12 +126,6 @@ note:
    │
 13 │         return u64(0)
    │                ^^^^^^ u64: Value
-
-note: 
-   ┌─ numeric_sizes.fe:13:16
-   │
-13 │         return u64(0)
-   │                ^^^ TypeConstructor(Base(Numeric(U64)))
 
 note: 
    ┌─ numeric_sizes.fe:15:5
@@ -183,12 +159,6 @@ note:
    │                ^^^^^^^ u128: Value
 
 note: 
-   ┌─ numeric_sizes.fe:16:16
-   │
-16 │         return u128(0)
-   │                ^^^^ TypeConstructor(Base(Numeric(U128)))
-
-note: 
    ┌─ numeric_sizes.fe:18:5
    │  
 18 │ ╭     pub fn get_u256_min() -> u256:
@@ -218,12 +188,6 @@ note:
    │
 19 │         return u256(0)
    │                ^^^^^^^ u256: Value
-
-note: 
-   ┌─ numeric_sizes.fe:19:16
-   │
-19 │         return u256(0)
-   │                ^^^^ TypeConstructor(Base(Numeric(U256)))
 
 note: 
    ┌─ numeric_sizes.fe:21:5
@@ -263,12 +227,6 @@ note:
    │                ^^^^^^^^ i8: Value
 
 note: 
-   ┌─ numeric_sizes.fe:22:16
-   │
-22 │         return i8(-128)
-   │                ^^ TypeConstructor(Base(Numeric(I8)))
-
-note: 
    ┌─ numeric_sizes.fe:24:5
    │  
 24 │ ╭     pub fn get_i16_min() -> i16:
@@ -304,12 +262,6 @@ note:
    │
 25 │         return i16(-32768)
    │                ^^^^^^^^^^^ i16: Value
-
-note: 
-   ┌─ numeric_sizes.fe:25:16
-   │
-25 │         return i16(-32768)
-   │                ^^^ TypeConstructor(Base(Numeric(I16)))
 
 note: 
    ┌─ numeric_sizes.fe:27:5
@@ -349,12 +301,6 @@ note:
    │                ^^^^^^^^^^^^^^^^ i32: Value
 
 note: 
-   ┌─ numeric_sizes.fe:28:16
-   │
-28 │         return i32(-2147483648)
-   │                ^^^ TypeConstructor(Base(Numeric(I32)))
-
-note: 
    ┌─ numeric_sizes.fe:30:5
    │  
 30 │ ╭     pub fn get_i64_min() -> i64:
@@ -390,12 +336,6 @@ note:
    │
 31 │         return i64(-9223372036854775808)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value
-
-note: 
-   ┌─ numeric_sizes.fe:31:16
-   │
-31 │         return i64(-9223372036854775808)
-   │                ^^^ TypeConstructor(Base(Numeric(I64)))
 
 note: 
    ┌─ numeric_sizes.fe:33:5
@@ -435,12 +375,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value
 
 note: 
-   ┌─ numeric_sizes.fe:34:16
-   │
-34 │         return i128(-170141183460469231731687303715884105728)
-   │                ^^^^ TypeConstructor(Base(Numeric(I128)))
-
-note: 
    ┌─ numeric_sizes.fe:36:5
    │  
 36 │ ╭     pub fn get_i256_min() -> i256:
@@ -478,12 +412,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value
 
 note: 
-   ┌─ numeric_sizes.fe:37:16
-   │
-37 │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
-   │                ^^^^ TypeConstructor(Base(Numeric(I256)))
-
-note: 
    ┌─ numeric_sizes.fe:39:5
    │  
 39 │ ╭     pub fn get_u8_max() -> u8:
@@ -513,12 +441,6 @@ note:
    │
 40 │         return u8(255)
    │                ^^^^^^^ u8: Value
-
-note: 
-   ┌─ numeric_sizes.fe:40:16
-   │
-40 │         return u8(255)
-   │                ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
    ┌─ numeric_sizes.fe:42:5
@@ -552,12 +474,6 @@ note:
    │                ^^^^^^^^^^ u16: Value
 
 note: 
-   ┌─ numeric_sizes.fe:43:16
-   │
-43 │         return u16(65535)
-   │                ^^^ TypeConstructor(Base(Numeric(U16)))
-
-note: 
    ┌─ numeric_sizes.fe:45:5
    │  
 45 │ ╭     pub fn get_u32_max() -> u32:
@@ -587,12 +503,6 @@ note:
    │
 46 │         return u32(4294967295)
    │                ^^^^^^^^^^^^^^^ u32: Value
-
-note: 
-   ┌─ numeric_sizes.fe:46:16
-   │
-46 │         return u32(4294967295)
-   │                ^^^ TypeConstructor(Base(Numeric(U32)))
 
 note: 
    ┌─ numeric_sizes.fe:48:5
@@ -626,12 +536,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u64: Value
 
 note: 
-   ┌─ numeric_sizes.fe:49:16
-   │
-49 │         return u64(18446744073709551615)
-   │                ^^^ TypeConstructor(Base(Numeric(U64)))
-
-note: 
    ┌─ numeric_sizes.fe:51:5
    │  
 51 │ ╭     pub fn get_u128_max() -> u128:
@@ -661,12 +565,6 @@ note:
    │
 52 │         return u128(340282366920938463463374607431768211455)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u128: Value
-
-note: 
-   ┌─ numeric_sizes.fe:52:16
-   │
-52 │         return u128(340282366920938463463374607431768211455)
-   │                ^^^^ TypeConstructor(Base(Numeric(U128)))
 
 note: 
    ┌─ numeric_sizes.fe:54:5
@@ -700,12 +598,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ numeric_sizes.fe:55:16
-   │
-55 │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
-   │                ^^^^ TypeConstructor(Base(Numeric(U256)))
-
-note: 
    ┌─ numeric_sizes.fe:57:5
    │  
 57 │ ╭     pub fn get_i8_max() -> i8:
@@ -735,12 +627,6 @@ note:
    │
 58 │         return i8(127)
    │                ^^^^^^^ i8: Value
-
-note: 
-   ┌─ numeric_sizes.fe:58:16
-   │
-58 │         return i8(127)
-   │                ^^ TypeConstructor(Base(Numeric(I8)))
 
 note: 
    ┌─ numeric_sizes.fe:60:5
@@ -774,12 +660,6 @@ note:
    │                ^^^^^^^^^^ i16: Value
 
 note: 
-   ┌─ numeric_sizes.fe:61:16
-   │
-61 │         return i16(32767)
-   │                ^^^ TypeConstructor(Base(Numeric(I16)))
-
-note: 
    ┌─ numeric_sizes.fe:63:5
    │  
 63 │ ╭     pub fn get_i32_max() -> i32:
@@ -809,12 +689,6 @@ note:
    │
 64 │         return i32(2147483647)
    │                ^^^^^^^^^^^^^^^ i32: Value
-
-note: 
-   ┌─ numeric_sizes.fe:64:16
-   │
-64 │         return i32(2147483647)
-   │                ^^^ TypeConstructor(Base(Numeric(I32)))
 
 note: 
    ┌─ numeric_sizes.fe:66:5
@@ -848,12 +722,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ i64: Value
 
 note: 
-   ┌─ numeric_sizes.fe:67:16
-   │
-67 │         return i64(9223372036854775807)
-   │                ^^^ TypeConstructor(Base(Numeric(I64)))
-
-note: 
    ┌─ numeric_sizes.fe:69:5
    │  
 69 │ ╭     pub fn get_i128_max() -> i128:
@@ -885,12 +753,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i128: Value
 
 note: 
-   ┌─ numeric_sizes.fe:70:16
-   │
-70 │         return i128(170141183460469231731687303715884105727)
-   │                ^^^^ TypeConstructor(Base(Numeric(I128)))
-
-note: 
    ┌─ numeric_sizes.fe:72:5
    │  
 72 │ ╭     pub fn get_i256_max() -> i256:
@@ -920,11 +782,5 @@ note:
    │
 73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ i256: Value
-
-note: 
-   ┌─ numeric_sizes.fe:73:16
-   │
-73 │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
-   │                ^^^^ TypeConstructor(Base(Numeric(I256)))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -146,14 +146,6 @@ note:
      }
 
 note: 
-   ┌─ ownable.fe:16:19
-   │
-16 │     self._owner = address(0)
-   │                   ^^^^^^^ TypeConstructor(Base(Address))
-17 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
-   │                                                                    ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
    ┌─ ownable.fe:19:3
    │  
 19 │ ╭   pub fn transferOwnership(self, newOwner: address):
@@ -263,11 +255,5 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ ownable.fe:21:24
-   │
-21 │     assert newOwner != address(0)
-   │                        ^^^^^^^ TypeConstructor(Base(Address))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -160,12 +160,6 @@ note:
    │             u256: Storage { nonce: None }
 
 note: 
-   ┌─ pure_fn_standalone.fe:11:34
-   │
-11 │             self.points[user] += add_bonus(val)
-   │                                  ^^^^^^^^^ Pure(FunctionId(0))
-
-note: 
    ┌─ pure_fn_standalone.fe:15:5
    │  
 15 │ ╭     pub fn bar(self, x: u256) -> u256:
@@ -274,16 +268,5 @@ note:
    │
 20 │         return self.points[a]
    │                ^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
-
-note: 
-   ┌─ pure_fn_standalone.fe:16:26
-   │
-16 │         let a: address = address(x)
-   │                          ^^^^^^^ TypeConstructor(Base(Address))
-17 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(1) }
-18 │         self.cool_users[a] = true
-19 │         self.add_points(a, 100)
-   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(0)), method: FunctionId(1) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
@@ -40,10 +40,4 @@ note:
 3 │         return i128(-3)
   │                ^^^^^^^^ i128: Value
 
-note: 
-  ┌─ return_i128_cast.fe:3:16
-  │
-3 │         return i128(-3)
-  │                ^^^^ TypeConstructor(Base(Numeric(I128)))
-
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
@@ -34,10 +34,4 @@ note:
 3 │         return u128(42)
   │                ^^^^^^^^ u128: Value
 
-note: 
-  ┌─ return_u128_cast.fe:3:16
-  │
-3 │         return u128(42)
-  │                ^^^^ TypeConstructor(Base(Numeric(U128)))
-
 

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
@@ -31,12 +31,6 @@ note:
   │                ^^^^^ u256: Value
 
 note: 
-  ┌─ return_u256_from_called_fn.fe:5:16
-  │
-5 │         return foo()
-  │                ^^^ Pure(FunctionId(1))
-
-note: 
   ┌─ return_u256_from_called_fn.fe:7:5
   │  
 7 │ ╭     pub fn foo() -> u256:

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
@@ -221,16 +221,4 @@ note:
 11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
-note: 
-   ┌─ return_u256_from_called_fn_with_args.fe:11:26
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                          ^^^ Pure(FunctionId(1))
-
-note: 
-   ┌─ return_u256_from_called_fn_with_args.fe:11:16
-   │
-11 │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
-   │                ^^^ Pure(FunctionId(0))
-
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -60,12 +60,6 @@ note:
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ revert.fe:12:9
-   │
-12 │         std::revert_insufficient_funds()
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(5))
-
-note: 
    ┌─ revert.fe:14:5
    │  
 14 │ ╭     pub fn revert_other_error():
@@ -95,12 +89,6 @@ note:
    │
 15 │         revert OtherError(msg: 1, val: true)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
-
-note: 
-   ┌─ revert.fe:15:16
-   │
-15 │         revert OtherError(msg: 1, val: true)
-   │                ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "OtherError", id: StructId(0), field_count: 2 }))
 
 note: 
    ┌─ revert.fe:17:5
@@ -156,13 +144,5 @@ note:
    │
 19 │         revert self.my_other_error.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => Memory
-
-note: 
-   ┌─ revert.fe:18:31
-   │
-18 │         self.my_other_error = OtherError(msg: 1, val: true)
-   │                               ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "OtherError", id: StructId(0), field_count: 2 }))
-19 │         revert self.my_other_error.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "OtherError", id: StructId(0), field_count: 2 }) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -40,7 +40,7 @@ note:
    ┌─ revert.fe:11:5
    │  
 11 │ ╭     pub fn revert_custom_error():
-12 │ │         std::revert_insufficient_funds()
+12 │ │         std::send_value(address(0), 100)
    │ ╰────────────────────────────────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
@@ -54,9 +54,23 @@ note:
      }
 
 note: 
+   ┌─ revert.fe:12:33
+   │
+12 │         std::send_value(address(0), 100)
+   │                                 ^ u256: Value
+
+note: 
+   ┌─ revert.fe:12:25
+   │
+12 │         std::send_value(address(0), 100)
+   │                         ^^^^^^^^^^  ^^^ u256: Value
+   │                         │            
+   │                         address: Value
+
+note: 
    ┌─ revert.fe:12:9
    │
-12 │         std::revert_insufficient_funds()
+12 │         std::send_value(address(0), 100)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 

--- a/crates/analyzer/tests/snapshots/analysis__send_value.snap
+++ b/crates/analyzer/tests/snapshots/analysis__send_value.snap
@@ -7,8 +7,8 @@ note:
   ┌─ send_value.fe:2:5
   │  
 2 │ ╭     pub fn send_them_wei(to: address, wei: u256):
-3 │ │         send_value(to, wei)
-  │ ╰───────────────────────────^ attributes hash: 1344491078926082800
+3 │ │         std::send_value(to, wei)
+  │ ╰────────────────────────────────^ attributes hash: 1344491078926082800
   │  
   = FunctionSignature {
         self_decl: None,
@@ -40,17 +40,17 @@ note:
     }
 
 note: 
-  ┌─ send_value.fe:3:20
+  ┌─ send_value.fe:3:25
   │
-3 │         send_value(to, wei)
-  │                    ^^  ^^^ u256: Value
-  │                    │    
-  │                    address: Value
+3 │         std::send_value(to, wei)
+  │                         ^^  ^^^ u256: Value
+  │                         │    
+  │                         address: Value
 
 note: 
   ┌─ send_value.fe:3:9
   │
-3 │         send_value(to, wei)
-  │         ^^^^^^^^^^^^^^^^^^^ (): Value
+3 │         std::send_value(to, wei)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__send_value.snap
+++ b/crates/analyzer/tests/snapshots/analysis__send_value.snap
@@ -53,10 +53,4 @@ note:
 3 │         send_value(to, wei)
   │         ^^^^^^^^^^^^^^^^^^^ (): Value
 
-note: 
-  ┌─ send_value.fe:3:9
-  │
-3 │         send_value(to, wei)
-  │         ^^^^^^^^^^ BuiltinFunction(SendValue)
-
 

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -190,12 +190,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Memory
 
 note: 
-   ┌─ sized_vals_in_sto.fe:21:16
-   │
-21 │         return self.nums.to_mem()
-   │                ^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 42, inner: Numeric(U256) }) }
-
-note: 
    ┌─ sized_vals_in_sto.fe:23:5
    │  
 23 │ ╭     pub fn write_str(self, x: String<26>):
@@ -277,12 +271,6 @@ note:
    │
 27 │         return self.str.to_mem()
    │                ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
-
-note: 
-   ┌─ sized_vals_in_sto.fe:27:16
-   │
-27 │         return self.str.to_mem()
-   │                ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 26 }) }
 
 note: 
    ┌─ sized_vals_in_sto.fe:29:5
@@ -398,13 +386,5 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ sized_vals_in_sto.fe:32:19
-   │
-32 │             nums: self.nums.to_mem(),
-   │                   ^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 42, inner: Numeric(U256) }) }
-33 │             str: self.str.to_mem()
-   │                  ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 26 }) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -124,12 +124,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^ String<100>: Memory
 
 note: 
-   ┌─ strings.fe:21:16
-   │
-21 │         return String<100>("foo")
-   │                ^^^^^^ TypeConstructor(String(FeString { max_size: 100 }))
-
-note: 
    ┌─ strings.fe:23:5
    │  
 23 │ ╭     pub fn shorter_string_assign():

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -16,7 +16,7 @@ note:
   │  
 5 │ ╭   pub fn new(x: u64, y: u64) -> Point:
 6 │ │     return Point(x, y)
-  │ ╰──────────────────────^ attributes hash: 15239695565073513268
+  │ ╰──────────────────────^ attributes hash: 18058161240499911688
   │  
   = FunctionSignature {
         self_decl: None,
@@ -46,9 +46,6 @@ note:
             Struct(
                 Struct {
                     name: "Point",
-                    id: StructId(
-                        0,
-                    ),
                     field_count: 2,
                 },
             ),
@@ -70,17 +67,11 @@ note:
   │            ^^^^^^^^^^^ Point: Memory
 
 note: 
-  ┌─ struct_fns.fe:6:12
-  │
-6 │     return Point(x, y)
-  │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
-
-note: 
   ┌─ struct_fns.fe:8:3
   │  
 8 │ ╭   pub fn origin() -> Point:
 9 │ │     return Point(x: 0, y: 0)
-  │ ╰────────────────────────────^ attributes hash: 1766050550231886475
+  │ ╰────────────────────────────^ attributes hash: 3063535909107835097
   │  
   = FunctionSignature {
         self_decl: None,
@@ -89,9 +80,6 @@ note:
             Struct(
                 Struct {
                     name: "Point",
-                    id: StructId(
-                        0,
-                    ),
                     field_count: 2,
                 },
             ),
@@ -111,12 +99,6 @@ note:
   │
 9 │     return Point(x: 0, y: 0)
   │            ^^^^^^^^^^^^^^^^^ Point: Memory
-
-note: 
-  ┌─ struct_fns.fe:9:12
-  │
-9 │     return Point(x: 0, y: 0)
-  │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 
 note: 
    ┌─ struct_fns.fe:12:3
@@ -359,7 +341,7 @@ note:
 32 │ │     let x: u64 = self.x + other.x
 33 │ │     let y: u64 = self.y + other.y
 34 │ │     return Point(x, y)
-   │ ╰──────────────────────^ attributes hash: 15351893842694786918
+   │ ╰──────────────────────^ attributes hash: 2850570852780374671
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -372,9 +354,6 @@ note:
                      Struct(
                          Struct {
                              name: "Point",
-                             id: StructId(
-                                 0,
-                             ),
                              field_count: 2,
                          },
                      ),
@@ -385,9 +364,6 @@ note:
              Struct(
                  Struct {
                      name: "Point",
-                     id: StructId(
-                         0,
-                     ),
                      field_count: 2,
                  },
              ),
@@ -459,12 +435,6 @@ note:
    │
 34 │     return Point(x, y)
    │            ^^^^^^^^^^^ Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:34:12
-   │
-34 │     return Point(x, y)
-   │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 
 note: 
    ┌─ struct_fns.fe:36:1
@@ -575,19 +545,6 @@ note:
    │
 43 │   assert p3.x == 6 and p3.y == 12
    │          ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-
-note: 
-   ┌─ struct_fns.fe:37:19
-   │
-37 │   let p1: Point = Point.origin()
-   │                   ^^^^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(2) }
-38 │   p1.translate(5, 10)
-   │   ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(6) }
-39 │ 
-40 │   let p2: Point = Point(x: 1, y: 2)
-   │                   ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
-41 │   let p3: Point = p1.add(p2)
-   │                   ^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(7) }
 
 note: 
    ┌─ struct_fns.fe:48:3
@@ -758,21 +715,5 @@ note:
    │
 56 │     return p.y
    │            ^^^ u64: Memory => Value
-
-note: 
-   ┌─ struct_fns.fe:49:5
-   │
-49 │     do_pointy_things()
-   │     ^^^^^^^^^^^^^^^^ Pure(FunctionId(0))
-50 │ 
-51 │     let p: Point = Point.new(x, y)
-   │                    ^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(1) }
-52 │     assert p.x == x and p.y == y
-53 │     p.set_x(100)
-   │     ^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(4) }
-54 │     p.reflect()
-   │     ^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(5) }
-55 │     assert p.x() == y and p.y == 100
-   │            ^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(3) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -36,7 +36,7 @@ note:
    │  
 15 │ ╭     pub fn new(val: u256) -> Mixed:
 16 │ │         return Mixed(foo: val, bar: false)
-   │ ╰──────────────────────────────────────────^ attributes hash: 14840391711119122636
+   │ ╰──────────────────────────────────────────^ attributes hash: 6039711179716888913
    │  
    = FunctionSignature {
          self_decl: None,
@@ -56,9 +56,6 @@ note:
              Struct(
                  Struct {
                      name: "Mixed",
-                     id: StructId(
-                         2,
-                     ),
                      field_count: 2,
                  },
              ),
@@ -78,12 +75,6 @@ note:
    │
 16 │         return Mixed(foo: val, bar: false)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mixed: Memory
-
-note: 
-   ┌─ structs.fe:16:16
-   │
-16 │         return Mixed(foo: val, bar: false)
-   │                ^^^^^ TypeConstructor(Struct(Struct { name: "Mixed", id: StructId(2), field_count: 2 }))
 
 note: 
    ┌─ structs.fe:19:5
@@ -134,12 +125,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-   ┌─ structs.fe:25:16
-   │
-25 │         return self.abi_encode()
-   │                ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Struct(Struct { name: "House", id: StructId(3), field_count: 4 }) }
-
-note: 
    ┌─ structs.fe:27:5
    │  
 27 │ ╭     pub fn hash(self) -> u256:
@@ -177,18 +162,6 @@ note:
    │
 28 │         return keccak256(self.encode())
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-
-note: 
-   ┌─ structs.fe:28:26
-   │
-28 │         return keccak256(self.encode())
-   │                          ^^^^^^^^^^^ ValueMethod { is_self: true, class: Struct(StructId(3)), method: FunctionId(1) }
-
-note: 
-   ┌─ structs.fe:28:16
-   │
-28 │         return keccak256(self.encode())
-   │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 note: 
    ┌─ structs.fe:30:5
@@ -1103,24 +1076,6 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^ String<3>: Storage { nonce: Some(1) } => Memory
 
 note: 
-   ┌─ structs.fe:45:20
-   │
-45 │             point: Point(x: 100, y: 200),
-   │                    ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
-
-note: 
-   ┌─ structs.fe:42:23
-   │
-42 │         self.my_bar = Bar(
-   │                       ^^^ TypeConstructor(Struct(Struct { name: "Bar", id: StructId(1), field_count: 4 }))
-   ·
-73 │         self.my_bar.point = Point(x: 100, y: 200)
-   │                             ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
-   ·
-87 │         return self.my_bar.name.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 3 }) }
-
-note: 
     ┌─ structs.fe:89:5
     │  
  89 │ ╭     pub fn complex_struct_in_memory(self) -> String<3>:
@@ -1758,21 +1713,6 @@ note:
     │                ^^^^^^^^ String<3>: Memory
 
 note: 
-   ┌─ structs.fe:93:20
-   │
-93 │             point: Point(x: 100, y: 200),
-   │                    ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
-
-note: 
-    ┌─ structs.fe:90:24
-    │
- 90 │         let val: Bar = Bar(
-    │                        ^^^ TypeConstructor(Struct(Struct { name: "Bar", id: StructId(1), field_count: 4 }))
-    ·
-121 │         val.point = Point(x: 100, y: 200)
-    │                     ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
-
-note: 
     ┌─ structs.fe:137:5
     │  
 137 │ ╭     pub fn create_mixed(self) -> u256:
@@ -1821,17 +1761,11 @@ note:
     │                ^^^^^^^^^ u256: Memory => Value
 
 note: 
-    ┌─ structs.fe:138:28
-    │
-138 │         let mixed: Mixed = Mixed.new(1)
-    │                            ^^^^^^^^^ AssociatedFunction { class: Struct(StructId(2)), function: FunctionId(0) }
-
-note: 
     ┌─ structs.fe:141:5
     │  
 141 │ ╭     pub fn set_house(self, data: House):
 142 │ │         self.my_house = data
-    │ ╰────────────────────────────^ attributes hash: 14004499701394096532
+    │ ╰────────────────────────────^ attributes hash: 10849681860906772965
     │  
     = FunctionSignature {
           self_decl: Some(
@@ -1844,9 +1778,6 @@ note:
                       Struct(
                           Struct {
                               name: "House",
-                              id: StructId(
-                                  3,
-                              ),
                               field_count: 4,
                           },
                       ),
@@ -1879,7 +1810,7 @@ note:
     │  
 144 │ ╭     pub fn get_house(self) -> House:
 145 │ │         return self.my_house.to_mem()
-    │ ╰─────────────────────────────────────^ attributes hash: 4535161131583011266
+    │ ╰─────────────────────────────────────^ attributes hash: 11127515449597783668
     │  
     = FunctionSignature {
           self_decl: Some(
@@ -1890,9 +1821,6 @@ note:
               Struct(
                   Struct {
                       name: "House",
-                      id: StructId(
-                          3,
-                      ),
                       field_count: 4,
                   },
               ),
@@ -1916,12 +1844,6 @@ note:
     │
 145 │         return self.my_house.to_mem()
     │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Memory
-
-note: 
-    ┌─ structs.fe:145:16
-    │
-145 │         return self.my_house.to_mem()
-    │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "House", id: StructId(3), field_count: 4 }) }
 
 note: 
     ┌─ structs.fe:147:5
@@ -2512,36 +2434,6 @@ note:
     │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
 
 note: 
-    ┌─ structs.fe:151:20
-    │
-151 │             rooms: u8(5),
-    │                    ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-    ┌─ structs.fe:148:25
-    │
-148 │         self.my_house = House(
-    │                         ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
-    ·
-156 │         assert self.my_house.rooms == u8(5)
-    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-    ·
-162 │         assert self.my_house.rooms == u8(5)
-    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-    ·
-168 │         assert self.my_house.rooms == u8(5)
-    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-    ·
-173 │         assert self.my_house.rooms == u8(5)
-    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-174 │         assert self.my_house.vacant
-175 │         self.my_house.rooms = u8(100)
-    │                               ^^ TypeConstructor(Base(Numeric(U8)))
-    ·
-178 │         assert self.my_house.rooms == u8(100)
-    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
     ┌─ structs.fe:181:5
     │  
 181 │ ╭     pub fn bar() -> u256:
@@ -2832,30 +2724,6 @@ note:
     │                ^^^^^^^^^^^^^ u256: Memory => Value
 
 note: 
-    ┌─ structs.fe:185:20
-    │
-185 │             rooms: u8(20),
-    │                    ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-    ┌─ structs.fe:182:31
-    │
-182 │         let building: House = House(
-    │                               ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
-    ·
-190 │         assert building.rooms == u8(20)
-    │                                  ^^ TypeConstructor(Base(Numeric(U8)))
-    ·
-196 │         building.rooms = u8(10)
-    │                          ^^ TypeConstructor(Base(Numeric(U8)))
-    ·
-201 │         assert building.rooms == u8(10)
-    │                                  ^^ TypeConstructor(Base(Numeric(U8)))
-202 │ 
-203 │         building.expand()
-    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(3)), method: FunctionId(4) }
-
-note: 
     ┌─ structs.fe:209:5
     │  
 209 │ ╭     pub fn encode_house() -> Array<u8, 128>:
@@ -2927,21 +2795,6 @@ note:
     │                ^^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-    ┌─ structs.fe:213:20
-    │
-213 │             rooms: u8(20),
-    │                    ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-    ┌─ structs.fe:210:28
-    │
-210 │         let house: House = House(
-    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
-    ·
-216 │         return house.encode()
-    │                ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(3)), method: FunctionId(1) }
-
-note: 
     ┌─ structs.fe:218:5
     │  
 218 │ ╭     pub fn hashed_house() -> u256:
@@ -3008,20 +2861,5 @@ note:
     │
 225 │         return house.hash()
     │                ^^^^^^^^^^^^ u256: Value
-
-note: 
-    ┌─ structs.fe:222:20
-    │
-222 │             rooms: u8(20),
-    │                    ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-    ┌─ structs.fe:219:28
-    │
-219 │         let house: House = House(
-    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
-    ·
-225 │         return house.hash()
-    │                ^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(3)), method: FunctionId(2) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -550,14 +550,6 @@ note:
    │                             ^^^^^^^^^^^^^^^^^ (u256, i32): Memory
 
 note: 
-   ┌─ tuple_stress.fe:30:43
-   │
-30 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-   │                                           ^^^^                                   ^^^ TypeConstructor(Base(Numeric(I32)))
-   │                                           │                                       
-   │                                           TypeConstructor(Base(Numeric(U256)))
-
-note: 
    ┌─ tuple_stress.fe:33:5
    │  
 33 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32):
@@ -606,12 +598,6 @@ note:
    │
 34 │         return self.my_sto_tuple.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => Memory
-
-note: 
-   ┌─ tuple_stress.fe:34:16
-   │
-34 │         return self.my_sto_tuple.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Tuple(Tuple { items: [Base(Numeric(U256)), Base(Numeric(I32))] }) }
 
 note: 
    ┌─ tuple_stress.fe:36:5
@@ -716,15 +702,6 @@ note:
    │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ tuple_stress.fe:41:13
-   │
-41 │             address(26)
-   │             ^^^^^^^ TypeConstructor(Base(Address))
-42 │         )
-43 │         emit_my_event(my_tuple)
-   │         ^^^^^^^^^^^^^ Pure(FunctionId(5))
-
-note: 
    ┌─ tuple_stress.fe:45:5
    │  
 45 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> Array<u8, 96>:
@@ -780,11 +757,5 @@ note:
    │
 46 │         return my_tuple.abi_encode()
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u8, 96>: Memory
-
-note: 
-   ┌─ tuple_stress.fe:46:16
-   │
-46 │         return my_tuple.abi_encode()
-   │                ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Tuple(Tuple { items: [Base(Numeric(U256)), Base(Bool), Base(Address)] }) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -72,14 +72,6 @@ note:
   │                ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-  ┌─ two_contracts.fe:8:9
-  │
-8 │         self.other.set_foo_addr(self.address)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^ External { contract: ContractId(1), function: FunctionId(3) }
-9 │         return self.other.answer()
-  │                ^^^^^^^^^^^^^^^^^ External { contract: ContractId(1), function: FunctionId(4) }
-
-note: 
    ┌─ two_contracts.fe:11:5
    │  
 11 │ ╭     pub fn add(x: u256, y: u256) -> u256:
@@ -188,12 +180,6 @@ note:
    │                      ^^^^^^^^^ Foo: Value
 
 note: 
-   ┌─ two_contracts.fe:18:22
-   │
-18 │         self.other = Foo(addr)
-   │                      ^^^ TypeConstructor(Contract(Contract { name: "Foo", id: ContractId(0) }))
-
-note: 
    ┌─ two_contracts.fe:20:5
    │  
 20 │ ╭     pub fn answer(self) -> u256:
@@ -234,11 +220,5 @@ note:
    │
 21 │         return self.other.add(20, 22)
    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-
-note: 
-   ┌─ two_contracts.fe:21:16
-   │
-21 │         return self.other.add(20, 22)
-   │                ^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(2) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -299,10 +299,4 @@ note:
 28 │         return self.posts[id].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => Memory
 
-note: 
-   ┌─ type_aliases.fe:28:16
-   │
-28 │         return self.posts[id].to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 32 }) }
-
 

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -433,12 +433,6 @@ note:
      }
 
 note: 
-   ┌─ uniswap.fe:78:29
-   │
-78 │         emit Transfer(from: address(0), to, value)
-   │                             ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
    ┌─ uniswap.fe:80:5
    │  
 80 │ ╭     fn _burn(self, from: address, value: u256):
@@ -598,12 +592,6 @@ note:
              },
          ],
      }
-
-note: 
-   ┌─ uniswap.fe:83:33
-   │
-83 │         emit Transfer(from, to: address(0), value)
-   │                                 ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ uniswap.fe:85:5
@@ -964,12 +952,6 @@ note:
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ uniswap.fe:95:9
-   │
-95 │         self._approve(msg.sender, spender, value)
-   │         ^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(8) }
-
-note: 
     ┌─ uniswap.fe:98:5
     │  
  98 │ ╭     pub fn transfer(self, to: address, value: u256) -> bool:
@@ -1025,12 +1007,6 @@ note:
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 100 │         return true
     │                ^^^^ bool: Value
-
-note: 
-   ┌─ uniswap.fe:99:9
-   │
-99 │         self._transfer(msg.sender, to, value)
-   │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(9) }
 
 note: 
     ┌─ uniswap.fe:102:5
@@ -1188,12 +1164,6 @@ note:
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 107 │         return true
     │                ^^^^ bool: Value
-
-note: 
-    ┌─ uniswap.fe:106:9
-    │
-106 │         self._transfer(from, to, value)
-    │         ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(9) }
 
 note: 
     ┌─ uniswap.fe:109:5
@@ -1966,28 +1936,6 @@ note:
     │                ^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:139:31
-    │
-139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                               ^^^^^^^^^^^^^^^^ TypeConstructor(Contract(Contract { name: "UniswapV2Factory", id: ContractId(2) }))
-
-note: 
-    ┌─ uniswap.fe:139:31
-    │
-139 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ External { contract: ContractId(2), function: FunctionId(26) }
-140 │         let fee_on: bool = fee_to != address(0)
-    │                                      ^^^^^^^ TypeConstructor(Base(Address))
-    ·
-144 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                                    ^^^^ Pure(FunctionId(23))
-145 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                         ^^^^ Pure(FunctionId(23))
-    ·
-151 │                         self._mint(fee_to, liquidity)
-    │                         ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(6) }
-
-note: 
     ┌─ uniswap.fe:158:5
     │  
 158 │ ╭     pub fn mint(self, to: address) -> u256:
@@ -2383,48 +2331,6 @@ note:
               },
           ],
       }
-
-note: 
-    ┌─ uniswap.fe:162:30
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-
-note: 
-    ┌─ uniswap.fe:162:30
-    │
-162 │         let balance0: u256 = ERC20(self.token0).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-
-note: 
-    ┌─ uniswap.fe:163:30
-    │
-163 │         let balance1: u256 = ERC20(self.token1).balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-    ·
-167 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(17) }
-    ·
-171 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-    │                         ^^^^ Pure(FunctionId(23))
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │                        ^^^^^^^ TypeConstructor(Base(Address))
-
-note: 
-    ┌─ uniswap.fe:172:13
-    │
-172 │             self._mint(address(0), MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
-    │             ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(6) }
-173 │         else:
-174 │             liquidity = min((amount0 * total_supply) / reserve0, (amount1 * total_supply) / reserve1)
-    │                         ^^^ Pure(FunctionId(24))
-    ·
-178 │         self._mint(to, liquidity)
-    │         ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(6) }
-179 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ uniswap.fe:188:5
@@ -2860,35 +2766,6 @@ note:
               },
           ],
       }
-
-note: 
-    ┌─ uniswap.fe:191:29
-    │
-191 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-192 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-193 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-194 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-    ·
-197 │         let fee_on: bool = self._mint_fee(reserve0, reserve1)
-    │                            ^^^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(17) }
-    ·
-202 │         self._burn(self.address, liquidity)
-    │         ^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(7) }
-203 │         token0.transfer(to, amount0)
-    │         ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
-204 │         token1.transfer(to, amount1)
-    │         ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
-205 │         balance0 = token0.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-206 │         balance1 = token1.balanceOf(self.address)
-    │                    ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-207 │ 
-208 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ uniswap.fe:219:5
@@ -3497,33 +3374,6 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:225:29
-    │
-225 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-226 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-    ·
-229 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
-    │                      ^^^^^^^                   ^^^^^^^ TypeConstructor(Base(Address))
-    │                      │                          
-    │                      TypeConstructor(Base(Address))
-    ·
-232 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
-233 │         if amount1_out > 0:
-234 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
-    │             ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
-    ·
-239 │         let balance0: u256 = token0.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-240 │         let balance1: u256 = token1.balanceOf(self.address)
-    │                              ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-    ·
-252 │         self._update(balance0, balance1, reserve0, reserve1)
-    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
-
-note: 
     ┌─ uniswap.fe:256:5
     │  
 256 │ ╭     pub fn skim(self, to: address):
@@ -3673,31 +3523,6 @@ note:
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:257:29
-    │
-257 │         let token0: ERC20 = ERC20(self.token0) # gas savings
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-258 │         let token1: ERC20 = ERC20(self.token1) # gas savings
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-259 │ 
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-
-note: 
-    ┌─ uniswap.fe:260:9
-    │
-260 │         token0.transfer(to, token0.balanceOf(self.address) - self.reserve0)
-    │         ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-
-note: 
-    ┌─ uniswap.fe:261:9
-    │
-261 │         token1.transfer(to, token1.balanceOf(self.address) - self.reserve1)
-    │         ^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(1) }
-
-note: 
     ┌─ uniswap.fe:264:5
     │  
 264 │ ╭     pub fn sync(self):
@@ -3811,24 +3636,6 @@ note:
     │
 267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-
-note: 
-    ┌─ uniswap.fe:265:29
-    │
-265 │         let token0: ERC20 = ERC20(self.token0)
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-266 │         let token1: ERC20 = ERC20(self.token1)
-    │                             ^^^^^ TypeConstructor(Contract(Contract { name: "ERC20", id: ContractId(0) }))
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │                      ^^^^^^^^^^^^^^^^                ^^^^^^^^^^^^^^^^ External { contract: ContractId(0), function: FunctionId(0) }
-    │                      │                                
-    │                      External { contract: ContractId(0), function: FunctionId(0) }
-
-note: 
-    ┌─ uniswap.fe:267:9
-    │
-267 │         self._update(token0.balanceOf(self.address), token1.balanceOf(self.address), self.reserve0, self.reserve1)
-    │         ^^^^^^^^^^^^ ValueMethod { is_self: true, class: Contract(ContractId(1)), method: FunctionId(16) }
 
 note: 
     ┌─ uniswap.fe:269:5
@@ -4560,39 +4367,6 @@ note:
               },
           ],
       }
-
-note: 
-    ┌─ uniswap.fe:316:26
-    │
-316 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
-    │                          ^^^^^^^ TypeConstructor(Base(Address))
-317 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
-    │                                              ^^^^^^^ TypeConstructor(Base(Address))
-318 │ 
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Tuple(Tuple { items: [Base(Address), Base(Address)] }) }
-
-note: 
-    ┌─ uniswap.fe:319:26
-    │
-319 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                          ^^^^^^^^^ BuiltinFunction(Keccak256)
-320 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(0, salt)
-    │                                   ^^^^^^^^^^^^^^^^^^^^^ BuiltinAssociatedFunction { contract: ContractId(1), function: Create2 }
-321 │         pair.initialize(token0, token1)
-    │         ^^^^^^^^^^^^^^^ External { contract: ContractId(1), function: FunctionId(15) }
-322 │ 
-323 │         self.pairs[token0][token1] = address(pair)
-    │                                      ^^^^^^^ TypeConstructor(Base(Address))
-324 │         self.pairs[token1][token0] = address(pair)
-    │                                      ^^^^^^^ TypeConstructor(Base(Address))
-325 │         self.all_pairs[self.pair_counter] = address(pair)
-    │                                             ^^^^^^^ TypeConstructor(Base(Address))
-    ·
-328 │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
-    │                                                ^^^^^^^ TypeConstructor(Base(Address))
-329 │         return address(pair)
-    │                ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
     ┌─ uniswap.fe:331:5

--- a/crates/analyzer/tests/snapshots/errors__call_balance_of_with_2_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_balance_of_with_2_args.snap
@@ -4,11 +4,14 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `balance_of` expects 1 argument, but 2 were provided
-  ┌─ [snippet]:3:3
-  │
-3 │   balance_of(address(0), 2)
-  │   ^^^^^^^^^^ ----------  - supplied 2 arguments
-  │   │                       
-  │   expects 1 argument
+   ┌─ src/evm.fe:52:8
+   │
+52 │ pub fn balance_of(addr: address) -> u256:
+   │        ^^^^^^^^^^ expects 1 argument
+   │
+   ┌─ [snippet]:3:24
+   │
+ 3 │   std::evm::balance_of(address(0), 2)
+   │                        ----------  - supplied 2 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_balance_of_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_balance_of_with_wrong_type.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `bool` can not be used as an argument to `balance_of`
-  ┌─ [snippet]:3:13
+error: incorrect type for `balance_of` argument `addr`
+  ┌─ [snippet]:3:24
   │
-3 │   balance_of(true)
-  │             ^^^^^^ wrong type
-  │
-  = Note: `balance_of` expects an address argument
+3 │   std::evm::balance_of(true)
+  │                        ^^^^ this has type `bool`; expected type `address`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_balance_of_without_parameter.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_balance_of_without_parameter.snap
@@ -4,11 +4,14 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `balance_of` expects 1 argument, but 0 were provided
-  ┌─ [snippet]:3:3
-  │
-3 │   balance_of()
-  │   ^^^^^^^^^^-- supplied 0 arguments
-  │   │          
-  │   expects 1 argument
+   ┌─ src/evm.fe:52:8
+   │
+52 │ pub fn balance_of(addr: address) -> u256:
+   │        ^^^^^^^^^^ expects 1 argument
+   │
+   ┌─ [snippet]:3:23
+   │
+ 3 │   std::evm::balance_of()
+   │                       -- supplied 0 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_balance_with_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_balance_with_arg.snap
@@ -4,11 +4,14 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `balance` expects 0 arguments, but 1 was provided
-  ┌─ [snippet]:3:3
-  │
-3 │   balance(address(0))
-  │   ^^^^^^^ ---------- supplied 1 argument
-  │   │        
-  │   expects 0 arguments
+   ┌─ src/evm.fe:56:8
+   │
+56 │ pub fn balance() -> u256:
+   │        ^^^^^^^ expects 0 arguments
+   │
+   ┌─ [snippet]:3:21
+   │
+ 3 │   std::evm::balance(address(0))
+   │                     ---------- supplied 1 argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_send_value_with_1_arg.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_send_value_with_1_arg.snap
@@ -4,11 +4,14 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `send_value` expects 2 arguments, but 1 was provided
-  ┌─ [snippet]:3:3
-  │
-3 │   send_value(address(0))
-  │   ^^^^^^^^^^ ---------- supplied 1 argument
-  │   │           
-  │   expects 2 arguments
+   ┌─ src/lib.fe:11:8
+   │
+11 │ pub fn send_value(to: address, wei: u256):
+   │        ^^^^^^^^^^ expects 2 arguments
+   │
+   ┌─ [snippet]:3:19
+   │
+ 3 │   std::send_value(address(0))
+   │                   ---------- supplied 1 argument
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_send_value_with_3_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_send_value_with_3_args.snap
@@ -4,11 +4,14 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `send_value` expects 2 arguments, but 3 were provided
-  ┌─ [snippet]:3:3
-  │
-3 │   send_value(address(0), 0, 0)
-  │   ^^^^^^^^^^ ----------  -  - supplied 3 arguments
-  │   │                          
-  │   expects 2 arguments
+   ┌─ src/lib.fe:11:8
+   │
+11 │ pub fn send_value(to: address, wei: u256):
+   │        ^^^^^^^^^^ expects 2 arguments
+   │
+   ┌─ [snippet]:3:19
+   │
+ 3 │   std::send_value(address(0), 0, 0)
+   │                   ----------  -  - supplied 3 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_send_value_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_send_value_with_wrong_type.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `bool` can not be used as an argument to `send_value`
-  ┌─ [snippet]:3:14
+error: incorrect type for `send_value` argument `to`
+  ┌─ [snippet]:3:19
   │
-3 │   send_value(true, 0)
-  │              ^^^^ wrong type
-  │
-  = Note: `send_value` expects an `address` as first argument
+3 │   std::send_value(true, 0)
+  │                   ^^^^ this has type `bool`; expected type `address`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_send_value_with_wrong_type2.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_send_value_with_wrong_type2.snap
@@ -3,12 +3,10 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `bool` can not be used as an argument to `send_value`
-  ┌─ [snippet]:3:26
+error: incorrect type for `send_value` argument `wei`
+  ┌─ [snippet]:3:31
   │
-3 │   send_value(address(0), true)
-  │                          ^^^^ wrong type
-  │
-  = Note: `send_value` expects an `u256` as second argument
+3 │   std::send_value(address(0), true)
+  │                               ^^^^ this has type `bool`; expected type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_send_value_without_parameter.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_send_value_without_parameter.snap
@@ -4,11 +4,14 @@ expression: "error_string(\"[snippet]\", &src)"
 
 ---
 error: `send_value` expects 2 arguments, but 0 were provided
-  ┌─ [snippet]:3:3
-  │
-3 │   send_value()
-  │   ^^^^^^^^^^-- supplied 0 arguments
-  │   │          
-  │   expects 2 arguments
+   ┌─ src/lib.fe:11:8
+   │
+11 │ pub fn send_value(to: address, wei: u256):
+   │        ^^^^^^^^^^ expects 2 arguments
+   │
+   ┌─ [snippet]:3:18
+   │
+ 3 │   std::send_value()
+   │                  -- supplied 0 arguments
 
 

--- a/crates/library/std/src/evm.fe
+++ b/crates/library/std/src/evm.fe
@@ -1,0 +1,293 @@
+# Basic context accessor functions.
+# These should be unsafe when the Context object is introduced.
+
+pub fn chain_id() -> u256:
+  unsafe:
+    return __chainid()
+
+pub fn base_fee() -> u256:
+  unsafe:
+    return __basefee()
+
+pub fn origin() -> address:
+  unsafe:
+    return address(__origin())
+
+pub fn gas_price() -> u256:
+  unsafe:
+    return __gasprice()
+
+pub fn block_hash(b: u256) -> u256:
+  unsafe:
+    return __blockhash(b)
+
+pub fn coin_base() -> address:
+  unsafe:
+    return address(__coinbase())
+
+pub fn timestamp() -> u256:
+  unsafe:
+    return __timestamp()
+
+pub fn block_number() -> u256:
+  unsafe:
+    return __number()
+
+pub fn difficulty() -> u256:
+  unsafe:
+    return __difficulty()
+
+pub fn gas_limit() -> u256:
+  unsafe:
+    return __gaslimit()
+
+pub fn gas() -> u256:
+  unsafe:
+    return __gas()
+
+pub fn self_address() -> address:
+  unsafe:
+    return address(__address())
+
+pub fn balance_of(addr: address) -> u256:
+  unsafe:
+    return __balance(u256(addr))
+
+pub fn balance() -> u256:
+  unsafe:
+    return __selfbalance()
+
+pub fn caller() -> address:
+  unsafe:
+    return address(__caller())
+
+pub fn call_value() -> u256:
+  unsafe:
+    return __callvalue()
+
+
+# Overflowing math ops. Should these be unsafe or named
+# `overflowing_add`, etc?
+pub fn add(x: u256, y: u256) -> u256:
+  unsafe:
+    return __add(x, y)
+
+pub fn sub(x: u256, y: u256) -> u256:
+  unsafe:
+    return __sub(x, y)
+
+pub fn mul(x: u256, y: u256) -> u256:
+  unsafe:
+    return __mul(x, y)
+
+pub fn div(x: u256, y: u256) -> u256:
+  unsafe:
+    return __div(x, y)
+
+pub fn sdiv(x: u256, y: u256) -> u256:
+  unsafe:
+    return __sdiv(x, y)
+
+pub fn mod(x: u256, y: u256) -> u256:
+  unsafe:
+    return __mod(x, y)
+
+pub fn smod(x: u256, y: u256) -> u256:
+  unsafe:
+    return __smod(x, y)
+
+pub fn exp(x: u256, y: u256) -> u256:
+  unsafe:
+    return __exp(x, y)
+
+pub fn addmod(x: u256, y: u256, m: u256) -> u256:
+  unsafe:
+    return __addmod(x, y, m)
+
+pub fn mulmod(x: u256, y: u256, m: u256) -> u256:
+  unsafe:
+    return __mulmod(x, y, m)
+
+pub fn sign_extend(i: u256, x: u256) -> u256:
+  unsafe:
+    return __signextend(i, x)
+
+
+
+# Comparison ops
+# TODO: return bool (see issue #653)
+pub fn lt(x: u256, y: u256) -> u256:
+  unsafe:
+    return __lt(x, y)
+
+pub fn gt(x: u256, y: u256) -> u256:
+  unsafe:
+    return __gt(x, y)
+
+pub fn slt(x: u256, y: u256) -> u256:
+  unsafe:
+    return __slt(x, y)
+
+pub fn sgt(x: u256, y: u256) -> u256:
+  unsafe:
+    return __sgt(x, y)
+
+pub fn eq(x: u256, y: u256) -> u256:
+  unsafe:
+    return __eq(x, y)
+
+pub fn is_zero(x: u256) -> u256:
+  unsafe:
+    return __iszero(x)
+
+
+# Bitwise ops
+pub fn bitwise_and(x: u256, y: u256) -> u256:
+  unsafe:
+    return __and(x, y)
+
+pub fn bitwise_or(x: u256, y: u256) -> u256:
+  unsafe:
+    return __or(x, y)
+
+pub fn bitwise_not(x: u256) -> u256:
+  unsafe:
+    return __not(x)
+
+pub fn xor(x: u256, y: u256) -> u256:
+  unsafe:
+    return __xor(x, y)
+
+pub fn byte(offset: u256, x: u256) -> u256:
+  unsafe:
+    return __byte(offset, x)
+
+pub fn shl(x: u256, y: u256) -> u256:
+  unsafe:
+    return __shl(x, y)
+
+pub fn shr(x: u256, y: u256) -> u256:
+  unsafe:
+    return __shr(x, y)
+
+pub fn sar(x: u256, y: u256) -> u256:
+  unsafe:
+    return __sar(x, y)
+
+
+# Evm state access and control
+pub unsafe fn return_mem(location: u256, len: u256):
+    return __return(location, len)
+
+pub unsafe fn revert_mem(location: u256, len: u256):
+    return __revert(location, len)
+
+pub unsafe fn selfdestruct(addr: address):
+    return __selfdestruct(u256(addr))
+
+# Invalid opcode. Equivalent to revert(0, 0),
+# except that all remaining gas in the current context
+# is consumed.
+pub unsafe fn invalid():
+    return __invalid()
+
+pub unsafe fn stop():
+    return __stop()
+
+pub unsafe fn pc() -> u256:
+    return __pc()
+
+# TODO: dunno if we should enable this
+# pub unsafe fn pop(x: u256):
+#     return __pop(x)
+
+pub unsafe fn mload(p: u256) -> u256:
+    return __mload(p)
+
+pub unsafe fn mstore(p: u256, v: u256):
+    return __mstore(p, v)
+
+pub unsafe fn mstore8(p: u256, v: u256):
+    return __mstore8(p, v)
+
+pub unsafe fn sload(p: u256) -> u256:
+    return __sload(p)
+
+pub unsafe fn sstore(p: u256, v: u256):
+    return __sstore(p, v)
+
+pub unsafe fn msize() -> u256:
+    return __msize()
+
+pub unsafe fn call_data_load(p: u256) -> u256:
+    return __calldataload(p)
+
+pub unsafe fn call_data_size() -> u256:
+    return __calldatasize()
+
+pub unsafe fn call_data_copy(t: u256, f: u256, s: u256):
+    return __calldatacopy(t, f, s)
+
+pub unsafe fn code_size() -> u256:
+    return __codesize()
+
+pub unsafe fn code_copy(t: u256, f: u256, s: u256):
+    return __codecopy(t, f, s)
+
+pub unsafe fn return_data_size() -> u256:
+    return __returndatasize()
+
+pub unsafe fn return_data_copy(t: u256, f: u256, s: u256):
+    return __returndatacopy(t, f, s)
+
+pub unsafe fn extcodesize(addr: address) -> u256:
+    return __extcodesize(u256(addr))
+
+pub unsafe fn ext_code_copy(addr: address, t: u256, f: u256, s: u256):
+    return __extcodecopy(u256(addr), t, f, s)
+
+pub unsafe fn ext_code_hash(addr: address) -> u256:
+    return __extcodehash(u256(addr))
+
+pub unsafe fn keccak256_mem(location: u256, len: u256) -> u256:
+    return __keccak256(location, len)
+
+
+# Contract creation and calling
+
+pub unsafe fn create(v: u256, p: u256, n: u256) -> address:
+    return address(__create(v, p, n))
+
+pub unsafe fn create2(v: u256, p: u256, n: u256, s: u256) -> address:
+    return address(__create2(v, p, n, s))
+
+# TODO: return bool (success)
+pub unsafe fn call(g: u256, addr: address, value: u256, in_: u256, insize: u256, out: u256, outsize: u256) -> u256:
+    return __call(g, u256(addr), value, in_, insize, out, outsize)
+
+pub unsafe fn call_code(g: u256, addr: address, value: u256, in_: u256, insize: u256, out: u256, outsize: u256) -> u256:
+    return __callcode(g, u256(addr), value, in_, insize, out, outsize)
+
+pub unsafe fn delegate_call(g: u256, addr: address, in_: u256, insize: u256, out: u256, outsize: u256) -> u256:
+    return __delegatecall(g, u256(addr), in_, insize, out, outsize)
+
+pub unsafe fn static_call(g: u256, addr: address, in_: u256, insize: u256, out: u256, outsize: u256) -> u256:
+    return __staticcall(g, u256(addr), in_, insize, out, outsize)
+
+
+# Logging functions
+
+pub unsafe fn log0(p: u256, s: u256):
+    return __log0(p, s)
+
+pub unsafe fn log1(p: u256, s: u256, t1: u256):
+    return __log1(p, s, t1)
+
+pub unsafe fn log2(p: u256, s: u256, t1: u256, t2: u256):
+    return __log2(p, s, t1, t2)
+
+pub unsafe fn log3(p: u256, s: u256, t1: u256, t2: u256, t3: u256):
+    return __log3(p, s, t1, t2, t3)
+
+pub unsafe fn log4(p: u256, s: u256, t1: u256, t2: u256, t3: u256, t4: u256):
+    return __log4(p, s, t1, t2, t3, t4)

--- a/crates/library/std/src/lib.fe
+++ b/crates/library/std/src/lib.fe
@@ -1,10 +1,18 @@
-const ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE: u256 = 0x100
-
-pub struct Error:
-  pub code: u256
-
 pub fn get_42() -> u256:
     return 42
 
-pub fn revert_insufficient_funds():
-    revert Error(code: ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE)
+# TODO: move these into some module of standard error codes
+const ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE: u256 = 0x100
+const ERROR_FAILED_SEND_VALUE: u256 = 0x101
+
+pub struct Error:
+    pub code: u256
+
+pub fn send_value(to: address, wei: u256):
+  unsafe:
+    if evm::balance() < wei:
+        revert Error(code: ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE)
+
+    let success: u256 = evm::call(evm::gas(), to, wei, 0, 0, 0, 0)
+    if success == 0:
+        revert Error(code: ERROR_FAILED_SEND_VALUE)

--- a/crates/lowering/tests/snapshots/lowering__and_or.snap
+++ b/crates/lowering/tests/snapshots/lowering__and_or.snap
@@ -8,7 +8,7 @@ struct $tuple_bool_bool_:
     pub item1: bool
 
 contract Foo:
-    pub fn bar() -> ():
+    pub fn bar() -> bool:
         let $boolean_expr_result_0: bool = true
         if not false:
             $boolean_expr_result_0 = true
@@ -33,7 +33,7 @@ contract Foo:
 
         return ()
 
-    pub fn nested_ternary() -> ():
+    pub fn nested_ternary() -> bool:
         let a: bool = true
         let b: bool = false
         let x: bool = true
@@ -173,9 +173,8 @@ contract Foo:
 
         return $boolean_expr_result_0
 
-    pub fn baz(val: bool) -> ():
-        pass
-        return ()
+    pub fn baz(val: bool) -> bool:
+        return val
 
     pub fn double_baz(val: bool, val2: bool) -> ():
         pass

--- a/crates/lowering/tests/snapshots/lowering__module_const.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_const.snap
@@ -28,7 +28,7 @@ contract Foo:
     table: Map<u256, u256>
 
     pub fn revert_with_bar() -> ():
-        revert Bar(val=10)
+        revert Bar(val: 10)
         return ()
 
     pub fn return_unit() -> ():

--- a/crates/lowering/tests/snapshots/lowering__module_const.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_const.snap
@@ -22,10 +22,14 @@ const IS_ADMIN: bool = true
 const UNIT: () = ()
 
 struct Bar:
-    val: u256
+    pub val: u256
 
 contract Foo:
     table: Map<u256, u256>
+
+    pub fn revert_with_bar() -> ():
+        revert Bar(val=10)
+        return ()
 
     pub fn return_unit() -> ():
         return ()

--- a/crates/lowering/tests/snapshots/lowering__struct_fn.snap
+++ b/crates/lowering/tests/snapshots/lowering__struct_fn.snap
@@ -4,7 +4,7 @@ expression: lowered
 
 ---
 struct Foo:
-    x: u256
+    pub x: u256
 
     pub fn set_x(self, new: u256) -> u256:
         let old: u256 = self.get_x()

--- a/crates/test-files/fixtures/features/balances.fe
+++ b/crates/test-files/fixtures/features/balances.fe
@@ -1,3 +1,5 @@
+use std::evm::{balance, balance_of}
+
 contract Foo:
     pub fn my_balance(self) -> u256:
         return balance()

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -9,7 +9,7 @@ contract Foo:
         revert
 
     pub fn revert_custom_error():
-        std::revert_insufficient_funds()
+        std::send_value(address(0), 100)
 
     pub fn revert_other_error():
         revert OtherError(msg: 1, val: true)

--- a/crates/test-files/fixtures/features/send_value.fe
+++ b/crates/test-files/fixtures/features/send_value.fe
@@ -1,3 +1,3 @@
 contract Foo:
     pub fn send_them_wei(to: address, wei: u256):
-        send_value(to, wei)
+        std::send_value(to, wei)

--- a/crates/test-files/fixtures/lowering/and_or.fe
+++ b/crates/test-files/fixtures/lowering/and_or.fe
@@ -1,6 +1,6 @@
 contract Foo:
 
-    pub fn bar():
+    pub fn bar() -> bool:
         return baz(false or true)
 
     pub fn nested():
@@ -11,7 +11,7 @@ contract Foo:
             let y: bool = false
             return double_baz(a and b, x or y)
 
-    pub fn nested_ternary():
+    pub fn nested_ternary() -> bool:
         let a: bool = true
         let b: bool = false
         let x: bool = true
@@ -47,9 +47,8 @@ contract Foo:
     pub fn short_mixed(first: bool, second: bool, third: bool, fourth: bool) -> bool:
         return (first or second) and third or fourth
 
-    pub fn baz(val: bool):
-        pass
+    pub fn baz(val: bool) -> bool:
+        return val
 
     pub fn double_baz(val: bool, val2: bool):
         pass
-

--- a/crates/test-files/fixtures/lowering/module_const.fe
+++ b/crates/test-files/fixtures/lowering/module_const.fe
@@ -11,7 +11,7 @@ contract Foo:
   table: Map<u256, u256>
 
   pub fn revert_with_bar():
-    revert Bar(val=TEN)
+    revert Bar(val: TEN)
 
   pub fn return_unit():
     return UNIT

--- a/crates/test-files/fixtures/lowering/module_const.fe
+++ b/crates/test-files/fixtures/lowering/module_const.fe
@@ -4,11 +4,14 @@ const IS_ADMIN: bool = true
 const UNIT: () = ()
 
 struct Bar:
-  val: u256
+  pub val: u256
 
 contract Foo:
 
   table: Map<u256, u256>
+
+  pub fn revert_with_bar():
+    revert Bar(val=TEN)
 
   pub fn return_unit():
     return UNIT

--- a/crates/test-files/fixtures/lowering/struct_fn.fe
+++ b/crates/test-files/fixtures/lowering/struct_fn.fe
@@ -1,5 +1,5 @@
 struct Foo:
-  x: u256
+  pub x: u256
 
   pub fn set_x(self, new: u256) -> u256:
     let old: u256 = self.get_x()

--- a/crates/test-files/fixtures/lowering/struct_fn.fe
+++ b/crates/test-files/fixtures/lowering/struct_fn.fe
@@ -10,6 +10,6 @@ struct Foo:
     return self.x
 
 fn main():
-  let foo: Foo = Foo(x = 10)
+  let foo: Foo = Foo(x: 10)
   foo.set_x(100)
   assert foo.get_x() == 100

--- a/crates/yulgen/src/constants.rs
+++ b/crates/yulgen/src/constants.rs
@@ -66,6 +66,4 @@ pub const PANIC_OVER_OR_UNDERFLOW: usize = 0x11;
 pub const PANIC_DIV_OR_MOD_BY_ZERO: usize = 0x12;
 pub const PANIC_OUT_OF_BOUNDS: usize = 0x32;
 
-pub const ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE: usize = 0x100;
-pub const ERROR_FAILED_SEND_VALUE: usize = 0x101;
 pub const ERROR_INVALID_ABI_DATA: usize = 0x103;

--- a/crates/yulgen/src/db/queries/functions.rs
+++ b/crates/yulgen/src/db/queries/functions.rs
@@ -193,6 +193,7 @@ where
                 for_each_stmt(body, f);
                 for_each_stmt(or_else, f);
             }
+            ast::FuncStmt::Unsafe(body) => for_each_stmt(body, f),
             _ => {}
         }
     }

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -109,9 +109,6 @@ fn expr_call(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
                 let size = identifier_expression! { (size.size()) };
                 expression! { [func_name]([yul_args[0].to_owned()], [size]) }
             }
-            GlobalFunction::SendValue => {
-                expression! { send_value([yul_args[0].to_owned()], [yul_args[1].to_owned()]) }
-            }
         },
         CallType::Intrinsic(func) => {
             let yul_name = identifier! { (func.as_ref().strip_prefix("__").unwrap()) };

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -112,12 +112,6 @@ fn expr_call(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Expression {
             GlobalFunction::SendValue => {
                 expression! { send_value([yul_args[0].to_owned()], [yul_args[1].to_owned()]) }
             }
-            GlobalFunction::Balance => {
-                expression! { selfbalance() }
-            }
-            GlobalFunction::BalanceOf => {
-                expression! { balance([yul_args[0].to_owned()]) }
-            }
         },
         CallType::Intrinsic(func) => {
             let yul_name = identifier! { (func.as_ref().strip_prefix("__").unwrap()) };

--- a/crates/yulgen/src/runtime/functions/contracts.rs
+++ b/crates/yulgen/src/runtime/functions/contracts.rs
@@ -1,10 +1,8 @@
-use crate::constants::{ERROR_FAILED_SEND_VALUE, ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE};
-use crate::operations::revert as revert_operations;
 use yultsur::*;
 
 /// Return all contacts runtime functions
 pub fn all() -> Vec<yul::Statement> {
-    vec![create2(), create(), send_value()]
+    vec![create2(), create()]
 }
 
 /// Function that executes the `create2` operation.
@@ -25,20 +23,6 @@ pub fn create() -> yul::Statement {
             (let mptr := alloc(data_size))
             (datacopy(mptr, data_ptr, data_size))
             (return_address := create(value, mptr, data_size))
-        }
-    }
-}
-
-/// Function that sends wei from the contract to another address
-pub fn send_value() -> yul::Statement {
-    function_definition! {
-        // Inspired by: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5b28259dacf47fc208e03611eb3ba8eeaed63cc0/contracts/utils/Address.sol#L54-L59
-        function send_value(to_address, value_in_wei) -> result {
-            (if (lt((selfbalance()), value_in_wei)) { [revert_operations::error_revert_numeric(ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE)] })
-            (let success := call((gas()) , to_address, value_in_wei, 0, 0, 0, 0))
-            (if (iszero(success)) { [revert_operations::error_revert_numeric(ERROR_FAILED_SEND_VALUE)] })
-            // send_value returns the unit type but we need to return something.
-            (result := 0x0)
         }
     }
 }

--- a/newsfragments/629.feature.md
+++ b/newsfragments/629.feature.md
@@ -1,0 +1,16 @@
+The Fe standard library now includes a `std::evm` module, which provides functions that perform low-level evm operations.
+Many of these are marked `unsafe`, and thus can only be used inside of an `unsafe` function or an `unsafe` block.
+
+Example:
+```
+use std::evm::{mstore, mload}
+
+fn memory_shenanigans():
+  unsafe:
+    mstore(0x20, 42)
+    let x: u256 = mload(0x20)
+    assert x == 42
+```
+
+The global functions `balance` and `balance_of` have been removed; these can now be called as `std::evm::balance()`, etc.
+The global function `send_value` has been ported to Fe, and is now available as `std::send_value`.


### PR DESCRIPTION
Depends on #628

This adds simple wrappers around the intrinsics to `std::evm`, deletes the global `balance`, `balance_of`, and `send_value` (which is now in `std`)

The functions that access chian/msg/tx context are not currently marked as unsafe, but should be when the Context object is ready.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
