### PR TITLE
Fixed a crash with a certain unprintable ASCII char

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -424,7 +424,7 @@ fn is_valid_string(val: &str) -> bool {
         13u8, // Carriage return
     ];
 
-    const PRINTABLE_ASCII: RangeInclusive<u8> = 31u8..=126u8;
+    const PRINTABLE_ASCII: RangeInclusive<u8> = 32u8..=126u8;
 
     for x in val.as_bytes() {
         if ALLOWED_SPECIAL_CHARS.contains(x) || PRINTABLE_ASCII.contains(x) {

--- a/crates/test-files/fixtures/crashes/agroce551.fe
+++ b/crates/test-files/fixtures/crashes/agroce551.fe
@@ -1,0 +1,3 @@
+contract o:
+ pub fn l(b:bool):
+  ""

--- a/crates/tests/src/crashes.rs
+++ b/crates/tests/src/crashes.rs
@@ -18,5 +18,6 @@ macro_rules! test_file {
 
 test_file! { agroce531 }
 test_file! { agroce550 }
+test_file! { agroce551 }
 test_file! { agroce623 }
 test_file! { revert_const }

--- a/newsfragments/551.bugfix.md
+++ b/newsfragments/551.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a crash that happend when using a certain unprintable ASCII char


### PR DESCRIPTION


### What was wrong?

A certain unprintable ASCII char lead to an ICE (#551)

### How was it fixed?

This was due to an off-by-one error in our ASCII validation. That char should have been recognized as illegal.
