### PR TITLE
Exclude `goerli.etherscan.io` from linkcheck

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,4 +11,4 @@ additional-css = ["theme/reference.css"]
 [output.linkcheck]
 follow-web-links = true
 warning-policy = "error"
-exclude = [ 'github\.com' ]
+exclude = [ 'github\.com', 'goerli\.etherscan\.io' ]


### PR DESCRIPTION
### What was wrong?
`https://goerli.etherscan.io/` rejects requests from lintkcheck.


### How was it fixed?
Just excluded `goerli.ehterscan.io`.
