### PR TITLE
Return instead of revert when contract is called without data

### DIFF
--- a/crates/tests/src/snapshots/fe_compiler_tests__demo_uniswap__uniswap_contracts.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__demo_uniswap__uniswap_contracts.snap
@@ -12,7 +12,7 @@ balanceOf([Address(0x0000000000000000000000000000000000000000)]) used 744 gas
 get_reserves([]) used 1217 gas
 swap([Uint(1993), Uint(0), Address(0x0000000000000000000000000000000000000042)]) used 36265 gas
 get_reserves([]) used 1217 gas
-transfer([Address(0x0630026d44712d2748b1e0a496b73f03e74e077d), Uint(141421356237309503880)]) used 6048 gas
+transfer([Address(0x90c84d90bb9fd08f46f6b7efc23b758feb9c2d56), Uint(141421356237309503880)]) used 6048 gas
 burn([Address(0x1000000000000000000000000000000000000001)]) used 4959 gas
 get_reserves([]) used 1217 gas
 

--- a/crates/yulgen/src/runtime/abi_dispatcher.rs
+++ b/crates/yulgen/src/runtime/abi_dispatcher.rs
@@ -24,12 +24,12 @@ pub fn dispatcher(
         .collect::<Vec<_>>();
 
     let dispatcher = if arms.is_empty() {
-        statement! { revert(0, 0) }
+        statement! { return(0, 0) }
     } else {
         switch! {
             switch (cloadn(0, 4))
             [arms...]
-            (default { (revert(0, 0)) })
+            (default { (return(0, 0)) })
         }
     };
 

--- a/crates/yulgen/tests/snapshots/yulgen__abi_dispatcher.snap
+++ b/crates/yulgen/tests/snapshots/yulgen__abi_dispatcher.snap
@@ -17,4 +17,4 @@ case 0x771602f7 {
     let encoding_size := add(32, 0)
     return(encoding_start, encoding_size)
 }
-default { revert(0, 0) } }
+default { return(0, 0) } }

--- a/newsfragments/694.bugfix.md
+++ b/newsfragments/694.bugfix.md
@@ -1,0 +1,5 @@
+Return instead of revert when contract is called without data.
+
+If a contract is called without data so that no function is invoked,
+we would previously `revert` but that would leave us without a 
+way to send ETH to a contract so instead it will cause a `return` now.


### PR DESCRIPTION
Otherwise, there would currently be no way to send ETH
to a contract.