### PR TITLE
Add a red-bold hint to remember to update the website

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,4 +110,5 @@ push-tag:
 	# Tag the release with the current version number
 	git tag "v$$(cargo pkgid fe | cut -d# -f2 | cut -d: -f2)"
 	git push --tags upstream master
+	printf "\033[1m\033[31mConsider to redeploy the website now\n"
 


### PR DESCRIPTION
### What was wrong?

Our website was out of date (showing `0.11.0` from December to download). This is because we currently need to redeploy our (static) website whenever we cut a new release.

### How was it fixed?

Not really but adding a bold red note to show after we push a release to Github.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
