### PR TITLE
Support non-base type fields in structs

### DIFF
--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -346,6 +346,13 @@ pub fn contract_field_type(
         scope.not_yet_implemented("contract field initial value assignment", value_node.span);
     }
 
+    if matches!(typ, Ok(Type::Struct(Struct { id, .. })) if id.has_complex_fields(db)) {
+        scope.not_yet_implemented(
+            "structs in storage aren't yet allowed to contain fields with complex types",
+            node.span,
+        );
+    }
+
     Analysis {
         value: typ,
         diagnostics: Rc::new(scope.diagnostics),

--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -126,6 +126,10 @@ pub fn function_signature(
                 Ok(FixedSize::unit())
             } else {
                 match type_desc(&mut scope, type_node)?.try_into() {
+                    Ok(FixedSize::Struct(val)) if val.id.has_complex_fields(db) && function.is_public(db) => {
+                        scope.not_yet_implemented("structs with complex fields can't be returned from public functions yet", type_node.span);
+                        Ok(FixedSize::Struct(val))
+                    }
                     Ok(typ) => Ok(typ),
                     Err(_) => Err(TypeError::new(scope.error(
                         "function return type must have a fixed size",

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -96,11 +96,21 @@ pub fn struct_field_type(
         scope.not_yet_implemented("struct field initial value assignment", field_data.ast.span);
     }
     let typ = match type_desc(&mut scope, typ) {
-        Ok(types::Type::Base(base)) => Ok(types::FixedSize::Base(base)),
-        Ok(_) => Err(TypeError::new(scope.not_yet_implemented(
-            "non-primitive type struct fields",
-            field_data.ast.span,
-        ))),
+        Ok(typ) => match typ.try_into() {
+            Ok(FixedSize::Contract(contract)) => {
+                scope.not_yet_implemented(
+                    "contract types aren't yet supported as struct fields",
+                    field_data.ast.span,
+                );
+                Ok(FixedSize::Contract(contract))
+            }
+            Ok(typ) => Ok(typ),
+            Err(_) => Err(TypeError::new(scope.error(
+                "struct field type must have a fixed size",
+                field_data.ast.span,
+                "this can't be used as an struct field",
+            ))),
+        },
         Err(err) => Err(err),
     };
 

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -1337,6 +1337,12 @@ impl StructId {
         Some(self.field(db, name)?.typ(db))
     }
 
+    pub fn has_complex_fields(&self, db: &dyn AnalyzerDb) -> bool {
+        self.fields(db)
+            .iter()
+            .any(|(_, field)| !matches!(field.typ(db), Ok(types::FixedSize::Base(_))))
+    }
+
     pub fn fields(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<SmolStr, StructFieldId>> {
         db.struct_field_map(*self).value
     }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -500,6 +500,10 @@ impl FixedSize {
         self == &Self::Base(Base::Unit)
     }
 
+    pub fn is_base(&self) -> bool {
+        matches!(self, FixedSize::Base(_))
+    }
+
     /// Creates an instance of bool.
     pub fn bool() -> Self {
         FixedSize::Base(Base::Bool)

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -287,6 +287,7 @@ test_file! { return_call_to_fn_without_return }
 test_file! { return_from_init }
 test_file! { return_lt_mixed_types }
 test_file! { return_type_undefined }
+test_file! { return_complex_struct }
 test_file! { return_type_not_fixedsize }
 test_file! { undefined_type_param }
 

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -6,82 +6,102 @@ expression: "build_snapshot(&files, module_id, &db)"
 note: 
   ┌─ features/structs.fe:2:5
   │
-2 │     pub foo: u256
-  │     ^^^^^^^^^^^^^ u256
-3 │     bar: bool
-  │     ^^^^^^^^^ bool
+2 │     pub x: u256
+  │     ^^^^^^^^^^^ u256
+3 │     pub y: u256
+  │     ^^^^^^^^^^^ u256
 
 note: 
-  ┌─ features/structs.fe:5:5
-  │  
-5 │ ╭     pub fn new(val: u256) -> Mixed:
-6 │ │         return Mixed(foo=val, bar=false)
-  │ ╰────────────────────────────────────────^ attributes hash: 1457966546801734592
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        params: [
-            FunctionParam {
-                name: "val",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Struct(
-                Struct {
-                    name: "Mixed",
-                    id: StructId(
-                        0,
-                    ),
-                    field_count: 2,
-                },
-            ),
-        ),
-    }
-
-note: 
-  ┌─ features/structs.fe:6:26
+  ┌─ features/structs.fe:6:5
   │
-6 │         return Mixed(foo=val, bar=false)
-  │                          ^^^      ^^^^^ bool: Value
-  │                          │         
-  │                          u256: Value
+6 │     pub name: String<3>
+  │     ^^^^^^^^^^^^^^^^^^^ String<3>
+7 │     pub numbers: Array<u256, 2>
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 2>
+8 │     pub point: Point
+  │     ^^^^^^^^^^^^^^^^ Point
+9 │     pub something: (u256, bool)
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool)
 
 note: 
-  ┌─ features/structs.fe:6:16
-  │
-6 │         return Mixed(foo=val, bar=false)
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^^ Mixed: Memory
-
-note: 
-  ┌─ features/structs.fe:6:16
-  │
-6 │         return Mixed(foo=val, bar=false)
-  │                ^^^^^ TypeConstructor(Struct(Struct { name: "Mixed", id: StructId(0), field_count: 2 }))
-
-note: 
-   ┌─ features/structs.fe:9:5
+   ┌─ features/structs.fe:12:5
    │
- 9 │     pub price: u256
+12 │     pub foo: u256
+   │     ^^^^^^^^^^^^^ u256
+13 │     bar: bool
+   │     ^^^^^^^^^ bool
+
+note: 
+   ┌─ features/structs.fe:15:5
+   │  
+15 │ ╭     pub fn new(val: u256) -> Mixed:
+16 │ │         return Mixed(foo=val, bar=false)
+   │ ╰────────────────────────────────────────^ attributes hash: 14840391711119122636
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [
+             FunctionParam {
+                 name: "val",
+                 typ: Ok(
+                     Base(
+                         Numeric(
+                             U256,
+                         ),
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Struct(
+                 Struct {
+                     name: "Mixed",
+                     id: StructId(
+                         2,
+                     ),
+                     field_count: 2,
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:16:26
+   │
+16 │         return Mixed(foo=val, bar=false)
+   │                          ^^^      ^^^^^ bool: Value
+   │                          │         
+   │                          u256: Value
+
+note: 
+   ┌─ features/structs.fe:16:16
+   │
+16 │         return Mixed(foo=val, bar=false)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ Mixed: Memory
+
+note: 
+   ┌─ features/structs.fe:16:16
+   │
+16 │         return Mixed(foo=val, bar=false)
+   │                ^^^^^ TypeConstructor(Struct(Struct { name: "Mixed", id: StructId(2), field_count: 2 }))
+
+note: 
+   ┌─ features/structs.fe:19:5
+   │
+19 │     pub price: u256
    │     ^^^^^^^^^^^^^^^ u256
-10 │     pub size: u256
+20 │     pub size: u256
    │     ^^^^^^^^^^^^^^ u256
-11 │     pub rooms: u8
+21 │     pub rooms: u8
    │     ^^^^^^^^^^^^^ u8
-12 │     pub vacant: bool
+22 │     pub vacant: bool
    │     ^^^^^^^^^^^^^^^^ bool
 
 note: 
-   ┌─ features/structs.fe:14:5
+   ┌─ features/structs.fe:24:5
    │  
-14 │ ╭     pub fn encode(self) -> Array<u8, 128>:
-15 │ │         return self.abi_encode()
+24 │ ╭     pub fn encode(self) -> Array<u8, 128>:
+25 │ │         return self.abi_encode()
    │ ╰────────────────────────────────^ attributes hash: 17909223604408730591
    │  
    = FunctionSignature {
@@ -102,28 +122,28 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:15:16
+   ┌─ features/structs.fe:25:16
    │
-15 │         return self.abi_encode()
+25 │         return self.abi_encode()
    │                ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:15:16
+   ┌─ features/structs.fe:25:16
    │
-15 │         return self.abi_encode()
+25 │         return self.abi_encode()
    │                ^^^^^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-   ┌─ features/structs.fe:15:16
+   ┌─ features/structs.fe:25:16
    │
-15 │         return self.abi_encode()
-   │                ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Struct(Struct { name: "House", id: StructId(1), field_count: 4 }) }
+25 │         return self.abi_encode()
+   │                ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: AbiEncode, typ: Struct(Struct { name: "House", id: StructId(3), field_count: 4 }) }
 
 note: 
-   ┌─ features/structs.fe:17:5
+   ┌─ features/structs.fe:27:5
    │  
-17 │ ╭     pub fn hash(self) -> u256:
-18 │ │         return keccak256(self.encode())
+27 │ ╭     pub fn hash(self) -> u256:
+28 │ │         return keccak256(self.encode())
    │ ╰───────────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
@@ -141,40 +161,40 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:18:26
+   ┌─ features/structs.fe:28:26
    │
-18 │         return keccak256(self.encode())
+28 │         return keccak256(self.encode())
    │                          ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:18:26
+   ┌─ features/structs.fe:28:26
    │
-18 │         return keccak256(self.encode())
+28 │         return keccak256(self.encode())
    │                          ^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-   ┌─ features/structs.fe:18:16
+   ┌─ features/structs.fe:28:16
    │
-18 │         return keccak256(self.encode())
+28 │         return keccak256(self.encode())
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ features/structs.fe:18:26
+   ┌─ features/structs.fe:28:26
    │
-18 │         return keccak256(self.encode())
-   │                          ^^^^^^^^^^^ ValueMethod { is_self: true, class: Struct(StructId(1)), method: FunctionId(1) }
+28 │         return keccak256(self.encode())
+   │                          ^^^^^^^^^^^ ValueMethod { is_self: true, class: Struct(StructId(3)), method: FunctionId(1) }
 
 note: 
-   ┌─ features/structs.fe:18:16
+   ┌─ features/structs.fe:28:16
    │
-18 │         return keccak256(self.encode())
+28 │         return keccak256(self.encode())
    │                ^^^^^^^^^ BuiltinFunction(Keccak256)
 
 note: 
-   ┌─ features/structs.fe:20:5
+   ┌─ features/structs.fe:30:5
    │  
-20 │ ╭     pub fn price_per_sqft(self) -> u256:
-21 │ │         return self.price / self.size
+30 │ ╭     pub fn price_per_sqft(self) -> u256:
+31 │ │         return self.price / self.size
    │ ╰─────────────────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
@@ -192,37 +212,37 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:21:16
+   ┌─ features/structs.fe:31:16
    │
-21 │         return self.price / self.size
+31 │         return self.price / self.size
    │                ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:21:16
+   ┌─ features/structs.fe:31:16
    │
-21 │         return self.price / self.size
+31 │         return self.price / self.size
    │                ^^^^^^^^^^   ^^^^ House: Memory
    │                │             
    │                u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:21:29
+   ┌─ features/structs.fe:31:29
    │
-21 │         return self.price / self.size
+31 │         return self.price / self.size
    │                             ^^^^^^^^^ u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:21:16
+   ┌─ features/structs.fe:31:16
    │
-21 │         return self.price / self.size
+31 │         return self.price / self.size
    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ features/structs.fe:23:5
+   ┌─ features/structs.fe:33:5
    │  
-23 │ ╭     pub fn expand(self):
-24 │ │         self.rooms += 1
-25 │ │         self.size += 100
+33 │ ╭     pub fn expand(self):
+34 │ │         self.rooms += 1
+35 │ │         self.size += 100
    │ ╰────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
@@ -238,41 +258,693 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:24:9
+   ┌─ features/structs.fe:34:9
    │
-24 │         self.rooms += 1
+34 │         self.rooms += 1
    │         ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:24:9
+   ┌─ features/structs.fe:34:9
    │
-24 │         self.rooms += 1
+34 │         self.rooms += 1
    │         ^^^^^^^^^^    ^ u8: Value
    │         │              
    │         u8: Memory
-25 │         self.size += 100
+35 │         self.size += 100
    │         ^^^^ House: Memory
 
 note: 
-   ┌─ features/structs.fe:25:9
+   ┌─ features/structs.fe:35:9
    │
-25 │         self.size += 100
+35 │         self.size += 100
    │         ^^^^^^^^^    ^^^ u256: Value
    │         │             
    │         u256: Memory
 
 note: 
-   ┌─ features/structs.fe:28:5
+   ┌─ features/structs.fe:38:5
    │
-28 │     my_house: House
+38 │     my_house: House
    │     ^^^^^^^^^^^^^^^ House
 
 note: 
-   ┌─ features/structs.fe:30:5
+   ┌─ features/structs.fe:40:5
    │  
-30 │ ╭     pub fn create_mixed(self) -> u256:
-31 │ │         let mixed: Mixed = Mixed.new(1)
-32 │ │         return mixed.foo
+40 │ ╭     pub fn complex_struct_in_memory(self) -> String<3>:
+41 │ │         let val: Bar = Bar(
+42 │ │             name="foo",
+43 │ │             numbers=[1, 2],
+   · │
+85 │ │ 
+86 │ │         return val.name
+   │ ╰───────────────────────^ attributes hash: 297256089255013543
+   │  
+   = FunctionSignature {
+         self_decl: Some(
+             Mutable,
+         ),
+         params: [],
+         return_type: Ok(
+             String(
+                 FeString {
+                     max_size: 3,
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ features/structs.fe:41:18
+   │
+41 │         let val: Bar = Bar(
+   │                  ^^^ Bar
+
+note: 
+   ┌─ features/structs.fe:42:18
+   │
+42 │             name="foo",
+   │                  ^^^^^ String<3>: Memory
+43 │             numbers=[1, 2],
+   │                      ^  ^ u256: Value
+   │                      │   
+   │                      u256: Value
+
+note: 
+   ┌─ features/structs.fe:43:21
+   │
+43 │             numbers=[1, 2],
+   │                     ^^^^^^ Array<u256, 2>: Memory
+44 │             point=Point(x=100, y=200),
+   │                           ^^^    ^^^ u256: Value
+   │                           │       
+   │                           u256: Value
+
+note: 
+   ┌─ features/structs.fe:44:19
+   │
+44 │             point=Point(x=100, y=200),
+   │                   ^^^^^^^^^^^^^^^^^^^ Point: Memory
+45 │             something=(1, true),
+   │                        ^  ^^^^ bool: Value
+   │                        │   
+   │                        u256: Value
+
+note: 
+   ┌─ features/structs.fe:45:23
+   │
+45 │             something=(1, true),
+   │                       ^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:41:24
+   │  
+41 │           let val: Bar = Bar(
+   │ ╭────────────────────────^
+42 │ │             name="foo",
+43 │ │             numbers=[1, 2],
+44 │ │             point=Point(x=100, y=200),
+45 │ │             something=(1, true),
+46 │ │         )
+   │ ╰─────────^ Bar: Memory
+   · │
+49 │           assert val.numbers[0] == 1
+   │                  ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:49:16
+   │
+49 │         assert val.numbers[0] == 1
+   │                ^^^^^^^^^^^ ^ u256: Value
+   │                │            
+   │                Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:49:16
+   │
+49 │         assert val.numbers[0] == 1
+   │                ^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:49:16
+   │
+49 │         assert val.numbers[0] == 1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+50 │         assert val.numbers[1] == 2
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:50:16
+   │
+50 │         assert val.numbers[1] == 2
+   │                ^^^^^^^^^^^ ^ u256: Value
+   │                │            
+   │                Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:50:16
+   │
+50 │         assert val.numbers[1] == 2
+   │                ^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:50:16
+   │
+50 │         assert val.numbers[1] == 2
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+51 │         assert val.point.x == 100
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:51:16
+   │
+51 │         assert val.point.x == 100
+   │                ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:51:16
+   │
+51 │         assert val.point.x == 100
+   │                ^^^^^^^^^^^    ^^^ u256: Value
+   │                │               
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:51:16
+   │
+51 │         assert val.point.x == 100
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value
+52 │         assert val.point.y == 200
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:52:16
+   │
+52 │         assert val.point.y == 200
+   │                ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:52:16
+   │
+52 │         assert val.point.y == 200
+   │                ^^^^^^^^^^^    ^^^ u256: Value
+   │                │               
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:52:16
+   │
+52 │         assert val.point.y == 200
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value
+53 │         assert val.something.item0 == 1
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:53:16
+   │
+53 │         assert val.something.item0 == 1
+   │                ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:53:16
+   │
+53 │         assert val.something.item0 == 1
+   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                       
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:53:16
+   │
+53 │         assert val.something.item0 == 1
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+54 │         assert val.something.item1
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:54:16
+   │
+54 │         assert val.something.item1
+   │                ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:54:16
+   │
+54 │         assert val.something.item1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Memory => Value
+   ·
+57 │         val.numbers[0] = 10
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:57:9
+   │
+57 │         val.numbers[0] = 10
+   │         ^^^^^^^^^^^ ^ u256: Value
+   │         │            
+   │         Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:57:9
+   │
+57 │         val.numbers[0] = 10
+   │         ^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                 
+   │         u256: Memory
+58 │         val.numbers[1] = 20
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:58:9
+   │
+58 │         val.numbers[1] = 20
+   │         ^^^^^^^^^^^ ^ u256: Value
+   │         │            
+   │         Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:58:9
+   │
+58 │         val.numbers[1] = 20
+   │         ^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                 
+   │         u256: Memory
+59 │         assert val.numbers[0] == 10
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert val.numbers[0] == 10
+   │                ^^^^^^^^^^^ ^ u256: Value
+   │                │            
+   │                Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert val.numbers[0] == 10
+   │                ^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:59:16
+   │
+59 │         assert val.numbers[0] == 10
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+60 │         assert val.numbers[1] == 20
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert val.numbers[1] == 20
+   │                ^^^^^^^^^^^ ^ u256: Value
+   │                │            
+   │                Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert val.numbers[1] == 20
+   │                ^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:60:16
+   │
+60 │         assert val.numbers[1] == 20
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+61 │         # We can set the array itself
+62 │         val.numbers = [1, 2]
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:62:9
+   │
+62 │         val.numbers = [1, 2]
+   │         ^^^^^^^^^^^    ^  ^ u256: Value
+   │         │              │   
+   │         │              u256: Value
+   │         Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:62:23
+   │
+62 │         val.numbers = [1, 2]
+   │                       ^^^^^^ Array<u256, 2>: Memory
+63 │         assert val.numbers[0] == 1
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:63:16
+   │
+63 │         assert val.numbers[0] == 1
+   │                ^^^^^^^^^^^ ^ u256: Value
+   │                │            
+   │                Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:63:16
+   │
+63 │         assert val.numbers[0] == 1
+   │                ^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:63:16
+   │
+63 │         assert val.numbers[0] == 1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+64 │         assert val.numbers[1] == 2
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:64:16
+   │
+64 │         assert val.numbers[1] == 2
+   │                ^^^^^^^^^^^ ^ u256: Value
+   │                │            
+   │                Array<u256, 2>: Memory
+
+note: 
+   ┌─ features/structs.fe:64:16
+   │
+64 │         assert val.numbers[1] == 2
+   │                ^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                  
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:64:16
+   │
+64 │         assert val.numbers[1] == 2
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+   ·
+67 │         val.point.x = 1000
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:67:9
+   │
+67 │         val.point.x = 1000
+   │         ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:67:9
+   │
+67 │         val.point.x = 1000
+   │         ^^^^^^^^^^^   ^^^^ u256: Value
+   │         │              
+   │         u256: Memory
+68 │         val.point.y = 2000
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:68:9
+   │
+68 │         val.point.y = 2000
+   │         ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:68:9
+   │
+68 │         val.point.y = 2000
+   │         ^^^^^^^^^^^   ^^^^ u256: Value
+   │         │              
+   │         u256: Memory
+69 │         assert val.point.x == 1000
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert val.point.x == 1000
+   │                ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert val.point.x == 1000
+   │                ^^^^^^^^^^^    ^^^^ u256: Value
+   │                │               
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:69:16
+   │
+69 │         assert val.point.x == 1000
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+70 │         assert val.point.y == 2000
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert val.point.y == 2000
+   │                ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert val.point.y == 2000
+   │                ^^^^^^^^^^^    ^^^^ u256: Value
+   │                │               
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:70:16
+   │
+70 │         assert val.point.y == 2000
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+71 │         # We can set the point itself
+72 │         val.point = Point(x=100, y=200)
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:72:9
+   │
+72 │         val.point = Point(x=100, y=200)
+   │         ^^^^^^^^^           ^^^    ^^^ u256: Value
+   │         │                   │       
+   │         │                   u256: Value
+   │         Point: Memory
+
+note: 
+   ┌─ features/structs.fe:72:21
+   │
+72 │         val.point = Point(x=100, y=200)
+   │                     ^^^^^^^^^^^^^^^^^^^ Point: Memory
+73 │         assert val.point.x == 100
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:73:16
+   │
+73 │         assert val.point.x == 100
+   │                ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:73:16
+   │
+73 │         assert val.point.x == 100
+   │                ^^^^^^^^^^^    ^^^ u256: Value
+   │                │               
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:73:16
+   │
+73 │         assert val.point.x == 100
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value
+74 │         assert val.point.y == 200
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:74:16
+   │
+74 │         assert val.point.y == 200
+   │                ^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ features/structs.fe:74:16
+   │
+74 │         assert val.point.y == 200
+   │                ^^^^^^^^^^^    ^^^ u256: Value
+   │                │               
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:74:16
+   │
+74 │         assert val.point.y == 200
+   │                ^^^^^^^^^^^^^^^^^^ bool: Value
+   ·
+77 │         val.something.item0 = 10
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:77:9
+   │
+77 │         val.something.item0 = 10
+   │         ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:77:9
+   │
+77 │         val.something.item0 = 10
+   │         ^^^^^^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                      
+   │         u256: Memory
+78 │         val.something.item1 = false
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:78:9
+   │
+78 │         val.something.item1 = false
+   │         ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:78:9
+   │
+78 │         val.something.item1 = false
+   │         ^^^^^^^^^^^^^^^^^^^   ^^^^^ bool: Value
+   │         │                      
+   │         bool: Memory
+79 │         assert val.something.item0 == 10
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:79:16
+   │
+79 │         assert val.something.item0 == 10
+   │                ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:79:16
+   │
+79 │         assert val.something.item0 == 10
+   │                ^^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                       
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:79:16
+   │
+79 │         assert val.something.item0 == 10
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+80 │         assert not val.something.item1
+   │                    ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:80:20
+   │
+80 │         assert not val.something.item1
+   │                    ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:80:20
+   │
+80 │         assert not val.something.item1
+   │                    ^^^^^^^^^^^^^^^^^^^ bool: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:80:16
+   │
+80 │         assert not val.something.item1
+   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+81 │         # We can set the tuple itself
+82 │         val.something = (1, true)
+   │         ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:82:9
+   │
+82 │         val.something = (1, true)
+   │         ^^^^^^^^^^^^^    ^  ^^^^ bool: Value
+   │         │                │   
+   │         │                u256: Value
+   │         (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:82:25
+   │
+82 │         val.something = (1, true)
+   │                         ^^^^^^^^^ (u256, bool): Memory
+83 │         assert val.something.item0 == 1
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:83:16
+   │
+83 │         assert val.something.item0 == 1
+   │                ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:83:16
+   │
+83 │         assert val.something.item0 == 1
+   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                       
+   │                u256: Memory => Value
+
+note: 
+   ┌─ features/structs.fe:83:16
+   │
+83 │         assert val.something.item0 == 1
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+84 │         assert val.something.item1
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:84:16
+   │
+84 │         assert val.something.item1
+   │                ^^^^^^^^^^^^^ (u256, bool): Memory
+
+note: 
+   ┌─ features/structs.fe:84:16
+   │
+84 │         assert val.something.item1
+   │                ^^^^^^^^^^^^^^^^^^^ bool: Memory => Value
+85 │ 
+86 │         return val.name
+   │                ^^^ Bar: Memory
+
+note: 
+   ┌─ features/structs.fe:86:16
+   │
+86 │         return val.name
+   │                ^^^^^^^^ String<3>: Memory
+
+note: 
+   ┌─ features/structs.fe:44:19
+   │
+44 │             point=Point(x=100, y=200),
+   │                   ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+
+note: 
+   ┌─ features/structs.fe:41:24
+   │
+41 │         let val: Bar = Bar(
+   │                        ^^^ TypeConstructor(Struct(Struct { name: "Bar", id: StructId(1), field_count: 4 }))
+   ·
+72 │         val.point = Point(x=100, y=200)
+   │                     ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+
+note: 
+   ┌─ features/structs.fe:88:5
+   │  
+88 │ ╭     pub fn create_mixed(self) -> u256:
+89 │ │         let mixed: Mixed = Mixed.new(1)
+90 │ │         return mixed.foo
    │ ╰────────────────────────^ attributes hash: 2875164910451995213
    │  
    = FunctionSignature {
@@ -290,43 +962,43 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:31:20
+   ┌─ features/structs.fe:89:20
    │
-31 │         let mixed: Mixed = Mixed.new(1)
+89 │         let mixed: Mixed = Mixed.new(1)
    │                    ^^^^^ Mixed
 
 note: 
-   ┌─ features/structs.fe:31:38
+   ┌─ features/structs.fe:89:38
    │
-31 │         let mixed: Mixed = Mixed.new(1)
+89 │         let mixed: Mixed = Mixed.new(1)
    │                                      ^ u256: Value
 
 note: 
-   ┌─ features/structs.fe:31:28
+   ┌─ features/structs.fe:89:28
    │
-31 │         let mixed: Mixed = Mixed.new(1)
+89 │         let mixed: Mixed = Mixed.new(1)
    │                            ^^^^^^^^^^^^ Mixed: Memory
-32 │         return mixed.foo
+90 │         return mixed.foo
    │                ^^^^^ Mixed: Memory
 
 note: 
-   ┌─ features/structs.fe:32:16
+   ┌─ features/structs.fe:90:16
    │
-32 │         return mixed.foo
+90 │         return mixed.foo
    │                ^^^^^^^^^ u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:31:28
+   ┌─ features/structs.fe:89:28
    │
-31 │         let mixed: Mixed = Mixed.new(1)
-   │                            ^^^^^^^^^ AssociatedFunction { class: Struct(StructId(0)), function: FunctionId(0) }
+89 │         let mixed: Mixed = Mixed.new(1)
+   │                            ^^^^^^^^^ AssociatedFunction { class: Struct(StructId(2)), function: FunctionId(0) }
 
 note: 
-   ┌─ features/structs.fe:34:5
+   ┌─ features/structs.fe:92:5
    │  
-34 │ ╭     pub fn set_house(self, data: House):
-35 │ │         self.my_house = data
-   │ ╰────────────────────────────^ attributes hash: 9345407860387613771
+92 │ ╭     pub fn set_house(self, data: House):
+93 │ │         self.my_house = data
+   │ ╰────────────────────────────^ attributes hash: 14004499701394096532
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -340,7 +1012,7 @@ note:
                          Struct {
                              name: "House",
                              id: StructId(
-                                 1,
+                                 3,
                              ),
                              field_count: 4,
                          },
@@ -356,25 +1028,25 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:35:9
+   ┌─ features/structs.fe:93:9
    │
-35 │         self.my_house = data
+93 │         self.my_house = data
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:35:9
+   ┌─ features/structs.fe:93:9
    │
-35 │         self.my_house = data
+93 │         self.my_house = data
    │         ^^^^^^^^^^^^^   ^^^^ House: Memory
    │         │                
    │         House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:37:5
+   ┌─ features/structs.fe:95:5
    │  
-37 │ ╭     pub fn get_house(self) -> House:
-38 │ │         return self.my_house.to_mem()
-   │ ╰─────────────────────────────────────^ attributes hash: 3213903632176759353
+95 │ ╭     pub fn get_house(self) -> House:
+96 │ │         return self.my_house.to_mem()
+   │ ╰─────────────────────────────────────^ attributes hash: 4535161131583011266
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -386,7 +1058,7 @@ note:
                  Struct {
                      name: "House",
                      id: StructId(
-                         1,
+                         3,
                      ),
                      field_count: 4,
                  },
@@ -395,657 +1067,657 @@ note:
      }
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:96:16
    │
-38 │         return self.my_house.to_mem()
+96 │         return self.my_house.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:96:16
    │
-38 │         return self.my_house.to_mem()
+96 │         return self.my_house.to_mem()
    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:96:16
    │
-38 │         return self.my_house.to_mem()
+96 │         return self.my_house.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^ House: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ features/structs.fe:38:16
+   ┌─ features/structs.fe:96:16
    │
-38 │         return self.my_house.to_mem()
-   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "House", id: StructId(1), field_count: 4 }) }
+96 │         return self.my_house.to_mem()
+   │                ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "House", id: StructId(3), field_count: 4 }) }
 
 note: 
-   ┌─ features/structs.fe:40:5
-   │  
-40 │ ╭     pub fn create_house(self):
-41 │ │         self.my_house = House(
-42 │ │             price=1,
-43 │ │             size=2,
-   · │
-71 │ │         assert self.my_house.rooms == u8(100)
-72 │ │         assert self.my_house.vacant
-   │ ╰───────────────────────────────────^ attributes hash: 17603814563784536273
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
-
-note: 
-   ┌─ features/structs.fe:41:9
-   │
-41 │         self.my_house = House(
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:41:9
-   │
-41 │         self.my_house = House(
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-42 │             price=1,
-   │                   ^ u256: Value
-43 │             size=2,
-   │                  ^ u256: Value
-44 │             rooms=u8(5),
-   │                      ^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:44:19
-   │
-44 │             rooms=u8(5),
-   │                   ^^^^^ u8: Value
-45 │             vacant=false
-   │                    ^^^^^ bool: Value
-
-note: 
-   ┌─ features/structs.fe:41:25
-   │  
-41 │           self.my_house = House(
-   │ ╭─────────────────────────^
-42 │ │             price=1,
-43 │ │             size=2,
-44 │ │             rooms=u8(5),
-45 │ │             vacant=false
-46 │ │         )
-   │ ╰─────────^ House: Memory
-47 │           assert self.my_house.price == 1
-   │                  ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:47:16
-   │
-47 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:47:16
-   │
-47 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:47:16
-   │
-47 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-48 │         assert self.my_house.size == 2
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
-48 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
-48 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^^^^^^    ^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:48:16
-   │
-48 │         assert self.my_house.size == 2
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-49 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:49:16
-   │
-49 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:49:16
-   │
-49 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:49:39
-   │
-49 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:49:16
-   │
-49 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-50 │         assert self.my_house.vacant == false
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:50:16
-   │
-50 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:50:16
-   │
-50 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:50:16
-   │
-50 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-51 │         # We change only the size and check other fields are unchanged
-52 │         self.my_house.size = 50
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:52:9
-   │
-52 │         self.my_house.size = 50
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:52:9
-   │
-52 │         self.my_house.size = 50
-   │         ^^^^^^^^^^^^^^^^^^   ^^ u256: Value
-   │         │                     
-   │         u256: Storage { nonce: Some(0) }
-53 │         assert self.my_house.size == 50
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:53:16
-   │
-53 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-54 │         assert self.my_house.price == 1
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:54:16
-   │
-54 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:54:16
-   │
-54 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:54:16
-   │
-54 │         assert self.my_house.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-55 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:55:16
-   │
-55 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:55:16
-   │
-55 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:55:39
-   │
-55 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:55:16
-   │
-55 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-56 │         assert self.my_house.vacant == false
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:56:16
-   │
-56 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:56:16
-   │
-56 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:56:16
-   │
-56 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-57 │         # We change only the price and check other fields are unchanged
-58 │         self.my_house.price = 1000
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:58:9
-   │
-58 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:58:9
-   │
-58 │         self.my_house.price = 1000
-   │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
-   │         │                      
-   │         u256: Storage { nonce: Some(0) }
-59 │         assert self.my_house.size == 50
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:59:16
-   │
-59 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-60 │         assert self.my_house.price == 1000
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:60:16
-   │
-60 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:60:16
-   │
-60 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:60:16
-   │
-60 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-61 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:61:16
-   │
-61 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:61:16
-   │
-61 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:61:39
-   │
-61 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:61:16
-   │
-61 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-62 │         assert self.my_house.vacant == false
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:62:16
-   │
-62 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:62:16
-   │
-62 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                        
-   │                bool: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:62:16
-   │
-62 │         assert self.my_house.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-63 │         self.my_house.vacant = true
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:63:9
-   │
-63 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:63:9
-   │
-63 │         self.my_house.vacant = true
-   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value
-   │         │                       
-   │         bool: Storage { nonce: Some(0) }
-64 │         assert self.my_house.size == 50
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:64:16
-   │
-64 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:64:16
-   │
-64 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:64:16
-   │
-64 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-65 │         assert self.my_house.price == 1000
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:65:16
-   │
-65 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:65:16
-   │
-65 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:65:16
-   │
-65 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-66 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:66:16
-   │
-66 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:66:16
-   │
-66 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:66:39
-   │
-66 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:66:16
-   │
-66 │         assert self.my_house.rooms == u8(5)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-67 │         assert self.my_house.vacant
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:67:16
-   │
-67 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
-68 │         self.my_house.rooms = u8(100)
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:68:9
-   │
-68 │         self.my_house.rooms = u8(100)
-   │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:68:9
-   │
-68 │         self.my_house.rooms = u8(100)
-   │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value
-   │         │                         
-   │         u8: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:68:31
-   │
-68 │         self.my_house.rooms = u8(100)
-   │                               ^^^^^^^ u8: Value
-69 │         assert self.my_house.size == 50
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                      
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:69:16
-   │
-69 │         assert self.my_house.size == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-70 │         assert self.my_house.price == 1000
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:70:16
-   │
-70 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:70:16
-   │
-70 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
-   │                │                       
-   │                u256: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:70:16
-   │
-70 │         assert self.my_house.price == 1000
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-71 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:71:16
-   │
-71 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:71:16
-   │
-71 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^^^^^^^       ^^^ u8: Value
-   │                │                          
-   │                u8: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:71:39
-   │
-71 │         assert self.my_house.rooms == u8(100)
-   │                                       ^^^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:71:16
-   │
-71 │         assert self.my_house.rooms == u8(100)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-72 │         assert self.my_house.vacant
-   │                ^^^^ Foo: Value
-
-note: 
-   ┌─ features/structs.fe:72:16
-   │
-72 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ features/structs.fe:72:16
-   │
-72 │         assert self.my_house.vacant
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
-
-note: 
-   ┌─ features/structs.fe:44:19
-   │
-44 │             rooms=u8(5),
-   │                   ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-   ┌─ features/structs.fe:41:25
-   │
-41 │         self.my_house = House(
-   │                         ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
-   ·
-49 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-55 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-61 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-66 │         assert self.my_house.rooms == u8(5)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-67 │         assert self.my_house.vacant
-68 │         self.my_house.rooms = u8(100)
-   │                               ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-71 │         assert self.my_house.rooms == u8(100)
-   │                                       ^^ TypeConstructor(Base(Numeric(U8)))
-
-note: 
-    ┌─ features/structs.fe:74:5
+    ┌─ features/structs.fe:98:5
     │  
- 74 │ ╭     pub fn bar() -> u256:
- 75 │ │         let building: House = House(
- 76 │ │             price=300,
- 77 │ │             size=500,
+ 98 │ ╭     pub fn create_house(self):
+ 99 │ │         self.my_house = House(
+100 │ │             price=1,
+101 │ │             size=2,
     · │
- 99 │ │ 
-100 │ │         return building.size
+129 │ │         assert self.my_house.rooms == u8(100)
+130 │ │         assert self.my_house.vacant
+    │ ╰───────────────────────────────────^ attributes hash: 17603814563784536273
+    │  
+    = FunctionSignature {
+          self_decl: Some(
+              Mutable,
+          ),
+          params: [],
+          return_type: Ok(
+              Base(
+                  Unit,
+              ),
+          ),
+      }
+
+note: 
+   ┌─ features/structs.fe:99:9
+   │
+99 │         self.my_house = House(
+   │         ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:99:9
+    │
+ 99 │         self.my_house = House(
+    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+100 │             price=1,
+    │                   ^ u256: Value
+101 │             size=2,
+    │                  ^ u256: Value
+102 │             rooms=u8(5),
+    │                      ^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:102:19
+    │
+102 │             rooms=u8(5),
+    │                   ^^^^^ u8: Value
+103 │             vacant=false,
+    │                    ^^^^^ bool: Value
+
+note: 
+    ┌─ features/structs.fe:99:25
+    │  
+ 99 │           self.my_house = House(
+    │ ╭─────────────────────────^
+100 │ │             price=1,
+101 │ │             size=2,
+102 │ │             rooms=u8(5),
+103 │ │             vacant=false,
+104 │ │         )
+    │ ╰─────────^ House: Memory
+105 │           assert self.my_house.price == 1
+    │                  ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:105:16
+    │
+105 │         assert self.my_house.price == 1
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:105:16
+    │
+105 │         assert self.my_house.price == 1
+    │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
+    │                │                       
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:105:16
+    │
+105 │         assert self.my_house.price == 1
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+106 │         assert self.my_house.size == 2
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:106:16
+    │
+106 │         assert self.my_house.size == 2
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:106:16
+    │
+106 │         assert self.my_house.size == 2
+    │                ^^^^^^^^^^^^^^^^^^    ^ u256: Value
+    │                │                      
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:106:16
+    │
+106 │         assert self.my_house.size == 2
+    │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+107 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:107:16
+    │
+107 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:107:16
+    │
+107 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+    │                │                          
+    │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:107:39
+    │
+107 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:107:16
+    │
+107 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+108 │         assert self.my_house.vacant == false
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:108:16
+    │
+108 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:108:16
+    │
+108 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+    │                │                        
+    │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:108:16
+    │
+108 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+109 │         # We change only the size and check other fields are unchanged
+110 │         self.my_house.size = 50
+    │         ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:110:9
+    │
+110 │         self.my_house.size = 50
+    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:110:9
+    │
+110 │         self.my_house.size = 50
+    │         ^^^^^^^^^^^^^^^^^^   ^^ u256: Value
+    │         │                     
+    │         u256: Storage { nonce: Some(0) }
+111 │         assert self.my_house.size == 50
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:111:16
+    │
+111 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:111:16
+    │
+111 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+    │                │                      
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:111:16
+    │
+111 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+112 │         assert self.my_house.price == 1
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:112:16
+    │
+112 │         assert self.my_house.price == 1
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:112:16
+    │
+112 │         assert self.my_house.price == 1
+    │                ^^^^^^^^^^^^^^^^^^^    ^ u256: Value
+    │                │                       
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:112:16
+    │
+112 │         assert self.my_house.price == 1
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+113 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:113:16
+    │
+113 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:113:16
+    │
+113 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+    │                │                          
+    │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:113:39
+    │
+113 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:113:16
+    │
+113 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+114 │         assert self.my_house.vacant == false
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:114:16
+    │
+114 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:114:16
+    │
+114 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+    │                │                        
+    │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:114:16
+    │
+114 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+115 │         # We change only the price and check other fields are unchanged
+116 │         self.my_house.price = 1000
+    │         ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:116:9
+    │
+116 │         self.my_house.price = 1000
+    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:116:9
+    │
+116 │         self.my_house.price = 1000
+    │         ^^^^^^^^^^^^^^^^^^^   ^^^^ u256: Value
+    │         │                      
+    │         u256: Storage { nonce: Some(0) }
+117 │         assert self.my_house.size == 50
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:117:16
+    │
+117 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:117:16
+    │
+117 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+    │                │                      
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:117:16
+    │
+117 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+118 │         assert self.my_house.price == 1000
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:118:16
+    │
+118 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:118:16
+    │
+118 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+    │                │                       
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:118:16
+    │
+118 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+119 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:119:16
+    │
+119 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:119:16
+    │
+119 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+    │                │                          
+    │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:119:39
+    │
+119 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:119:16
+    │
+119 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+120 │         assert self.my_house.vacant == false
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:120:16
+    │
+120 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:120:16
+    │
+120 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+    │                │                        
+    │                bool: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:120:16
+    │
+120 │         assert self.my_house.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+121 │         self.my_house.vacant = true
+    │         ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:121:9
+    │
+121 │         self.my_house.vacant = true
+    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:121:9
+    │
+121 │         self.my_house.vacant = true
+    │         ^^^^^^^^^^^^^^^^^^^^   ^^^^ bool: Value
+    │         │                       
+    │         bool: Storage { nonce: Some(0) }
+122 │         assert self.my_house.size == 50
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:122:16
+    │
+122 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:122:16
+    │
+122 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+    │                │                      
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:122:16
+    │
+122 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+123 │         assert self.my_house.price == 1000
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:123:16
+    │
+123 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:123:16
+    │
+123 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+    │                │                       
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:123:16
+    │
+123 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+124 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:124:16
+    │
+124 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:124:16
+    │
+124 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^       ^ u8: Value
+    │                │                          
+    │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:124:39
+    │
+124 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:124:16
+    │
+124 │         assert self.my_house.rooms == u8(5)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+125 │         assert self.my_house.vacant
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:125:16
+    │
+125 │         assert self.my_house.vacant
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:125:16
+    │
+125 │         assert self.my_house.vacant
+    │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
+126 │         self.my_house.rooms = u8(100)
+    │         ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:126:9
+    │
+126 │         self.my_house.rooms = u8(100)
+    │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:126:9
+    │
+126 │         self.my_house.rooms = u8(100)
+    │         ^^^^^^^^^^^^^^^^^^^      ^^^ u8: Value
+    │         │                         
+    │         u8: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:126:31
+    │
+126 │         self.my_house.rooms = u8(100)
+    │                               ^^^^^^^ u8: Value
+127 │         assert self.my_house.size == 50
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:127:16
+    │
+127 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:127:16
+    │
+127 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^    ^^ u256: Value
+    │                │                      
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:127:16
+    │
+127 │         assert self.my_house.size == 50
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+128 │         assert self.my_house.price == 1000
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:128:16
+    │
+128 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:128:16
+    │
+128 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^^^^^^^    ^^^^ u256: Value
+    │                │                       
+    │                u256: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:128:16
+    │
+128 │         assert self.my_house.price == 1000
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+129 │         assert self.my_house.rooms == u8(100)
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:129:16
+    │
+129 │         assert self.my_house.rooms == u8(100)
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:129:16
+    │
+129 │         assert self.my_house.rooms == u8(100)
+    │                ^^^^^^^^^^^^^^^^^^^       ^^^ u8: Value
+    │                │                          
+    │                u8: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:129:39
+    │
+129 │         assert self.my_house.rooms == u8(100)
+    │                                       ^^^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:129:16
+    │
+129 │         assert self.my_house.rooms == u8(100)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+130 │         assert self.my_house.vacant
+    │                ^^^^ Foo: Value
+
+note: 
+    ┌─ features/structs.fe:130:16
+    │
+130 │         assert self.my_house.vacant
+    │                ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
+
+note: 
+    ┌─ features/structs.fe:130:16
+    │
+130 │         assert self.my_house.vacant
+    │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
+
+note: 
+    ┌─ features/structs.fe:102:19
+    │
+102 │             rooms=u8(5),
+    │                   ^^ TypeConstructor(Base(Numeric(U8)))
+
+note: 
+    ┌─ features/structs.fe:99:25
+    │
+ 99 │         self.my_house = House(
+    │                         ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
+    ·
+107 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+    ·
+113 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+    ·
+119 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+    ·
+124 │         assert self.my_house.rooms == u8(5)
+    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+125 │         assert self.my_house.vacant
+126 │         self.my_house.rooms = u8(100)
+    │                               ^^ TypeConstructor(Base(Numeric(U8)))
+    ·
+129 │         assert self.my_house.rooms == u8(100)
+    │                                       ^^ TypeConstructor(Base(Numeric(U8)))
+
+note: 
+    ┌─ features/structs.fe:132:5
+    │  
+132 │ ╭     pub fn bar() -> u256:
+133 │ │         let building: House = House(
+134 │ │             price=300,
+135 │ │             size=500,
+    · │
+157 │ │ 
+158 │ │         return building.size
     │ ╰────────────────────────────^ attributes hash: 17979516652885443340
     │  
     = FunctionSignature {
@@ -1061,305 +1733,305 @@ note:
       }
 
 note: 
-   ┌─ features/structs.fe:75:23
-   │
-75 │         let building: House = House(
-   │                       ^^^^^ House
-
-note: 
-   ┌─ features/structs.fe:76:19
-   │
-76 │             price=300,
-   │                   ^^^ u256: Value
-77 │             size=500,
-   │                  ^^^ u256: Value
-78 │             rooms=u8(20),
-   │                      ^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:78:19
-   │
-78 │             rooms=u8(20),
-   │                   ^^^^^^ u8: Value
-79 │             vacant=true
-   │                    ^^^^ bool: Value
-
-note: 
-   ┌─ features/structs.fe:75:31
-   │  
-75 │           let building: House = House(
-   │ ╭───────────────────────────────^
-76 │ │             price=300,
-77 │ │             size=500,
-78 │ │             rooms=u8(20),
-79 │ │             vacant=true
-80 │ │         )
-   │ ╰─────────^ House: Memory
-81 │           assert building.size == 500
-   │                  ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:81:16
-   │
-81 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^    ^^^ u256: Value
-   │                │                 
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:81:16
-   │
-81 │         assert building.size == 500
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-82 │         assert building.price == 300
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:82:16
-   │
-82 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^    ^^^ u256: Value
-   │                │                  
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:82:16
-   │
-82 │         assert building.price == 300
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-83 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:83:16
-   │
-83 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^       ^^ u8: Value
-   │                │                     
-   │                u8: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:83:34
-   │
-83 │         assert building.rooms == u8(20)
-   │                                  ^^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:83:16
-   │
-83 │         assert building.rooms == u8(20)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-84 │         assert building.vacant
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:84:16
-   │
-84 │         assert building.vacant
-   │                ^^^^^^^^^^^^^^^ bool: Memory => Value
-85 │ 
-86 │         building.vacant = false
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:86:9
-   │
-86 │         building.vacant = false
-   │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value
-   │         │                  
-   │         bool: Memory
-87 │         building.price = 1
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:87:9
-   │
-87 │         building.price = 1
-   │         ^^^^^^^^^^^^^^   ^ u256: Value
-   │         │                 
-   │         u256: Memory
-88 │         building.size = 2
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:88:9
-   │
-88 │         building.size = 2
-   │         ^^^^^^^^^^^^^   ^ u256: Value
-   │         │                
-   │         u256: Memory
-89 │         building.rooms = u8(10)
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:89:9
-   │
-89 │         building.rooms = u8(10)
-   │         ^^^^^^^^^^^^^^      ^^ u8: Value
-   │         │                    
-   │         u8: Memory
-
-note: 
-   ┌─ features/structs.fe:89:26
-   │
-89 │         building.rooms = u8(10)
-   │                          ^^^^^^ u8: Value
-90 │ 
-91 │         assert building.vacant == false
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:91:16
-   │
-91 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value
-   │                │                   
-   │                bool: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:91:16
-   │
-91 │         assert building.vacant == false
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-92 │         assert building.price == 1
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:92:16
-   │
-92 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^    ^ u256: Value
-   │                │                  
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:92:16
-   │
-92 │         assert building.price == 1
-   │                ^^^^^^^^^^^^^^^^^^^ bool: Value
-93 │         assert building.size == 2
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:93:16
-   │
-93 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^    ^ u256: Value
-   │                │                 
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:93:16
-   │
-93 │         assert building.size == 2
-   │                ^^^^^^^^^^^^^^^^^^ bool: Value
-94 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:94:16
-   │
-94 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^       ^^ u8: Value
-   │                │                     
-   │                u8: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:94:34
-   │
-94 │         assert building.rooms == u8(10)
-   │                                  ^^^^^^ u8: Value
-
-note: 
-   ┌─ features/structs.fe:94:16
-   │
-94 │         assert building.rooms == u8(10)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-95 │ 
-96 │         building.expand()
-   │         ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:96:9
-   │
-96 │         building.expand()
-   │         ^^^^^^^^^^^^^^^^^ (): Value
-97 │         assert building.size == 102
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:97:16
-   │
-97 │         assert building.size == 102
-   │                ^^^^^^^^^^^^^    ^^^ u256: Value
-   │                │                 
-   │                u256: Memory => Value
-
-note: 
-   ┌─ features/structs.fe:97:16
-   │
-97 │         assert building.size == 102
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-98 │         assert building.rooms == 11
-   │                ^^^^^^^^ House: Memory
-
-note: 
-   ┌─ features/structs.fe:98:16
-   │
-98 │         assert building.rooms == 11
-   │                ^^^^^^^^^^^^^^    ^^ u8: Value
-   │                │                  
-   │                u8: Memory => Value
-
-note: 
-    ┌─ features/structs.fe:98:16
+    ┌─ features/structs.fe:133:23
     │
- 98 │         assert building.rooms == 11
+133 │         let building: House = House(
+    │                       ^^^^^ House
+
+note: 
+    ┌─ features/structs.fe:134:19
+    │
+134 │             price=300,
+    │                   ^^^ u256: Value
+135 │             size=500,
+    │                  ^^^ u256: Value
+136 │             rooms=u8(20),
+    │                      ^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:136:19
+    │
+136 │             rooms=u8(20),
+    │                   ^^^^^^ u8: Value
+137 │             vacant=true,
+    │                    ^^^^ bool: Value
+
+note: 
+    ┌─ features/structs.fe:133:31
+    │  
+133 │           let building: House = House(
+    │ ╭───────────────────────────────^
+134 │ │             price=300,
+135 │ │             size=500,
+136 │ │             rooms=u8(20),
+137 │ │             vacant=true,
+138 │ │         )
+    │ ╰─────────^ House: Memory
+139 │           assert building.size == 500
+    │                  ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:139:16
+    │
+139 │         assert building.size == 500
+    │                ^^^^^^^^^^^^^    ^^^ u256: Value
+    │                │                 
+    │                u256: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:139:16
+    │
+139 │         assert building.size == 500
     │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
- 99 │ 
-100 │         return building.size
+140 │         assert building.price == 300
     │                ^^^^^^^^ House: Memory
 
 note: 
-    ┌─ features/structs.fe:100:16
+    ┌─ features/structs.fe:140:16
     │
-100 │         return building.size
+140 │         assert building.price == 300
+    │                ^^^^^^^^^^^^^^    ^^^ u256: Value
+    │                │                  
+    │                u256: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:140:16
+    │
+140 │         assert building.price == 300
+    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
+141 │         assert building.rooms == u8(20)
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:141:16
+    │
+141 │         assert building.rooms == u8(20)
+    │                ^^^^^^^^^^^^^^       ^^ u8: Value
+    │                │                     
+    │                u8: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:141:34
+    │
+141 │         assert building.rooms == u8(20)
+    │                                  ^^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:141:16
+    │
+141 │         assert building.rooms == u8(20)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+142 │         assert building.vacant
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:142:16
+    │
+142 │         assert building.vacant
+    │                ^^^^^^^^^^^^^^^ bool: Memory => Value
+143 │ 
+144 │         building.vacant = false
+    │         ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:144:9
+    │
+144 │         building.vacant = false
+    │         ^^^^^^^^^^^^^^^   ^^^^^ bool: Value
+    │         │                  
+    │         bool: Memory
+145 │         building.price = 1
+    │         ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:145:9
+    │
+145 │         building.price = 1
+    │         ^^^^^^^^^^^^^^   ^ u256: Value
+    │         │                 
+    │         u256: Memory
+146 │         building.size = 2
+    │         ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:146:9
+    │
+146 │         building.size = 2
+    │         ^^^^^^^^^^^^^   ^ u256: Value
+    │         │                
+    │         u256: Memory
+147 │         building.rooms = u8(10)
+    │         ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:147:9
+    │
+147 │         building.rooms = u8(10)
+    │         ^^^^^^^^^^^^^^      ^^ u8: Value
+    │         │                    
+    │         u8: Memory
+
+note: 
+    ┌─ features/structs.fe:147:26
+    │
+147 │         building.rooms = u8(10)
+    │                          ^^^^^^ u8: Value
+148 │ 
+149 │         assert building.vacant == false
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:149:16
+    │
+149 │         assert building.vacant == false
+    │                ^^^^^^^^^^^^^^^    ^^^^^ bool: Value
+    │                │                   
+    │                bool: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:149:16
+    │
+149 │         assert building.vacant == false
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+150 │         assert building.price == 1
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:150:16
+    │
+150 │         assert building.price == 1
+    │                ^^^^^^^^^^^^^^    ^ u256: Value
+    │                │                  
+    │                u256: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:150:16
+    │
+150 │         assert building.price == 1
+    │                ^^^^^^^^^^^^^^^^^^^ bool: Value
+151 │         assert building.size == 2
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:151:16
+    │
+151 │         assert building.size == 2
+    │                ^^^^^^^^^^^^^    ^ u256: Value
+    │                │                 
+    │                u256: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:151:16
+    │
+151 │         assert building.size == 2
+    │                ^^^^^^^^^^^^^^^^^^ bool: Value
+152 │         assert building.rooms == u8(10)
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:152:16
+    │
+152 │         assert building.rooms == u8(10)
+    │                ^^^^^^^^^^^^^^       ^^ u8: Value
+    │                │                     
+    │                u8: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:152:34
+    │
+152 │         assert building.rooms == u8(10)
+    │                                  ^^^^^^ u8: Value
+
+note: 
+    ┌─ features/structs.fe:152:16
+    │
+152 │         assert building.rooms == u8(10)
+    │                ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+153 │ 
+154 │         building.expand()
+    │         ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:154:9
+    │
+154 │         building.expand()
+    │         ^^^^^^^^^^^^^^^^^ (): Value
+155 │         assert building.size == 102
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:155:16
+    │
+155 │         assert building.size == 102
+    │                ^^^^^^^^^^^^^    ^^^ u256: Value
+    │                │                 
+    │                u256: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:155:16
+    │
+155 │         assert building.size == 102
+    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+156 │         assert building.rooms == 11
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:156:16
+    │
+156 │         assert building.rooms == 11
+    │                ^^^^^^^^^^^^^^    ^^ u8: Value
+    │                │                  
+    │                u8: Memory => Value
+
+note: 
+    ┌─ features/structs.fe:156:16
+    │
+156 │         assert building.rooms == 11
+    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+157 │ 
+158 │         return building.size
+    │                ^^^^^^^^ House: Memory
+
+note: 
+    ┌─ features/structs.fe:158:16
+    │
+158 │         return building.size
     │                ^^^^^^^^^^^^^ u256: Memory => Value
 
 note: 
-   ┌─ features/structs.fe:78:19
-   │
-78 │             rooms=u8(20),
-   │                   ^^ TypeConstructor(Base(Numeric(U8)))
+    ┌─ features/structs.fe:136:19
+    │
+136 │             rooms=u8(20),
+    │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-   ┌─ features/structs.fe:75:31
-   │
-75 │         let building: House = House(
-   │                               ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
-   ·
-83 │         assert building.rooms == u8(20)
-   │                                  ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-89 │         building.rooms = u8(10)
-   │                          ^^ TypeConstructor(Base(Numeric(U8)))
-   ·
-94 │         assert building.rooms == u8(10)
-   │                                  ^^ TypeConstructor(Base(Numeric(U8)))
-95 │ 
-96 │         building.expand()
-   │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(1)), method: FunctionId(4) }
+    ┌─ features/structs.fe:133:31
+    │
+133 │         let building: House = House(
+    │                               ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
+    ·
+141 │         assert building.rooms == u8(20)
+    │                                  ^^ TypeConstructor(Base(Numeric(U8)))
+    ·
+147 │         building.rooms = u8(10)
+    │                          ^^ TypeConstructor(Base(Numeric(U8)))
+    ·
+152 │         assert building.rooms == u8(10)
+    │                                  ^^ TypeConstructor(Base(Numeric(U8)))
+153 │ 
+154 │         building.expand()
+    │         ^^^^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(3)), method: FunctionId(4) }
 
 note: 
-    ┌─ features/structs.fe:102:5
+    ┌─ features/structs.fe:160:5
     │  
-102 │ ╭     pub fn encode_house() -> Array<u8, 128>:
-103 │ │         let house: House = House(
-104 │ │             price=300,
-105 │ │             size=500,
+160 │ ╭     pub fn encode_house() -> Array<u8, 128>:
+161 │ │         let house: House = House(
+162 │ │             price=300,
+163 │ │             size=500,
     · │
-108 │ │         )
-109 │ │         return house.encode()
+166 │ │         )
+167 │ │         return house.encode()
     │ ╰─────────────────────────────^ attributes hash: 6092146250611764360
     │  
     = FunctionSignature {
@@ -1378,74 +2050,74 @@ note:
       }
 
 note: 
-    ┌─ features/structs.fe:103:20
+    ┌─ features/structs.fe:161:20
     │
-103 │         let house: House = House(
+161 │         let house: House = House(
     │                    ^^^^^ House
 
 note: 
-    ┌─ features/structs.fe:104:19
+    ┌─ features/structs.fe:162:19
     │
-104 │             price=300,
+162 │             price=300,
     │                   ^^^ u256: Value
-105 │             size=500,
+163 │             size=500,
     │                  ^^^ u256: Value
-106 │             rooms=u8(20),
+164 │             rooms=u8(20),
     │                      ^^ u8: Value
 
 note: 
-    ┌─ features/structs.fe:106:19
+    ┌─ features/structs.fe:164:19
     │
-106 │             rooms=u8(20),
+164 │             rooms=u8(20),
     │                   ^^^^^^ u8: Value
-107 │             vacant=true
+165 │             vacant=true,
     │                    ^^^^ bool: Value
 
 note: 
-    ┌─ features/structs.fe:103:28
+    ┌─ features/structs.fe:161:28
     │  
-103 │           let house: House = House(
+161 │           let house: House = House(
     │ ╭────────────────────────────^
-104 │ │             price=300,
-105 │ │             size=500,
-106 │ │             rooms=u8(20),
-107 │ │             vacant=true
-108 │ │         )
+162 │ │             price=300,
+163 │ │             size=500,
+164 │ │             rooms=u8(20),
+165 │ │             vacant=true,
+166 │ │         )
     │ ╰─────────^ House: Memory
-109 │           return house.encode()
+167 │           return house.encode()
     │                  ^^^^^ House: Memory
 
 note: 
-    ┌─ features/structs.fe:109:16
+    ┌─ features/structs.fe:167:16
     │
-109 │         return house.encode()
+167 │         return house.encode()
     │                ^^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-    ┌─ features/structs.fe:106:19
+    ┌─ features/structs.fe:164:19
     │
-106 │             rooms=u8(20),
+164 │             rooms=u8(20),
     │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-    ┌─ features/structs.fe:103:28
+    ┌─ features/structs.fe:161:28
     │
-103 │         let house: House = House(
-    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
+161 │         let house: House = House(
+    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
     ·
-109 │         return house.encode()
-    │                ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(1)), method: FunctionId(1) }
+167 │         return house.encode()
+    │                ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(3)), method: FunctionId(1) }
 
 note: 
-    ┌─ features/structs.fe:111:5
+    ┌─ features/structs.fe:169:5
     │  
-111 │ ╭     pub fn hashed_house() -> u256:
-112 │ │         let house: House = House(
-113 │ │             price=300,
-114 │ │             size=500,
+169 │ ╭     pub fn hashed_house() -> u256:
+170 │ │         let house: House = House(
+171 │ │             price=300,
+172 │ │             size=500,
     · │
-117 │ │         )
-118 │ │         return house.hash()
+175 │ │         )
+176 │ │         return house.hash()
     │ ╰───────────────────────────^ attributes hash: 17979516652885443340
     │  
     = FunctionSignature {
@@ -1461,62 +2133,62 @@ note:
       }
 
 note: 
-    ┌─ features/structs.fe:112:20
+    ┌─ features/structs.fe:170:20
     │
-112 │         let house: House = House(
+170 │         let house: House = House(
     │                    ^^^^^ House
 
 note: 
-    ┌─ features/structs.fe:113:19
+    ┌─ features/structs.fe:171:19
     │
-113 │             price=300,
+171 │             price=300,
     │                   ^^^ u256: Value
-114 │             size=500,
+172 │             size=500,
     │                  ^^^ u256: Value
-115 │             rooms=u8(20),
+173 │             rooms=u8(20),
     │                      ^^ u8: Value
 
 note: 
-    ┌─ features/structs.fe:115:19
+    ┌─ features/structs.fe:173:19
     │
-115 │             rooms=u8(20),
+173 │             rooms=u8(20),
     │                   ^^^^^^ u8: Value
-116 │             vacant=true
+174 │             vacant=true,
     │                    ^^^^ bool: Value
 
 note: 
-    ┌─ features/structs.fe:112:28
+    ┌─ features/structs.fe:170:28
     │  
-112 │           let house: House = House(
+170 │           let house: House = House(
     │ ╭────────────────────────────^
-113 │ │             price=300,
-114 │ │             size=500,
-115 │ │             rooms=u8(20),
-116 │ │             vacant=true
-117 │ │         )
+171 │ │             price=300,
+172 │ │             size=500,
+173 │ │             rooms=u8(20),
+174 │ │             vacant=true,
+175 │ │         )
     │ ╰─────────^ House: Memory
-118 │           return house.hash()
+176 │           return house.hash()
     │                  ^^^^^ House: Memory
 
 note: 
-    ┌─ features/structs.fe:118:16
+    ┌─ features/structs.fe:176:16
     │
-118 │         return house.hash()
+176 │         return house.hash()
     │                ^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ features/structs.fe:115:19
+    ┌─ features/structs.fe:173:19
     │
-115 │             rooms=u8(20),
+173 │             rooms=u8(20),
     │                   ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
-    ┌─ features/structs.fe:112:28
+    ┌─ features/structs.fe:170:28
     │
-112 │         let house: House = House(
-    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(1), field_count: 4 }))
+170 │         let house: House = House(
+    │                            ^^^^^ TypeConstructor(Struct(Struct { name: "House", id: StructId(3), field_count: 4 }))
     ·
-118 │         return house.hash()
-    │                ^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(1)), method: FunctionId(2) }
+176 │         return house.hash()
+    │                ^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(3)), method: FunctionId(2) }
 
 

--- a/crates/analyzer/tests/snapshots/errors__return_complex_struct.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_complex_struct.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, &src)"
+
+---
+error: feature not yet implemented: structs with complex fields can't be returned from public functions yet
+  ┌─ compile_errors/return_complex_struct.fe:5:17
+  │
+5 │   pub fn f() -> Foo:
+  │                 ^^^ not yet implemented
+
+

--- a/crates/test-files/fixtures/compile_errors/return_complex_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/return_complex_struct.fe
@@ -1,0 +1,6 @@
+struct Foo:
+  pub bar: Array<u256,2>
+
+contract C:
+  pub fn f() -> Foo:
+    return Foo(bar=[1, 2])

--- a/crates/test-files/fixtures/features/structs.fe
+++ b/crates/test-files/fixtures/features/structs.fe
@@ -1,3 +1,13 @@
+struct Point:
+    pub x: u256
+    pub y: u256
+
+struct Bar:
+    pub name: String<3>
+    pub numbers: Array<u256, 2>
+    pub point: Point
+    pub something: (u256, bool)
+
 struct Mixed:
     pub foo: u256
     bar: bool
@@ -27,6 +37,54 @@ struct House:
 contract Foo:
     my_house: House
 
+    pub fn complex_struct_in_memory(self) -> String<3>:
+        let val: Bar = Bar(
+            name="foo",
+            numbers=[1, 2],
+            point=Point(x=100, y=200),
+            something=(1, true),
+        )
+
+        # Asserting the values as they were set initially
+        assert val.numbers[0] == 1
+        assert val.numbers[1] == 2
+        assert val.point.x == 100
+        assert val.point.y == 200
+        assert val.something.item0 == 1
+        assert val.something.item1
+
+        # We can change the values of the array
+        val.numbers[0] = 10
+        val.numbers[1] = 20
+        assert val.numbers[0] == 10
+        assert val.numbers[1] == 20
+        # We can set the array itself
+        val.numbers = [1, 2]
+        assert val.numbers[0] == 1
+        assert val.numbers[1] == 2
+
+        # We can change the values of the Point
+        val.point.x = 1000
+        val.point.y = 2000
+        assert val.point.x == 1000
+        assert val.point.y == 2000
+        # We can set the point itself
+        val.point = Point(x=100, y=200)
+        assert val.point.x == 100
+        assert val.point.y == 200
+
+        # We can change the value of the tuple
+        val.something.item0 = 10
+        val.something.item1 = false
+        assert val.something.item0 == 10
+        assert not val.something.item1
+        # We can set the tuple itself
+        val.something = (1, true)
+        assert val.something.item0 == 1
+        assert val.something.item1
+
+        return val.name
+
     pub fn create_mixed(self) -> u256:
         let mixed: Mixed = Mixed.new(1)
         return mixed.foo
@@ -42,7 +100,7 @@ contract Foo:
             price=1,
             size=2,
             rooms=u8(5),
-            vacant=false
+            vacant=false,
         )
         assert self.my_house.price == 1
         assert self.my_house.size == 2
@@ -76,7 +134,7 @@ contract Foo:
             price=300,
             size=500,
             rooms=u8(20),
-            vacant=true
+            vacant=true,
         )
         assert building.size == 500
         assert building.price == 300
@@ -104,7 +162,7 @@ contract Foo:
             price=300,
             size=500,
             rooms=u8(20),
-            vacant=true
+            vacant=true,
         )
         return house.encode()
 
@@ -113,6 +171,6 @@ contract Foo:
             price=300,
             size=500,
             rooms=u8(20),
-            vacant=true
+            vacant=true,
         )
         return house.hash()

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -1228,7 +1228,14 @@ fn structs() {
             )),
         );
 
-        harness.test_function(&mut executor, "create_mixed", &[], Some(&uint_token(1)))
+        harness.test_function(&mut executor, "create_mixed", &[], Some(&uint_token(1)));
+
+        harness.test_function(
+            &mut executor,
+            "complex_struct_in_memory",
+            &[],
+            Some(&string_token("foo")),
+        );
     });
 }
 

--- a/crates/yulgen/src/db.rs
+++ b/crates/yulgen/src/db.rs
@@ -47,9 +47,9 @@ pub trait YulgenDb:
     #[salsa::invoke(queries::structs::struct_qualified_name)]
     fn struct_qualified_name(&self, id: StructId) -> SmolStr;
     #[salsa::invoke(queries::structs::struct_getter_name)]
-    fn struct_getter_name(&self, id: StructId, field: SmolStr) -> SmolStr;
+    fn struct_getter_name(&self, id: StructId, field: SmolStr, deref: bool) -> SmolStr;
     #[salsa::invoke(queries::structs::struct_getter_fn)]
-    fn struct_getter_fn(&self, id: StructId, field: SmolStr) -> yul::Statement;
+    fn struct_getter_fn(&self, id: StructId, field: SmolStr, deref: bool) -> yul::Statement;
     #[salsa::invoke(queries::structs::struct_init_name)]
     fn struct_init_name(&self, id: StructId) -> SmolStr;
     #[salsa::invoke(queries::structs::struct_init_fn)]

--- a/crates/yulgen/src/db/queries/structs.rs
+++ b/crates/yulgen/src/db/queries/structs.rs
@@ -1,6 +1,7 @@
 use crate::db::YulgenDb;
 use crate::types::{AbiType, AsAbiType, EvmSized};
 use fe_analyzer::namespace::items::{Item, StructId, TypeDef};
+use fe_analyzer::namespace::types::FixedSize;
 use smol_str::SmolStr;
 use std::rc::Rc;
 use yultsur::*;
@@ -36,11 +37,28 @@ pub fn struct_qualified_name(db: &dyn YulgenDb, struct_: StructId) -> SmolStr {
     .into()
 }
 
-pub fn struct_getter_name(db: &dyn YulgenDb, struct_: StructId, field: SmolStr) -> SmolStr {
-    format!("{}.get_{}_ptr", db.struct_qualified_name(struct_), field).into()
+pub fn struct_getter_name(
+    db: &dyn YulgenDb,
+    struct_: StructId,
+    field: SmolStr,
+    deref: bool,
+) -> SmolStr {
+    let suffix = if deref { "" } else { "_raw" };
+    format!(
+        "{}.get_{}_ptr{}",
+        db.struct_qualified_name(struct_),
+        field,
+        suffix
+    )
+    .into()
 }
 
-pub fn struct_getter_fn(db: &dyn YulgenDb, struct_: StructId, field: SmolStr) -> yul::Statement {
+pub fn struct_getter_fn(
+    db: &dyn YulgenDb,
+    struct_: StructId,
+    field: SmolStr,
+    deref: bool,
+) -> yul::Statement {
     let fields = struct_.fields(db.upcast());
 
     let (index, _, field_id) = fields
@@ -48,19 +66,54 @@ pub fn struct_getter_fn(db: &dyn YulgenDb, struct_: StructId, field: SmolStr) ->
         .expect("invalid struct field name");
 
     let field_type = field_id.typ(db.upcast()).expect("struct field error");
-
     // The value of each field occupies 32 bytes. This includes values with sizes
     // less than 32 bytes. So, when we get the pointer to the value of a struct
     // field, we must take into consideration the left-padding. The left-padding is
     // equal to the difference between the value's size and 32 bytes, so we end up
     // adding the word offset and the byte offset.
-    let field_offset = index * 32 + (32 - field_type.size());
+    let field_offset = if !field_type.is_base() {
+        // For now we just assume that non-base types are always stored as references and so the size of the field
+        // is always of the size of a pointer (32 bytes)
+        index * 32
+    } else if field_type.size() < 32 {
+        index * 32 + (32 - field_type.size())
+    } else {
+        index * field_type.size()
+    };
 
-    let function_name = identifier! { (db.struct_getter_name(struct_, field)) };
+    let function_name = identifier! { (db.struct_getter_name(struct_, field, deref)) };
     let offset = literal_expression! { (field_offset) };
-    function_definition! {
+
+    let normal_getter = function_definition! {
+        function [function_name.clone()](ptr) -> return_val {
+            (return_val := add(ptr, [offset.clone()]))
+        }
+    };
+
+    let deref_getter = function_definition! {
         function [function_name](ptr) -> return_val {
-             (return_val := add(ptr, [offset]))
+            (return_val := mload((add(ptr, [offset]))))
+        }
+    };
+
+    match field_type {
+        // We generate two different kind of getters:
+        // 1. get_x_ptr:     Returns a pointer to the memory location where the data is set.
+        //                   If `x` is a reference type, we will have to perform one dereferenceing step
+        //                   to get to that actual pointer. That is because the field contains a 32 byte
+        //                   reference itself.
+        // 2. get_x_ptr_raw: Returns a pointer that does not automatically dereference contained references.
+        //                   This is useful for assignments where one wants to override a field `foo` of a struct
+        //                   that might be of type Array<u256, 2> with an entirely new array e.g. val.foo = [100, 200]
+        //                   In that case, we don't want to follow the stored reference because we want to override
+        //                   it entirely.
+        FixedSize::Base(_) => normal_getter,
+        _ => {
+            if deref {
+                deref_getter
+            } else {
+                normal_getter
+            }
         }
     }
 }
@@ -128,7 +181,12 @@ pub fn struct_api_fns(db: &dyn YulgenDb, struct_: StructId) -> Vec<yul::Statemen
         struct_
             .fields(db.upcast())
             .keys()
-            .map(|name| db.struct_getter_fn(struct_, name.clone()))
+            .map(|name| db.struct_getter_fn(struct_, name.clone(), false))
+            .collect(),
+        struct_
+            .fields(db.upcast())
+            .keys()
+            .map(|name| db.struct_getter_fn(struct_, name.clone(), true))
             .collect(),
     ]
     .concat()

--- a/crates/yulgen/src/operations/structs.rs
+++ b/crates/yulgen/src/operations/structs.rs
@@ -13,6 +13,6 @@ pub fn get_attribute(
     field_name: &str,
     val: yul::Expression,
 ) -> yul::Expression {
-    let function_name = identifier! { (db.struct_getter_name(struct_, field_name.into())) };
+    let function_name = identifier! { (db.struct_getter_name(struct_, field_name.into(), true)) };
     expression! { [function_name]([val]) }
 }

--- a/newsfragments/343.feature.md
+++ b/newsfragments/343.feature.md
@@ -1,0 +1,5 @@
+Support non-base type fields in structs
+
+Support is currently limited in two ways:
+  - Structs with complex fields can not be returned from public functions
+  - Structs with complex fields can not be stored in storage


### PR DESCRIPTION
### What was wrong?

As described in #343 structs can currently only use fields with base types. That limitation should be lifted.

### How was it fixed?

Structs can now use any fixed size type (except contract types for now) as field types. However, support is currently limited in two major ways:
  - Structs with complex fields can not be returned from public functions
  - Structs with complex fields can not be stored in storage

That functionality is expected to arrive with follow up PRs.

I should also say that the implementation based on `get_x_ptr` / `get_x_ptr_raw` feels a bit dirty (especially the part where we derive the `_raw` API from the non `raw` one). But this seems like something that would naturally evolve in another direction if we add explicit reference semantics so it may be ok for now.