### PR TITLE
Allow public unsafe smart contract functions to be called from outside

### DIFF
--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -2,7 +2,7 @@ use crate::context::{AnalyzerContext, CallType, FunctionBody};
 use crate::db::{Analysis, AnalyzerDb};
 use crate::errors::TypeError;
 use crate::namespace::items::{
-    Class, DepGraph, DepGraphWrapper, DepLocality, FunctionId, Item, TypeDef,
+    DepGraph, DepGraphWrapper, DepLocality, FunctionId, Item, TypeDef,
 };
 use crate::namespace::scopes::{BlockScope, BlockScopeType, FunctionScope, ItemScope};
 use crate::namespace::types::{self, Contract, CtxDecl, FixedSize, SelfDecl, Struct, Type};
@@ -26,17 +26,6 @@ pub fn function_signature(
 
     let mut scope = ItemScope::new(db, function.module(db));
     let fn_parent = function.class(db);
-
-    if_chain! {
-        if let Some(Class::Contract(_)) = fn_parent;
-        if let Some(pub_span) = function.pub_span(db);
-        if let Some(unsafe_span) = function.unsafe_span(db);
-        then {
-            scope.error("public contract functions can't be unsafe",
-                        pub_span + unsafe_span,
-                        "a contract function can be either `pub` or `unsafe`, but not both");
-        }
-    }
 
     let mut self_decl = None;
     let mut ctx_decl = None;

--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -1,9 +1,7 @@
 use crate::context::{AnalyzerContext, CallType, FunctionBody};
 use crate::db::{Analysis, AnalyzerDb};
 use crate::errors::TypeError;
-use crate::namespace::items::{
-    DepGraph, DepGraphWrapper, DepLocality, FunctionId, Item, TypeDef,
-};
+use crate::namespace::items::{DepGraph, DepGraphWrapper, DepLocality, FunctionId, Item, TypeDef};
 use crate::namespace::scopes::{BlockScope, BlockScopeType, FunctionScope, ItemScope};
 use crate::namespace::types::{self, Contract, CtxDecl, FixedSize, SelfDecl, Struct, Type};
 use crate::traversal::functions::traverse_statements;

--- a/crates/analyzer/tests/snapshots/errors__unsafe_misuse.snap
+++ b/crates/analyzer/tests/snapshots/errors__unsafe_misuse.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
-
 ---
 error: unsafe function `mod_priv` can only be called in an unsafe function or block
    ┌─ compile_errors/unsafe_misuse.fe:10:3
@@ -13,18 +12,6 @@ error: unsafe function `mod_priv` can only be called in an unsafe function or bl
    │   ^^^^^^^^ call to unsafe function
    │
    = Hint: put this call in an `unsafe` block if you're confident that it's safe to use here
-
-error: public contract functions can't be unsafe
-   ┌─ compile_errors/unsafe_misuse.fe:18:3
-   │
-18 │   pub unsafe fn pub_self(self): # BAD
-   │   ^^^^^^^^^^ a contract function can be either `pub` or `unsafe`, but not both
-
-error: public contract functions can't be unsafe
-   ┌─ compile_errors/unsafe_misuse.fe:20:3
-   │
-20 │   pub unsafe fn pub_noself(): # BAD
-   │   ^^^^^^^^^^ a contract function can be either `pub` or `unsafe`, but not both
 
 error: unsafe function `priv_self` can only be called in an unsafe function or block
    ┌─ compile_errors/unsafe_misuse.fe:38:5

--- a/crates/test-files/fixtures/compile_errors/unsafe_misuse.fe
+++ b/crates/test-files/fixtures/compile_errors/unsafe_misuse.fe
@@ -14,10 +14,10 @@ pub fn g():
     mod_priv() # OK
 
 contract Foo:
-  # pub unsafe contract functions aren't allowed
-  pub unsafe fn pub_self(self): # BAD
+  # pub unsafe contract functions are allowed
+  pub unsafe fn pub_self(self): # Ok
     pass
-  pub unsafe fn pub_noself(): # BAD
+  pub unsafe fn pub_noself(): # Ok
     pass
 
   # non-pub contract fns can be unsafe


### PR DESCRIPTION
### What was wrong?
`unsafe` functions weren't allowed to be public (`pub`) as described in #687 

### How was it fixed?
The issue was fixed by removing the block of code that checked whether the function is both `pub` and `unsafe`. i.e by removing the [following check](https://github.com/ethereum/fe/blob/master/crates/analyzer/src/db/queries/functions.rs#L30-L39).

Later, the tests were updated to respect the same by updating the snapshots using `cargo insta review`.