### PR TITLE
Use colon for arg labels (`transfer(from: a, to: b)`)

### DIFF
--- a/crates/analyzer/src/traversal/call_args.rs
+++ b/crates/analyzer/src/traversal/call_args.rs
@@ -157,7 +157,7 @@ pub fn validate_arg_labels(
                             "missing argument label",
                             vec![Label::primary(
                                 Span::new(arg_val.span.file_id, arg_val.span.start, arg_val.span.start),
-                                format!("add `{}=` here", expected_label),
+                                format!("add `{}:` here", expected_label),
                             )],
                             vec![format!(
                                 "Note: this label is optional if the argument is a variable named `{}`.",

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -572,10 +572,10 @@ note:
    │  
 59 │ ╭     pub fn get_my_struct() -> MyStruct:
 60 │ │         return MyStruct(
-61 │ │             my_num=42,
-62 │ │             my_num2=u8(26),
-63 │ │             my_bool=true,
-64 │ │             my_addr=address(123456)
+61 │ │             my_num: 42,
+62 │ │             my_num2: u8(26),
+63 │ │             my_bool: true,
+64 │ │             my_addr: address(123456)
 65 │ │         )
    │ ╰─────────^ attributes hash: 12792745713144811261
    │  
@@ -596,49 +596,49 @@ note:
      }
 
 note: 
-   ┌─ abi_encoding_stress.fe:61:20
+   ┌─ abi_encoding_stress.fe:61:21
    │
-61 │             my_num=42,
-   │                    ^^ u256: Value
-62 │             my_num2=u8(26),
-   │                        ^^ u8: Value
+61 │             my_num: 42,
+   │                     ^^ u256: Value
+62 │             my_num2: u8(26),
+   │                         ^^ u8: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:62:21
+   ┌─ abi_encoding_stress.fe:62:22
    │
-62 │             my_num2=u8(26),
-   │                     ^^^^^^ u8: Value
-63 │             my_bool=true,
-   │                     ^^^^ bool: Value
-64 │             my_addr=address(123456)
-   │                             ^^^^^^ u256: Value
+62 │             my_num2: u8(26),
+   │                      ^^^^^^ u8: Value
+63 │             my_bool: true,
+   │                      ^^^^ bool: Value
+64 │             my_addr: address(123456)
+   │                              ^^^^^^ u256: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:64:21
+   ┌─ abi_encoding_stress.fe:64:22
    │
-64 │             my_addr=address(123456)
-   │                     ^^^^^^^^^^^^^^^ address: Value
+64 │             my_addr: address(123456)
+   │                      ^^^^^^^^^^^^^^^ address: Value
 
 note: 
    ┌─ abi_encoding_stress.fe:60:16
    │  
 60 │           return MyStruct(
    │ ╭────────────────^
-61 │ │             my_num=42,
-62 │ │             my_num2=u8(26),
-63 │ │             my_bool=true,
-64 │ │             my_addr=address(123456)
+61 │ │             my_num: 42,
+62 │ │             my_num2: u8(26),
+63 │ │             my_bool: true,
+64 │ │             my_addr: address(123456)
 65 │ │         )
    │ ╰─────────^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:62:21
+   ┌─ abi_encoding_stress.fe:62:22
    │
-62 │             my_num2=u8(26),
-   │                     ^^ TypeConstructor(Base(Numeric(U8)))
-63 │             my_bool=true,
-64 │             my_addr=address(123456)
-   │                     ^^^^^^^ TypeConstructor(Base(Address))
+62 │             my_num2: u8(26),
+   │                      ^^ TypeConstructor(Base(Numeric(U8)))
+63 │             my_bool: true,
+64 │             my_addr: address(123456)
+   │                      ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ abi_encoding_stress.fe:60:16
@@ -760,10 +760,10 @@ note:
    │  
 74 │ ╭     pub fn emit_my_event(self):
 75 │ │         emit MyEvent(
-76 │ │             my_addrs=self.my_addrs.to_mem(),
-77 │ │             my_u128=self.my_u128,
+76 │ │             my_addrs: self.my_addrs.to_mem(),
+77 │ │             my_u128: self.my_u128,
    · │
-81 │ │             my_bytes=self.my_bytes.to_mem()
+81 │ │             my_bytes: self.my_bytes.to_mem()
 82 │ │         )
    │ ╰─────────^ attributes hash: 17603814563784536273
    │  
@@ -780,90 +780,90 @@ note:
      }
 
 note: 
-   ┌─ abi_encoding_stress.fe:76:22
+   ┌─ abi_encoding_stress.fe:76:23
    │
-76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^ Foo: Value
-
-note: 
-   ┌─ abi_encoding_stress.fe:76:22
-   │
-76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) }
-
-note: 
-   ┌─ abi_encoding_stress.fe:76:22
-   │
-76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Memory
-77 │             my_u128=self.my_u128,
-   │                     ^^^^ Foo: Value
-
-note: 
-   ┌─ abi_encoding_stress.fe:77:21
-   │
-77 │             my_u128=self.my_u128,
-   │                     ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Value
-78 │             my_string=self.my_string.to_mem(),
+76 │             my_addrs: self.my_addrs.to_mem(),
    │                       ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:78:23
+   ┌─ abi_encoding_stress.fe:76:23
    │
-78 │             my_string=self.my_string.to_mem(),
-   │                       ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) }
+76 │             my_addrs: self.my_addrs.to_mem(),
+   │                       ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:78:23
+   ┌─ abi_encoding_stress.fe:76:23
    │
-78 │             my_string=self.my_string.to_mem(),
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Memory
-79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^ Foo: Value
-
-note: 
-   ┌─ abi_encoding_stress.fe:79:21
-   │
-79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) }
-
-note: 
-   ┌─ abi_encoding_stress.fe:79:21
-   │
-79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Memory
-80 │             my_bool=self.my_bool,
-   │                     ^^^^ Foo: Value
-
-note: 
-   ┌─ abi_encoding_stress.fe:80:21
-   │
-80 │             my_bool=self.my_bool,
-   │                     ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Value
-81 │             my_bytes=self.my_bytes.to_mem()
+76 │             my_addrs: self.my_addrs.to_mem(),
+   │                       ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Memory
+77 │             my_u128: self.my_u128,
    │                      ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:81:22
+   ┌─ abi_encoding_stress.fe:77:22
    │
-81 │             my_bytes=self.my_bytes.to_mem()
-   │                      ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) }
+77 │             my_u128: self.my_u128,
+   │                      ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Value
+78 │             my_string: self.my_string.to_mem(),
+   │                        ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:81:22
+   ┌─ abi_encoding_stress.fe:78:24
    │
-81 │             my_bytes=self.my_bytes.to_mem()
-   │                      ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
+78 │             my_string: self.my_string.to_mem(),
+   │                        ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ abi_encoding_stress.fe:78:24
+   │
+78 │             my_string: self.my_string.to_mem(),
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Memory
+79 │             my_u16s: self.my_u16s.to_mem(),
+   │                      ^^^^ Foo: Value
+
+note: 
+   ┌─ abi_encoding_stress.fe:79:22
+   │
+79 │             my_u16s: self.my_u16s.to_mem(),
+   │                      ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) }
+
+note: 
+   ┌─ abi_encoding_stress.fe:79:22
+   │
+79 │             my_u16s: self.my_u16s.to_mem(),
+   │                      ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Memory
+80 │             my_bool: self.my_bool,
+   │                      ^^^^ Foo: Value
+
+note: 
+   ┌─ abi_encoding_stress.fe:80:22
+   │
+80 │             my_bool: self.my_bool,
+   │                      ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Value
+81 │             my_bytes: self.my_bytes.to_mem()
+   │                       ^^^^ Foo: Value
+
+note: 
+   ┌─ abi_encoding_stress.fe:81:23
+   │
+81 │             my_bytes: self.my_bytes.to_mem()
+   │                       ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) }
+
+note: 
+   ┌─ abi_encoding_stress.fe:81:23
+   │
+81 │             my_bytes: self.my_bytes.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
 
 note: 
    ┌─ abi_encoding_stress.fe:75:9
    │  
 75 │ ╭         emit MyEvent(
-76 │ │             my_addrs=self.my_addrs.to_mem(),
-77 │ │             my_u128=self.my_u128,
-78 │ │             my_string=self.my_string.to_mem(),
+76 │ │             my_addrs: self.my_addrs.to_mem(),
+77 │ │             my_u128: self.my_u128,
+78 │ │             my_string: self.my_string.to_mem(),
    · │
-81 │ │             my_bytes=self.my_bytes.to_mem()
+81 │ │             my_bytes: self.my_bytes.to_mem()
 82 │ │         )
    │ ╰─────────^ attributes hash: 2185685122923697263
    │  
@@ -945,17 +945,17 @@ note:
      }
 
 note: 
-   ┌─ abi_encoding_stress.fe:76:22
+   ┌─ abi_encoding_stress.fe:76:23
    │
-76 │             my_addrs=self.my_addrs.to_mem(),
-   │                      ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 5, inner: Address }) }
-77 │             my_u128=self.my_u128,
-78 │             my_string=self.my_string.to_mem(),
-   │                       ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 10 }) }
-79 │             my_u16s=self.my_u16s.to_mem(),
-   │                     ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 255, inner: Numeric(U16) }) }
-80 │             my_bool=self.my_bool,
-81 │             my_bytes=self.my_bytes.to_mem()
-   │                      ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 100, inner: Numeric(U8) }) }
+76 │             my_addrs: self.my_addrs.to_mem(),
+   │                       ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 5, inner: Address }) }
+77 │             my_u128: self.my_u128,
+78 │             my_string: self.my_string.to_mem(),
+   │                        ^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 10 }) }
+79 │             my_u16s: self.my_u16s.to_mem(),
+   │                      ^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 255, inner: Numeric(U16) }) }
+80 │             my_bool: self.my_bool,
+81 │             my_bytes: self.my_bytes.to_mem()
+   │                       ^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 100, inner: Numeric(U8) }) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -8,8 +8,8 @@ note:
    │  
  9 │ ╭     pub fn get_my_baz() -> Baz:
 10 │ │         assert file_items_work()
-11 │ │         return Baz(my_bool=true, my_u256=26)
-   │ ╰────────────────────────────────────────────^ attributes hash: 12324314335460528585
+11 │ │         return Baz(my_bool: true, my_u256: 26)
+   │ ╰──────────────────────────────────────────────^ attributes hash: 12324314335460528585
    │  
    = FunctionSignature {
          self_decl: None,
@@ -32,31 +32,31 @@ note:
    │
 10 │         assert file_items_work()
    │                ^^^^^^^^^^^^^^^^^ bool: Value
-11 │         return Baz(my_bool=true, my_u256=26)
-   │                            ^^^^          ^^ u256: Value
-   │                            │              
-   │                            bool: Value
+11 │         return Baz(my_bool: true, my_u256: 26)
+   │                             ^^^^           ^^ u256: Value
+   │                             │               
+   │                             bool: Value
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:11:16
    │
-11 │         return Baz(my_bool=true, my_u256=26)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Baz: Memory
+11 │         return Baz(my_bool: true, my_u256: 26)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Baz: Memory
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:10:16
    │
 10 │         assert file_items_work()
    │                ^^^^^^^^^^^^^^^ Pure(FunctionId(0))
-11 │         return Baz(my_bool=true, my_u256=26)
+11 │         return Baz(my_bool: true, my_u256: 26)
    │                ^^^ TypeConstructor(Struct(Struct { name: "Baz", id: StructId(4), field_count: 2 }))
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:13:5
    │  
 13 │ ╭     pub fn get_my_bing() -> Bong:
-14 │ │         return Bong(my_address=address(42))
-   │ ╰───────────────────────────────────────────^ attributes hash: 13981777418891958772
+14 │ │         return Bong(my_address: address(42))
+   │ ╰────────────────────────────────────────────^ attributes hash: 13981777418891958772
    │  
    = FunctionSignature {
          self_decl: None,
@@ -75,33 +75,33 @@ note:
      }
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:14:40
+   ┌─ ingots/basic_ingot/src/main.fe:14:41
    │
-14 │         return Bong(my_address=address(42))
-   │                                        ^^ u256: Value
+14 │         return Bong(my_address: address(42))
+   │                                         ^^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:14:32
+   ┌─ ingots/basic_ingot/src/main.fe:14:33
    │
-14 │         return Bong(my_address=address(42))
-   │                                ^^^^^^^^^^^ address: Value
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:14:16
-   │
-14 │         return Bong(my_address=address(42))
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
-
-note: 
-   ┌─ ingots/basic_ingot/src/main.fe:14:32
-   │
-14 │         return Bong(my_address=address(42))
-   │                                ^^^^^^^ TypeConstructor(Base(Address))
+14 │         return Bong(my_address: address(42))
+   │                                 ^^^^^^^^^^^ address: Value
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:14:16
    │
-14 │         return Bong(my_address=address(42))
+14 │         return Bong(my_address: address(42))
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
+
+note: 
+   ┌─ ingots/basic_ingot/src/main.fe:14:33
+   │
+14 │         return Bong(my_address: address(42))
+   │                                 ^^^^^^^ TypeConstructor(Base(Address))
+
+note: 
+   ┌─ ingots/basic_ingot/src/main.fe:14:16
+   │
+14 │         return Bong(my_address: address(42))
    │                ^^^^ TypeConstructor(Struct(Struct { name: "Bing", id: StructId(3), field_count: 1 }))
 
 note: 
@@ -171,9 +171,9 @@ note:
    │  
 22 │ ╭     pub fn get_my_dyng() -> dong::Dyng:
 23 │ │         return dong::Dyng(
-24 │ │             my_address=address(8),
-25 │ │             my_u256=42,
-26 │ │             my_i8=-1
+24 │ │             my_address: address(8),
+25 │ │             my_u256: 42,
+26 │ │             my_i8: -1
 27 │ │         )
    │ ╰─────────^ attributes hash: 8107142401187261877
    │  
@@ -194,43 +194,43 @@ note:
      }
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:24:32
+   ┌─ ingots/basic_ingot/src/main.fe:24:33
    │
-24 │             my_address=address(8),
-   │                                ^ u256: Value
+24 │             my_address: address(8),
+   │                                 ^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:24:24
+   ┌─ ingots/basic_ingot/src/main.fe:24:25
    │
-24 │             my_address=address(8),
-   │                        ^^^^^^^^^^ address: Value
-25 │             my_u256=42,
-   │                     ^^ u256: Value
-26 │             my_i8=-1
-   │                    ^ u256: Value
+24 │             my_address: address(8),
+   │                         ^^^^^^^^^^ address: Value
+25 │             my_u256: 42,
+   │                      ^^ u256: Value
+26 │             my_i8: -1
+   │                     ^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:26:19
+   ┌─ ingots/basic_ingot/src/main.fe:26:20
    │
-26 │             my_i8=-1
-   │                   ^^ i8: Value
+26 │             my_i8: -1
+   │                    ^^ i8: Value
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:23:16
    │  
 23 │           return dong::Dyng(
    │ ╭────────────────^
-24 │ │             my_address=address(8),
-25 │ │             my_u256=42,
-26 │ │             my_i8=-1
+24 │ │             my_address: address(8),
+25 │ │             my_u256: 42,
+26 │ │             my_i8: -1
 27 │ │         )
    │ ╰─────────^ Dyng: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:24:24
+   ┌─ ingots/basic_ingot/src/main.fe:24:25
    │
-24 │             my_address=address(8),
-   │                        ^^^^^^^ TypeConstructor(Base(Address))
+24 │             my_address: address(8),
+   │                         ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:23:16
@@ -443,8 +443,8 @@ note:
   ┌─ ingots/basic_ingot/src/ding/dong.fe:8:1
   │  
 8 │ ╭ fn get_bing() -> Bing:
-9 │ │     return Bing(my_address=address(0))
-  │ ╰──────────────────────────────────────^ attributes hash: 13981777418891958772
+9 │ │     return Bing(my_address: address(0))
+  │ ╰───────────────────────────────────────^ attributes hash: 13981777418891958772
   │  
   = FunctionSignature {
         self_decl: None,
@@ -463,33 +463,33 @@ note:
     }
 
 note: 
-  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:36
+  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:37
   │
-9 │     return Bing(my_address=address(0))
-  │                                    ^ u256: Value
+9 │     return Bing(my_address: address(0))
+  │                                     ^ u256: Value
 
 note: 
-  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:28
+  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:29
   │
-9 │     return Bing(my_address=address(0))
-  │                            ^^^^^^^^^^ address: Value
-
-note: 
-  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:12
-  │
-9 │     return Bing(my_address=address(0))
-  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
-
-note: 
-  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:28
-  │
-9 │     return Bing(my_address=address(0))
-  │                            ^^^^^^^ TypeConstructor(Base(Address))
+9 │     return Bing(my_address: address(0))
+  │                             ^^^^^^^^^^ address: Value
 
 note: 
   ┌─ ingots/basic_ingot/src/ding/dong.fe:9:12
   │
-9 │     return Bing(my_address=address(0))
+9 │     return Bing(my_address: address(0))
+  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
+
+note: 
+  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:29
+  │
+9 │     return Bing(my_address: address(0))
+  │                             ^^^^^^^ TypeConstructor(Base(Address))
+
+note: 
+  ┌─ ingots/basic_ingot/src/ding/dong.fe:9:12
+  │
+9 │     return Bing(my_address: address(0))
   │            ^^^^ TypeConstructor(Struct(Struct { name: "Bing", id: StructId(3), field_count: 1 }))
 
 

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -809,8 +809,8 @@ note:
    ┌─ data_copying_stress.fe:74:5
    │  
 74 │ ╭     fn emit_my_event_internal(some_string: String<42>, some_u256: u256):
-75 │ │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │ ╰──────────────────────────────────────────────────────────────^ attributes hash: 18022359820804226717
+75 │ │         emit MyEvent(my_string: some_string, my_u256: some_u256)
+   │ ╰────────────────────────────────────────────────────────────────^ attributes hash: 18022359820804226717
    │  
    = FunctionSignature {
          self_decl: None,
@@ -844,18 +844,18 @@ note:
      }
 
 note: 
-   ┌─ data_copying_stress.fe:75:32
+   ┌─ data_copying_stress.fe:75:33
    │
-75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │                                ^^^^^^^^^^^          ^^^^^^^^^ u256: Value
-   │                                │                     
-   │                                String<42>: Memory
+75 │         emit MyEvent(my_string: some_string, my_u256: some_u256)
+   │                                 ^^^^^^^^^^^           ^^^^^^^^^ u256: Value
+   │                                 │                      
+   │                                 String<42>: Memory
 
 note: 
    ┌─ data_copying_stress.fe:75:9
    │
-75 │         emit MyEvent(my_string=some_string, my_u256=some_u256)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 595206297963940250
+75 │         emit MyEvent(my_string: some_string, my_u256: some_u256)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 595206297963940250
    │
    = Event {
          name: "MyEvent",

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -781,8 +781,8 @@ note:
 68 │ │         _before_token_transfer(sender, recipient, value)
 69 │ │         self._balances[sender] = self._balances[sender] - value
 70 │ │         self._balances[recipient] = self._balances[recipient] + value
-71 │ │         emit Transfer(from=sender, to=recipient, value=value)
-   │ ╰─────────────────────────────────────────────────────────────^ attributes hash: 7042698306793056303
+71 │ │         emit Transfer(from: sender, to: recipient, value)
+   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 7042698306793056303
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -949,17 +949,17 @@ note:
    │
 70 │         self._balances[recipient] = self._balances[recipient] + value
    │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-71 │         emit Transfer(from=sender, to=recipient, value=value)
-   │                            ^^^^^^     ^^^^^^^^^        ^^^^^ u256: Value
-   │                            │          │                 
-   │                            │          address: Value
-   │                            address: Value
+71 │         emit Transfer(from: sender, to: recipient, value)
+   │                             ^^^^^^      ^^^^^^^^^  ^^^^^ u256: Value
+   │                             │           │           
+   │                             │           address: Value
+   │                             address: Value
 
 note: 
    ┌─ erc20_token.fe:71:9
    │
-71 │         emit Transfer(from=sender, to=recipient, value=value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+71 │         emit Transfer(from: sender, to: recipient, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
    │
    = Event {
          name: "Transfer",
@@ -1014,8 +1014,8 @@ note:
 75 │ │         _before_token_transfer(address(0), account, value)
 76 │ │         self._total_supply = self._total_supply + value
 77 │ │         self._balances[account] = self._balances[account] + value
-78 │ │         emit Transfer(from=address(0), to=account, value=value)
-   │ ╰───────────────────────────────────────────────────────────────^ attributes hash: 2595623246297064609
+78 │ │         emit Transfer(from: address(0), to: account, value)
+   │ ╰───────────────────────────────────────────────────────────^ attributes hash: 2595623246297064609
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -1148,23 +1148,23 @@ note:
    │
 77 │         self._balances[account] = self._balances[account] + value
    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                                    ^ u256: Value
+78 │         emit Transfer(from: address(0), to: account, value)
+   │                                     ^ u256: Value
 
 note: 
-   ┌─ erc20_token.fe:78:28
+   ┌─ erc20_token.fe:78:29
    │
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                            ^^^^^^^^^^     ^^^^^^^        ^^^^^ u256: Value
-   │                            │              │               
-   │                            │              address: Value
-   │                            address: Value
+78 │         emit Transfer(from: address(0), to: account, value)
+   │                             ^^^^^^^^^^      ^^^^^^^  ^^^^^ u256: Value
+   │                             │               │         
+   │                             │               address: Value
+   │                             address: Value
 
 note: 
    ┌─ erc20_token.fe:78:9
    │
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+78 │         emit Transfer(from: address(0), to: account, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
    │
    = Event {
          name: "Transfer",
@@ -1215,8 +1215,8 @@ note:
 75 │         _before_token_transfer(address(0), account, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
    ·
-78 │         emit Transfer(from=address(0), to=account, value=value)
-   │                            ^^^^^^^ TypeConstructor(Base(Address))
+78 │         emit Transfer(from: address(0), to: account, value)
+   │                             ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ erc20_token.fe:80:5
@@ -1226,8 +1226,8 @@ note:
 82 │ │         _before_token_transfer(account, address(0), value)
 83 │ │         self._balances[account] = self._balances[account] - value
 84 │ │         self._total_supply = self._total_supply - value
-85 │ │         emit Transfer(from=account, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────────────^ attributes hash: 2595623246297064609
+85 │ │         emit Transfer(from: account, to: address(0), value)
+   │ ╰───────────────────────────────────────────────────────────^ attributes hash: 2595623246297064609
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -1361,24 +1361,24 @@ note:
    │
 84 │         self._total_supply = self._total_supply - value
    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                            ^^^^^^^             ^ u256: Value
-   │                            │                    
-   │                            address: Value
+85 │         emit Transfer(from: account, to: address(0), value)
+   │                             ^^^^^^^              ^ u256: Value
+   │                             │                     
+   │                             address: Value
 
 note: 
-   ┌─ erc20_token.fe:85:40
+   ┌─ erc20_token.fe:85:42
    │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                                        ^^^^^^^^^^  ^^^^^ u256: Value
-   │                                        │            
-   │                                        address: Value
+85 │         emit Transfer(from: account, to: address(0), value)
+   │                                          ^^^^^^^^^^  ^^^^^ u256: Value
+   │                                          │            
+   │                                          address: Value
 
 note: 
    ┌─ erc20_token.fe:85:9
    │
-85 │         emit Transfer(from=account, to=address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+85 │         emit Transfer(from: account, to: address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
    │
    = Event {
          name: "Transfer",
@@ -1429,8 +1429,8 @@ note:
 82 │         _before_token_transfer(account, address(0), value)
    │         ^^^^^^^^^^^^^^^^^^^^^^ Pure(FunctionId(17))
    ·
-85 │         emit Transfer(from=account, to=address(0), value)
-   │                                        ^^^^^^^ TypeConstructor(Base(Address))
+85 │         emit Transfer(from: account, to: address(0), value)
+   │                                          ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ erc20_token.fe:87:5

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -41,8 +41,8 @@ note:
    ┌─ events.fe:19:5
    │  
 19 │ ╭     pub fn emit_nums():
-20 │ │         emit Nums(num1=26, num2=42)
-   │ ╰───────────────────────────────────^ attributes hash: 15148455653558261645
+20 │ │         emit Nums(num1: 26, num2: 42)
+   │ ╰─────────────────────────────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
          self_decl: None,
@@ -55,18 +55,18 @@ note:
      }
 
 note: 
-   ┌─ events.fe:20:24
+   ┌─ events.fe:20:25
    │
-20 │         emit Nums(num1=26, num2=42)
-   │                        ^^       ^^ u256: Value
-   │                        │         
-   │                        u256: Value
+20 │         emit Nums(num1: 26, num2: 42)
+   │                         ^^        ^^ u256: Value
+   │                         │          
+   │                         u256: Value
 
 note: 
    ┌─ events.fe:20:9
    │
-20 │         emit Nums(num1=26, num2=42)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4681095448721924839
+20 │         emit Nums(num1: 26, num2: 42)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4681095448721924839
    │
    = Event {
          name: "Nums",
@@ -100,8 +100,8 @@ note:
    ┌─ events.fe:22:5
    │  
 22 │ ╭     pub fn emit_bases(addr: address):
-23 │ │         emit Bases(num=26, addr)
-   │ ╰────────────────────────────────^ attributes hash: 14507092098124791222
+23 │ │         emit Bases(num: 26, addr)
+   │ ╰─────────────────────────────────^ attributes hash: 14507092098124791222
    │  
    = FunctionSignature {
          self_decl: None,
@@ -123,18 +123,18 @@ note:
      }
 
 note: 
-   ┌─ events.fe:23:24
+   ┌─ events.fe:23:25
    │
-23 │         emit Bases(num=26, addr)
-   │                        ^^  ^^^^ address: Value
-   │                        │    
-   │                        u256: Value
+23 │         emit Bases(num: 26, addr)
+   │                         ^^  ^^^^ address: Value
+   │                         │    
+   │                         u256: Value
 
 note: 
    ┌─ events.fe:23:9
    │
-23 │         emit Bases(num=26, addr)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4407350417102602838
+23 │         emit Bases(num: 26, addr)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4407350417102602838
    │
    = Event {
          name: "Bases",
@@ -166,8 +166,8 @@ note:
    ┌─ events.fe:25:5
    │  
 25 │ ╭     pub fn emit_mix(addr: address, my_bytes: Array<u8, 100>):
-26 │ │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │ ╰──────────────────────────────────────────────────^ attributes hash: 11181555056051097974
+26 │ │         emit Mix(num1: 26, addr, num2: 42, my_bytes)
+   │ ╰────────────────────────────────────────────────────^ attributes hash: 11181555056051097974
    │  
    = FunctionSignature {
          self_decl: None,
@@ -202,20 +202,20 @@ note:
      }
 
 note: 
-   ┌─ events.fe:26:23
+   ┌─ events.fe:26:24
    │
-26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │                       ^^  ^^^^       ^^  ^^^^^^^^ Array<u8, 100>: Memory
-   │                       │   │          │    
-   │                       │   │          u256: Value
-   │                       │   address: Value
-   │                       u256: Value
+26 │         emit Mix(num1: 26, addr, num2: 42, my_bytes)
+   │                        ^^  ^^^^        ^^  ^^^^^^^^ Array<u8, 100>: Memory
+   │                        │   │           │    
+   │                        │   │           u256: Value
+   │                        │   address: Value
+   │                        u256: Value
 
 note: 
    ┌─ events.fe:26:9
    │
-26 │         emit Mix(num1=26, addr, num2=42, my_bytes)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12006518826467385253
+26 │         emit Mix(num1: 26, addr, num2: 42, my_bytes)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12006518826467385253
    │
    = Event {
          name: "Mix",

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -23,8 +23,8 @@ note:
 13 │ │         self.messages[msg.sender] = book_msg
 14 │ │ 
 15 │ │         # Emit the `Signed` event
-16 │ │         emit Signed(book_msg=book_msg)
-   │ ╰──────────────────────────────────────^ attributes hash: 13094560277149760495
+16 │ │         emit Signed(book_msg)
+   │ ╰─────────────────────────────^ attributes hash: 13094560277149760495
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -71,14 +71,14 @@ note:
    │         │                            
    │         String<100>: Storage { nonce: None }
    ·
-16 │         emit Signed(book_msg=book_msg)
-   │                              ^^^^^^^^ String<100>: Memory
+16 │         emit Signed(book_msg)
+   │                     ^^^^^^^^ String<100>: Memory
 
 note: 
    ┌─ guest_book.fe:16:9
    │
-16 │         emit Signed(book_msg=book_msg)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3840771212935086148
+16 │         emit Signed(book_msg)
+   │         ^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3840771212935086148
    │
    = Event {
          name: "Signed",

--- a/crates/analyzer/tests/snapshots/analysis__module_level_events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__module_level_events.snap
@@ -17,8 +17,8 @@ note:
   ┌─ module_level_events.fe:6:5
   │  
 6 │ ╭     fn transfer(to : address, value : u256):
-7 │ │         emit Transfer(sender=msg.sender, receiver=to, value)
-  │ ╰────────────────────────────────────────────────────────────^ attributes hash: 5430479256040439660
+7 │ │         emit Transfer(sender: msg.sender, receiver: to, value)
+  │ ╰──────────────────────────────────────────────────────────────^ attributes hash: 5430479256040439660
   │  
   = FunctionSignature {
         self_decl: None,
@@ -50,19 +50,19 @@ note:
     }
 
 note: 
-  ┌─ module_level_events.fe:7:30
+  ┌─ module_level_events.fe:7:31
   │
-7 │         emit Transfer(sender=msg.sender, receiver=to, value)
-  │                              ^^^^^^^^^^           ^^  ^^^^^ u256: Value
-  │                              │                    │    
-  │                              │                    address: Value
-  │                              address: Value
+7 │         emit Transfer(sender: msg.sender, receiver: to, value)
+  │                               ^^^^^^^^^^            ^^  ^^^^^ u256: Value
+  │                               │                     │    
+  │                               │                     address: Value
+  │                               address: Value
 
 note: 
   ┌─ module_level_events.fe:7:9
   │
-7 │         emit Transfer(sender=msg.sender, receiver=to, value)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17986960071624595337
+7 │         emit Transfer(sender: msg.sender, receiver: to, value)
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17986960071624595337
   │
   = Event {
         name: "Transfer",

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -54,8 +54,8 @@ note:
 14 │ ╭   pub fn renounceOwnership(self):
 15 │ │     assert msg.sender == self._owner
 16 │ │     self._owner = address(0)
-17 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │ ╰────────────────────────────────────────────────────────────────────────────^ attributes hash: 17603814563784536273
+17 │ │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
+   │ ╰──────────────────────────────────────────────────────────────────────────────^ attributes hash: 17603814563784536273
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -104,22 +104,22 @@ note:
    │
 16 │     self._owner = address(0)
    │                   ^^^^^^^^^^ address: Value
-17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                             ^^^^^^^^^^                   ^ u256: Value
-   │                                             │                             
-   │                                             address: Value
+17 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
+   │                                              ^^^^^^^^^^                    ^ u256: Value
+   │                                              │                              
+   │                                              address: Value
 
 note: 
-   ┌─ ownable.fe:17:66
+   ┌─ ownable.fe:17:68
    │
-17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                                                  ^^^^^^^^^^ address: Value
+17 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
+   │                                                                    ^^^^^^^^^^ address: Value
 
 note: 
    ┌─ ownable.fe:17:5
    │
-17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
+17 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
    │
    = Event {
          name: "OwnershipTransferred",
@@ -150,8 +150,8 @@ note:
    │
 16 │     self._owner = address(0)
    │                   ^^^^^^^ TypeConstructor(Base(Address))
-17 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
-   │                                                                  ^^^^^^^ TypeConstructor(Base(Address))
+17 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
+   │                                                                    ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ ownable.fe:19:3
@@ -160,8 +160,8 @@ note:
 20 │ │     assert msg.sender == self._owner
 21 │ │     assert newOwner != address(0)
 22 │ │     self._owner = newOwner
-23 │ │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 6773896465733249515
+23 │ │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner)
+   │ ╰──────────────────────────────────────────────────────────────────^ attributes hash: 6773896465733249515
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -229,16 +229,16 @@ note:
    │     ^^^^^^^^^^^   ^^^^^^^^ address: Value
    │     │              
    │     address: Storage { nonce: Some(0) }
-23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │                                             ^^^^^^^^^^  ^^^^^^^^ address: Value
-   │                                             │            
-   │                                             address: Value
+23 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner)
+   │                                              ^^^^^^^^^^  ^^^^^^^^ address: Value
+   │                                              │            
+   │                                              address: Value
 
 note: 
    ┌─ ownable.fe:23:5
    │
-23 │     emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
+23 │     emit OwnershipTransferred(previousOwner: msg.sender, newOwner)
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
    │
    = Event {
          name: "OwnershipTransferred",

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -69,8 +69,8 @@ note:
    ┌─ revert.fe:14:5
    │  
 14 │ ╭     pub fn revert_other_error():
-15 │ │         revert OtherError(msg=1, val=true)
-   │ ╰──────────────────────────────────────────^ attributes hash: 15148455653558261645
+15 │ │         revert OtherError(msg: 1, val: true)
+   │ ╰────────────────────────────────────────────^ attributes hash: 15148455653558261645
    │  
    = FunctionSignature {
          self_decl: None,
@@ -83,30 +83,30 @@ note:
      }
 
 note: 
-   ┌─ revert.fe:15:31
+   ┌─ revert.fe:15:32
    │
-15 │         revert OtherError(msg=1, val=true)
-   │                               ^      ^^^^ bool: Value
-   │                               │       
-   │                               u256: Value
+15 │         revert OtherError(msg: 1, val: true)
+   │                                ^       ^^^^ bool: Value
+   │                                │        
+   │                                u256: Value
 
 note: 
    ┌─ revert.fe:15:16
    │
-15 │         revert OtherError(msg=1, val=true)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
+15 │         revert OtherError(msg: 1, val: true)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
 
 note: 
    ┌─ revert.fe:15:16
    │
-15 │         revert OtherError(msg=1, val=true)
+15 │         revert OtherError(msg: 1, val: true)
    │                ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "OtherError", id: StructId(0), field_count: 2 }))
 
 note: 
    ┌─ revert.fe:17:5
    │  
 17 │ ╭     pub fn revert_other_error_from_sto(self):
-18 │ │         self.my_other_error = OtherError(msg=1, val=true)
+18 │ │         self.my_other_error = OtherError(msg: 1, val: true)
 19 │ │         revert self.my_other_error.to_mem()
    │ ╰───────────────────────────────────────────^ attributes hash: 17603814563784536273
    │  
@@ -125,23 +125,23 @@ note:
 note: 
    ┌─ revert.fe:18:9
    │
-18 │         self.my_other_error = OtherError(msg=1, val=true)
+18 │         self.my_other_error = OtherError(msg: 1, val: true)
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ revert.fe:18:9
    │
-18 │         self.my_other_error = OtherError(msg=1, val=true)
-   │         ^^^^^^^^^^^^^^^^^^^                  ^      ^^^^ bool: Value
-   │         │                                    │       
-   │         │                                    u256: Value
+18 │         self.my_other_error = OtherError(msg: 1, val: true)
+   │         ^^^^^^^^^^^^^^^^^^^                   ^       ^^^^ bool: Value
+   │         │                                     │        
+   │         │                                     u256: Value
    │         OtherError: Storage { nonce: Some(0) }
 
 note: 
    ┌─ revert.fe:18:31
    │
-18 │         self.my_other_error = OtherError(msg=1, val=true)
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
+18 │         self.my_other_error = OtherError(msg: 1, val: true)
+   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
 19 │         revert self.my_other_error.to_mem()
    │                ^^^^ Foo: Value
 
@@ -160,7 +160,7 @@ note:
 note: 
    ┌─ revert.fe:18:31
    │
-18 │         self.my_other_error = OtherError(msg=1, val=true)
+18 │         self.my_other_error = OtherError(msg: 1, val: true)
    │                               ^^^^^^^^^^ TypeConstructor(Struct(Struct { name: "OtherError", id: StructId(0), field_count: 2 }))
 19 │         revert self.my_other_error.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Struct(Struct { name: "OtherError", id: StructId(0), field_count: 2 }) }

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -289,9 +289,9 @@ note:
    │  
 29 │ ╭     pub fn emit_event(self):
 30 │ │         emit MyEvent(
-31 │ │             num=self.num,
-32 │ │             nums=self.nums.to_mem(),
-33 │ │             str=self.str.to_mem()
+31 │ │             num: self.num,
+32 │ │             nums: self.nums.to_mem(),
+33 │ │             str: self.str.to_mem()
 34 │ │         )
    │ ╰─────────^ attributes hash: 17603814563784536273
    │  
@@ -308,52 +308,52 @@ note:
      }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:31:17
+   ┌─ sized_vals_in_sto.fe:31:18
    │
-31 │             num=self.num,
-   │                 ^^^^ Foo: Value
-
-note: 
-   ┌─ sized_vals_in_sto.fe:31:17
-   │
-31 │             num=self.num,
-   │                 ^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
-32 │             nums=self.nums.to_mem(),
+31 │             num: self.num,
    │                  ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:32:18
+   ┌─ sized_vals_in_sto.fe:31:18
    │
-32 │             nums=self.nums.to_mem(),
-   │                  ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) }
+31 │             num: self.num,
+   │                  ^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
+32 │             nums: self.nums.to_mem(),
+   │                   ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:32:18
+   ┌─ sized_vals_in_sto.fe:32:19
    │
-32 │             nums=self.nums.to_mem(),
-   │                  ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Memory
-33 │             str=self.str.to_mem()
-   │                 ^^^^ Foo: Value
+32 │             nums: self.nums.to_mem(),
+   │                   ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:33:17
+   ┌─ sized_vals_in_sto.fe:32:19
    │
-33 │             str=self.str.to_mem()
-   │                 ^^^^^^^^ String<26>: Storage { nonce: Some(2) }
+32 │             nums: self.nums.to_mem(),
+   │                   ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Memory
+33 │             str: self.str.to_mem()
+   │                  ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:33:17
+   ┌─ sized_vals_in_sto.fe:33:18
    │
-33 │             str=self.str.to_mem()
-   │                 ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
+33 │             str: self.str.to_mem()
+   │                  ^^^^^^^^ String<26>: Storage { nonce: Some(2) }
+
+note: 
+   ┌─ sized_vals_in_sto.fe:33:18
+   │
+33 │             str: self.str.to_mem()
+   │                  ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
 
 note: 
    ┌─ sized_vals_in_sto.fe:30:9
    │  
 30 │ ╭         emit MyEvent(
-31 │ │             num=self.num,
-32 │ │             nums=self.nums.to_mem(),
-33 │ │             str=self.str.to_mem()
+31 │ │             num: self.num,
+32 │ │             nums: self.nums.to_mem(),
+33 │ │             str: self.str.to_mem()
 34 │ │         )
    │ ╰─────────^ attributes hash: 9998967556022527347
    │  
@@ -400,11 +400,11 @@ note:
      }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:32:18
+   ┌─ sized_vals_in_sto.fe:32:19
    │
-32 │             nums=self.nums.to_mem(),
-   │                  ^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 42, inner: Numeric(U256) }) }
-33 │             str=self.str.to_mem()
-   │                 ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 26 }) }
+32 │             nums: self.nums.to_mem(),
+   │                   ^^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: Array(Array { size: 42, inner: Numeric(U256) }) }
+33 │             str: self.str.to_mem()
+   │                  ^^^^^^^^^^^^^^^ BuiltinValueMethod { method: ToMem, typ: String(FeString { max_size: 26 }) }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -79,8 +79,8 @@ note:
   ┌─ struct_fns.fe:8:3
   │  
 8 │ ╭   pub fn origin() -> Point:
-9 │ │     return Point(x=0, y=0)
-  │ ╰──────────────────────────^ attributes hash: 1766050550231886475
+9 │ │     return Point(x: 0, y: 0)
+  │ ╰────────────────────────────^ attributes hash: 1766050550231886475
   │  
   = FunctionSignature {
         self_decl: None,
@@ -99,23 +99,23 @@ note:
     }
 
 note: 
-  ┌─ struct_fns.fe:9:20
+  ┌─ struct_fns.fe:9:21
   │
-9 │     return Point(x=0, y=0)
-  │                    ^    ^ u64: Value
-  │                    │     
-  │                    u64: Value
+9 │     return Point(x: 0, y: 0)
+  │                     ^     ^ u64: Value
+  │                     │      
+  │                     u64: Value
 
 note: 
   ┌─ struct_fns.fe:9:12
   │
-9 │     return Point(x=0, y=0)
-  │            ^^^^^^^^^^^^^^^ Point: Memory
+9 │     return Point(x: 0, y: 0)
+  │            ^^^^^^^^^^^^^^^^^ Point: Memory
 
 note: 
   ┌─ struct_fns.fe:9:12
   │
-9 │     return Point(x=0, y=0)
+9 │     return Point(x: 0, y: 0)
   │            ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 
 note: 
@@ -494,7 +494,7 @@ note:
 37 │   let p1: Point = Point.origin()
    │           ^^^^^ Point
    ·
-40 │   let p2: Point = Point(x=1, y=2)
+40 │   let p2: Point = Point(x: 1, y: 2)
    │           ^^^^^ Point
 41 │   let p3: Point = p1.add(p2)
    │           ^^^^^ Point
@@ -516,16 +516,16 @@ note:
 38 │   p1.translate(5, 10)
    │   ^^^^^^^^^^^^^^^^^^^ (): Value
 39 │ 
-40 │   let p2: Point = Point(x=1, y=2)
-   │                           ^    ^ u64: Value
-   │                           │     
-   │                           u64: Value
+40 │   let p2: Point = Point(x: 1, y: 2)
+   │                            ^     ^ u64: Value
+   │                            │      
+   │                            u64: Value
 
 note: 
    ┌─ struct_fns.fe:40:19
    │
-40 │   let p2: Point = Point(x=1, y=2)
-   │                   ^^^^^^^^^^^^^^^ Point: Memory
+40 │   let p2: Point = Point(x: 1, y: 2)
+   │                   ^^^^^^^^^^^^^^^^^ Point: Memory
 41 │   let p3: Point = p1.add(p2)
    │                   ^^     ^^ Point: Memory
    │                   │       
@@ -584,7 +584,7 @@ note:
 38 │   p1.translate(5, 10)
    │   ^^^^^^^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(6) }
 39 │ 
-40 │   let p2: Point = Point(x=1, y=2)
+40 │   let p2: Point = Point(x: 1, y: 2)
    │                   ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 41 │   let p3: Point = p1.add(p2)
    │                   ^^^^^^ ValueMethod { is_self: false, class: Struct(StructId(0)), method: FunctionId(7) }

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -35,8 +35,8 @@ note:
    ┌─ structs.fe:15:5
    │  
 15 │ ╭     pub fn new(val: u256) -> Mixed:
-16 │ │         return Mixed(foo=val, bar=false)
-   │ ╰────────────────────────────────────────^ attributes hash: 14840391711119122636
+16 │ │         return Mixed(foo: val, bar: false)
+   │ ╰──────────────────────────────────────────^ attributes hash: 14840391711119122636
    │  
    = FunctionSignature {
          self_decl: None,
@@ -66,23 +66,23 @@ note:
      }
 
 note: 
-   ┌─ structs.fe:16:26
+   ┌─ structs.fe:16:27
    │
-16 │         return Mixed(foo=val, bar=false)
-   │                          ^^^      ^^^^^ bool: Value
-   │                          │         
-   │                          u256: Value
+16 │         return Mixed(foo: val, bar: false)
+   │                           ^^^       ^^^^^ bool: Value
+   │                           │          
+   │                           u256: Value
 
 note: 
    ┌─ structs.fe:16:16
    │
-16 │         return Mixed(foo=val, bar=false)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ Mixed: Memory
+16 │         return Mixed(foo: val, bar: false)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Mixed: Memory
 
 note: 
    ┌─ structs.fe:16:16
    │
-16 │         return Mixed(foo=val, bar=false)
+16 │         return Mixed(foo: val, bar: false)
    │                ^^^^^ TypeConstructor(Struct(Struct { name: "Mixed", id: StructId(2), field_count: 2 }))
 
 note: 
@@ -294,8 +294,8 @@ note:
    │  
 41 │ ╭     pub fn complex_struct_in_storage(self) -> String<3>:
 42 │ │         self.my_bar = Bar(
-43 │ │             name="foo",
-44 │ │             numbers=[1, 2],
+43 │ │             name: "foo",
+44 │ │             numbers: [1, 2],
    · │
 86 │ │ 
 87 │ │         return self.my_bar.name.to_mem()
@@ -326,48 +326,48 @@ note:
    │
 42 │         self.my_bar = Bar(
    │         ^^^^^^^^^^^ Bar: Storage { nonce: Some(1) }
-43 │             name="foo",
-   │                  ^^^^^ String<3>: Memory
-44 │             numbers=[1, 2],
-   │                      ^  ^ u256: Value
-   │                      │   
-   │                      u256: Value
+43 │             name: "foo",
+   │                   ^^^^^ String<3>: Memory
+44 │             numbers: [1, 2],
+   │                       ^  ^ u256: Value
+   │                       │   
+   │                       u256: Value
 
 note: 
-   ┌─ structs.fe:44:21
+   ┌─ structs.fe:44:22
    │
-44 │             numbers=[1, 2],
-   │                     ^^^^^^ Array<u256, 2>: Memory
-45 │             point=Point(x=100, y=200),
-   │                           ^^^    ^^^ u256: Value
-   │                           │       
-   │                           u256: Value
+44 │             numbers: [1, 2],
+   │                      ^^^^^^ Array<u256, 2>: Memory
+45 │             point: Point(x: 100, y: 200),
+   │                             ^^^     ^^^ u256: Value
+   │                             │        
+   │                             u256: Value
 
 note: 
-   ┌─ structs.fe:45:19
+   ┌─ structs.fe:45:20
    │
-45 │             point=Point(x=100, y=200),
-   │                   ^^^^^^^^^^^^^^^^^^^ Point: Memory
-46 │             something=(1, true),
-   │                        ^  ^^^^ bool: Value
-   │                        │   
-   │                        u256: Value
+45 │             point: Point(x: 100, y: 200),
+   │                    ^^^^^^^^^^^^^^^^^^^^^ Point: Memory
+46 │             something: (1, true),
+   │                         ^  ^^^^ bool: Value
+   │                         │   
+   │                         u256: Value
 
 note: 
-   ┌─ structs.fe:46:23
+   ┌─ structs.fe:46:24
    │
-46 │             something=(1, true),
-   │                       ^^^^^^^^^ (u256, bool): Memory
+46 │             something: (1, true),
+   │                        ^^^^^^^^^ (u256, bool): Memory
 
 note: 
    ┌─ structs.fe:42:23
    │  
 42 │           self.my_bar = Bar(
    │ ╭───────────────────────^
-43 │ │             name="foo",
-44 │ │             numbers=[1, 2],
-45 │ │             point=Point(x=100, y=200),
-46 │ │             something=(1, true),
+43 │ │             name: "foo",
+44 │ │             numbers: [1, 2],
+45 │ │             point: Point(x: 100, y: 200),
+46 │ │             something: (1, true),
 47 │ │         )
    │ ╰─────────^ Bar: Memory
    · │
@@ -830,29 +830,29 @@ note:
 71 │         assert self.my_bar.point.y == 2000
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 72 │         # We can set the point itself
-73 │         self.my_bar.point = Point(x=100, y=200)
+73 │         self.my_bar.point = Point(x: 100, y: 200)
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ structs.fe:73:9
    │
-73 │         self.my_bar.point = Point(x=100, y=200)
+73 │         self.my_bar.point = Point(x: 100, y: 200)
    │         ^^^^^^^^^^^ Bar: Storage { nonce: Some(1) }
 
 note: 
    ┌─ structs.fe:73:9
    │
-73 │         self.my_bar.point = Point(x=100, y=200)
-   │         ^^^^^^^^^^^^^^^^^           ^^^    ^^^ u256: Value
-   │         │                           │       
-   │         │                           u256: Value
+73 │         self.my_bar.point = Point(x: 100, y: 200)
+   │         ^^^^^^^^^^^^^^^^^            ^^^     ^^^ u256: Value
+   │         │                            │        
+   │         │                            u256: Value
    │         Point: Storage { nonce: Some(1) }
 
 note: 
    ┌─ structs.fe:73:29
    │
-73 │         self.my_bar.point = Point(x=100, y=200)
-   │                             ^^^^^^^^^^^^^^^^^^^ Point: Memory
+73 │         self.my_bar.point = Point(x: 100, y: 200)
+   │                             ^^^^^^^^^^^^^^^^^^^^^ Point: Memory
 74 │         assert self.my_bar.point.x == 100
    │                ^^^^ Foo: Value
 
@@ -1103,10 +1103,10 @@ note:
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^ String<3>: Storage { nonce: Some(1) } => Memory
 
 note: 
-   ┌─ structs.fe:45:19
+   ┌─ structs.fe:45:20
    │
-45 │             point=Point(x=100, y=200),
-   │                   ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+45 │             point: Point(x: 100, y: 200),
+   │                    ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 
 note: 
    ┌─ structs.fe:42:23
@@ -1114,7 +1114,7 @@ note:
 42 │         self.my_bar = Bar(
    │                       ^^^ TypeConstructor(Struct(Struct { name: "Bar", id: StructId(1), field_count: 4 }))
    ·
-73 │         self.my_bar.point = Point(x=100, y=200)
+73 │         self.my_bar.point = Point(x: 100, y: 200)
    │                             ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
    ·
 87 │         return self.my_bar.name.to_mem()
@@ -1125,8 +1125,8 @@ note:
     │  
  89 │ ╭     pub fn complex_struct_in_memory(self) -> String<3>:
  90 │ │         let val: Bar = Bar(
- 91 │ │             name="foo",
- 92 │ │             numbers=[1, 2],
+ 91 │ │             name: "foo",
+ 92 │ │             numbers: [1, 2],
     · │
 134 │ │ 
 135 │ │         return val.name
@@ -1153,50 +1153,50 @@ note:
    │                  ^^^ Bar
 
 note: 
-   ┌─ structs.fe:91:18
+   ┌─ structs.fe:91:19
    │
-91 │             name="foo",
-   │                  ^^^^^ String<3>: Memory
-92 │             numbers=[1, 2],
-   │                      ^  ^ u256: Value
-   │                      │   
-   │                      u256: Value
+91 │             name: "foo",
+   │                   ^^^^^ String<3>: Memory
+92 │             numbers: [1, 2],
+   │                       ^  ^ u256: Value
+   │                       │   
+   │                       u256: Value
 
 note: 
-   ┌─ structs.fe:92:21
+   ┌─ structs.fe:92:22
    │
-92 │             numbers=[1, 2],
-   │                     ^^^^^^ Array<u256, 2>: Memory
-93 │             point=Point(x=100, y=200),
-   │                           ^^^    ^^^ u256: Value
-   │                           │       
-   │                           u256: Value
+92 │             numbers: [1, 2],
+   │                      ^^^^^^ Array<u256, 2>: Memory
+93 │             point: Point(x: 100, y: 200),
+   │                             ^^^     ^^^ u256: Value
+   │                             │        
+   │                             u256: Value
 
 note: 
-   ┌─ structs.fe:93:19
+   ┌─ structs.fe:93:20
    │
-93 │             point=Point(x=100, y=200),
-   │                   ^^^^^^^^^^^^^^^^^^^ Point: Memory
-94 │             something=(1, true),
-   │                        ^  ^^^^ bool: Value
-   │                        │   
-   │                        u256: Value
+93 │             point: Point(x: 100, y: 200),
+   │                    ^^^^^^^^^^^^^^^^^^^^^ Point: Memory
+94 │             something: (1, true),
+   │                         ^  ^^^^ bool: Value
+   │                         │   
+   │                         u256: Value
 
 note: 
-   ┌─ structs.fe:94:23
+   ┌─ structs.fe:94:24
    │
-94 │             something=(1, true),
-   │                       ^^^^^^^^^ (u256, bool): Memory
+94 │             something: (1, true),
+   │                        ^^^^^^^^^ (u256, bool): Memory
 
 note: 
    ┌─ structs.fe:90:24
    │  
 90 │           let val: Bar = Bar(
    │ ╭────────────────────────^
-91 │ │             name="foo",
-92 │ │             numbers=[1, 2],
-93 │ │             point=Point(x=100, y=200),
-94 │ │             something=(1, true),
+91 │ │             name: "foo",
+92 │ │             numbers: [1, 2],
+93 │ │             point: Point(x: 100, y: 200),
+94 │ │             something: (1, true),
 95 │ │         )
    │ ╰─────────^ Bar: Memory
    · │
@@ -1557,23 +1557,23 @@ note:
 119 │         assert val.point.y == 2000
     │                ^^^^^^^^^^^^^^^^^^^ bool: Value
 120 │         # We can set the point itself
-121 │         val.point = Point(x=100, y=200)
+121 │         val.point = Point(x: 100, y: 200)
     │         ^^^ Bar: Memory
 
 note: 
     ┌─ structs.fe:121:9
     │
-121 │         val.point = Point(x=100, y=200)
-    │         ^^^^^^^^^           ^^^    ^^^ u256: Value
-    │         │                   │       
-    │         │                   u256: Value
+121 │         val.point = Point(x: 100, y: 200)
+    │         ^^^^^^^^^            ^^^     ^^^ u256: Value
+    │         │                    │        
+    │         │                    u256: Value
     │         Point: Memory
 
 note: 
     ┌─ structs.fe:121:21
     │
-121 │         val.point = Point(x=100, y=200)
-    │                     ^^^^^^^^^^^^^^^^^^^ Point: Memory
+121 │         val.point = Point(x: 100, y: 200)
+    │                     ^^^^^^^^^^^^^^^^^^^^^ Point: Memory
 122 │         assert val.point.x == 100
     │                ^^^ Bar: Memory
 
@@ -1758,10 +1758,10 @@ note:
     │                ^^^^^^^^ String<3>: Memory
 
 note: 
-   ┌─ structs.fe:93:19
+   ┌─ structs.fe:93:20
    │
-93 │             point=Point(x=100, y=200),
-   │                   ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
+93 │             point: Point(x: 100, y: 200),
+   │                    ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 
 note: 
     ┌─ structs.fe:90:24
@@ -1769,7 +1769,7 @@ note:
  90 │         let val: Bar = Bar(
     │                        ^^^ TypeConstructor(Struct(Struct { name: "Bar", id: StructId(1), field_count: 4 }))
     ·
-121 │         val.point = Point(x=100, y=200)
+121 │         val.point = Point(x: 100, y: 200)
     │                     ^^^^^ TypeConstructor(Struct(Struct { name: "Point", id: StructId(0), field_count: 2 }))
 
 note: 
@@ -1928,8 +1928,8 @@ note:
     │  
 147 │ ╭     pub fn create_house(self):
 148 │ │         self.my_house = House(
-149 │ │             price=1,
-150 │ │             size=2,
+149 │ │             price: 1,
+150 │ │             size: 2,
     · │
 178 │ │         assert self.my_house.rooms == u8(100)
 179 │ │         assert self.my_house.vacant
@@ -1958,30 +1958,30 @@ note:
     │
 148 │         self.my_house = House(
     │         ^^^^^^^^^^^^^ House: Storage { nonce: Some(0) }
-149 │             price=1,
+149 │             price: 1,
+    │                    ^ u256: Value
+150 │             size: 2,
     │                   ^ u256: Value
-150 │             size=2,
-    │                  ^ u256: Value
-151 │             rooms=u8(5),
-    │                      ^ u8: Value
+151 │             rooms: u8(5),
+    │                       ^ u8: Value
 
 note: 
-    ┌─ structs.fe:151:19
+    ┌─ structs.fe:151:20
     │
-151 │             rooms=u8(5),
-    │                   ^^^^^ u8: Value
-152 │             vacant=false,
-    │                    ^^^^^ bool: Value
+151 │             rooms: u8(5),
+    │                    ^^^^^ u8: Value
+152 │             vacant: false,
+    │                     ^^^^^ bool: Value
 
 note: 
     ┌─ structs.fe:148:25
     │  
 148 │           self.my_house = House(
     │ ╭─────────────────────────^
-149 │ │             price=1,
-150 │ │             size=2,
-151 │ │             rooms=u8(5),
-152 │ │             vacant=false,
+149 │ │             price: 1,
+150 │ │             size: 2,
+151 │ │             rooms: u8(5),
+152 │ │             vacant: false,
 153 │ │         )
     │ ╰─────────^ House: Memory
 154 │           assert self.my_house.price == 1
@@ -2512,10 +2512,10 @@ note:
     │                ^^^^^^^^^^^^^^^^^^^^ bool: Storage { nonce: Some(0) } => Value
 
 note: 
-    ┌─ structs.fe:151:19
+    ┌─ structs.fe:151:20
     │
-151 │             rooms=u8(5),
-    │                   ^^ TypeConstructor(Base(Numeric(U8)))
+151 │             rooms: u8(5),
+    │                    ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
     ┌─ structs.fe:148:25
@@ -2546,8 +2546,8 @@ note:
     │  
 181 │ ╭     pub fn bar() -> u256:
 182 │ │         let building: House = House(
-183 │ │             price=300,
-184 │ │             size=500,
+183 │ │             price: 300,
+184 │ │             size: 500,
     · │
 206 │ │ 
 207 │ │         return building.size
@@ -2572,32 +2572,32 @@ note:
     │                       ^^^^^ House
 
 note: 
-    ┌─ structs.fe:183:19
+    ┌─ structs.fe:183:20
     │
-183 │             price=300,
+183 │             price: 300,
+    │                    ^^^ u256: Value
+184 │             size: 500,
     │                   ^^^ u256: Value
-184 │             size=500,
-    │                  ^^^ u256: Value
-185 │             rooms=u8(20),
-    │                      ^^ u8: Value
+185 │             rooms: u8(20),
+    │                       ^^ u8: Value
 
 note: 
-    ┌─ structs.fe:185:19
+    ┌─ structs.fe:185:20
     │
-185 │             rooms=u8(20),
-    │                   ^^^^^^ u8: Value
-186 │             vacant=true,
-    │                    ^^^^ bool: Value
+185 │             rooms: u8(20),
+    │                    ^^^^^^ u8: Value
+186 │             vacant: true,
+    │                     ^^^^ bool: Value
 
 note: 
     ┌─ structs.fe:182:31
     │  
 182 │           let building: House = House(
     │ ╭───────────────────────────────^
-183 │ │             price=300,
-184 │ │             size=500,
-185 │ │             rooms=u8(20),
-186 │ │             vacant=true,
+183 │ │             price: 300,
+184 │ │             size: 500,
+185 │ │             rooms: u8(20),
+186 │ │             vacant: true,
 187 │ │         )
     │ ╰─────────^ House: Memory
 188 │           assert building.size == 500
@@ -2832,10 +2832,10 @@ note:
     │                ^^^^^^^^^^^^^ u256: Memory => Value
 
 note: 
-    ┌─ structs.fe:185:19
+    ┌─ structs.fe:185:20
     │
-185 │             rooms=u8(20),
-    │                   ^^ TypeConstructor(Base(Numeric(U8)))
+185 │             rooms: u8(20),
+    │                    ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
     ┌─ structs.fe:182:31
@@ -2860,8 +2860,8 @@ note:
     │  
 209 │ ╭     pub fn encode_house() -> Array<u8, 128>:
 210 │ │         let house: House = House(
-211 │ │             price=300,
-212 │ │             size=500,
+211 │ │             price: 300,
+212 │ │             size: 500,
     · │
 215 │ │         )
 216 │ │         return house.encode()
@@ -2889,32 +2889,32 @@ note:
     │                    ^^^^^ House
 
 note: 
-    ┌─ structs.fe:211:19
+    ┌─ structs.fe:211:20
     │
-211 │             price=300,
+211 │             price: 300,
+    │                    ^^^ u256: Value
+212 │             size: 500,
     │                   ^^^ u256: Value
-212 │             size=500,
-    │                  ^^^ u256: Value
-213 │             rooms=u8(20),
-    │                      ^^ u8: Value
+213 │             rooms: u8(20),
+    │                       ^^ u8: Value
 
 note: 
-    ┌─ structs.fe:213:19
+    ┌─ structs.fe:213:20
     │
-213 │             rooms=u8(20),
-    │                   ^^^^^^ u8: Value
-214 │             vacant=true,
-    │                    ^^^^ bool: Value
+213 │             rooms: u8(20),
+    │                    ^^^^^^ u8: Value
+214 │             vacant: true,
+    │                     ^^^^ bool: Value
 
 note: 
     ┌─ structs.fe:210:28
     │  
 210 │           let house: House = House(
     │ ╭────────────────────────────^
-211 │ │             price=300,
-212 │ │             size=500,
-213 │ │             rooms=u8(20),
-214 │ │             vacant=true,
+211 │ │             price: 300,
+212 │ │             size: 500,
+213 │ │             rooms: u8(20),
+214 │ │             vacant: true,
 215 │ │         )
     │ ╰─────────^ House: Memory
 216 │           return house.encode()
@@ -2927,10 +2927,10 @@ note:
     │                ^^^^^^^^^^^^^^ Array<u8, 128>: Memory
 
 note: 
-    ┌─ structs.fe:213:19
+    ┌─ structs.fe:213:20
     │
-213 │             rooms=u8(20),
-    │                   ^^ TypeConstructor(Base(Numeric(U8)))
+213 │             rooms: u8(20),
+    │                    ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
     ┌─ structs.fe:210:28
@@ -2946,8 +2946,8 @@ note:
     │  
 218 │ ╭     pub fn hashed_house() -> u256:
 219 │ │         let house: House = House(
-220 │ │             price=300,
-221 │ │             size=500,
+220 │ │             price: 300,
+221 │ │             size: 500,
     · │
 224 │ │         )
 225 │ │         return house.hash()
@@ -2972,32 +2972,32 @@ note:
     │                    ^^^^^ House
 
 note: 
-    ┌─ structs.fe:220:19
+    ┌─ structs.fe:220:20
     │
-220 │             price=300,
+220 │             price: 300,
+    │                    ^^^ u256: Value
+221 │             size: 500,
     │                   ^^^ u256: Value
-221 │             size=500,
-    │                  ^^^ u256: Value
-222 │             rooms=u8(20),
-    │                      ^^ u8: Value
+222 │             rooms: u8(20),
+    │                       ^^ u8: Value
 
 note: 
-    ┌─ structs.fe:222:19
+    ┌─ structs.fe:222:20
     │
-222 │             rooms=u8(20),
-    │                   ^^^^^^ u8: Value
-223 │             vacant=true,
-    │                    ^^^^ bool: Value
+222 │             rooms: u8(20),
+    │                    ^^^^^^ u8: Value
+223 │             vacant: true,
+    │                     ^^^^ bool: Value
 
 note: 
     ┌─ structs.fe:219:28
     │  
 219 │           let house: House = House(
     │ ╭────────────────────────────^
-220 │ │             price=300,
-221 │ │             size=500,
-222 │ │             rooms=u8(20),
-223 │ │             vacant=true,
+220 │ │             price: 300,
+221 │ │             size: 500,
+222 │ │             rooms: u8(20),
+223 │ │             vacant: true,
 224 │ │         )
     │ ╰─────────^ House: Memory
 225 │           return house.hash()
@@ -3010,10 +3010,10 @@ note:
     │                ^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ structs.fe:222:19
+    ┌─ structs.fe:222:20
     │
-222 │             rooms=u8(20),
-    │                   ^^ TypeConstructor(Base(Numeric(U8)))
+222 │             rooms: u8(20),
+    │                    ^^ TypeConstructor(Base(Numeric(U8)))
 
 note: 
     ┌─ structs.fe:219:28

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -278,8 +278,8 @@ note:
 75 │ ╭     fn _mint(self, to: address, value: u256):
 76 │ │         self.total_supply = self.total_supply + value
 77 │ │         self.balances[to] = self.balances[to] + value
-78 │ │         emit Transfer(from=address(0), to, value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 12612842918375381504
+78 │ │         emit Transfer(from: address(0), to, value)
+   │ ╰──────────────────────────────────────────────────^ attributes hash: 12612842918375381504
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -379,23 +379,23 @@ note:
    │
 77 │         self.balances[to] = self.balances[to] + value
    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-78 │         emit Transfer(from=address(0), to, value)
-   │                                    ^ u256: Value
+78 │         emit Transfer(from: address(0), to, value)
+   │                                     ^ u256: Value
 
 note: 
-   ┌─ uniswap.fe:78:28
+   ┌─ uniswap.fe:78:29
    │
-78 │         emit Transfer(from=address(0), to, value)
-   │                            ^^^^^^^^^^  ^^  ^^^^^ u256: Value
-   │                            │           │    
-   │                            │           address: Value
-   │                            address: Value
+78 │         emit Transfer(from: address(0), to, value)
+   │                             ^^^^^^^^^^  ^^  ^^^^^ u256: Value
+   │                             │           │    
+   │                             │           address: Value
+   │                             address: Value
 
 note: 
    ┌─ uniswap.fe:78:9
    │
-78 │         emit Transfer(from=address(0), to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+78 │         emit Transfer(from: address(0), to, value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
    │
    = Event {
          name: "Transfer",
@@ -433,10 +433,10 @@ note:
      }
 
 note: 
-   ┌─ uniswap.fe:78:28
+   ┌─ uniswap.fe:78:29
    │
-78 │         emit Transfer(from=address(0), to, value)
-   │                            ^^^^^^^ TypeConstructor(Base(Address))
+78 │         emit Transfer(from: address(0), to, value)
+   │                             ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ uniswap.fe:80:5
@@ -444,8 +444,8 @@ note:
 80 │ ╭     fn _burn(self, from: address, value: u256):
 81 │ │         self.balances[from] = self.balances[from] - value
 82 │ │         self.total_supply = self.total_supply - value
-83 │ │         emit Transfer(from, to=address(0), value)
-   │ ╰─────────────────────────────────────────────────^ attributes hash: 1338340295882506748
+83 │ │         emit Transfer(from, to: address(0), value)
+   │ ╰──────────────────────────────────────────────────^ attributes hash: 1338340295882506748
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -545,24 +545,24 @@ note:
    │
 82 │         self.total_supply = self.total_supply - value
    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-83 │         emit Transfer(from, to=address(0), value)
-   │                       ^^^^             ^ u256: Value
-   │                       │                 
+83 │         emit Transfer(from, to: address(0), value)
+   │                       ^^^^              ^ u256: Value
+   │                       │                  
    │                       address: Value
 
 note: 
-   ┌─ uniswap.fe:83:32
+   ┌─ uniswap.fe:83:33
    │
-83 │         emit Transfer(from, to=address(0), value)
-   │                                ^^^^^^^^^^  ^^^^^ u256: Value
-   │                                │            
-   │                                address: Value
+83 │         emit Transfer(from, to: address(0), value)
+   │                                 ^^^^^^^^^^  ^^^^^ u256: Value
+   │                                 │            
+   │                                 address: Value
 
 note: 
    ┌─ uniswap.fe:83:9
    │
-83 │         emit Transfer(from, to=address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
+83 │         emit Transfer(from, to: address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
    │
    = Event {
          name: "Transfer",
@@ -600,10 +600,10 @@ note:
      }
 
 note: 
-   ┌─ uniswap.fe:83:32
+   ┌─ uniswap.fe:83:33
    │
-83 │         emit Transfer(from, to=address(0), value)
-   │                                ^^^^^^^ TypeConstructor(Base(Address))
+83 │         emit Transfer(from, to: address(0), value)
+   │                                 ^^^^^^^ TypeConstructor(Base(Address))
 
 note: 
    ┌─ uniswap.fe:85:5
@@ -1405,8 +1405,8 @@ note:
 125 │ │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
     · │
 134 │ │         self.block_timestamp_last = block_timestamp
-135 │ │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │ ╰─────────────────────────────────────────────────────────────────^ attributes hash: 15880403329314631128
+135 │ │         emit Sync(reserve0: self.reserve0, reserve1: self.reserve1)
+    │ ╰───────────────────────────────────────────────────────────────────^ attributes hash: 15880403329314631128
     │  
     = FunctionSignature {
           self_decl: Some(
@@ -1657,28 +1657,28 @@ note:
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value
     │         │                            
     │         u256: Storage { nonce: Some(9) }
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │                            ^^^^ UniswapV2Pair: Value
+135 │         emit Sync(reserve0: self.reserve0, reserve1: self.reserve1)
+    │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:135:28
+    ┌─ uniswap.fe:135:29
     │
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │                            ^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
-    │                            │                        
-    │                            u256: Storage { nonce: Some(7) } => Value
+135 │         emit Sync(reserve0: self.reserve0, reserve1: self.reserve1)
+    │                             ^^^^^^^^^^^^^            ^^^^ UniswapV2Pair: Value
+    │                             │                         
+    │                             u256: Storage { nonce: Some(7) } => Value
 
 note: 
-    ┌─ uniswap.fe:135:52
+    ┌─ uniswap.fe:135:54
     │
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │                                                    ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
+135 │         emit Sync(reserve0: self.reserve0, reserve1: self.reserve1)
+    │                                                      ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
     ┌─ uniswap.fe:135:9
     │
-135 │         emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11491202868117077488
+135 │         emit Sync(reserve0: self.reserve0, reserve1: self.reserve1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11491202868117077488
     │
     = Event {
           name: "Sync",
@@ -1995,7 +1995,7 @@ note:
 160 │ │         let reserve0: u256 = self.reserve0
 161 │ │         let reserve1: u256 = self.reserve1
     · │
-184 │ │         emit Mint(sender=msg.sender, amount0, amount1)
+184 │ │         emit Mint(sender: msg.sender, amount0, amount1)
 185 │ │         return liquidity
     │ ╰────────────────────────^ attributes hash: 11001367211577482977
     │  
@@ -2333,19 +2333,19 @@ note:
 182 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
     │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
 183 │ 
-184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^ u256: Value
-    │                          │           │         
-    │                          │           u256: Value
-    │                          address: Value
+184 │         emit Mint(sender: msg.sender, amount0, amount1)
+    │                           ^^^^^^^^^^  ^^^^^^^  ^^^^^^^ u256: Value
+    │                           │           │         
+    │                           │           u256: Value
+    │                           address: Value
 185 │         return liquidity
     │                ^^^^^^^^^ u256: Value
 
 note: 
     ┌─ uniswap.fe:184:9
     │
-184 │         emit Mint(sender=msg.sender, amount0, amount1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4243961805717991435
+184 │         emit Mint(sender: msg.sender, amount0, amount1)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4243961805717991435
     │
     = Event {
           name: "Mint",
@@ -2434,7 +2434,7 @@ note:
 190 │ │         let reserve1: u256 = self.reserve1
 191 │ │         let token0: ERC20 = ERC20(self.token0)
     · │
-213 │ │         emit Burn(sender=msg.sender, amount0, amount1, to)
+213 │ │         emit Burn(sender: msg.sender, amount0, amount1, to)
 214 │ │         return (amount0, amount1)
     │ ╰─────────────────────────────────^ attributes hash: 2815259610692259424
     │  
@@ -2792,12 +2792,12 @@ note:
 211 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
     │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
 212 │ 
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │                          ^^^^^^^^^^  ^^^^^^^  ^^^^^^^  ^^ address: Value
-    │                          │           │        │         
-    │                          │           │        u256: Value
-    │                          │           u256: Value
-    │                          address: Value
+213 │         emit Burn(sender: msg.sender, amount0, amount1, to)
+    │                           ^^^^^^^^^^  ^^^^^^^  ^^^^^^^  ^^ address: Value
+    │                           │           │        │         
+    │                           │           │        u256: Value
+    │                           │           u256: Value
+    │                           address: Value
 214 │         return (amount0, amount1)
     │                 ^^^^^^^  ^^^^^^^ u256: Value
     │                 │         
@@ -2812,8 +2812,8 @@ note:
 note: 
     ┌─ uniswap.fe:213:9
     │
-213 │         emit Burn(sender=msg.sender, amount0, amount1, to)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10738919684795162003
+213 │         emit Burn(sender: msg.sender, amount0, amount1, to)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10738919684795162003
     │
     = Event {
           name: "Burn",
@@ -2899,8 +2899,8 @@ note:
 222 │ │         let reserve1: u256 = self.reserve1
     · │
 252 │ │         self._update(balance0, balance1, reserve0, reserve1)
-253 │ │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │ ╰──────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 5877065548740974671
+253 │ │         emit Swap(sender: msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+    │ ╰───────────────────────────────────────────────────────────────────────────────────────────^ attributes hash: 5877065548740974671
     │  
     = FunctionSignature {
           self_decl: Some(
@@ -3413,20 +3413,20 @@ note:
     │
 252 │         self._update(balance0, balance1, reserve0, reserve1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │                          ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^  ^^ address: Value
-    │                          │           │           │           │            │             
-    │                          │           │           │           │            u256: Value
-    │                          │           │           │           u256: Value
-    │                          │           │           u256: Value
-    │                          │           u256: Value
-    │                          address: Value
+253 │         emit Swap(sender: msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+    │                           ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^  ^^ address: Value
+    │                           │           │           │           │            │             
+    │                           │           │           │           │            u256: Value
+    │                           │           │           │           u256: Value
+    │                           │           │           u256: Value
+    │                           │           u256: Value
+    │                           address: Value
 
 note: 
     ┌─ uniswap.fe:253:9
     │
-253 │         emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16055667627771619025
+253 │         emit Swap(sender: msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16055667627771619025
     │
     = Event {
           name: "Swap",
@@ -4161,7 +4161,7 @@ note:
 313 │ │ 
 314 │ │         let token0: address = token_a if token_a < token_b else token_b
     · │
-328 │ │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+328 │ │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
 329 │ │         return address(pair)
     │ ╰────────────────────────────^ attributes hash: 1028840135620418462
     │  
@@ -4483,25 +4483,25 @@ note:
 326 │         self.pair_counter = self.pair_counter + 1
     │                             ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 327 │ 
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                          ^^^^^^  ^^^^^^               ^^^^ UniswapV2Pair: Value
-    │                          │       │                     
+328 │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
+    │                          ^^^^^^  ^^^^^^                ^^^^ UniswapV2Pair: Value
+    │                          │       │                      
     │                          │       address: Value
     │                          address: Value
 
 note: 
-    ┌─ uniswap.fe:328:47
+    ┌─ uniswap.fe:328:48
     │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                               ^^^^^^^^^^^^^        ^^^^ UniswapV2Factory: Value
-    │                                               │                     
-    │                                               address: Value
+328 │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
+    │                                                ^^^^^^^^^^^^^         ^^^^ UniswapV2Factory: Value
+    │                                                │                      
+    │                                                address: Value
 
 note: 
-    ┌─ uniswap.fe:328:68
+    ┌─ uniswap.fe:328:70
     │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                                                    ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
+328 │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
+    │                                                                      ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
 329 │         return address(pair)
     │                        ^^^^ UniswapV2Pair: Value
 
@@ -4514,8 +4514,8 @@ note:
 note: 
     ┌─ uniswap.fe:328:9
     │
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13094055123344570742
+328 │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13094055123344570742
     │
     = Event {
           name: "PairCreated",
@@ -4589,8 +4589,8 @@ note:
 325 │         self.all_pairs[self.pair_counter] = address(pair)
     │                                             ^^^^^^^ TypeConstructor(Base(Address))
     ·
-328 │         emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
-    │                                               ^^^^^^^ TypeConstructor(Base(Address))
+328 │         emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
+    │                                                ^^^^^^^ TypeConstructor(Base(Address))
 329 │         return address(pair)
     │                ^^^^^^^ TypeConstructor(Base(Address))
 

--- a/crates/analyzer/tests/snapshots/errors__bad_ingot.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_ingot.snap
@@ -67,9 +67,9 @@ error: function name conflicts with the ingot named "std"
    │    ^^^ `std` is already defined
 
 error: incorrect type for `Foo` argument `my_num`
-  ┌─ compile_errors/bad_ingot/src/main.fe:9:32
+  ┌─ compile_errors/bad_ingot/src/main.fe:9:33
   │
-9 │         return foo::Foo(my_num=true)
-  │                                ^^^^ this has type `bool`; expected type `u256`
+9 │         return foo::Foo(my_num: true)
+  │                                 ^^^^ this has type `bool`; expected type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_event_with_wrong_types.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_event_with_wrong_types.snap
@@ -3,32 +3,16 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: missing argument label
-  ┌─ compile_errors/call_event_with_wrong_types.fe:7:22
-  │
-7 │         emit MyEvent("foo bar", 1000)
-  │                      ^ add `val_1=` here
-  │
-  = Note: this label is optional if the argument is a variable named `val_1`.
-
-error: missing argument label
-  ┌─ compile_errors/call_event_with_wrong_types.fe:7:33
-  │
-7 │         emit MyEvent("foo bar", 1000)
-  │                                 ^ add `val_2=` here
-  │
-  = Note: this label is optional if the argument is a variable named `val_2`.
-
 error: incorrect type for `MyEvent` argument `val_1`
-  ┌─ compile_errors/call_event_with_wrong_types.fe:7:22
+  ┌─ compile_errors/call_event_with_wrong_types.fe:7:29
   │
-7 │         emit MyEvent("foo bar", 1000)
-  │                      ^^^^^^^^^ this has type `String<7>`; expected type `String<5>`
+7 │         emit MyEvent(val_1: "foo bar", val_2: 1000)
+  │                             ^^^^^^^^^ this has type `String<7>`; expected type `String<5>`
 
 error: literal out of range for `u8`
-  ┌─ compile_errors/call_event_with_wrong_types.fe:7:33
+  ┌─ compile_errors/call_event_with_wrong_types.fe:7:47
   │
-7 │         emit MyEvent("foo bar", 1000)
-  │                                 ^^^^ does not fit into type `u8`
+7 │         emit MyEvent(val_1: "foo bar", val_2: 1000)
+  │                                               ^^^^ does not fit into type `u8`
 
 

--- a/crates/analyzer/tests/snapshots/errors__emit_bad_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__emit_bad_args.snap
@@ -6,39 +6,39 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: `Foo` expects 3 arguments, but 4 were provided
   ┌─ compile_errors/emit_bad_args.fe:8:10
   │
-8 │     emit Foo((1, 2), z=10, y=true, x=5)
-  │          ^^^ ------  ----  ------  --- supplied 4 arguments
-  │          │                          
+8 │     emit Foo((1, 2), z: 10, y: true, x: 5)
+  │          ^^^ ------  -----  -------  ---- supplied 4 arguments
+  │          │                            
   │          expects 3 arguments
 
 error: missing argument label
   ┌─ compile_errors/emit_bad_args.fe:8:14
   │
-8 │     emit Foo((1, 2), z=10, y=true, x=5)
-  │              ^ add `x=` here
+8 │     emit Foo((1, 2), z: 10, y: true, x: 5)
+  │              ^ add `x:` here
   │
   = Note: this label is optional if the argument is a variable named `x`.
 
 error: argument label mismatch
   ┌─ compile_errors/emit_bad_args.fe:8:22
   │
-8 │     emit Foo((1, 2), z=10, y=true, x=5)
+8 │     emit Foo((1, 2), z: 10, y: true, x: 5)
   │                      ^ expected `y`
   │
   = Note: arguments must be provided in order.
 
 error: argument label mismatch
-  ┌─ compile_errors/emit_bad_args.fe:8:28
+  ┌─ compile_errors/emit_bad_args.fe:8:29
   │
-8 │     emit Foo((1, 2), z=10, y=true, x=5)
-  │                            ^ expected `z`
+8 │     emit Foo((1, 2), z: 10, y: true, x: 5)
+  │                             ^ expected `z`
   │
   = Note: arguments must be provided in order.
 
 error: incorrect type for `Foo` argument `x`
   ┌─ compile_errors/emit_bad_args.fe:8:14
   │
-8 │     emit Foo((1, 2), z=10, y=true, x=5)
+8 │     emit Foo((1, 2), z: 10, y: true, x: 5)
   │              ^^^^^^ this has type `(u256, u256)`; expected type `address`
 
 

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args.snap
@@ -6,13 +6,13 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: argument label mismatch
   ┌─ compile_errors/mislabeled_call_args.fe:4:13
   │
-4 │         bar(doesnt_exist=1, me_neither=2)
+4 │         bar(doesnt_exist: 1, me_neither: 2)
   │             ^^^^^^^^^^^^ expected `val1`
 
 error: argument label mismatch
-  ┌─ compile_errors/mislabeled_call_args.fe:4:29
+  ┌─ compile_errors/mislabeled_call_args.fe:4:30
   │
-4 │         bar(doesnt_exist=1, me_neither=2)
-  │                             ^^^^^^^^^^ expected `val2`
+4 │         bar(doesnt_exist: 1, me_neither: 2)
+  │                              ^^^^^^^^^^ expected `val2`
 
 

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_external_contract_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_external_contract_call.snap
@@ -6,13 +6,13 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: argument label mismatch
    ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:10:25
    │
-10 │     Foo(address(0)).baz(doesnt_exist=1, me_neither=4)
+10 │     Foo(address(0)).baz(doesnt_exist: 1, me_neither: 4)
    │                         ^^^^^^^^^^^^ expected `val1`
 
 error: argument label mismatch
-   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:10:41
+   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:10:42
    │
-10 │     Foo(address(0)).baz(doesnt_exist=1, me_neither=4)
-   │                                         ^^^^^^^^^^ expected `val2`
+10 │     Foo(address(0)).baz(doesnt_exist: 1, me_neither: 4)
+   │                                          ^^^^^^^^^^ expected `val2`
 
 

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_self.snap
@@ -6,13 +6,13 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: argument label mismatch
   ┌─ compile_errors/mislabeled_call_args_self.fe:4:18
   │
-4 │         self.bar(doesnt_exist=1, me_neither=2)
+4 │         self.bar(doesnt_exist: 1, me_neither: 2)
   │                  ^^^^^^^^^^^^ expected `val1`
 
 error: argument label mismatch
-  ┌─ compile_errors/mislabeled_call_args_self.fe:4:34
+  ┌─ compile_errors/mislabeled_call_args_self.fe:4:35
   │
-4 │         self.bar(doesnt_exist=1, me_neither=2)
-  │                                  ^^^^^^^^^^ expected `val2`
+4 │         self.bar(doesnt_exist: 1, me_neither: 2)
+  │                                   ^^^^^^^^^^ expected `val2`
 
 

--- a/crates/analyzer/tests/snapshots/errors__not_callable.snap
+++ b/crates/analyzer/tests/snapshots/errors__not_callable.snap
@@ -12,7 +12,7 @@ error: `u256` type is not callable
 error: `MyEvent` is not callable
    ┌─ compile_errors/not_callable.fe:10:5
    │
-10 │     MyEvent(x=10)
+10 │     MyEvent(x: 10)
    │     ^^^^^^^ `MyEvent` is an event, and can't be constructed in this context
    │
    = Hint: to emit an event, use `emit MyEvent(..)`

--- a/crates/analyzer/tests/snapshots/errors__struct_call_bad_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_call_bad_args.snap
@@ -6,24 +6,24 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: `House` expects 2 arguments, but 3 were provided
   ┌─ compile_errors/struct_call_bad_args.fe:8:31
   │
-8 │         let my_house: House = House(price=false, vacant=100, bar=address(0))
-  │                               ^^^^^ -----------  ----------  -------------- supplied 3 arguments
-  │                               │                               
+8 │         let my_house: House = House(price: false, vacant: 100, bar: address(0))
+  │                               ^^^^^ ------------  -----------  --------------- supplied 3 arguments
+  │                               │                                 
   │                               expects 2 arguments
 
 error: argument label mismatch
   ┌─ compile_errors/struct_call_bad_args.fe:8:37
   │
-8 │         let my_house: House = House(price=false, vacant=100, bar=address(0))
+8 │         let my_house: House = House(price: false, vacant: 100, bar: address(0))
   │                                     ^^^^^ expected `vacant`
   │
   = Note: arguments must be provided in order.
 
 error: argument label mismatch
-  ┌─ compile_errors/struct_call_bad_args.fe:8:50
+  ┌─ compile_errors/struct_call_bad_args.fe:8:51
   │
-8 │         let my_house: House = House(price=false, vacant=100, bar=address(0))
-  │                                                  ^^^^^^ expected `price`
+8 │         let my_house: House = House(price: false, vacant: 100, bar: address(0))
+  │                                                   ^^^^^^ expected `price`
   │
   = Note: arguments must be provided in order.
 

--- a/crates/analyzer/tests/snapshots/errors__struct_call_without_kw_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_call_without_kw_args.snap
@@ -6,8 +6,8 @@ expression: "error_string(&path, test_files::fixture(path))"
 error: missing argument label
   ┌─ compile_errors/struct_call_without_kw_args.fe:8:37
   │
-8 │         let my_house: House = House(true, price=1000000)
-  │                                     ^ add `vacant=` here
+8 │         let my_house: House = House(true, price: 1000000)
+  │                                     ^ add `vacant:` here
   │
   = Note: this label is optional if the argument is a variable named `vacant`.
 

--- a/crates/library/std/src/lib.fe
+++ b/crates/library/std/src/lib.fe
@@ -7,4 +7,4 @@ pub fn get_42() -> u256:
     return 42
 
 pub fn revert_insufficient_funds():
-    revert Error(code=ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE)
+    revert Error(code: ERROR_INSUFFICIENT_FUNDS_TO_SEND_VALUE)

--- a/crates/lowering/tests/snapshots/lowering__and_or.snap
+++ b/crates/lowering/tests/snapshots/lowering__and_or.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_bool_bool_:
@@ -65,7 +65,7 @@ contract Foo:
         if a:
             $boolean_expr_result_1 = b
 
-        let z: $tuple_bool_bool_ = $tuple_bool_bool_(item0=$boolean_expr_result_1, item1=$boolean_expr_result_0)
+        let z: $tuple_bool_bool_ = $tuple_bool_bool_(item0: $boolean_expr_result_1, item1: $boolean_expr_result_0)
         return ()
 
     pub fn short_or(first: bool, second: bool, third: bool, fourth: bool) -> bool:

--- a/crates/lowering/tests/snapshots/lowering__base_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__base_tuple.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_bool_address_:
@@ -40,13 +40,13 @@ contract Foo:
         my_other_tuple: $tuple_address_address_
 
     pub fn bar(my_num: u256, my_bool: bool) -> $tuple_u256_bool_:
-        return $tuple_u256_bool_(item0=my_num, item1=my_bool)
+        return $tuple_u256_bool_(item0: my_num, item1: my_bool)
 
     pub fn baz() -> $tuple_u256_bool_u8_address_:
-        return $tuple_u256_bool_u8_address_(item0=999999, item1=false, item2=u8(42), item3=address(26))
+        return $tuple_u256_bool_u8_address_(item0: 999999, item1: false, item2: u8(42), item3: address(26))
 
     pub fn bing() -> ():
-        let foo: $tuple_address_address_u16_i32_bool_ = $tuple_address_address_u16_i32_bool_(item0=address(0), item1=address(0), item2=u16(0), item3=i32(0), item4=false)
+        let foo: $tuple_address_address_u16_i32_bool_ = $tuple_address_address_u16_i32_bool_(item0: address(0), item1: address(0), item2: u16(0), item3: i32(0), item4: false)
         return ()
 
     pub fn bop(my_tuple1: $tuple_u256_bool_, my_tuple2: $tuple_u256_bool_u8_address_, my_tuple3: $tuple_address_address_u16_i32_bool_) -> ():
@@ -54,5 +54,5 @@ contract Foo:
         return ()
 
     pub fn food() -> ():
-        emit MyEvent(my_tuple=$tuple_bool_bool_(item0=false, item1=true), my_other_tuple=$tuple_address_address_(item0=address(0), item1=address(1)))
+        emit MyEvent(my_tuple: $tuple_bool_bool_(item0: false, item1: true), my_other_tuple: $tuple_address_address_(item0: address(0), item1: address(1)))
         return ()

--- a/crates/lowering/tests/snapshots/lowering__map_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__map_tuple.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_u256_u8_:
@@ -15,5 +15,5 @@ contract Foo:
     tuples: Map<u256, $tuple_address_tuple_u256_u8__>
 
     pub fn bar(self, x: u256) -> u256:
-        self.tuples[0] = $tuple_address_tuple_u256_u8__(item0=address(100), item1=$tuple_u256_u8_(item0=x, item1=5))
+        self.tuples[0] = $tuple_address_tuple_u256_u8__(item0: address(100), item1: $tuple_u256_u8_(item0: x, item1: 5))
         return self.tuples[0].item1.item0

--- a/crates/lowering/tests/snapshots/lowering__module_const.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_const.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_u256_u256_:
@@ -34,8 +34,8 @@ contract Foo:
         let my_calc: u256 = 3 * 10
         let my_other_calc: u256 = 3 * 3
         let my_array: Array<u256, 2> = list_expr_array_u256_2(3, 10)
-        let my_tuple: $tuple_u256_u256_ = $tuple_u256_u256_(item0=3, item1=10)
-        let my_bar: Bar = Bar(val=3)
+        let my_tuple: $tuple_u256_u256_ = $tuple_u256_u256_(item0: 3, item1: 10)
+        let my_bar: Bar = Bar(val: 3)
         while 3 > 4:
             pass
 
@@ -50,7 +50,7 @@ contract Foo:
                 return 3 * 10
             else:
                 if true:
-                    revert Bar(val=3)
+                    revert Bar(val: 3)
 
 
 

--- a/crates/lowering/tests/snapshots/lowering__module_fn.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_fn.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_u256_u8_:
@@ -19,7 +19,7 @@ fn list_expr_array_u8_3(val0: u8, val1: u8, val2: u8) -> Array<u8, 3>:
     return generated_array
 
 fn return_tuple() -> $tuple_address_tuple_u256_u8__:
-    return $tuple_address_tuple_u256_u8__(item0=address(0), item1=$tuple_u256_u8_(item0=10, item1=20))
+    return $tuple_address_tuple_u256_u8__(item0: address(0), item1: $tuple_u256_u8_(item0: 10, item1: 20))
 
 fn return_array() -> Array<u8, 3>:
     return list_expr_array_u8_3(1, 2, 3)

--- a/crates/lowering/tests/snapshots/lowering__module_level_events.snap
+++ b/crates/lowering/tests/snapshots/lowering__module_level_events.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 event Transfer:
@@ -10,5 +10,5 @@ event Transfer:
 
 contract Foo:
     fn transfer(to: address, value: u256) -> ():
-        emit Transfer(sender=msg.sender, receiver=to, value)
+        emit Transfer(sender: msg.sender, receiver: to, value)
         return ()

--- a/crates/lowering/tests/snapshots/lowering__nested_tuple.snap
+++ b/crates/lowering/tests/snapshots/lowering__nested_tuple.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_u8_bool_:
@@ -24,5 +24,5 @@ contract Foo:
     tup: $tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___
 
     pub fn bar(self, x: u256) -> u8:
-        self.tup = $tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___(item0=1, item1=$tuple_u8_bool_(item0=0, item1=true), item2=$tuple_address_tuple_u8_u8__(item0=address(0), item1=$tuple_u8_u8_(item0=10, item1=100)))
+        self.tup = $tuple_u256_tuple_u8_bool__tuple_address_tuple_u8_u8___(item0: 1, item1: $tuple_u8_bool_(item0: 0, item1: true), item2: $tuple_address_tuple_u8_u8__(item0: address(0), item1: $tuple_u8_u8_(item0: 10, item1: 100)))
         return self.tup.item2.item1.item0

--- a/crates/lowering/tests/snapshots/lowering__struct_fn.snap
+++ b/crates/lowering/tests/snapshots/lowering__struct_fn.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct Foo:
@@ -15,7 +15,7 @@ struct Foo:
         return self.x
 
 fn main() -> ():
-    let foo: Foo = Foo(x=10)
+    let foo: Foo = Foo(x: 10)
     foo.set_x(100)
     assert foo.get_x() == 100
     return ()

--- a/crates/lowering/tests/snapshots/lowering__ternary.snap
+++ b/crates/lowering/tests/snapshots/lowering__ternary.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lowering/tests/lowering.rs
-expression: lowered_code
+expression: lowered
 
 ---
 struct $tuple_u256_u256_:
@@ -75,7 +75,7 @@ contract Foo:
         else:
             $ternary_result_1 = b
 
-        let z: $tuple_u256_u256_ = $tuple_u256_u256_(item0=$ternary_result_1, item1=$ternary_result_0)
+        let z: $tuple_u256_u256_ = $tuple_u256_u256_(item0: $ternary_result_1, item1: $ternary_result_0)
         return ()
 
     pub fn baz(val: u256) -> ():

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -790,8 +790,13 @@ impl fmt::Display for Expr {
 
 impl fmt::Display for CallArg {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if let Some(label) = self.label.as_ref() {
-            write!(f, "{}={}", label.kind, self.value.kind)
+        if let Some(label) = &self.label {
+            if let Expr::Name(var_name) = &self.value.kind {
+                if var_name == &label.kind {
+                    return write!(f, "{}", var_name);
+                }
+            }
+            write!(f, "{}: {}", label.kind, self.value.kind)
         } else {
             write!(f, "{}", self.value.kind)
         }

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -81,6 +81,8 @@ test_parse_err! { expr_bad_prefix, expressions::parse_expr, "*x + 1" }
 test_parse_err! { expr_path_left, expressions::parse_expr, "(1 + 2)::foo::bar" }
 test_parse_err! { expr_path_right, expressions::parse_expr, "foo::10::bar" }
 test_parse_err! { expr_dotted_number, expressions::parse_expr, "3.14" }
+test_parse_err! { expr_call_eq_label, expressions::parse_expr, "foo(bar=1, baz = 2)" }
+test_parse_err! { expr_assignment, expressions::parse_expr, "1 + (x = y)" }
 test_parse_err! { for_no_in, functions::parse_stmt, "for x:\n pass" }
 test_parse_err! { fn_no_args, module::parse_module, "fn f:\n  return 5" }
 test_parse_err! { fn_unsafe_pub, module::parse_module, "unsafe pub fn f():\n  return 5" }

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -67,7 +67,7 @@ macro_rules! test_parse {
 }
 
 test_parse! { expr_call1, expressions::parse_expr, "foo()" }
-test_parse! { expr_call2, expressions::parse_expr, "foo(1,2,x=3)" }
+test_parse! { expr_call2, expressions::parse_expr, "foo(1,2,x:3)" }
 test_parse! { expr_attr1, expressions::parse_expr, "foo.bar[0][y]" }
 test_parse! { expr_attr2, expressions::parse_expr, "a[x].b[y](1)" }
 test_parse! { expr_num1, expressions::parse_expr, "12345" }
@@ -110,7 +110,7 @@ test_parse! { stmt_aug_lsh, functions::parse_stmt, "x <<= y" }
 test_parse! { stmt_aug_rsh, functions::parse_stmt, "x >>= y" }
 test_parse! { stmt_aug_exp, functions::parse_stmt, "x **= y" }
 test_parse! { stmt_emit1, functions::parse_stmt, "emit Foo()" }
-test_parse! { stmt_emit2, functions::parse_stmt, "emit Foo(1, 2, x=y)" }
+test_parse! { stmt_emit2, functions::parse_stmt, "emit Foo(1, 2, x: y)" }
 test_parse! { stmt_path_type, functions::parse_stmt, "let x: foo::Bar = foo::Bar(1, 2)" }
 test_parse! { stmt_return1, functions::parse_stmt, "return" }
 test_parse! { stmt_return2, functions::parse_stmt, "return x" }
@@ -230,7 +230,7 @@ contract GuestBook:
     pub fn sign(self, book_msg: BookMsg):
         self.guest_book[msg.sender] = book_msg
 
-        emit Signed(book_msg=book_msg)
+        emit Signed(book_msg: book_msg)
 
     pub fn get_msg(self, addr: address) -> BookMsg:
         return self.guest_book[addr]
@@ -243,5 +243,5 @@ event Transfer:
     value: u256
 contract Foo:
     fn transfer(to : address, value : u256):
-        emit Transfer(sender=msg.sender, receiver=to, value)
+        emit Transfer(sender: msg.sender, receiver: to, value)
 "# }

--- a/crates/parser/tests/cases/snapshots/cases__errors__expr_assignment.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__expr_assignment.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(expr_assignment), expressions::parse_expr,\n           \"1 + (x = y)\")"
+
+---
+error: Unexpected token while parsing expression in parentheses
+  ┌─ expr_assignment:1:8
+  │
+1 │ 1 + (x = y)
+  │        ^ unexpected token
+
+

--- a/crates/parser/tests/cases/snapshots/cases__errors__expr_call_eq_label.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__expr_call_eq_label.snap
@@ -1,0 +1,26 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(expr_call_eq_label), expressions::parse_expr,\n           \"foo(bar=1, baz = 2)\")"
+
+---
+error: Syntax error in argument list
+  ┌─ expr_call_eq_label:1:8
+  │
+1 │ foo(bar=1, baz = 2)
+  │        ^ unexpected `=`
+  │
+  = Argument labels should be followed by `:`.
+  = Hint: try `bar:`
+  = If this is a variable assignment, it must be a standalone statement.
+
+error: Syntax error in argument list
+  ┌─ expr_call_eq_label:1:16
+  │
+1 │ foo(bar=1, baz = 2)
+  │                ^ unexpected `=`
+  │
+  = Argument labels should be followed by `:`.
+  = Hint: try `baz:`
+  = If this is a variable assignment, it must be a standalone statement.
+
+

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(guest_book), module::parse_module,\n           r#\"\ntype BookMsg = Array<bytes, 100>\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub fn sign(self, book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg=book_msg)\n\n    pub fn get_msg(self, addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
+expression: "ast_string(stringify!(guest_book), try_parse_module,\n           r#\"\ntype BookMsg = Array<bytes, 100>\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub fn sign(self, book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg: book_msg)\n\n    pub fn get_msg(self, addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
 
 ---
 Node(
@@ -314,55 +314,55 @@ Node(
                               value: Node(
                                 kind: Name("book_msg"),
                                 span: Span(
-                                  start: 266,
-                                  end: 274,
+                                  start: 267,
+                                  end: 275,
                                 ),
                               ),
                             ),
                             span: Span(
                               start: 257,
-                              end: 274,
+                              end: 275,
                             ),
                           ),
                         ],
                         span: Span(
                           start: 256,
-                          end: 275,
+                          end: 276,
                         ),
                       ),
                     ),
                     span: Span(
                       start: 245,
-                      end: 275,
+                      end: 276,
                     ),
                   ),
                 ],
               ),
               span: Span(
                 start: 151,
-                end: 275,
+                end: 276,
               ),
             )),
             Function(Node(
               kind: Function(
                 pub_: Some(Span(
-                  start: 281,
-                  end: 284,
+                  start: 282,
+                  end: 285,
                 )),
                 unsafe_: None,
                 name: Node(
                   kind: "get_msg",
                   span: Span(
-                    start: 288,
-                    end: 295,
+                    start: 289,
+                    end: 296,
                   ),
                 ),
                 args: [
                   Node(
                     kind: Zelf,
                     span: Span(
-                      start: 296,
-                      end: 300,
+                      start: 297,
+                      end: 301,
                     ),
                   ),
                   Node(
@@ -370,8 +370,8 @@ Node(
                       name: Node(
                         kind: "addr",
                         span: Span(
-                          start: 302,
-                          end: 306,
+                          start: 303,
+                          end: 307,
                         ),
                       ),
                       typ: Node(
@@ -379,14 +379,14 @@ Node(
                           base: "address",
                         ),
                         span: Span(
-                          start: 308,
-                          end: 315,
+                          start: 309,
+                          end: 316,
                         ),
                       ),
                     )),
                     span: Span(
-                      start: 302,
-                      end: 315,
+                      start: 303,
+                      end: 316,
                     ),
                   ),
                 ],
@@ -395,8 +395,8 @@ Node(
                     base: "BookMsg",
                   ),
                   span: Span(
-                    start: 320,
-                    end: 327,
+                    start: 321,
+                    end: 328,
                   ),
                 )),
                 body: [
@@ -409,47 +409,47 @@ Node(
                               value: Node(
                                 kind: Name("self"),
                                 span: Span(
-                                  start: 344,
-                                  end: 348,
+                                  start: 345,
+                                  end: 349,
                                 ),
                               ),
                               attr: Node(
                                 kind: "guest_book",
                                 span: Span(
-                                  start: 349,
-                                  end: 359,
+                                  start: 350,
+                                  end: 360,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 344,
-                              end: 359,
+                              start: 345,
+                              end: 360,
                             ),
                           ),
                           index: Node(
                             kind: Name("addr"),
                             span: Span(
-                              start: 360,
-                              end: 364,
+                              start: 361,
+                              end: 365,
                             ),
                           ),
                         ),
                         span: Span(
-                          start: 344,
-                          end: 365,
+                          start: 345,
+                          end: 366,
                         ),
                       )),
                     ),
                     span: Span(
-                      start: 337,
-                      end: 365,
+                      start: 338,
+                      end: 366,
                     ),
                   ),
                 ],
               ),
               span: Span(
-                start: 281,
-                end: 365,
+                start: 282,
+                end: 366,
               ),
             )),
           ],
@@ -457,13 +457,13 @@ Node(
         ),
         span: Span(
           start: 35,
-          end: 365,
+          end: 366,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 365,
+    end: 366,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_level_events), module::parse_module,\n           r#\"\nevent Transfer:\n    idx sender: address\n    idx receiver: address\n    value: u256\ncontract Foo:\n    fn transfer(to : address, value : u256):\n        emit Transfer(sender=msg.sender, receiver=to, value)\n\"#)"
+expression: "ast_string(stringify!(module_level_events), try_parse_module,\n           r#\"\nevent Transfer:\n    idx sender: address\n    idx receiver: address\n    value: u256\ncontract Foo:\n    fn transfer(to : address, value : u256):\n        emit Transfer(sender: msg.sender, receiver: to, value)\n\"#)"
 
 ---
 Node(
@@ -198,27 +198,27 @@ Node(
                                   value: Node(
                                     kind: Name("msg"),
                                     span: Span(
-                                      start: 171,
-                                      end: 174,
+                                      start: 172,
+                                      end: 175,
                                     ),
                                   ),
                                   attr: Node(
                                     kind: "sender",
                                     span: Span(
-                                      start: 175,
-                                      end: 181,
+                                      start: 176,
+                                      end: 182,
                                     ),
                                   ),
                                 ),
                                 span: Span(
-                                  start: 171,
-                                  end: 181,
+                                  start: 172,
+                                  end: 182,
                                 ),
                               ),
                             ),
                             span: Span(
                               start: 164,
-                              end: 181,
+                              end: 182,
                             ),
                           ),
                           Node(
@@ -226,21 +226,21 @@ Node(
                               label: Some(Node(
                                 kind: "receiver",
                                 span: Span(
-                                  start: 183,
-                                  end: 191,
+                                  start: 184,
+                                  end: 192,
                                 ),
                               )),
                               value: Node(
                                 kind: Name("to"),
                                 span: Span(
-                                  start: 192,
-                                  end: 194,
+                                  start: 194,
+                                  end: 196,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 183,
-                              end: 194,
+                              start: 184,
+                              end: 196,
                             ),
                           ),
                           Node(
@@ -249,33 +249,33 @@ Node(
                               value: Node(
                                 kind: Name("value"),
                                 span: Span(
-                                  start: 196,
-                                  end: 201,
+                                  start: 198,
+                                  end: 203,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 196,
-                              end: 201,
+                              start: 198,
+                              end: 203,
                             ),
                           ),
                         ],
                         span: Span(
                           start: 163,
-                          end: 202,
+                          end: 204,
                         ),
                       ),
                     ),
                     span: Span(
                       start: 150,
-                      end: 202,
+                      end: 204,
                     ),
                   ),
                 ],
               ),
               span: Span(
                 start: 101,
-                end: 202,
+                end: 204,
               ),
             )),
           ],
@@ -283,13 +283,13 @@ Node(
         ),
         span: Span(
           start: 83,
-          end: 202,
+          end: 204,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 202,
+    end: 204,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_emit2.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_emit2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(stmt_emit2), functions::parse_stmt,\n           \"emit Foo(1, 2, x=y)\")"
+expression: "ast_string(stringify!(stmt_emit2), functions::parse_stmt,\n           \"emit Foo(1, 2, x: y)\")"
 
 ---
 Node(
@@ -58,25 +58,25 @@ Node(
             value: Node(
               kind: Name("y"),
               span: Span(
-                start: 17,
-                end: 18,
+                start: 18,
+                end: 19,
               ),
             ),
           ),
           span: Span(
             start: 15,
-            end: 18,
+            end: 19,
           ),
         ),
       ],
       span: Span(
         start: 8,
-        end: 19,
+        end: 20,
       ),
     ),
   ),
   span: Span(
     start: 0,
-    end: 19,
+    end: 20,
   ),
 )

--- a/crates/test-files/fixtures/compile_errors/bad_ingot/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_ingot/src/main.fe
@@ -6,7 +6,7 @@ use none::*
 contract Bar:
 
     pub fn a() -> foo::Foo:
-        return foo::Foo(my_num=true)
+        return foo::Foo(my_num: true)
 
 fn std():
     pass

--- a/crates/test-files/fixtures/compile_errors/call_event_with_wrong_types.fe
+++ b/crates/test-files/fixtures/compile_errors/call_event_with_wrong_types.fe
@@ -4,4 +4,4 @@ contract Foo:
         idx val_2: u8
 
     pub fn foo():
-        emit MyEvent("foo bar", 1000)
+        emit MyEvent(val_1: "foo bar", val_2: 1000)

--- a/crates/test-files/fixtures/compile_errors/call_undefined_function_on_memory_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/call_undefined_function_on_memory_struct.fe
@@ -3,5 +3,5 @@ struct Something:
 
 contract Bar:
   pub fn test():
-    let thingy: Something = Something(val=u8(1))
+    let thingy: Something = Something(val: u8(1))
     thingy.doesnt_exist()

--- a/crates/test-files/fixtures/compile_errors/emit_bad_args.fe
+++ b/crates/test-files/fixtures/compile_errors/emit_bad_args.fe
@@ -5,4 +5,4 @@ contract Bar:
     z: bool
 
   pub fn test():
-    emit Foo((1, 2), z=10, y=true, x=5)
+    emit Foo((1, 2), z: 10, y: true, x: 5)

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args.fe
@@ -1,7 +1,7 @@
 contract Foo:
 
     pub fn baz():
-        bar(doesnt_exist=1, me_neither=2)
+        bar(doesnt_exist: 1, me_neither: 2)
     
     pub fn bar(val1: u256, val2: u256):
         pass

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
@@ -7,4 +7,4 @@ contract Foo:
 
 contract Bar:
   pub fn test():
-    Foo(address(0)).baz(doesnt_exist=1, me_neither=4)
+    Foo(address(0)).baz(doesnt_exist: 1, me_neither: 4)

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args_self.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args_self.fe
@@ -1,7 +1,7 @@
 contract Foo:
 
     pub fn baz(self):
-        self.bar(doesnt_exist=1, me_neither=2)
+        self.bar(doesnt_exist: 1, me_neither: 2)
 
     pub fn bar(self, val1: u256, val2: u256):
         pass

--- a/crates/test-files/fixtures/compile_errors/not_callable.fe
+++ b/crates/test-files/fixtures/compile_errors/not_callable.fe
@@ -7,7 +7,7 @@ contract Foo:
     5()
 
   fn call_event():
-    MyEvent(x=10)
+    MyEvent(x: 10)
 
   fn call_block():
     block()

--- a/crates/test-files/fixtures/compile_errors/return_complex_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/return_complex_struct.fe
@@ -3,4 +3,4 @@ struct Foo:
 
 contract C:
   pub fn f() -> Foo:
-    return Foo(bar=[1, 2])
+    return Foo(bar: [1, 2])

--- a/crates/test-files/fixtures/compile_errors/self_misuse.fe
+++ b/crates/test-files/fixtures/compile_errors/self_misuse.fe
@@ -15,7 +15,7 @@ struct S:
     self()
 
   fn g(self):
-    self = S(x = 10)
+    self = S(x: 10)
 
   fn h(self):
     change_x(self) # allowed

--- a/crates/test-files/fixtures/compile_errors/struct_call_bad_args.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_call_bad_args.fe
@@ -5,4 +5,4 @@ struct House:
 contract Foo:
 
     pub fn bar():
-        let my_house: House = House(price=false, vacant=100, bar=address(0))
+        let my_house: House = House(price: false, vacant: 100, bar: address(0))

--- a/crates/test-files/fixtures/compile_errors/struct_call_without_kw_args.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_call_without_kw_args.fe
@@ -5,4 +5,4 @@ struct House:
 contract Foo:
 
     pub fn bar():
-        let my_house: House = House(true, price=1000000)
+        let my_house: House = House(true, price: 1000000)

--- a/crates/test-files/fixtures/compile_errors/struct_private_constructor.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_private_constructor.fe
@@ -5,4 +5,4 @@ struct House:
 contract Foo:
 
     pub fn bar():
-        let my_house: House = House(vacant=true, price=1000000)
+        let my_house: House = House(vacant: true, price: 1000000)

--- a/crates/test-files/fixtures/demos/erc20_token.fe
+++ b/crates/test-files/fixtures/demos/erc20_token.fe
@@ -68,21 +68,21 @@ contract ERC20:
         _before_token_transfer(sender, recipient, value)
         self._balances[sender] = self._balances[sender] - value
         self._balances[recipient] = self._balances[recipient] + value
-        emit Transfer(from=sender, to=recipient, value=value)
+        emit Transfer(from: sender, to: recipient, value)
 
     fn _mint(self, account: address, value: u256):
         assert account != address(0)
         _before_token_transfer(address(0), account, value)
         self._total_supply = self._total_supply + value
         self._balances[account] = self._balances[account] + value
-        emit Transfer(from=address(0), to=account, value=value)
+        emit Transfer(from: address(0), to: account, value)
 
     fn _burn(self, account: address, value: u256):
         assert account != address(0)
         _before_token_transfer(account, address(0), value)
         self._balances[account] = self._balances[account] - value
         self._total_supply = self._total_supply - value
-        emit Transfer(from=account, to=address(0), value)
+        emit Transfer(from: account, to: address(0), value)
 
     fn _approve(self, owner: address, spender: address, value: u256):
         assert owner != address(0)

--- a/crates/test-files/fixtures/demos/guest_book.fe
+++ b/crates/test-files/fixtures/demos/guest_book.fe
@@ -13,7 +13,7 @@ contract GuestBook:
         self.messages[msg.sender] = book_msg
 
         # Emit the `Signed` event
-        emit Signed(book_msg=book_msg)
+        emit Signed(book_msg)
 
     pub fn get_msg(self, addr: address) -> String<100>:
         # Copying data from storage to memory

--- a/crates/test-files/fixtures/demos/uniswap.fe
+++ b/crates/test-files/fixtures/demos/uniswap.fe
@@ -75,12 +75,12 @@ contract UniswapV2Pair:
     fn _mint(self, to: address, value: u256):
         self.total_supply = self.total_supply + value
         self.balances[to] = self.balances[to] + value
-        emit Transfer(from=address(0), to, value)
+        emit Transfer(from: address(0), to, value)
 
     fn _burn(self, from: address, value: u256):
         self.balances[from] = self.balances[from] - value
         self.total_supply = self.total_supply - value
-        emit Transfer(from, to=address(0), value)
+        emit Transfer(from, to: address(0), value)
 
     fn _approve(self, owner: address, spender: address, value: u256):
         self.allowances[owner][spender] = value
@@ -132,7 +132,7 @@ contract UniswapV2Pair:
         self.reserve0 = balance0
         self.reserve1 = balance1
         self.block_timestamp_last = block_timestamp
-        emit Sync(reserve0=self.reserve0, reserve1=self.reserve1)
+        emit Sync(reserve0: self.reserve0, reserve1: self.reserve1)
 
     # if fee is on, mint liquidity equivalent to 1/6th of the growth in sqrt(k)
     fn _mint_fee(self, reserve0: u256, reserve1: u256) -> bool:
@@ -181,7 +181,7 @@ contract UniswapV2Pair:
         if fee_on:
             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
 
-        emit Mint(sender=msg.sender, amount0, amount1)
+        emit Mint(sender: msg.sender, amount0, amount1)
         return liquidity
 
     # this low-level function should be called from a contract which performs important safety checks
@@ -210,7 +210,7 @@ contract UniswapV2Pair:
         if fee_on:
             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
 
-        emit Burn(sender=msg.sender, amount0, amount1, to)
+        emit Burn(sender: msg.sender, amount0, amount1, to)
         return (amount0, amount1)
 
     # this low-level function should be called from a contract which performs important safety checks
@@ -250,7 +250,7 @@ contract UniswapV2Pair:
         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
 
         self._update(balance0, balance1, reserve0, reserve1)
-        emit Swap(sender=msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
+        emit Swap(sender: msg.sender, amount0_in, amount1_in, amount0_out, amount1_out, to)
 
     # force balances to match reserves
     pub fn skim(self, to: address):
@@ -325,7 +325,7 @@ contract UniswapV2Factory:
         self.all_pairs[self.pair_counter] = address(pair)
         self.pair_counter = self.pair_counter + 1
 
-        emit PairCreated(token0, token1, pair=address(pair), index=self.pair_counter)
+        emit PairCreated(token0, token1, pair: address(pair), index: self.pair_counter)
         return address(pair)
 
     pub fn set_fee_to(self, fee_to: address):

--- a/crates/test-files/fixtures/features/events.fe
+++ b/crates/test-files/fixtures/features/events.fe
@@ -17,13 +17,13 @@ contract Foo:
         addrs: Array<address, 2>
 
     pub fn emit_nums():
-        emit Nums(num1=26, num2=42)
+        emit Nums(num1: 26, num2: 42)
 
     pub fn emit_bases(addr: address):
-        emit Bases(num=26, addr)
+        emit Bases(num: 26, addr)
 
     pub fn emit_mix(addr: address, my_bytes: Array<u8, 100>):
-        emit Mix(num1=26, addr, num2=42, my_bytes)
+        emit Mix(num1: 26, addr, num2: 42, my_bytes)
 
     pub fn emit_addresses(addr1: address, addr2: address):
         let addrs: Array<address, 2>

--- a/crates/test-files/fixtures/features/module_level_events.fe
+++ b/crates/test-files/fixtures/features/module_level_events.fe
@@ -4,4 +4,4 @@ event Transfer:
     value: u256
 contract Foo:
     fn transfer(to : address, value : u256):
-        emit Transfer(sender=msg.sender, receiver=to, value)
+        emit Transfer(sender: msg.sender, receiver: to, value)

--- a/crates/test-files/fixtures/features/ownable.fe
+++ b/crates/test-files/fixtures/features/ownable.fe
@@ -14,10 +14,10 @@ contract Ownable:
   pub fn renounceOwnership(self):
     assert msg.sender == self._owner
     self._owner = address(0)
-    emit OwnershipTransferred(previousOwner=msg.sender, newOwner=address(0))
+    emit OwnershipTransferred(previousOwner: msg.sender, newOwner: address(0))
 
   pub fn transferOwnership(self, newOwner: address):
     assert msg.sender == self._owner
     assert newOwner != address(0)
     self._owner = newOwner
-    emit OwnershipTransferred(previousOwner=msg.sender, newOwner)
+    emit OwnershipTransferred(previousOwner: msg.sender, newOwner)

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -12,8 +12,8 @@ contract Foo:
         std::revert_insufficient_funds()
 
     pub fn revert_other_error():
-        revert OtherError(msg=1, val=true)
+        revert OtherError(msg: 1, val: true)
 
     pub fn revert_other_error_from_sto(self):
-        self.my_other_error = OtherError(msg=1, val=true)
+        self.my_other_error = OtherError(msg: 1, val: true)
         revert self.my_other_error.to_mem()

--- a/crates/test-files/fixtures/features/sized_vals_in_sto.fe
+++ b/crates/test-files/fixtures/features/sized_vals_in_sto.fe
@@ -28,7 +28,7 @@ contract Foo:
 
     pub fn emit_event(self):
         emit MyEvent(
-            num=self.num,
-            nums=self.nums.to_mem(),
-            str=self.str.to_mem()
+            num: self.num,
+            nums: self.nums.to_mem(),
+            str: self.str.to_mem()
         )

--- a/crates/test-files/fixtures/features/strings.fe
+++ b/crates/test-files/fixtures/features/strings.fe
@@ -9,7 +9,7 @@ contract Foo:
         s5: String<100>
 
     pub fn __init__(s1: String<42>, a: address, s2: String<26>, u: u256, s3: String<100>):
-        emit MyEvent(s2, u, s1, s3, a, s4="static string", s5=String<100>("foo"))
+        emit MyEvent(s2, u, s1, s3, a, s4: "static string", s5: String<100>("foo"))
 
     pub fn bar(s1: String<100>, s2: String<100>) -> String<100>:
         return s2

--- a/crates/test-files/fixtures/features/struct_fns.fe
+++ b/crates/test-files/fixtures/features/struct_fns.fe
@@ -6,7 +6,7 @@ struct Point:
     return Point(x, y)
 
   pub fn origin() -> Point:
-    return Point(x=0, y=0)
+    return Point(x: 0, y: 0)
 
   # function name can match field name
   pub fn x(self) -> u64:
@@ -37,7 +37,7 @@ pub fn do_pointy_things():
   let p1: Point = Point.origin()
   p1.translate(5, 10)
 
-  let p2: Point = Point(x=1, y=2)
+  let p2: Point = Point(x: 1, y: 2)
   let p3: Point = p1.add(p2)
 
   assert p3.x == 6 and p3.y == 12

--- a/crates/test-files/fixtures/features/structs.fe
+++ b/crates/test-files/fixtures/features/structs.fe
@@ -13,7 +13,7 @@ struct Mixed:
     bar: bool
 
     pub fn new(val: u256) -> Mixed:
-        return Mixed(foo=val, bar=false)
+        return Mixed(foo: val, bar: false)
 
 struct House:
     pub price: u256
@@ -40,10 +40,10 @@ contract Foo:
 
     pub fn complex_struct_in_storage(self) -> String<3>:
         self.my_bar = Bar(
-            name="foo",
-            numbers=[1, 2],
-            point=Point(x=100, y=200),
-            something=(1, true),
+            name: "foo",
+            numbers: [1, 2],
+            point: Point(x: 100, y: 200),
+            something: (1, true),
         )
 
         # Asserting the values as they were set initially
@@ -70,7 +70,7 @@ contract Foo:
         assert self.my_bar.point.x == 1000
         assert self.my_bar.point.y == 2000
         # We can set the point itself
-        self.my_bar.point = Point(x=100, y=200)
+        self.my_bar.point = Point(x: 100, y: 200)
         assert self.my_bar.point.x == 100
         assert self.my_bar.point.y == 200
 
@@ -88,10 +88,10 @@ contract Foo:
 
     pub fn complex_struct_in_memory(self) -> String<3>:
         let val: Bar = Bar(
-            name="foo",
-            numbers=[1, 2],
-            point=Point(x=100, y=200),
-            something=(1, true),
+            name: "foo",
+            numbers: [1, 2],
+            point: Point(x: 100, y: 200),
+            something: (1, true),
         )
 
         # Asserting the values as they were set initially
@@ -118,7 +118,7 @@ contract Foo:
         assert val.point.x == 1000
         assert val.point.y == 2000
         # We can set the point itself
-        val.point = Point(x=100, y=200)
+        val.point = Point(x: 100, y: 200)
         assert val.point.x == 100
         assert val.point.y == 200
 
@@ -146,10 +146,10 @@ contract Foo:
 
     pub fn create_house(self):
         self.my_house = House(
-            price=1,
-            size=2,
-            rooms=u8(5),
-            vacant=false,
+            price: 1,
+            size: 2,
+            rooms: u8(5),
+            vacant: false,
         )
         assert self.my_house.price == 1
         assert self.my_house.size == 2
@@ -180,10 +180,10 @@ contract Foo:
 
     pub fn bar() -> u256:
         let building: House = House(
-            price=300,
-            size=500,
-            rooms=u8(20),
-            vacant=true,
+            price: 300,
+            size: 500,
+            rooms: u8(20),
+            vacant: true,
         )
         assert building.size == 500
         assert building.price == 300
@@ -208,18 +208,18 @@ contract Foo:
 
     pub fn encode_house() -> Array<u8, 128>:
         let house: House = House(
-            price=300,
-            size=500,
-            rooms=u8(20),
-            vacant=true,
+            price: 300,
+            size: 500,
+            rooms: u8(20),
+            vacant: true,
         )
         return house.encode()
 
     pub fn hashed_house() -> u256:
         let house: House = House(
-            price=300,
-            size=500,
-            rooms=u8(20),
-            vacant=true,
+            price: 300,
+            size: 500,
+            rooms: u8(20),
+            vacant: true,
         )
         return house.hash()

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dong.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dong.fe
@@ -6,4 +6,4 @@ struct Dyng:
   pub my_i8: i8
 
 fn get_bing() -> Bing:
-    return Bing(my_address=address(0))
+    return Bing(my_address: address(0))

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/main.fe
@@ -8,10 +8,10 @@ use bing::BingContract
 contract Foo:
     pub fn get_my_baz() -> Baz:
         assert file_items_work()
-        return Baz(my_bool=true, my_u256=26)
+        return Baz(my_bool: true, my_u256: 26)
 
     pub fn get_my_bing() -> Bong:
-        return Bong(my_address=address(42))
+        return Bong(my_address: address(42))
 
     pub fn get_42() -> u256:
         return get_42_backend()
@@ -21,9 +21,9 @@ contract Foo:
 
     pub fn get_my_dyng() -> dong::Dyng:
         return dong::Dyng(
-            my_address=address(8),
-            my_u256=42,
-            my_i8=-1
+            my_address: address(8),
+            my_u256: 42,
+            my_i8: -1
         )
 
     pub fn create_bing_contract() -> u256:

--- a/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
@@ -3,7 +3,7 @@ use foo::{Foo, Bar, FooBar}
 contract FooBarBing:
     pub fn get_bar() -> Bar:
         return Bar(
-            my_u256=24
+            my_u256: 24
         )
 
     pub fn create_foobar_contract() -> u256:

--- a/crates/test-files/fixtures/ingots/visibility_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/visibility_ingot/src/main.fe
@@ -2,7 +2,7 @@ use foo::{get_42_backend, Precision, Bing}
 
 contract Foo:
     pub fn get_addr() -> Bing:
-        return Bing(my_address=address(24))
+        return Bing(my_address: address(24))
 
     pub fn get_precision() -> Precision:
         return 18

--- a/crates/test-files/fixtures/lowering/base_tuple.fe
+++ b/crates/test-files/fixtures/lowering/base_tuple.fe
@@ -23,6 +23,6 @@ contract Foo:
 
     pub fn food():
         emit MyEvent(
-            my_tuple=(false, true),
-            my_other_tuple=(address(0), address(1))
+            my_tuple: (false, true),
+            my_other_tuple: (address(0), address(1))
         )

--- a/crates/test-files/fixtures/lowering/module_const.fe
+++ b/crates/test-files/fixtures/lowering/module_const.fe
@@ -20,7 +20,7 @@ contract Foo:
 
     let my_array: Array<u256, 2> = [THREE, TEN]
     let my_tuple: (u256, u256) = (THREE, TEN)
-    let my_bar: Bar = Bar(val=THREE)
+    let my_bar: Bar = Bar(val: THREE)
 
     while THREE > 4:
         pass
@@ -35,6 +35,6 @@ contract Foo:
     elif TEN == 10:
         return THREE * TEN
     elif IS_ADMIN:
-        revert Bar(val=THREE)
+        revert Bar(val: THREE)
 
     return self.table[THREE]

--- a/crates/test-files/fixtures/lowering/module_level_events.fe
+++ b/crates/test-files/fixtures/lowering/module_level_events.fe
@@ -4,4 +4,4 @@ event Transfer:
     value: u256
 contract Foo:
     fn transfer(to : address, value : u256):
-        emit Transfer(sender=msg.sender, receiver=to, value)
+        emit Transfer(sender: msg.sender, receiver: to, value)

--- a/crates/test-files/fixtures/printing/guest_book_no_comments.fe
+++ b/crates/test-files/fixtures/printing/guest_book_no_comments.fe
@@ -6,7 +6,7 @@ contract GuestBook:
 
     pub fn sign(self, book_msg: String<100>):
         self.messages[msg.sender] = book_msg
-        emit Signed(book_msg=book_msg)
+        emit Signed(book_msg)
 
     pub fn get_msg(self, addr: address) -> String<100>:
         return self.messages[addr].to_mem()

--- a/crates/test-files/fixtures/stress/abi_encoding_stress.fe
+++ b/crates/test-files/fixtures/stress/abi_encoding_stress.fe
@@ -58,10 +58,10 @@ contract Foo:
 
     pub fn get_my_struct() -> MyStruct:
         return MyStruct(
-            my_num=42,
-            my_num2=u8(26),
-            my_bool=true,
-            my_addr=address(123456)
+            my_num: 42,
+            my_num2: u8(26),
+            my_bool: true,
+            my_addr: address(123456)
         )
 
     pub fn mod_my_struct(my_struct: MyStruct) -> MyStruct:
@@ -73,10 +73,10 @@ contract Foo:
 
     pub fn emit_my_event(self):
         emit MyEvent(
-            my_addrs=self.my_addrs.to_mem(),
-            my_u128=self.my_u128,
-            my_string=self.my_string.to_mem(),
-            my_u16s=self.my_u16s.to_mem(),
-            my_bool=self.my_bool,
-            my_bytes=self.my_bytes.to_mem()
+            my_addrs: self.my_addrs.to_mem(),
+            my_u128: self.my_u128,
+            my_string: self.my_string.to_mem(),
+            my_u16s: self.my_u16s.to_mem(),
+            my_bool: self.my_bool,
+            my_bytes: self.my_bytes.to_mem()
         )

--- a/crates/test-files/fixtures/stress/data_copying_stress.fe
+++ b/crates/test-files/fixtures/stress/data_copying_stress.fe
@@ -72,7 +72,7 @@ contract Foo:
         )
 
     fn emit_my_event_internal(some_string: String<42>, some_u256: u256):
-        emit MyEvent(my_string=some_string, my_u256=some_u256)
+        emit MyEvent(my_string: some_string, my_u256: some_u256)
 
     pub fn set_my_addrs(self, my_addrs: Array<address, 3>):
         self.my_addrs = my_addrs

--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -38,11 +38,11 @@ contract Foo:
         revert
 
     pub fn do_revert_with_data():
-        revert SomeError(code=4711)
+        revert SomeError(code: 4711)
 
     # Having the return type exercises a different path in the compiler
     pub fn do_revert_with_data2() -> bool:
-        revert SomeError(code=4711)
+        revert SomeError(code: 4711)
 
 contract FooProxy:
     foo: Foo

--- a/docs/src/spec/expressions/attribute.md
+++ b/docs/src/spec/expressions/attribute.md
@@ -21,7 +21,7 @@ contract Foo:
     some_tuple: (bool, u256)
 
     fn get_point() -> Point:
-        return Point(x=100, y=500)
+        return Point(x: 100, y: 500)
 
     pub fn baz(some_point: Point, some_tuple: (bool, u256)):
         # Different examples of attribute expressions

--- a/docs/src/spec/expressions/call.md
+++ b/docs/src/spec/expressions/call.md
@@ -26,7 +26,7 @@ Example:
 contract Foo:
 
     pub fn baz():
-        bar(100, val2=300)
+        bar(100, val2: 300)
 
     pub fn bar(val1: u256, val2: u256):
         pass

--- a/docs/src/spec/items/contracts.md
+++ b/docs/src/spec/items/contracts.md
@@ -37,7 +37,7 @@ contract GuestBook:
 
     pub fn sign(self, book_msg: String<100>):
         self.messages[msg.sender] = book_msg
-        emit Signed(book_msg=book_msg)
+        emit Signed(book_msg: book_msg)
 
     pub fn get_msg(self, addr: address) -> String<100>:
         return self.messages[addr].to_mem()

--- a/docs/src/spec/items/events.md
+++ b/docs/src/spec/items/events.md
@@ -27,7 +27,7 @@ contract Foo:
     fn transfer(to : address, value : u256):
         # Heavy logic here
         # All done, log the event for listeners
-        emit Transfer(sender=msg.sender, receiver=to, value)
+        emit Transfer(sender: msg.sender, receiver: to, value)
 ```
 
 [NEWLINE]: ../lexical_structure/tokens.md#newline

--- a/docs/src/spec/items/structs.md
+++ b/docs/src/spec/items/structs.md
@@ -20,7 +20,7 @@ struct Point:
     x: u256
     y: u256
 
-p = Point {x: 10, y: 11}
+p = Point(x: 10, y: 11)
 px: u256 = p.x;
 ```
 

--- a/docs/src/spec/statements/emit.md
+++ b/docs/src/spec/statements/emit.md
@@ -12,7 +12,7 @@
 > &nbsp;&nbsp; _CallArg_&nbsp;( `,` _CallArg_ )<sup>\*</sup> `,`<sup>?</sup>
 >
 > _CallArg_ :\
-> &nbsp;&nbsp; (_CallArgLabel_ `=`)<sup>?</sup> [_Expression_]
+> &nbsp;&nbsp; (_CallArgLabel_ `:`)<sup>?</sup> [_Expression_]
 >
 > _CallArgLabel_ :\
 > &nbsp;&nbsp; [IDENTIFIER]<sup>Label must correspond to the name of the event property at the given position. It can be omitted if parameter name and event property name are equal.</sup>
@@ -31,7 +31,7 @@ contract Foo:
         my_bytes: Array<u8, 100>
 
     pub fn emit_mix(addr: address, my_bytes: Array<u8, 100>):
-        emit Mix(num1=26, addr, num2=42, my_bytes)
+        emit Mix(num1: 26, addr, num2: 42, my_bytes)
 ```
 
 [_Expression_]: ../expressions/index.md

--- a/docs/src/spec/type_system/types/struct.md
+++ b/docs/src/spec/type_system/types/struct.md
@@ -20,8 +20,9 @@ contract Example:
   area: Rectangle
 
   fn do_something():
+    let length: u256 = 20
     # A rectangle in memory
-    square: Rectangle = Rectangle(width=10, length=10)
+    let square: Rectangle = Rectangle(width: 10, length)
 ```
 
 All fields of struct types are always initialized.

--- a/fuzz/fixtures/fe/erc20.fe
+++ b/fuzz/fixtures/fe/erc20.fe
@@ -73,7 +73,7 @@ contract ERC20:
 
         self._balances[sender] = self._balances[sender] - value
         self._balances[recipient] = self._balances[recipient] + value
-        emit Transfer(from=sender, to=recipient, value=value)
+        emit Transfer(from: sender, to: recipient, value: value)
 
     fn _mint(account: address, value: u256):
         assert account != address(0)
@@ -82,7 +82,7 @@ contract ERC20:
 
         self._total_supply = self._total_supply + value
         self._balances[account] = self._balances[account] + value
-        emit Transfer(from=address(0), to=account, value=value)
+        emit Transfer(from: address(0), to: account, value: value)
 
     fn _burn(account: address, value: u256):
         assert account != address(0)
@@ -91,7 +91,7 @@ contract ERC20:
 
         self._balances[account] = self._balances[account] - value
         self._total_supply = self._total_supply - value
-        emit Transfer(from=account, to=address(0), value)
+        emit Transfer(from: account, to: address(0), value)
 
     fn _approve(owner: address, spender: address, value: u256):
         assert owner != address(0)

--- a/newsfragments/636.feature.md
+++ b/newsfragments/636.feature.md
@@ -19,10 +19,10 @@ contract Foo:
 
     pub fn complex_struct_in_storage(self) -> String<3>:
         self.my_bar = Bar(
-            name="foo",
-            numbers=[1, 2],
-            point=Point(x=100, y=200),
-            something=(1, true),
+            name: "foo",
+            numbers: [1, 2],
+            point: Point(x: 100, y: 200),
+            something: (1, true),
         )
 
         # Asserting the values as they were set initially

--- a/newsfragments/665.feature.md
+++ b/newsfragments/665.feature.md
@@ -1,0 +1,10 @@
+Argument label syntax now uses `:` instead of `=`. Example:
+
+```
+struct Foo:
+  x: u256
+  y: u256
+
+let x: MyStruct = MyStruct(x: 10, y: 11)
+# previously:     MyStruct(x = 10, y = 11)
+```

--- a/newsfragments/80.feature.md
+++ b/newsfragments/80.feature.md
@@ -1,4 +1,4 @@
-Support module level events
+Events can now be defined outside of contracts.
 
 Example:
 ```
@@ -8,10 +8,10 @@ event Transfer:
     value: u256
 
 contract Foo:
-    fn transferFoo(to : address, value : u256):
-        emit Transfer(sender=msg.sender, receiver=to, value)
+    fn transferFoo(to: address, value: u256):
+        emit Transfer(sender: msg.sender, receiver: to, value)
 
 contract Bar:
-    fn transferBar(to : address, value : u256):
-        emit Transfer(sender=msg.sender, receiver=to, value)
+    fn transferBar(to: address, value: u256):
+        emit Transfer(sender: msg.sender, receiver: to, value)
 ```


### PR DESCRIPTION
Just a simple syntax change. Argument labels and their values are now separated by `:` instead of `=`.
Eg 
```
let x: Foo = Foo(x: 10, y: 11)
transfer(from: msg.sender, to: address(0))
```

This PR does not change anything about the use of `=` in expressions. Eg `1 + (x = y)` is still not allowed.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
