### PR TITLE
Add `apt update` in CI

### DIFF
--- a/.github/workflows/expensive.yml
+++ b/.github/workflows/expensive.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install system dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install system dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -45,6 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install system dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -108,6 +110,7 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
         uses: actions-rs/toolchain@v1
@@ -162,10 +165,12 @@ jobs:
       - name: Install Linux dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
+          sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install Mac System dependencies
         if: startsWith(matrix.os,'macOS')
         run: |
+          brew update
           brew install boost
       - name: Install rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
### What was wrong?
Currently, installing dependency fails in CI because package index points removed a dependent package(`libxnvctrl0_470.57.01-0ubuntu0.20.04.2_amd64.deb`).

### How was it fixed?
add `apt-get update` before `apt install ...`.
ref: https://github.com/actions/virtual-environments/issues/2924
ref: https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners

### To-Do
- [x] Clean up commit history
