### PR TITLE
Refactor complex struct handling

### DIFF
--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -3,6 +3,7 @@ use crate::context;
 use crate::context::Analysis;
 use crate::errors::{self, TypeError};
 use crate::impl_intern_key;
+use crate::namespace::types::FixedSize;
 use crate::namespace::types::{self, GenericType};
 use crate::traversal::pragma::check_pragma_version;
 use crate::AnalyzerDb;
@@ -1335,6 +1336,10 @@ impl StructId {
         name: &str,
     ) -> Option<Result<types::FixedSize, TypeError>> {
         Some(self.field(db, name)?.typ(db))
+    }
+
+    pub fn is_base_type(&self, db: &dyn AnalyzerDb, name: &str) -> bool {
+        matches!(self.field_type(db, name), Some(Ok(FixedSize::Base(_))))
     }
 
     pub fn has_complex_fields(&self, db: &dyn AnalyzerDb) -> bool {

--- a/crates/yulgen/src/db.rs
+++ b/crates/yulgen/src/db.rs
@@ -47,9 +47,9 @@ pub trait YulgenDb:
     #[salsa::invoke(queries::structs::struct_qualified_name)]
     fn struct_qualified_name(&self, id: StructId) -> SmolStr;
     #[salsa::invoke(queries::structs::struct_getter_name)]
-    fn struct_getter_name(&self, id: StructId, field: SmolStr, deref: bool) -> SmolStr;
+    fn struct_getter_name(&self, id: StructId, field: SmolStr) -> SmolStr;
     #[salsa::invoke(queries::structs::struct_getter_fn)]
-    fn struct_getter_fn(&self, id: StructId, field: SmolStr, deref: bool) -> yul::Statement;
+    fn struct_getter_fn(&self, id: StructId, field: SmolStr) -> yul::Statement;
     #[salsa::invoke(queries::structs::struct_init_name)]
     fn struct_init_name(&self, id: StructId) -> SmolStr;
     #[salsa::invoke(queries::structs::struct_init_fn)]

--- a/crates/yulgen/src/mappers/expressions.rs
+++ b/crates/yulgen/src/mappers/expressions.rs
@@ -477,7 +477,13 @@ fn expr_attribute(context: &mut FnContext, exp: &Node<fe::Expr>) -> yul::Express
             // struct `self` is handled like any other struct value,
             // and keeps the name `self` in the generated yul.
             let target = expr(context, target);
-            struct_operations::get_attribute(context.db, struct_.id, &field.kind, target)
+            struct_operations::get_attribute(
+                context.db,
+                context.adb,
+                struct_.id,
+                &field.kind,
+                target,
+            )
         }
         _ => panic!("invalid type for field access: {:?}", &target_attrs.typ),
     }

--- a/crates/yulgen/src/operations/structs.rs
+++ b/crates/yulgen/src/operations/structs.rs
@@ -1,5 +1,5 @@
 use crate::YulgenDb;
-use fe_analyzer::namespace::items::StructId;
+use fe_analyzer::{namespace::items::StructId, AnalyzerDb};
 use yultsur::*;
 
 pub fn init(db: &dyn YulgenDb, struct_: StructId, params: Vec<yul::Expression>) -> yul::Expression {
@@ -9,10 +9,16 @@ pub fn init(db: &dyn YulgenDb, struct_: StructId, params: Vec<yul::Expression>) 
 
 pub fn get_attribute(
     db: &dyn YulgenDb,
+    dba: &dyn AnalyzerDb,
     struct_: StructId,
     field_name: &str,
     val: yul::Expression,
 ) -> yul::Expression {
-    let function_name = identifier! { (db.struct_getter_name(struct_, field_name.into(), true)) };
-    expression! { [function_name]([val]) }
+    let function_name = identifier! { (db.struct_getter_name(struct_, field_name.into())) };
+
+    if struct_.is_base_type(dba, field_name) {
+        expression! { [function_name]([val]) }
+    } else {
+        expression! { mload(([function_name]([val]))) }
+    }
 }


### PR DESCRIPTION

### What was wrong?

When I wrote the handling of complex structs I changed the getter handling to create two different kind of getters. One with auto-deref and one without. I think it is better to keep the deref step out of the getters but for some reason the solution to it didn't occur to me.

### How was it fixed?

We add derefs (`mload`) to the get_attribute calls and remove them from those where the attribute is used assign a reference type in a struct field.
