### PR TITLE
fixed memory bug in storage maps

### DIFF
--- a/crates/yulgen/src/runtime/functions/data.rs
+++ b/crates/yulgen/src/runtime/functions/data.rs
@@ -350,7 +350,7 @@ pub fn alloc_mstoren() -> yul::Statement {
 pub fn map_value_ptr() -> yul::Statement {
     function_definition! {
         function map_value_ptr(a, b) -> return_val {
-            (let ptr := avail())
+            (let ptr := alloc(64))
             (mstore(ptr, a))
             (mstore((add(ptr, 32)), b))
             (let hash := keccak256(ptr, 64))

--- a/newsfragments/684.bugfix.md
+++ b/newsfragments/684.bugfix.md
@@ -1,0 +1,1 @@
+The region of memory used to compute the slot of a storage map value was not being allocated.


### PR DESCRIPTION
### What was wrong?

The region of memory used to compute the slot of a storage map value was not being allocated.

### How was it fixed?

:keyboard: 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
