### PR TITLE
Fix: Prevent solc-backend panic when non-existent path is passed to it as argument. (Fixes issue #641)

### DIFF
--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -157,6 +157,10 @@ fn build_ingot_filestore_for_dir(path: &str) -> FileStore {
     let mut files = FileStore::new();
 
     for entry in walker {
+        if entry.is_err() {
+            eprintln!("Error: {}", entry.unwrap_err());
+            std::process::exit(1)
+        }
         let entry = entry.unwrap();
         let file_path = &entry.path().to_string_lossy().to_string();
 


### PR DESCRIPTION
### What was wrong?
As stated in #641 , the `solc-backend` panics when a non-existent path is passed to it as an argument because `unwrap` was called directly on `entry` assuming that it is always `Ok` and not an `Err`. (in other words, directory errors were unhandled)

### How was it fixed?
Just added a checker before calling `unwrap`, this would exit the process with code `1` and avoids panic.
```rust
for entry in walker {
        if entry.is_err() {
            eprintln!("Error: {}", entry.unwrap_err());
            std::process::exit(1)
        }
        let entry = entry.unwrap();
      .......
```
Every item returned by the iterator is of type `Result<walkdir::DirEntry, walkdir::Error>`, so `entry.is_err()` check  needs to be called for each item. An alternative solution would be to check if the path exists before the for loop, but that would not guarantee that every item in the iteration is always of type `Ok(walkdir::DirEntry)`, because an `Err` can happen for so many reasons.  Also the error message obtained from `entry.unwrap_err()` is self-descriptive by itself, so no need to print anything extra from our side: 
```
Error: IO error for operation on wrong_path: No such file or directory (os error 2)
```


