### PR TITLE
signext unpacked ints

### DIFF
--- a/crates/test-files/fixtures/features/return_from_storage_array_i8.fe
+++ b/crates/test-files/fixtures/features/return_from_storage_array_i8.fe
@@ -1,0 +1,9 @@
+
+
+contract Foo:
+
+    some_thing: Array<i8, 1>
+
+    pub fn bar(self, val: i8) -> Array<i8, 1>:
+        self.some_thing[0] = val
+        return self.some_thing.to_mem()

--- a/crates/test-files/fixtures/features/return_int_array.fe
+++ b/crates/test-files/fixtures/features/return_int_array.fe
@@ -1,0 +1,6 @@
+contract Foo:
+    pub fn i8_array(bar: Array<i8, 4>) -> Array<i8, 4>:
+        return bar
+
+    pub fn i32_array(bar: Array<i32, 4>) -> Array<i32, 4>:
+        return bar

--- a/crates/test-files/fixtures/solidity/arrays.sol
+++ b/crates/test-files/fixtures/solidity/arrays.sol
@@ -1,0 +1,11 @@
+
+contract Foo {
+
+  int8[1] data;
+
+
+  function bar(int8 value) public returns(int8[1] memory) {
+    data = [value];
+    return data;
+  }
+}

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -68,7 +68,7 @@ impl ContractHarness {
         let function = &self.abi.functions[name][0];
         function
             .encode_input(input)
-            .unwrap_or_else(|_| panic!("Unable to encode input for {}", name))
+            .unwrap_or_else(|reason| panic!("Unable to encode input for {}: {:?}", name, reason))
     }
 
     pub fn capture_call_raw_bytes(

--- a/crates/tests/src/differential.rs
+++ b/crates/tests/src/differential.rs
@@ -249,8 +249,7 @@ proptest! {
             harness.capture_call(&mut executor, "get_data", &[]).assert_perfomed_equal().assert_fe_max_percentage_more_gas(150);
 
             harness.capture_call(&mut executor, "set_item", &[uint_token(my_num2.into()), int_token(my_num3.into())]).assert_any_success_or_revert_with_equal_return_data();
-            // Waiting on a fix for https://github.com/ethereum/fe/pull/581
-            //harness.capture_call(&mut executor, "get_items", &[]).assert_perfomed_equal();
+            harness.capture_call(&mut executor, "get_items", &[]).assert_perfomed_equal();
 
             harness.capture_call(&mut executor, "set_string", &[string_token(&my_long_string)]).assert_any_success_with_equal_return_data();
             harness.capture_call(&mut executor, "get_string", &[]).assert_perfomed_equal();

--- a/crates/tests/src/runtime.rs
+++ b/crates/tests/src/runtime.rs
@@ -224,7 +224,7 @@ fn test_runtime_abi_unpack() {
                 (let a := 0x0042002600530000000000000000000000000000000000000000000000000000)
                 (let packed := alloc_mstoren(a, 32))
                 (let unpacked := avail())
-                (abi_unpack(packed, 3, 2))
+                (abi_unpack(packed, 3, 2, 0))
 
                 (let elem0 := mload(unpacked))
                 (let elem1 := mload((add(unpacked, 32))))

--- a/crates/tests/src/solidity.rs
+++ b/crates/tests/src/solidity.rs
@@ -84,3 +84,18 @@ fn test_revert_reason_encoding(reason_str: &str, expected_encoding: &str) {
     let encoded = encode_error_reason(reason_str);
     assert_eq!(format!("0x{}", hex::encode(&encoded)), expected_encoding);
 }
+
+#[rstest(
+    method,
+    params,
+    expected,
+    case("bar", &[int_token(-10)], Some(int_array_token(&[-10]))),
+)]
+fn signext_int_array(method: &str, params: &[ethabi::Token], expected: Option<ethabi::Token>) {
+    with_executor(&|mut executor| {
+        let harness =
+            deploy_solidity_contract(&mut executor, "solidity/arrays.sol", "Foo", &[], true);
+
+        harness.test_function(&mut executor, method, params, expected.as_ref());
+    })
+}

--- a/crates/yulgen/src/operations/abi.rs
+++ b/crates/yulgen/src/operations/abi.rs
@@ -112,6 +112,7 @@ pub fn unpack(
     ptr: yul::Expression,
     array_size: yul::Expression,
     inner_data_size: yul::Expression,
+    signed: yul::Expression,
 ) -> yul::Statement {
-    statement! { abi_unpack([ptr], [array_size], [inner_data_size]) }
+    statement! { abi_unpack([ptr], [array_size], [inner_data_size], [signed]) }
 }

--- a/newsfragments/633.bugfix.md
+++ b/newsfragments/633.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a bug where int array elements were not sign extended in their ABI encodings.


### PR DESCRIPTION
### What was wrong?

We weren't `signext`ing int array elements when encoding (see #581).

### How was it fixed?

Added a `signed` parameter to the `abi_unpack` Yul method. If this value is set true, each element will be `signext`ed when unpacked.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
