### PR TITLE
fv crate

### DIFF
--- a/.github/workflows/expensive.yml
+++ b/.github/workflows/expensive.yml
@@ -29,10 +29,10 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       - name: Build
-        run: cargo test --workspace --all-features --no-run --locked -- --ignored
+        run: cargo test --workspace --features solc-backend --no-run --locked -- --ignored
       - name: Run expensive tests
         id: expensive_tests
-        run: cargo test --workspace --all-features --verbose -- --ignored
+        run: cargo test --workspace --features solc-backend --verbose -- --ignored
       - name: Report
         if: failure() && steps.expensive_tests.outcome == 'failure'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,9 +121,9 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v1
       - name: Build
-        run: cargo test --workspace --all-features --no-run --locked
+        run: cargo test --workspace --features solc-backend --no-run --locked
       - name: Run tests
-        run: cargo test --workspace --all-features --verbose
+        run: cargo test --workspace --features solc-backend --verbose
 
   wasm-test:
       runs-on: ubuntu-latest
@@ -179,7 +179,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Build
-        run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}
+        run: cargo build --features solc-backend --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
+name = "fv"
+version = "0.15.0-alpha"
+dependencies = [
+ "fe-driver",
+ "fe-test-files",
+ "fe-yulgen",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ docker-wasm-test:
 
 .PHONY: coverage
 coverage:
-	cargo tarpaulin --workspace --all-features --verbose --timeout 120 --exclude-files 'tests/*' --exclude-files 'main.rs' --out xml html -- --skip differential::
+	cargo tarpaulin --workspace --features solc-backend --verbose --timeout 120 --exclude-files 'tests/*' --exclude-files 'main.rs' --out xml html -- --skip differential::
 
 .PHONY: clippy
 clippy:
-	cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::upper-case-acronyms -A clippy::large-enum-variant -W clippy::redundant_closure_for_method_calls
+	cargo clippy --workspace --all-targets --features solc-backend -- -D warnings -A clippy::upper-case-acronyms -A clippy::large-enum-variant -W clippy::redundant_closure_for_method_calls
 
 .PHONY: rustfmt
 rustfmt:

--- a/crates/fe/src/main.rs
+++ b/crates/fe/src/main.rs
@@ -22,6 +22,7 @@ arg_enum! {
         Ast,
         LoweredAst,
         Bytecode,
+        RuntimeBytecode,
         Tokens,
         Yul,
     }
@@ -52,7 +53,15 @@ pub fn main() {
                 .short("e")
                 .long("emit")
                 .help("Comma separated compile targets e.g. -e=bytecode,yul")
-                .possible_values(&["abi", "bytecode", "ast", "tokens", "yul", "loweredAst"])
+                .possible_values(&[
+                    "abi",
+                    "bytecode",
+                    "runtimeBytecode",
+                    "ast",
+                    "tokens",
+                    "yul",
+                    "loweredAst",
+                ])
                 .default_value("abi,bytecode")
                 .use_delimiter(true)
                 .takes_value(true),
@@ -239,6 +248,15 @@ fn write_compiled_module(
         if targets.contains(&CompilationTarget::Bytecode) {
             let file_name = format!("{}.bin", &name);
             write_output(&contract_output_dir.join(file_name), &contract.bytecode)?;
+        }
+
+        #[cfg(feature = "solc-backend")]
+        if targets.contains(&CompilationTarget::RuntimeBytecode) {
+            let file_name = format!("{}.runtime.bin", &name);
+            write_output(
+                &contract_output_dir.join(file_name),
+                &contract.runtime_bytecode,
+            )?;
         }
     }
 

--- a/crates/fv/Cargo.toml
+++ b/crates/fv/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+authors = ["The Fe Developers <snakecharmers@ethereum.org>"]
+categories = ["cryptography::cryptocurrencies", "command-line-utilities", "development-tools"]
+description = "Fe formal verification utilities"
+edition = "2021"
+keywords = ["ethereum", "fe", "yul", "smart", "contract", "compiler"]
+license = "GPL-3.0-or-later"
+name = "fv"
+readme = "README.md"
+repository = "https://github.com/ethereum/fe"
+version = "0.15.0-alpha"
+
+[features]
+solc-backend = ["fe-driver/solc-backend"]
+kevm-backend = []
+
+[dependencies]
+fe-driver = {path = "../driver", version = "^0.15.0-alpha"}
+fe-yulgen = {path = "../yulgen", version = "^0.15.0-alpha"}
+fe-test-files = {path = "../test-files", version = "^0.15.0-alpha"}

--- a/crates/fv/README.md
+++ b/crates/fv/README.md
@@ -1,0 +1,41 @@
+# Fe Fv
+
+This crate contains utilities for building and running kevm specs.
+
+## kevm setup
+
+A system installation of [evm-semantics](https://github.com/fe-lang/evm-semantics) is required to run the specs. Please clone the repository and follow the installation directions.
+
+While in the `evm-semantics` project, `kompile` the Fe verification module:
+
+```commandline
+$ export PATH=$PATH:/path/to/evm-semantics/.build/usr/bin
+$ kevm kompile --backend haskell tests/specs/fe/verification.k                                  \
+    --directory tests/specs/fe/verification/haskell                                             \
+    --main-module VERIFICATION                                                                  \
+    --syntax-module VERIFICATION                                                                \
+    --concrete-rules-file tests/specs/fe/concrete-rules.txt                                     \
+    -I /usr/lib/kevm/include/kframework -I /usr/lib/kevm/blockchain-k-plugin/include/kframework
+```
+
+## running the proofs
+
+Once the evm-semantics project has been built, set the `KEVM_PATH` environment variable:
+
+```commandline
+$ export KEVM_PATH=/path/to/evm-semantics
+```
+
+and then run the tests: 
+
+```commandline
+$ cargo test --features "solc-backend, kevm-backend"
+```
+
+*Note: If you are working on a resource constrained device, you may not be able to run all tests simultaneously. If issues are encountered, run tests in smaller groups.*
+
+e.g.
+
+```commandline
+$ cargo test sanity_returns_42 --features "solc-backend, kevm-backend"
+```

--- a/crates/fv/src/lib.rs
+++ b/crates/fv/src/lib.rs
@@ -1,0 +1,63 @@
+#![cfg(feature = "kevm-backend")]
+use fe_yulgen::Db;
+use std::path::Path;
+use std::process::Command;
+use std::{env, fs};
+
+const SPECS_DIR: &str = "tests/specs/fe/";
+
+pub fn kevm_path() -> String {
+    env::var("KEVM_PATH").expect("`KEVM_PATH` not set")
+}
+
+pub fn run_spec(name: &str, src_path: &str, src: &str, spec: &str) -> Result<(), String> {
+    let kevm_path = kevm_path();
+
+    let spec = build_spec(name, src_path, src, spec);
+    let spec_path = Path::new(&kevm_path)
+        .join(SPECS_DIR)
+        .join(name)
+        .with_extension("k");
+    fs::write(spec_path.clone(), spec).expect("unable to write file");
+
+    let path = env::var("PATH").expect("PATH is not set");
+
+    let out = Command::new("kevm")
+        .arg("prove")
+        .arg(spec_path.to_str().unwrap())
+        .arg("--backend")
+        .arg("haskell")
+        .arg("--format-failures")
+        .arg("--directory")
+        .arg("tests/specs/fe/verification/haskell")
+        .env("PATH", format!(".build/usr/bin:{}", path))
+        .current_dir(&kevm_path)
+        .output()
+        .expect("failed to execute process");
+
+    if out.status.code() != Some(0) {
+        Err(format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&out.stderr),
+            String::from_utf8_lossy(&out.stdout)
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn build_spec(name: &str, src_path: &str, src: &str, spec: &str) -> String {
+    let mut db = Db::default();
+    let module = fe_driver::compile_single_file(&mut db, src_path, src, true, true).unwrap();
+
+    // replace placeholders
+    let mut new_spec = spec.to_owned().replace("$TEST_NAME", &name.to_uppercase());
+    for (name, contract) in module.contracts.iter() {
+        new_spec = new_spec.replace(
+            &format!("${}::RUNTIME", name),
+            &format!("\"0x{}\"", contract.runtime_bytecode),
+        )
+    }
+
+    new_spec
+}

--- a/crates/fv/tests/specs.rs
+++ b/crates/fv/tests/specs.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "kevm-backend")]
+
+/// Checks if a contract spec is valid.
+macro_rules! test_spec {
+    ($name:ident, $src_path:expr, $spec_path:expr) => {
+        #[test]
+        fn $name() {
+            let src = fe_test_files::fixture(concat!("kspecs/", $src_path));
+            let spec = fe_test_files::fixture(concat!("kspecs/", $spec_path));
+
+            if let Err(output) =
+                fv::run_spec(&stringify!($name).replace("_", "-"), $src_path, &src, &spec)
+            {
+                panic!("{}", output)
+            }
+        }
+    };
+}
+
+/// Checks if a contract spec is invalid.
+macro_rules! test_spec_invalid {
+    ($name:ident, $src_path:expr, $spec_path:expr) => {
+        #[test]
+        fn $name() {
+            let src = fe_test_files::fixture(concat!("kspecs/", $src_path));
+            let spec = fe_test_files::fixture(concat!("kspecs/", $spec_path));
+
+            match fv::run_spec(&stringify!($name).replace("_", "-"), $src_path, &src, &spec) {
+                Ok(()) => panic!("spec is valid"),
+                Err(output) => {
+                    // we want to make sure it didn't fail for some other reason
+                    if !output.contains("the claimed implication is not valid") {
+                        panic!("spec claim was not checked {}", output)
+                    }
+                }
+            }
+        }
+    };
+}
+
+test_spec! { sanity_returns_42, "sanity/foo.fe", "sanity/returns_42.k" }
+test_spec! { sanity_returns_in, "sanity/foo.fe", "sanity/returns_in.k" }
+test_spec! { sanity_returns_in_cond1, "sanity/foo.fe", "sanity/returns_in_cond1.k" }
+test_spec! { sanity_returns_in_cond2, "sanity/foo.fe", "sanity/returns_in_cond2.k" }
+
+// these are just for extra sanity
+test_spec_invalid! { sanity_returns_42_invalid, "sanity/foo.fe", "sanity/returns_42_invalid.k" }
+test_spec_invalid! { sanity_returns_in_invalid, "sanity/foo.fe", "sanity/returns_in_invalid.k" }
+test_spec_invalid! { sanity_returns_in_cond2_invalid, "sanity/foo.fe", "sanity/returns_in_cond2_invalid.k" }

--- a/crates/test-files/fixtures/kspecs/sanity/foo.fe
+++ b/crates/test-files/fixtures/kspecs/sanity/foo.fe
@@ -1,0 +1,31 @@
+use std::evm
+
+# always returns 42
+contract Returns42:
+    pub fn __call__():
+        unsafe:
+            evm::mstore(offset: 0, value: 42)
+            evm::return_mem(offset: 0, len: 32)
+
+
+# always returns `input`
+contract ReturnsIn:
+    pub fn __call__():
+        unsafe:
+            let input: u256 = evm::call_data_load(offset: 0)
+            evm::mstore(offset: 0, value: input)
+            evm::return_mem(offset: 0, len: 32)
+
+
+# returns `input`, except when `input == 42`, in which case it will return `26`
+contract ReturnsInCond:
+    pub fn __call__():
+        unsafe:
+            let input: u256 = evm::call_data_load(offset: 0)
+            let output: u256 = input
+
+            if input == 42:
+                output = 26
+
+            evm::mstore(offset: 0, value: output)
+            evm::return_mem(offset: 0, len: 32)

--- a/crates/test-files/fixtures/kspecs/sanity/returns_42.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_42.k
@@ -1,0 +1,105 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($Returns42::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($Returns42::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> _ </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($Returns42::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0 <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0 <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0 <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 42 ==Int OUT
+
+endmodule
+

--- a/crates/test-files/fixtures/kspecs/sanity/returns_42_invalid.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_42_invalid.k
@@ -1,0 +1,106 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($Returns42::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($Returns42::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> _ </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($Returns42::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0 <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0 <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0 <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 43 ==Int OUT
+
+
+endmodule
+

--- a/crates/test-files/fixtures/kspecs/sanity/returns_in.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_in.k
@@ -1,0 +1,106 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($ReturnsIn::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($ReturnsIn::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> #buf(32, IN) </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($ReturnsIn::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0  <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 0  <=Int IN         andBool IN         <Int (2 ^Int 256)
+        andBool IN ==Int OUT
+
+endmodule
+

--- a/crates/test-files/fixtures/kspecs/sanity/returns_in_cond1.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_in_cond1.k
@@ -1,0 +1,108 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($ReturnsInCond::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($ReturnsInCond::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> #buf(32, IN) </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($ReturnsInCond::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0  <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 0  <=Int IN         andBool IN         <Int (2 ^Int 256)
+        andBool 42 =/=Int IN
+        andBool IN ==Int OUT
+
+
+endmodule
+

--- a/crates/test-files/fixtures/kspecs/sanity/returns_in_cond2.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_in_cond2.k
@@ -1,0 +1,106 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($ReturnsInCond::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($ReturnsInCond::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> #buf(32, IN) </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($ReturnsInCond::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0  <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 42 ==Int IN
+        andBool 26 ==Int OUT
+
+endmodule
+

--- a/crates/test-files/fixtures/kspecs/sanity/returns_in_cond2_invalid.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_in_cond2_invalid.k
@@ -1,0 +1,105 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($ReturnsInCond::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($ReturnsInCond::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> #buf(32, IN) </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($ReturnsInCond::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0  <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 43 ==Int IN
+        andBool 26 ==Int OUT
+
+endmodule

--- a/crates/test-files/fixtures/kspecs/sanity/returns_in_invalid.k
+++ b/crates/test-files/fixtures/kspecs/sanity/returns_in_invalid.k
@@ -1,0 +1,106 @@
+module $TEST_NAME
+    imports VERIFICATION
+
+    claim
+
+    <kevm>
+        <k> #execute => #halt </k>
+        <exit-code> 1 </exit-code>
+        <mode> NORMAL </mode>
+        <schedule> ISTANBUL </schedule>
+
+        <ethereum>
+            <evm>
+                <output> _ => #buf(32, OUT) </output>
+                <statusCode> _ => EVMC_SUCCESS </statusCode>
+                <endPC> _ => ?_ </endPC>
+                <callStack> _ </callStack>
+                <interimStates> _ </interimStates>
+                <touchedAccounts> _ => ?_ </touchedAccounts>
+
+                <callState>
+                    <program> #parseByteStack($ReturnsIn::RUNTIME) </program>
+                    <jumpDests> #computeValidJumpDests(#parseByteStack($ReturnsIn::RUNTIME)) </jumpDests>
+
+                    <id> ACCT_ID </id> // contract owner
+                    <caller> CALLER_ID </caller> // who called this contract; in the beginning, origin // msg.sender
+
+                    <callData> #buf(32, IN) </callData>
+
+                    <callValue> 0 </callValue>
+                    <wordStack> .WordStack => ?_ </wordStack>
+                    <localMem> .Memory => ?_ </localMem>
+                    <pc> 0 => ?_ </pc>
+                    <gas> #gas(_VGAS) => ?_ </gas>
+                    <memoryUsed> 0 => ?_ </memoryUsed>
+                    <callGas> _ => ?_ </callGas>
+
+                    <static> false </static> // NOTE: non-static call
+                    <callDepth> CALL_DEPTH </callDepth>
+                </callState>
+
+                <substate>
+                    <selfDestruct> _ </selfDestruct>
+                    <log> _ </log>
+                    <refund> _ </refund> // TODO: more detail
+                    <accessedAccounts> _ => ?_ </accessedAccounts>
+                    <accessedStorage> _ => ?_ </accessedStorage>
+                </substate>
+
+                <gasPrice> _ </gasPrice>
+                <origin> ORIGIN_ID </origin> // who fires tx
+
+                <blockhashes> _ </blockhashes>
+                <block>
+                    <previousHash> _ </previousHash>
+                    <ommersHash> _ </ommersHash>
+                    <coinbase> _ </coinbase>
+                    <stateRoot> _ </stateRoot>
+                    <transactionsRoot> _ </transactionsRoot>
+                    <receiptsRoot> _ </receiptsRoot>
+                    <logsBloom> _ </logsBloom>
+                    <difficulty> _ </difficulty>
+                    <number> _ </number>
+                    <gasLimit> _ </gasLimit>
+                    <gasUsed> _ </gasUsed>
+                    <timestamp> _ </timestamp>
+                    <extraData> _ </extraData>
+                    <mixHash> _ </mixHash>
+                    <blockNonce> _ </blockNonce>
+                    <ommerBlockHeaders> _ </ommerBlockHeaders>
+                    <baseFee> _ </baseFee>
+                </block>
+            </evm>
+
+            <network>
+                <chainID> _ </chainID>
+
+                <activeAccounts> SetItem(ACCT_ID) _:Set </activeAccounts>
+
+                <accounts>
+                    <account>
+                        <acctID> ACCT_ID </acctID>
+                        <balance> _ </balance>
+                        <code> #parseByteStack($ReturnsIn::RUNTIME) </code>
+                        <storage> _ </storage>
+                        <origStorage> _ </origStorage>
+                        <nonce> _ </nonce>
+                    </account>
+                </accounts>
+
+                <txOrder> _ </txOrder>
+                <txPending> _ </txPending>
+                <messages> _ </messages>
+            </network>
+        </ethereum>
+    </kevm>
+
+    requires 0 <=Int ACCT_ID    andBool ACCT_ID    <Int (2 ^Int 160)
+        andBool 0  <=Int CALLER_ID  andBool CALLER_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int ORIGIN_ID  andBool ORIGIN_ID  <Int (2 ^Int 160)
+        andBool 0  <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1024
+        andBool 0  <=Int IN         andBool IN         <Int (2 ^Int 256)
+        andBool IN ==Int OUT +Int 1
+
+endmodule
+

--- a/crates/yulc/src/lib.rs
+++ b/crates/yulc/src/lib.rs
@@ -18,6 +18,18 @@ pub fn compile(
         .collect()
 }
 
+pub fn compile_runtimes(
+    contracts: impl Iterator<Item = (impl AsRef<str>, impl AsRef<str>)>,
+    optimize: bool,
+) -> Result<IndexMap<String, String>, YulcError> {
+    contracts
+        .map(|(name, yul_src)| {
+            compile_single_contract("runtime", yul_src.as_ref(), optimize)
+                .map(|bytecode| (name.as_ref().to_string(), bytecode))
+        })
+        .collect()
+}
+
 #[cfg(feature = "solc-backend")]
 /// Compiles a single Yul contract to bytecode.
 pub fn compile_single_contract(

--- a/crates/yulgen/src/db.rs
+++ b/crates/yulgen/src/db.rs
@@ -23,9 +23,13 @@ pub trait YulgenDb:
 {
     #[salsa::invoke(queries::compile_module)]
     fn compile_module(&self, module_id: ModuleId) -> IndexMap<String, String>;
+    #[salsa::invoke(queries::compile_module_runtimes)]
+    fn compile_module_runtimes(&self, module_id: ModuleId) -> IndexMap<String, String>;
 
     #[salsa::invoke(queries::contracts::contract_object)]
     fn contract_object(&self, contract: ContractId) -> yul::Object;
+    #[salsa::invoke(queries::contracts::contract_runtime_object)]
+    fn contract_runtime_object(&self, contract: ContractId) -> yul::Object;
     #[salsa::invoke(queries::contracts::contract_abi_dispatcher)]
     fn contract_abi_dispatcher(&self, contract: ContractId) -> Vec<yul::Statement>;
 

--- a/crates/yulgen/src/db/queries.rs
+++ b/crates/yulgen/src/db/queries.rs
@@ -16,6 +16,13 @@ pub fn compile_module(db: &dyn YulgenDb, module: ModuleId) -> IndexMap<String, S
         .collect()
 }
 
+pub fn compile_module_runtimes(db: &dyn YulgenDb, module: ModuleId) -> IndexMap<String, String> {
+    mappers::module::module_runtimes(db, module)
+        .drain()
+        .map(|(name, object)| (name, to_safe_json(object)))
+        .collect()
+}
+
 fn to_safe_json(obj: yul::Object) -> String {
     normalize_object(obj).to_string().replace('"', "\\\"")
 }

--- a/crates/yulgen/src/lib.rs
+++ b/crates/yulgen/src/lib.rs
@@ -27,3 +27,7 @@ mod utils;
 pub fn compile(db: &dyn YulgenDb, module: ModuleId) -> IndexMap<String, String> {
     db.compile_module(module)
 }
+
+pub fn compile_runtimes(db: &dyn YulgenDb, module: ModuleId) -> IndexMap<String, String> {
+    db.compile_module_runtimes(module)
+}

--- a/crates/yulgen/src/mappers/module.rs
+++ b/crates/yulgen/src/mappers/module.rs
@@ -21,3 +21,20 @@ pub fn module(db: &dyn YulgenDb, module: ModuleId) -> YulContracts {
             contracts
         })
 }
+
+pub fn module_runtimes(db: &dyn YulgenDb, module: ModuleId) -> YulContracts {
+    module
+        .all_contracts(db.upcast())
+        .iter()
+        .fold(YulContracts::new(), |mut contracts, id| {
+            let yul_contract = db.contract_runtime_object(*id);
+
+            if contracts
+                .insert(id.name(db.upcast()).to_string(), yul_contract)
+                .is_some()
+            {
+                panic!("duplicate contract definition");
+            }
+            contracts
+        })
+}

--- a/newsfragments/683.feature.md
+++ b/newsfragments/683.feature.md
@@ -1,0 +1,3 @@
+The `fe` binary can now emit runtime bytecode.
+
+e.g. `fe foo.fe --emit runtimeBytecode`

--- a/newsfragments/683.internal.md
+++ b/newsfragments/683.internal.md
@@ -1,0 +1,3 @@
+Added an `fv` crate with several kevm spec tests. 
+
+See the README in `crates/fv` for more information.


### PR DESCRIPTION
- added a `runtimeBytecode` output option. e.g. `fe foo.fe --emit runtimeBytecode`
- created a `fe-fv` crate and added some contract verification tests

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
