### PR TITLE
Improve parser error message when float is encountered

### DIFF
--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -395,22 +395,26 @@ fn infix_op(
 
         Dot => {
             let span = left.span + right.span;
-            if let Expr::Name(name) = right.kind {
-                Node::new(
+            match right.kind {
+                Expr::Name(name) => Node::new(
                     Expr::Attribute {
                         value: Box::new(left),
                         attr: Node::new(name, right.span),
                     },
                     span,
-                )
-            } else {
-                // TODO: check for float number and say something helpful
-                par.fancy_error(
-                    "failed to parse attribute expression",
-                    vec![Label::primary(right.span, "expected a name")],
-                    vec![],
-                );
-                return Err(ParseFailed);
+                ),
+                Expr::Num(_num) => {
+                    par.error(span, "floats not supported");
+                    return Err(ParseFailed);
+                }
+                _ => {
+                    par.fancy_error(
+                        "failed to parse attribute expression",
+                        vec![Label::primary(right.span, "expected a name")],
+                        vec![],
+                    );
+                    return Err(ParseFailed);
+                }
             }
         }
         ColonColon => {

--- a/crates/parser/tests/cases/snapshots/cases__errors__expr_dotted_number.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__expr_dotted_number.snap
@@ -3,10 +3,10 @@ source: crates/parser/tests/cases/errors.rs
 expression: "err_string(stringify!(expr_dotted_number), expressions::parse_expr, true,\n           \"3.14\")"
 
 ---
-error: failed to parse attribute expression
-  ┌─ expr_dotted_number:1:3
+error: floats not supported
+  ┌─ expr_dotted_number:1:1
   │
 1 │ 3.14
-  │   ^^ expected a name
+  │ ^^^^
 
 


### PR DESCRIPTION
### What was wrong?
Compiling `my_array[0] = 0.15` throws:
```
Unable to compile ./local/decimal.fe.
error: failed to parse attribute expression
  ┌─ ./local/decimal.fe:4:25
  │
4 │         my_array[0] = 0.15
  │                         ^^ expected a name
```
https://github.com/ethereum/fe/issues/224

### How was it fixed?
Added case to check for float
```
Unable to compile ./local/decimal.fe.
error: floats not supported
  ┌─ ./local/decimal.fe:4:23
  │
4 │         my_array[0] = 0.15
  │                       ^^^^
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
