### PR TITLE
Allow assignments from smaller string type to larger string type

### DIFF
--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -217,6 +217,7 @@ test_stmt! { revert_reason_not_struct, "revert 1" }
 test_stmt! { invalid_ascii, "String<2>(\"ä\")" }
 test_stmt! { invert_non_numeric, "~true" }
 
+test_file! { bad_string }
 test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }
 test_file! { bad_tuple_attr3 }

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -16,8 +16,8 @@ note:
   │         ^^^^^^^^^^^^^^^ String<100>
 7 │         a: address
   │         ^^^^^^^^^^ address
-8 │         s4: String<13>
-  │         ^^^^^^^^^^^^^^ String<13>
+8 │         s4: String<18>
+  │         ^^^^^^^^^^^^^^ String<18>
 9 │         s5: String<100>
   │         ^^^^^^^^^^^^^^^ String<100>
 
@@ -132,9 +132,38 @@ note:
 note: 
    ┌─ strings.fe:23:5
    │  
-23 │ ╭     pub fn return_special_chars() -> String<18>:
-24 │ │         return "\n\"'\r\t
-25 │ │         foo\\"
+23 │ ╭     pub fn shorter_string_assign():
+24 │ │         let s: String<18> = "fe"
+   │ ╰────────────────────────────────^ attributes hash: 15148455653558261645
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         params: [],
+         return_type: Ok(
+             Base(
+                 Unit,
+             ),
+         ),
+     }
+
+note: 
+   ┌─ strings.fe:24:16
+   │
+24 │         let s: String<18> = "fe"
+   │                ^^^^^^^^^^ String<18>
+
+note: 
+   ┌─ strings.fe:24:29
+   │
+24 │         let s: String<18> = "fe"
+   │                             ^^^^ String<18>: Memory
+
+note: 
+   ┌─ strings.fe:26:5
+   │  
+26 │ ╭     pub fn return_special_chars() -> String<18>:
+27 │ │         return "\n\"'\r\t
+28 │ │         foo\\"
    │ ╰──────────────^ attributes hash: 14991635520577142188
    │  
    = FunctionSignature {
@@ -150,11 +179,11 @@ note:
      }
 
 note: 
-   ┌─ strings.fe:24:16
+   ┌─ strings.fe:27:16
    │  
-24 │           return "\n\"'\r\t
+27 │           return "\n\"'\r\t
    │ ╭────────────────^
-25 │ │         foo\\"
+28 │ │         foo\\"
    │ ╰──────────────^ String<18>: Memory
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_string.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_string.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: type mismatch
+  ┌─ compile_errors/bad_string.fe:3:28
+  │
+3 │         let s: String<1> = "Fe"
+  │                            ^^^^ this has type `String<2>`; expected type `String<1>`
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_event_with_wrong_types.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_event_with_wrong_types.snap
@@ -6,29 +6,29 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: missing argument label
   ┌─ compile_errors/call_event_with_wrong_types.fe:7:22
   │
-7 │         emit MyEvent("foo", 1000)
+7 │         emit MyEvent("foo bar", 1000)
   │                      ^ add `val_1=` here
   │
   = Note: this label is optional if the argument is a variable named `val_1`.
 
 error: missing argument label
-  ┌─ compile_errors/call_event_with_wrong_types.fe:7:29
+  ┌─ compile_errors/call_event_with_wrong_types.fe:7:33
   │
-7 │         emit MyEvent("foo", 1000)
-  │                             ^ add `val_2=` here
+7 │         emit MyEvent("foo bar", 1000)
+  │                                 ^ add `val_2=` here
   │
   = Note: this label is optional if the argument is a variable named `val_2`.
 
 error: incorrect type for `MyEvent` argument `val_1`
   ┌─ compile_errors/call_event_with_wrong_types.fe:7:22
   │
-7 │         emit MyEvent("foo", 1000)
-  │                      ^^^^^ this has type `String<3>`; expected type `String<100>`
+7 │         emit MyEvent("foo bar", 1000)
+  │                      ^^^^^^^^^ this has type `String<7>`; expected type `String<5>`
 
 error: literal out of range for `u8`
-  ┌─ compile_errors/call_event_with_wrong_types.fe:7:29
+  ┌─ compile_errors/call_event_with_wrong_types.fe:7:33
   │
-7 │         emit MyEvent("foo", 1000)
-  │                             ^^^^ does not fit into type `u8`
+7 │         emit MyEvent("foo bar", 1000)
+  │                                 ^^^^ does not fit into type `u8`
 
 

--- a/crates/test-files/fixtures/compile_errors/bad_string.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_string.fe
@@ -1,0 +1,3 @@
+contract foo:
+    pub fn bar(self):
+        let s: String<1> = "Fe"

--- a/crates/test-files/fixtures/compile_errors/call_event_with_wrong_types.fe
+++ b/crates/test-files/fixtures/compile_errors/call_event_with_wrong_types.fe
@@ -1,7 +1,7 @@
 contract Foo:
     event MyEvent:
-        val_1: String<100>
+        val_1: String<5>
         idx val_2: u8
 
     pub fn foo():
-        emit MyEvent("foo", 1000)
+        emit MyEvent("foo bar", 1000)

--- a/crates/test-files/fixtures/features/strings.fe
+++ b/crates/test-files/fixtures/features/strings.fe
@@ -5,7 +5,7 @@ contract Foo:
         s1: String<42>
         s3: String<100>
         a: address
-        s4: String<13>
+        s4: String<18>
         s5: String<100>
 
     pub fn __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
@@ -19,7 +19,13 @@ contract Foo:
 
     pub fn return_casted_static_string() -> String<100>:
         return String<100>("foo")
+        
+    pub fn shorter_string_assign():
+        let s: String<18> = "fe"
 
     pub fn return_special_chars() -> String<18>:
         return "\n\"'\r\t
         foo\\"
+
+        
+        


### PR DESCRIPTION
### What was wrong?
Semantic analysis for string is too strict.
```python
let s: String<10> = "FOO"
```
should be accepted. 