### PR TITLE
Parse generic function definitons

### DIFF
--- a/crates/lowering/src/mappers/functions.rs
+++ b/crates/lowering/src/mappers/functions.rs
@@ -22,6 +22,7 @@ pub fn func_def(context: &mut ModuleContext, function: FunctionId) -> Node<fe::F
         unsafe_,
         name,
         args,
+        generic_params,
         return_type: return_type_node,
         body,
     } = &node.kind;
@@ -113,6 +114,7 @@ pub fn func_def(context: &mut ModuleContext, function: FunctionId) -> Node<fe::F
         unsafe_: *unsafe_,
         name: name.clone(),
         args,
+        generic_params: generic_params.clone(),
         return_type: Some(lowered_return_type),
         body: lowered_body,
     };

--- a/crates/lowering/src/mappers/module.rs
+++ b/crates/lowering/src/mappers/module.rs
@@ -202,6 +202,7 @@ fn list_expr_to_fn_def(array: &Array) -> ast::Function {
         unsafe_: None,
         name: names::list_expr_generator_fn_name(array).into_node(),
         args,
+        generic_params: Vec::new().into_node(),
         return_type,
         body: [vec![var_decl], assignments, vec![return_stmt]].concat(),
     }

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -123,6 +123,24 @@ impl Spanned for GenericArg {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub enum GenericParameter {
+    Unbounded(Node<SmolStr>),
+    Bounded {
+        name: Node<SmolStr>,
+        bound: Node<SmolStr>,
+    },
+}
+
+impl Spanned for GenericParameter {
+    fn span(&self) -> Span {
+        match self {
+            GenericParameter::Unbounded(node) => node.span,
+            GenericParameter::Bounded { name, bound } => name.span + bound.span,
+        }
+    }
+}
+
 /// struct or contract field, with optional 'pub' and 'const' qualifiers
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Field {
@@ -153,6 +171,7 @@ pub struct Function {
     pub pub_: Option<Span>,
     pub unsafe_: Option<Span>,
     pub name: Node<SmolStr>,
+    pub generic_params: Node<Vec<GenericParameter>>,
     pub args: Vec<Node<FunctionArg>>,
     pub return_type: Option<Node<TypeDesc>>,
     pub body: Vec<Node<FuncStmt>>,

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -141,6 +141,8 @@ test_parse! { type_tuple, types::parse_type_desc, "(u8, u16, address, Map<u8, u8
 test_parse! { type_unit, types::parse_type_desc, "()" }
 
 test_parse! { fn_def, try_parse_module, "fn transfer(from sender: address, to recip: address, _ val: u64) -> bool:\n false"}
+
+test_parse! { fn_def_generic, try_parse_module, "fn foo<T, R: Event>(this: T, that: R, _ val: u64) -> bool:\n false"}
 test_parse! { fn_def_pub, try_parse_module, "pub fn foo21(x: bool, y: address,) -> bool:\n x"}
 test_parse! { fn_def_unsafe, try_parse_module, "unsafe fn foo21(x: bool, y: address,) -> bool:\n x"}
 test_parse! { fn_def_pub_unsafe, try_parse_module, "pub unsafe fn foo21(x: bool, y: address,) -> bool:\n x"}

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(contract_def), module::parse_module,\n           r#\"contract Foo:\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n  pub fn foo() -> u8:\n    return 10\n  event Bar:\n    idx from: address\n\"#)"
+expression: "ast_string(stringify!(contract_def), try_parse_module,\n    r#\"contract Foo:\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n  pub fn foo() -> u8:\n    return 10\n  event Bar:\n    idx from: address\n\"#)"
 
 ---
 Node(
@@ -140,6 +140,13 @@ Node(
                 unsafe_: None,
                 name: Node(
                   kind: "foo",
+                  span: Span(
+                    start: 80,
+                    end: 83,
+                  ),
+                ),
+                generic_params: Node(
+                  kind: [],
                   span: Span(
                     start: 80,
                     end: 83,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_generic.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_generic.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def), try_parse_module,\n    \"fn transfer(from sender: address, to recip: address, _ val: u64) -> bool:\\n false\")"
+expression: "ast_string(stringify!(fn_def_generic), try_parse_module,\n    \"fn foo<T, R: Event>(this: T, that: R, _ val: u64) -> bool:\\n false\")"
 
 ---
 Node(
@@ -11,80 +11,92 @@ Node(
           pub_: None,
           unsafe_: None,
           name: Node(
-            kind: "transfer",
+            kind: "foo",
             span: Span(
               start: 3,
-              end: 11,
+              end: 6,
             ),
           ),
           generic_params: Node(
-            kind: [],
+            kind: [
+              Unbounded(Node(
+                kind: "T",
+                span: Span(
+                  start: 7,
+                  end: 8,
+                ),
+              )),
+              Bounded(
+                name: Node(
+                  kind: "R",
+                  span: Span(
+                    start: 10,
+                    end: 11,
+                  ),
+                ),
+                bound: Node(
+                  kind: "Event",
+                  span: Span(
+                    start: 13,
+                    end: 18,
+                  ),
+                ),
+              ),
+            ],
             span: Span(
-              start: 3,
-              end: 11,
+              start: 6,
+              end: 19,
             ),
           ),
           args: [
             Node(
               kind: Regular(RegularFunctionArg(
-                label: Some(Node(
-                  kind: "from",
-                  span: Span(
-                    start: 12,
-                    end: 16,
-                  ),
-                )),
+                label: None,
                 name: Node(
-                  kind: "sender",
+                  kind: "this",
                   span: Span(
-                    start: 17,
-                    end: 23,
+                    start: 20,
+                    end: 24,
                   ),
                 ),
                 typ: Node(
                   kind: Base(
-                    base: "address",
+                    base: "T",
                   ),
                   span: Span(
-                    start: 25,
-                    end: 32,
+                    start: 26,
+                    end: 27,
                   ),
                 ),
               )),
               span: Span(
-                start: 17,
-                end: 32,
+                start: 20,
+                end: 27,
               ),
             ),
             Node(
               kind: Regular(RegularFunctionArg(
-                label: Some(Node(
-                  kind: "to",
-                  span: Span(
-                    start: 34,
-                    end: 36,
-                  ),
-                )),
+                label: None,
                 name: Node(
-                  kind: "recip",
+                  kind: "that",
                   span: Span(
-                    start: 37,
-                    end: 42,
+                    start: 29,
+                    end: 33,
                   ),
                 ),
                 typ: Node(
                   kind: Base(
-                    base: "address",
+                    base: "R",
                   ),
                   span: Span(
-                    start: 44,
-                    end: 51,
+                    start: 35,
+                    end: 36,
                   ),
                 ),
               )),
               span: Span(
-                start: 37,
-                end: 51,
+                start: 29,
+                end: 36,
               ),
             ),
             Node(
@@ -92,15 +104,15 @@ Node(
                 label: Some(Node(
                   kind: "_",
                   span: Span(
-                    start: 53,
-                    end: 54,
+                    start: 38,
+                    end: 39,
                   ),
                 )),
                 name: Node(
                   kind: "val",
                   span: Span(
-                    start: 55,
-                    end: 58,
+                    start: 40,
+                    end: 43,
                   ),
                 ),
                 typ: Node(
@@ -108,14 +120,14 @@ Node(
                     base: "u64",
                   ),
                   span: Span(
-                    start: 60,
-                    end: 63,
+                    start: 45,
+                    end: 48,
                   ),
                 ),
               )),
               span: Span(
-                start: 55,
-                end: 63,
+                start: 40,
+                end: 48,
               ),
             ),
           ],
@@ -124,8 +136,8 @@ Node(
               base: "bool",
             ),
             span: Span(
-              start: 68,
-              end: 72,
+              start: 53,
+              end: 57,
             ),
           )),
           body: [
@@ -134,27 +146,27 @@ Node(
                 value: Node(
                   kind: Bool(false),
                   span: Span(
-                    start: 75,
-                    end: 80,
+                    start: 60,
+                    end: 65,
                   ),
                 ),
               ),
               span: Span(
-                start: 75,
-                end: 80,
+                start: 60,
+                end: 65,
               ),
             ),
           ],
         ),
         span: Span(
           start: 0,
-          end: 80,
+          end: 65,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 80,
+    end: 65,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_pub), try_parse_module,\n           \"pub fn foo21(x: bool, y: address,) -> bool:\\n x\")"
+expression: "ast_string(stringify!(fn_def_pub), try_parse_module,\n    \"pub fn foo21(x: bool, y: address,) -> bool:\\n x\")"
 
 ---
 Node(
@@ -15,6 +15,13 @@ Node(
           unsafe_: None,
           name: Node(
             kind: "foo21",
+            span: Span(
+              start: 7,
+              end: 12,
+            ),
+          ),
+          generic_params: Node(
+            kind: [],
             span: Span(
               start: 7,
               end: 12,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub_unsafe.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub_unsafe.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_pub_unsafe), try_parse_module,\n           \"pub unsafe fn foo21(x: bool, y: address,) -> bool:\\n x\")"
+expression: "ast_string(stringify!(fn_def_pub_unsafe), try_parse_module,\n    \"pub unsafe fn foo21(x: bool, y: address,) -> bool:\\n x\")"
 
 ---
 Node(
@@ -18,6 +18,13 @@ Node(
           )),
           name: Node(
             kind: "foo21",
+            span: Span(
+              start: 14,
+              end: 19,
+            ),
+          ),
+          generic_params: Node(
+            kind: [],
             span: Span(
               start: 14,
               end: 19,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_unsafe.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_unsafe.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_unsafe), try_parse_module,\n           \"unsafe fn foo21(x: bool, y: address,) -> bool:\\n x\")"
+expression: "ast_string(stringify!(fn_def_unsafe), try_parse_module,\n    \"unsafe fn foo21(x: bool, y: address,) -> bool:\\n x\")"
 
 ---
 Node(
@@ -15,6 +15,13 @@ Node(
           )),
           name: Node(
             kind: "foo21",
+            span: Span(
+              start: 10,
+              end: 15,
+            ),
+          ),
+          generic_params: Node(
+            kind: [],
             span: Span(
               start: 10,
               end: 15,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(guest_book), try_parse_module,\n           r#\"\ntype BookMsg = Array<bytes, 100>\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub fn sign(self, book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg: book_msg)\n\n    pub fn get_msg(self, addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
+expression: "ast_string(stringify!(guest_book), try_parse_module,\n    r#\"\ntype BookMsg = Array<bytes, 100>\n\ncontract GuestBook:\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed:\n        idx book_msg: BookMsg\n\n    pub fn sign(self, book_msg: BookMsg):\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg: book_msg)\n\n    pub fn get_msg(self, addr: address) -> BookMsg:\n        return self.guest_book[addr]\n\"#)"
 
 ---
 Node(
@@ -189,6 +189,13 @@ Node(
                     end: 162,
                   ),
                 ),
+                generic_params: Node(
+                  kind: [],
+                  span: Span(
+                    start: 158,
+                    end: 162,
+                  ),
+                ),
                 args: [
                   Node(
                     kind: Self_,
@@ -353,6 +360,13 @@ Node(
                 unsafe_: None,
                 name: Node(
                   kind: "get_msg",
+                  span: Span(
+                    start: 289,
+                    end: 296,
+                  ),
+                ),
+                generic_params: Node(
+                  kind: [],
                   span: Span(
                     start: 289,
                     end: 296,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_level_events), try_parse_module,\n           r#\"\nuse std::context::Context\n\nevent Transfer:\n    idx sender: address\n    idx receiver: address\n    value: u256\n\ncontract Foo:\n    fn transfer(ctx: Context, to: address, value: u256):\n        emit Transfer(ctx, sender: msg.sender, receiver: to, value)\n\"#)"
+expression: "ast_string(stringify!(module_level_events), try_parse_module,\n    r#\"\nuse std::context::Context\n\nevent Transfer:\n    idx sender: address\n    idx receiver: address\n    value: u256\n\ncontract Foo:\n    fn transfer(ctx: Context, to: address, value: u256):\n        emit Transfer(ctx, sender: msg.sender, receiver: to, value)\n\"#)"
 
 ---
 Node(
@@ -158,6 +158,13 @@ Node(
                 unsafe_: None,
                 name: Node(
                   kind: "transfer",
+                  span: Span(
+                    start: 132,
+                    end: 140,
+                  ),
+                ),
+                generic_params: Node(
+                  kind: [],
                   span: Span(
                     start: 132,
                     end: 140,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_stmts), try_parse_module,\n           r#\"\npragma 0.5.0\n\nuse foo::bar::{\n    bing as bong,\n    food::*\n}\n\ntype X = Map<u8, u16>\n\npub fn double(x: u8) -> u8:\n    return x * 2\n\nfn secret() -> u8:\n    return 0xBEEF\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
+expression: "ast_string(stringify!(module_stmts), try_parse_module,\n    r#\"\npragma 0.5.0\n\nuse foo::bar::{\n    bing as bong,\n    food::*\n}\n\ntype X = Map<u8, u16>\n\npub fn double(x: u8) -> u8:\n    return x * 2\n\nfn secret() -> u8:\n    return 0xBEEF\n\ncontract A:\n    pub const x: u256 = 10\n\ncontract B:\n    pub x: X\n\"#)"
 
 ---
 Node(
@@ -173,6 +173,13 @@ Node(
               end: 100,
             ),
           ),
+          generic_params: Node(
+            kind: [],
+            span: Span(
+              start: 94,
+              end: 100,
+            ),
+          ),
           args: [
             Node(
               kind: Regular(RegularFunctionArg(
@@ -260,6 +267,13 @@ Node(
           unsafe_: None,
           name: Node(
             kind: "secret",
+            span: Span(
+              start: 136,
+              end: 142,
+            ),
+          ),
+          generic_params: Node(
+            kind: [],
             span: Span(
               start: 136,
               end: 142,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(pub_contract_def), module::parse_module,\n           r#\"pub contract Foo:\n    pub fn foo() -> u8:\n      return 10\n\"#)"
+expression: "ast_string(stringify!(pub_contract_def), try_parse_module,\n    r#\"pub contract Foo:\n    pub fn foo() -> u8:\n      return 10\n\"#)"
 
 ---
 Node(
@@ -26,6 +26,13 @@ Node(
                 unsafe_: None,
                 name: Node(
                   kind: "foo",
+                  span: Span(
+                    start: 29,
+                    end: 32,
+                  ),
+                ),
+                generic_params: Node(
+                  kind: [],
                   span: Span(
                     start: 29,
                     end: 32,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(struct_def), module::parse_module,\n           r#\"struct S:\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8:\n    return self.z + self.y\n  unsafe fn bar():\n    pass\n\"#)"
+expression: "ast_string(stringify!(struct_def), try_parse_module,\n    r#\"struct S:\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8:\n    return self.z + self.y\n  unsafe fn bar():\n    pass\n\"#)"
 
 ---
 Node(
@@ -172,6 +172,13 @@ Node(
                     end: 78,
                   ),
                 ),
+                generic_params: Node(
+                  kind: [],
+                  span: Span(
+                    start: 75,
+                    end: 78,
+                  ),
+                ),
                 args: [
                   Node(
                     kind: Self_,
@@ -274,6 +281,13 @@ Node(
                 )),
                 name: Node(
                   kind: "bar",
+                  span: Span(
+                    start: 131,
+                    end: 134,
+                  ),
+                ),
+                generic_params: Node(
+                  kind: [],
                   span: Span(
                     start: 131,
                     end: 134,


### PR DESCRIPTION
### What was wrong?

We don't parse generic functions yet e.g. `fn do_it<T, E: Event>(me: T, eek: E):`

### How was it fixed?

Parse dat thing