### PR TITLE
Get rid of FixedSize

### DIFF
--- a/crates/abi/src/builder.rs
+++ b/crates/abi/src/builder.rs
@@ -100,9 +100,9 @@ fn function_def(db: &dyn AnalyzerDb, name: &str, fn_id: FunctionId, typ: FuncTyp
     }
 }
 
-fn components(db: &dyn AnalyzerDb, typ: &types::FixedSize) -> Vec<Component> {
+fn components(db: &dyn AnalyzerDb, typ: &types::Type) -> Vec<Component> {
     match typ {
-        types::FixedSize::Struct(types::Struct { id, .. }) => id
+        types::Type::Struct(types::Struct { id, .. }) => id
             .fields(db)
             .iter()
             .map(|(name, field_id)| Component {
@@ -113,7 +113,7 @@ fn components(db: &dyn AnalyzerDb, typ: &types::FixedSize) -> Vec<Component> {
                     .abi_json_name(),
             })
             .collect(),
-        types::FixedSize::Tuple(types::Tuple { items }) => items
+        types::Type::Tuple(types::Tuple { items }) => items
             .iter()
             .enumerate()
             .map(|(index, item)| Component {

--- a/crates/abi/src/elements.rs
+++ b/crates/abi/src/elements.rs
@@ -1,5 +1,5 @@
 use crate::errors::AbiError;
-use fe_analyzer::namespace::types::{Array, Base, FeString, FixedSize, Integer, Struct, Tuple};
+use fe_analyzer::namespace::types::{Array, Base, FeString, Integer, Struct, Tuple, Type};
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use std::collections::HashMap;
@@ -76,15 +76,16 @@ pub trait JsonAbi {
     fn abi_json_name(&self) -> String;
 }
 
-impl JsonAbi for FixedSize {
+impl JsonAbi for Type {
     fn abi_json_name(&self) -> String {
         match self {
-            FixedSize::Array(array) => array.abi_json_name(),
-            FixedSize::Base(base) => base.abi_json_name(),
-            FixedSize::Tuple(tuple) => tuple.abi_json_name(),
-            FixedSize::String(string) => string.abi_json_name(),
-            FixedSize::Contract(_) => "address".to_string(),
-            FixedSize::Struct(val) => val.abi_json_name(),
+            Type::Array(array) => array.abi_json_name(),
+            Type::Base(base) => base.abi_json_name(),
+            Type::Tuple(tuple) => tuple.abi_json_name(),
+            Type::String(string) => string.abi_json_name(),
+            Type::Contract(_) => "address".to_string(),
+            Type::Struct(val) => val.abi_json_name(),
+            _ => panic!("not abi encodable"),
         }
     }
 }

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -1,5 +1,5 @@
 use crate::namespace::items::{Class, ContractId, DiagnosticSink, EventId, FunctionId, Item};
-use crate::namespace::types::{FixedSize, SelfDecl, Struct, Type};
+use crate::namespace::types::{SelfDecl, Struct, Type};
 use crate::AnalyzerDb;
 use crate::{
     builtins::{ContractTypeMethod, GlobalFunction, Intrinsic, ValueMethod},
@@ -224,7 +224,7 @@ pub enum NamedThing {
     // SelfType // when/if we add a `Self` type keyword
     Variable {
         name: String,
-        typ: Result<FixedSize, TypeError>,
+        typ: Result<Type, TypeError>,
         is_const: bool,
         span: Span,
     },
@@ -358,13 +358,11 @@ pub enum Location {
 impl Location {
     /// The expected location of a value with the given type when being
     /// assigned, returned, or passed.
-    pub fn assign_location(typ: &FixedSize) -> Self {
+    pub fn assign_location(typ: &Type) -> Self {
         match typ {
-            FixedSize::Base(_) | FixedSize::Contract(_) => Location::Value,
-            FixedSize::Array(_)
-            | FixedSize::Tuple(_)
-            | FixedSize::String(_)
-            | FixedSize::Struct(_) => Location::Memory,
+            Type::Base(_) | Type::Contract(_) => Location::Value,
+            Type::Array(_) | Type::Tuple(_) | Type::String(_) | Type::Struct(_) => Location::Memory,
+            other => panic!("Type {other} can not be assigned, returned or passed"),
         }
     }
 }
@@ -379,7 +377,7 @@ pub struct FunctionBody {
 
     // This is the id of the VarDecl TypeDesc node
     // TODO: Do we really need this?
-    pub var_decl_types: IndexMap<NodeId, FixedSize>,
+    pub var_decl_types: IndexMap<NodeId, Type>,
     pub calls: IndexMap<NodeId, CallType>,
     pub spans: HashMap<NodeId, Span>,
 }

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -146,10 +146,7 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     #[salsa::invoke(queries::structs::struct_field_map)]
     fn struct_field_map(&self, id: StructId) -> Analysis<Rc<IndexMap<SmolStr, StructFieldId>>>;
     #[salsa::invoke(queries::structs::struct_field_type)]
-    fn struct_field_type(
-        &self,
-        field: StructFieldId,
-    ) -> Analysis<Result<types::FixedSize, TypeError>>;
+    fn struct_field_type(&self, field: StructFieldId) -> Analysis<Result<types::Type, TypeError>>;
     #[salsa::invoke(queries::structs::struct_all_functions)]
     fn struct_all_functions(&self, id: StructId) -> Rc<[FunctionId]>;
     #[salsa::invoke(queries::structs::struct_function_map)]

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -39,9 +39,9 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
                 typ: typ_node,
             } = &field.kind;
 
-            let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ.try_into() {
-                Ok(typ) => Ok(typ),
-                Err(_) => Err(TypeError::new(scope.error(
+            let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
+                typ if typ.has_fixed_size() => Ok(typ),
+                _ => Err(TypeError::new(scope.error(
                     "event field type must have a fixed size",
                     typ_node.span,
                     "this can't be used as an event field",

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -7,7 +7,7 @@ use crate::namespace::items::{
     StructFieldId, StructId, TypeDef,
 };
 use crate::namespace::scopes::ItemScope;
-use crate::namespace::types::{self, Contract, FixedSize, Struct};
+use crate::namespace::types::{self, Contract, Struct, Type};
 use crate::traversal::types::type_desc;
 use crate::AnalyzerDb;
 use fe_parser::ast;
@@ -72,7 +72,7 @@ pub fn struct_field_map(
 pub fn struct_field_type(
     db: &dyn AnalyzerDb,
     field: StructFieldId,
-) -> Analysis<Result<types::FixedSize, TypeError>> {
+) -> Analysis<Result<Type, TypeError>> {
     let field_data = field.data(db);
 
     let mut scope = ItemScope::new(db, field_data.parent.module(db));
@@ -92,16 +92,16 @@ pub fn struct_field_type(
         scope.not_yet_implemented("struct field initial value assignment", field_data.ast.span);
     }
     let typ = match type_desc(&mut scope, typ) {
-        Ok(typ) => match typ.try_into() {
-            Ok(FixedSize::Contract(contract)) => {
+        Ok(typ) => match typ {
+            Type::Contract(contract) => {
                 scope.not_yet_implemented(
                     "contract types aren't yet supported as struct fields",
                     field_data.ast.span,
                 );
-                Ok(FixedSize::Contract(contract))
+                Ok(Type::Contract(contract))
             }
-            Ok(typ) => Ok(typ),
-            Err(_) => Err(TypeError::new(scope.error(
+            typ if typ.has_fixed_size() => Ok(typ),
+            _ => Err(TypeError::new(scope.error(
                 "struct field type must have a fixed size",
                 field_data.ast.span,
                 "this can't be used as an struct field",
@@ -195,13 +195,13 @@ pub fn struct_dependency_graph(db: &dyn AnalyzerDb, struct_: StructId) -> DepGra
         .fields(db)
         .values()
         .filter_map(|field| match field.typ(db).ok()? {
-            FixedSize::Contract(Contract { id, .. }) => Some((
+            Type::Contract(Contract { id, .. }) => Some((
                 root,
                 Item::Type(TypeDef::Contract(id)),
                 DepLocality::External,
             )),
             // Not possible yet, but it will be soon
-            FixedSize::Struct(Struct { id, .. }) => {
+            Type::Struct(Struct { id, .. }) => {
                 Some((root, Item::Type(TypeDef::Struct(id)), DepLocality::Local))
             }
             _ => None,

--- a/crates/analyzer/src/errors.rs
+++ b/crates/analyzer/src/errors.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 ///
 /// Note that the "type" of a thing (eg the type of a `FunctionParam`)
 /// in [`crate::namespace::types`] is sometimes represented as a
-/// `Result<FixedSize, TypeError>`.
+/// `Result<Type, TypeError>`.
 ///
 /// If, for example, a function parameter has an undefined type, we emit a [`Diagnostic`] message,
 /// give that parameter a "type" of `Err(TypeError)`, and carry on. If/when that parameter is
@@ -124,7 +124,7 @@ pub struct AlreadyDefined;
 #[derive(Debug)]
 pub struct CannotMove;
 
-/// Error indicating that a [`Type`] can't be converted into a [`FixedSize`]
+/// Error indicating that a [`Type`] does not have a fixed size.
 #[derive(Debug)]
 pub struct NotFixedSize;
 

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -2,7 +2,6 @@ use crate::context;
 
 use crate::context::{Analysis, Constant};
 use crate::errors::{self, IncompleteItem, TypeError};
-use crate::namespace::types::FixedSize;
 use crate::namespace::types::{self, GenericType};
 use crate::traversal::pragma::check_pragma_version;
 use crate::AnalyzerDb;
@@ -1310,12 +1309,12 @@ impl StructId {
         &self,
         db: &dyn AnalyzerDb,
         name: &str,
-    ) -> Option<Result<types::FixedSize, TypeError>> {
+    ) -> Option<Result<types::Type, TypeError>> {
         Some(self.field(db, name)?.typ(db))
     }
 
     pub fn is_base_type(&self, db: &dyn AnalyzerDb, name: &str) -> bool {
-        matches!(self.field_type(db, name), Some(Ok(FixedSize::Base(_))))
+        matches!(self.field_type(db, name), Some(Ok(types::Type::Base(_))))
     }
 
     pub fn field_index(&self, db: &dyn AnalyzerDb, name: &str) -> Option<usize> {
@@ -1396,11 +1395,11 @@ impl StructFieldId {
     pub fn data(&self, db: &dyn AnalyzerDb) -> Rc<StructField> {
         db.lookup_intern_struct_field(*self)
     }
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::FixedSize, TypeError> {
+    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::Type, TypeError> {
         db.struct_field_type(*self).value
     }
     pub fn is_base_type(&self, db: &dyn AnalyzerDb) -> bool {
-        matches!(self.typ(db), Ok(FixedSize::Base(_)))
+        matches!(self.typ(db), Ok(types::Type::Base(_)))
     }
     pub fn is_public(&self, db: &dyn AnalyzerDb) -> bool {
         self.data(db).ast.kind.is_pub

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -6,7 +6,7 @@ use crate::context::{
 use crate::errors::{AlreadyDefined, IncompleteItem, TypeError};
 use crate::namespace::items::{Class, EventId, FunctionId, ModuleId};
 use crate::namespace::items::{Item, TypeDef};
-use crate::namespace::types::{FixedSize, Struct};
+use crate::namespace::types::{Struct, Type};
 use crate::AnalyzerDb;
 use fe_common::diagnostics::Diagnostic;
 use fe_common::Span;
@@ -16,8 +16,6 @@ use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Deref;
-
-use super::types::Type;
 
 pub struct ItemScope<'a> {
     db: &'a dyn AnalyzerDb,
@@ -172,7 +170,7 @@ impl<'a> FunctionScope<'a> {
         }
     }
 
-    pub fn function_return_type(&self) -> Result<FixedSize, TypeError> {
+    pub fn function_return_type(&self) -> Result<Type, TypeError> {
         self.function.signature(self.db).return_type.clone()
     }
 
@@ -195,7 +193,7 @@ impl<'a> FunctionScope<'a> {
     /// # Panics
     ///
     /// Panics if an entry already exists for the node id.
-    pub fn add_declaration(&self, node: &Node<ast::TypeDesc>, typ: FixedSize) {
+    pub fn add_declaration(&self, node: &Node<ast::TypeDesc>, typ: Type) {
         self.add_node(node);
         self.body
             .borrow_mut()
@@ -390,7 +388,7 @@ pub struct BlockScope<'a, 'b> {
     pub root: &'a FunctionScope<'b>,
     pub parent: Option<&'a BlockScope<'a, 'b>>,
     /// Maps Name -> (Type, is_const, span)
-    pub variable_defs: BTreeMap<String, (FixedSize, bool, Span)>,
+    pub variable_defs: BTreeMap<String, (Type, bool, Span)>,
     pub constant_defs: RefCell<BTreeMap<String, Constant>>,
     pub typ: BlockScopeType,
 }
@@ -533,7 +531,7 @@ impl<'a, 'b> BlockScope<'a, 'b> {
     pub fn add_var(
         &mut self,
         name: &str,
-        typ: FixedSize,
+        typ: Type,
         is_const: bool,
         span: Span,
     ) -> Result<(), AlreadyDefined> {

--- a/crates/analyzer/src/traversal/declarations.rs
+++ b/crates/analyzer/src/traversal/declarations.rs
@@ -1,7 +1,7 @@
 use crate::context::AnalyzerContext;
 use crate::errors::FatalError;
 use crate::namespace::scopes::BlockScope;
-use crate::namespace::types::FixedSize;
+use crate::namespace::types::Type;
 use crate::traversal::{const_expr, expressions, types};
 use fe_common::{diagnostics::Label, utils::humanize::pluralize_conditionally};
 use fe_parser::ast as fe;
@@ -10,21 +10,18 @@ use fe_parser::node::Node;
 /// Gather context information for var declarations and check for type errors.
 pub fn var_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalError> {
     if let fe::FuncStmt::VarDecl { target, typ, value } = &stmt.kind {
-        let declared_type = match FixedSize::try_from(types::type_desc(scope, typ)?) {
-            Ok(typ) => typ,
-            Err(_) => {
-                // If this conversion fails, the type must be a map (for now at least)
-                return Err(FatalError::new(scope.error(
-                    "invalid variable type",
-                    typ.span,
-                    "`Map` type can only be used as a contract field",
-                )));
-            }
-        };
+        let declared_type = types::type_desc(scope, typ)?;
+        if let Type::Map(_) = declared_type {
+            return Err(FatalError::new(scope.error(
+                "invalid variable type",
+                typ.span,
+                "`Map` type can only be used as a contract field",
+            )));
+        }
 
         if let Some(value) = value {
             let value_attributes =
-                expressions::assignable_expr(scope, value, Some(&declared_type.clone().into()))?;
+                expressions::assignable_expr(scope, value, Some(&declared_type))?;
 
             if declared_type != value_attributes.typ {
                 scope.type_error(
@@ -46,9 +43,9 @@ pub fn var_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(),
 
 pub fn const_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalError> {
     if let fe::FuncStmt::ConstantDecl { name, typ, value } = &stmt.kind {
-        let declared_type = match FixedSize::try_from(types::type_desc(scope, typ)?) {
-            Ok(typ) => typ,
-            Err(_) => {
+        let declared_type = match types::type_desc(scope, typ) {
+            Ok(typ) if typ.has_fixed_size() => typ,
+            _ => {
                 // If this conversion fails, the type must be a map (for now at least)
                 return Err(FatalError::new(scope.error(
                     "invalid constant type",
@@ -59,8 +56,7 @@ pub fn const_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(
         };
 
         // Perform semantic analysis before const evaluation.
-        let value_attributes =
-            expressions::assignable_expr(scope, value, Some(&declared_type.clone().into()))?;
+        let value_attributes = expressions::assignable_expr(scope, value, Some(&declared_type))?;
 
         if declared_type != value_attributes.typ {
             scope.type_error(
@@ -75,9 +71,7 @@ pub fn const_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(
         let const_value = const_expr::eval_expr(scope, value)?;
 
         scope.root.add_declaration(typ, declared_type.clone());
-        scope
-            .root
-            .map_variable_type(name, declared_type.clone().into());
+        scope.root.map_variable_type(name, declared_type.clone());
         // this logs a message on err, so it's safe to ignore here.
         let _ = scope.add_var(name.kind.as_str(), declared_type, true, name.span);
         scope.add_constant(name, value, const_value);
@@ -91,18 +85,18 @@ pub fn const_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(
 fn add_var(
     scope: &mut BlockScope,
     target: &Node<fe::VarDeclTarget>,
-    typ: FixedSize,
+    typ: Type,
 ) -> Result<(), FatalError> {
     match &target.kind {
         fe::VarDeclTarget::Name(name) => {
-            scope.root.map_variable_type(target, typ.clone().into());
+            scope.root.map_variable_type(target, typ.clone());
             // this logs a message on err, so it's safe to ignore here.
             let _ = scope.add_var(name, typ, false, target.span);
             Ok(())
         }
         fe::VarDeclTarget::Tuple(items) => {
             match typ {
-                FixedSize::Tuple(items_ty) => {
+                Type::Tuple(items_ty) => {
                     let items_ty = items_ty.items;
                     let items_ty_len = items_ty.as_vec().len();
                     if items.len() != items_ty_len {

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -1,7 +1,7 @@
 use crate::context::{AnalyzerContext, Constant, NamedThing};
 use crate::errors::TypeError;
 use crate::namespace::items::Item;
-use crate::namespace::types::{FixedSize, GenericArg, GenericParamKind, GenericType, Tuple, Type};
+use crate::namespace::types::{GenericArg, GenericParamKind, GenericType, Tuple, Type};
 use crate::traversal::call_args::validate_arg_count;
 use fe_common::diagnostics::Label;
 use fe_common::utils::humanize::pluralize_conditionally;
@@ -223,9 +223,9 @@ pub fn type_desc(
         ast::TypeDesc::Tuple { items } => {
             let types = items
                 .iter()
-                .map(|typ| match FixedSize::try_from(type_desc(context, typ)?) {
-                    Ok(typ) => Ok(typ),
-                    Err(_) => Err(TypeError::new(context.error(
+                .map(|typ| match type_desc(context, typ) {
+                    Ok(typ) if typ.has_fixed_size() => Ok(typ),
+                    _ => Err(TypeError::new(context.error(
                         "tuple elements must have fixed size",
                         typ.span,
                         "this can't be stored in a tuple",

--- a/crates/analyzer/src/traversal/utils.rs
+++ b/crates/analyzer/src/traversal/utils.rs
@@ -2,13 +2,9 @@ use fe_common::diagnostics::Label;
 use fe_common::Span;
 
 use crate::context::{AnalyzerContext, DiagnosticVoucher};
-use crate::errors::{BinaryOperationError, NotFixedSize};
-use crate::namespace::types::{FixedSize, Type};
+use crate::errors::BinaryOperationError;
+use crate::namespace::types::Type;
 use std::fmt::Display;
-
-pub fn types_to_fixed_sizes(sizes: &[Type]) -> Result<Vec<FixedSize>, NotFixedSize> {
-    sizes.iter().map(|param| param.clone().try_into()).collect()
-}
 
 pub fn add_bin_operations_errors(
     context: &mut dyn AnalyzerContext,

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -1,5 +1,5 @@
 use fe_analyzer::namespace::items::{self, IngotId, IngotMode, Item, ModuleId, TypeDef};
-use fe_analyzer::namespace::types::{Event, FixedSize};
+use fe_analyzer::namespace::types::{Event, Type};
 use fe_analyzer::{AnalyzerDb, TestDb};
 use fe_common::diagnostics::{diagnostics_string, print_diagnostics, Diagnostic, Label, Severity};
 use fe_common::files::{FileKind, Utf8Path};
@@ -450,7 +450,7 @@ fn event_diagnostics(event: items::EventId, db: &dyn AnalyzerDb) -> Vec<Diagnost
                     .iter()
                     .map(|field| field.typ.clone().unwrap()),
             )
-            .collect::<Vec<(Span, FixedSize)>>(),
+            .collect::<Vec<(Span, Type)>>(),
     )
 }
 

--- a/crates/lowering/src/ast_utils.rs
+++ b/crates/lowering/src/ast_utils.rs
@@ -1,4 +1,4 @@
-use fe_analyzer::namespace::types::FixedSize;
+use fe_analyzer::namespace::types::Type;
 use fe_parser::ast::{BoolOperator, CallArg, Expr, FuncStmt, UnaryOperator, VarDeclTarget};
 use fe_parser::node::{Node, NodeId};
 
@@ -437,7 +437,7 @@ pub fn inject_before_expression(
 /// Turns a ternary expression into a set of statements resembling an if/else block with equal
 /// functionality. Expects the type and variable result name to be provided as parameters.
 pub fn ternary_to_if(
-    ternary_type: FixedSize,
+    ternary_type: Type,
     expr: &Node<Expr>,
     result_name: &str,
 ) -> Vec<Node<FuncStmt>> {
@@ -449,7 +449,7 @@ pub fn ternary_to_if(
     {
         let mut stmts = vec![FuncStmt::VarDecl {
             target: VarDeclTarget::Name(result_name.into()).into_node(),
-            typ: names::fixed_size_type_desc(&ternary_type).into_node(),
+            typ: names::build_type_desc(&ternary_type).into_node(),
             value: None,
         }
         .into_node()];
@@ -490,7 +490,7 @@ pub fn ternary_to_if(
 /// Turns a boolean expression into a set of statements resembling an if/else block with equal
 /// functionality. Expects the type and variable result name to be provided as parameters.
 pub fn boolean_expr_to_if(
-    expr_type: FixedSize,
+    expr_type: Type,
     expr: &Node<Expr>,
     result_name: &str,
 ) -> Vec<Node<FuncStmt>> {
@@ -506,7 +506,7 @@ pub fn boolean_expr_to_if(
 
                 let mut stmts = vec![FuncStmt::VarDecl {
                     target: VarDeclTarget::Name(result_name.into()).into_node(),
-                    typ: names::fixed_size_type_desc(&expr_type).into_node(),
+                    typ: names::build_type_desc(&expr_type).into_node(),
                     value: Some(Expr::Bool(false).into_node()),
                 }
                 .into_node()];
@@ -534,7 +534,7 @@ pub fn boolean_expr_to_if(
                 //     res = right
                 let mut stmts = vec![FuncStmt::VarDecl {
                     target: VarDeclTarget::Name(result_name.into()).into_node(),
-                    typ: names::fixed_size_type_desc(&expr_type).into_node(),
+                    typ: names::build_type_desc(&expr_type).into_node(),
                     value: Some(Expr::Bool(true).into_node()),
                 }
                 .into_node()];
@@ -656,7 +656,7 @@ mod tests {
     use crate::ast_utils::ternary_to_if;
     use crate::ast_utils::StmtOrExpr;
     use crate::utils::ZeroSpanNode;
-    use fe_analyzer::namespace::types::FixedSize;
+    use fe_analyzer::namespace::types::Type;
     use fe_parser::ast::BinOperator;
     use fe_parser::ast::CallArg;
     use fe_parser::ast::Expr;
@@ -886,7 +886,7 @@ else:
         let second_ternary = all_ternary.get(1).unwrap();
         assert_eq!(second_ternary.original_id, ternary.original_id);
 
-        let ternary_type = FixedSize::u256();
+        let ternary_type = Type::u256();
 
         let transformed_outer = ternary_to_if(ternary_type.clone(), second_ternary, "outer");
 

--- a/crates/lowering/src/context.rs
+++ b/crates/lowering/src/context.rs
@@ -1,6 +1,6 @@
 use fe_analyzer::context::{ExpressionAttributes, FunctionBody};
 use fe_analyzer::namespace::items::{FunctionId, ModuleId};
-use fe_analyzer::namespace::types::{Array, FixedSize, Tuple};
+use fe_analyzer::namespace::types::{Array, Tuple, Type};
 use fe_analyzer::AnalyzerDb;
 use fe_parser::node::NodeId;
 use indexmap::IndexSet;
@@ -65,11 +65,11 @@ impl<'a, 'db> FnContext<'a, 'db> {
         self.body.expressions.get(&node_id.into())
     }
 
-    pub fn var_decl_type<T: Into<NodeId>>(&self, node_id: T) -> Option<&FixedSize> {
+    pub fn var_decl_type<T: Into<NodeId>>(&self, node_id: T) -> Option<&Type> {
         self.body.var_decl_types.get(&node_id.into())
     }
 
-    pub fn const_decl_type<T: Into<NodeId>>(&self, node_id: T) -> Option<&FixedSize> {
+    pub fn const_decl_type<T: Into<NodeId>>(&self, node_id: T) -> Option<&Type> {
         self.body.var_decl_types.get(&node_id.into())
     }
 }

--- a/crates/lowering/src/mappers/events.rs
+++ b/crates/lowering/src/mappers/events.rs
@@ -19,12 +19,7 @@ pub fn event_def(context: &mut ModuleContext, event: EventId) -> Node<ast::Event
                 typ: types::type_desc(
                     context,
                     node.kind.typ.clone(),
-                    &field
-                        .typ
-                        .as_ref()
-                        .expect("event field type error")
-                        .clone()
-                        .into(),
+                    &field.typ.as_ref().expect("event field type error").clone(),
                 ),
             }
             .into_node()

--- a/crates/lowering/src/mappers/structs.rs
+++ b/crates/lowering/src/mappers/structs.rs
@@ -39,7 +39,7 @@ fn struct_field(context: &mut ModuleContext, field: StructFieldId) -> Node<ast::
             is_pub: node.kind.is_pub,
             is_const: node.kind.is_const,
             name: node.kind.name.clone(),
-            typ: types::type_desc(context, node.kind.typ.clone(), &typ.into()),
+            typ: types::type_desc(context, node.kind.typ.clone(), &typ),
             value: node.kind.value.clone(),
         },
         node.span,

--- a/crates/lowering/src/mappers/types.rs
+++ b/crates/lowering/src/mappers/types.rs
@@ -12,7 +12,7 @@ pub fn type_desc(context: &mut ModuleContext, desc: Node<TypeDesc>, typ: &Type) 
             let typ = typ.as_tuple().expect("expected tuple type");
 
             for (item_desc, item_type) in items.into_iter().zip(typ.items.iter()) {
-                type_desc(context, item_desc, &item_type.clone().into());
+                type_desc(context, item_desc, &item_type.clone());
             }
             context.tuples.insert(typ.clone());
             Node::new(

--- a/crates/lowering/src/names.rs
+++ b/crates/lowering/src/names.rs
@@ -1,6 +1,6 @@
 use crate::names;
 use crate::utils::ZeroSpanNode;
-use fe_analyzer::namespace::types::{Array, Base, FixedSize, SafeNames, Tuple};
+use fe_analyzer::namespace::types::{Array, Base, SafeNames, Tuple, Type};
 use fe_parser::ast::{self, SmolStr};
 
 /// The name of a lowered list expression generator function.
@@ -13,33 +13,41 @@ pub fn tuple_struct_name(tuple: &Tuple) -> SmolStr {
     format!("${}", tuple.lower_snake()).into()
 }
 
-/// Maps a FixedSize type to its type description.
-pub fn fixed_size_type_desc(typ: &FixedSize) -> ast::TypeDesc {
+/// Maps a Type type to its type description.
+pub fn build_type_desc(typ: &Type) -> ast::TypeDesc {
     match typ {
-        FixedSize::Base(Base::Unit) => ast::TypeDesc::Unit,
-        FixedSize::Base(base) => ast::TypeDesc::Base { base: base.name() },
-        FixedSize::Array(array) => ast::TypeDesc::Generic {
+        Type::Base(Base::Unit) => ast::TypeDesc::Unit,
+        Type::Base(base) => ast::TypeDesc::Base { base: base.name() },
+        Type::Array(array) => ast::TypeDesc::Generic {
             base: SmolStr::new("Array").into_node(),
             args: vec![
-                ast::GenericArg::TypeDesc(
-                    fixed_size_type_desc(&FixedSize::Base(array.inner)).into_node(),
-                ),
+                ast::GenericArg::TypeDesc(build_type_desc(&Type::Base(array.inner)).into_node()),
                 ast::GenericArg::Int(array.size.into_node()),
             ]
             .into_node(),
         },
-        FixedSize::Tuple(tuple) => ast::TypeDesc::Base {
+        Type::Tuple(tuple) => ast::TypeDesc::Base {
             base: names::tuple_struct_name(tuple),
         },
-        FixedSize::String(string) => ast::TypeDesc::Generic {
+        Type::String(string) => ast::TypeDesc::Generic {
             base: SmolStr::new("String").into_node(),
             args: vec![ast::GenericArg::Int(string.max_size.into_node())].into_node(),
         },
-        FixedSize::Contract(contract) => ast::TypeDesc::Base {
+        Type::Contract(contract) => ast::TypeDesc::Base {
             base: contract.name.clone(),
         },
-        FixedSize::Struct(strukt) => ast::TypeDesc::Base {
+        Type::Struct(strukt) => ast::TypeDesc::Base {
             base: strukt.name.clone(),
+        },
+        Type::Map(map) => ast::TypeDesc::Generic {
+            base: SmolStr::new("Map").into_node(),
+            args: vec![ast::GenericArg::TypeDesc(
+                build_type_desc(&map.value).into_node(),
+            )]
+            .into_node(),
+        },
+        Type::SelfContract(contract) => ast::TypeDesc::Base {
+            base: contract.name.clone(),
         },
     }
 }

--- a/crates/mir/src/lower/function.rs
+++ b/crates/mir/src/lower/function.rs
@@ -37,7 +37,7 @@ pub fn lower_func_signature(db: &dyn MirDb, func: analyzer_items::FunctionId) ->
         let source = arg_source(db, func, &param.name);
         make_param(db, param.name.clone(), param.typ.clone().unwrap(), source)
     }));
-    let return_type = db.mir_lowered_type(analyzer_signature.return_type.clone().unwrap().into());
+    let return_type = db.mir_lowered_type(analyzer_signature.return_type.clone().unwrap());
 
     let linkage = if func.is_public(db.upcast()) {
         if has_self {

--- a/crates/mir/src/lower/types.rs
+++ b/crates/mir/src/lower/types.rs
@@ -32,7 +32,7 @@ pub fn lower_event_type(db: &dyn MirDb, event: analyzer_items::EventId) -> TypeI
         .fields
         .iter()
         .map(|field| {
-            let ty = db.mir_lowered_type(field.typ.clone().unwrap().into());
+            let ty = db.mir_lowered_type(field.typ.clone().unwrap());
             (field.name.clone(), ty, field.is_indexed)
         })
         .collect();
@@ -101,7 +101,7 @@ fn lower_tuple(db: &dyn MirDb, tup: &analyzer_types::Tuple) -> TypeId {
     let items = tup
         .items
         .iter()
-        .map(|item| db.mir_lowered_type(item.clone().into()))
+        .map(|item| db.mir_lowered_type(item.clone()))
         .collect();
 
     let def = TupleDef { items };
@@ -162,7 +162,7 @@ fn lower_struct(db: &dyn MirDb, struct_: &analyzer_types::Struct) -> TypeId {
         .iter()
         .map(|(fname, fid)| {
             let analyzer_types = fid.typ(db.upcast()).unwrap();
-            let ty = db.mir_lowered_type(analyzer_types.into());
+            let ty = db.mir_lowered_type(analyzer_types);
             (fname.clone(), ty)
         })
         .collect();

--- a/crates/yulgen/src/context.rs
+++ b/crates/yulgen/src/context.rs
@@ -1,6 +1,6 @@
 use crate::{AnalyzerDb, YulgenDb};
 use fe_analyzer::context::{CallType, ExpressionAttributes, FunctionBody};
-use fe_analyzer::namespace::types::{Event, FixedSize};
+use fe_analyzer::namespace::types::{Event, Type};
 use fe_parser::ast;
 use fe_parser::node::Node;
 use std::rc::Rc;
@@ -29,7 +29,7 @@ impl<'a> FnContext<'a> {
     }
 
     /// Get the type of a variable declaration.
-    pub fn declaration_type(&self, typ: &Node<ast::TypeDesc>) -> &FixedSize {
+    pub fn declaration_type(&self, typ: &Node<ast::TypeDesc>) -> &Type {
         self.fn_body
             .var_decl_types
             .get(&typ.id)

--- a/crates/yulgen/src/db/queries/contracts.rs
+++ b/crates/yulgen/src/db/queries/contracts.rs
@@ -7,7 +7,6 @@ use crate::types::{AbiDecodeLocation, AsAbiType};
 use fe_analyzer::builtins::ValueMethod;
 use fe_analyzer::context::CallType;
 use fe_analyzer::namespace::items::{walk_local_dependencies, ContractId, DepGraph, Item, TypeDef};
-use fe_analyzer::namespace::types::FixedSize;
 use fe_common::utils::keccak;
 use indexmap::IndexSet;
 use smol_str::SmolStr;
@@ -166,10 +165,6 @@ fn build_dependency_graph(
                             method: ValueMethod::AbiEncode,
                             typ,
                         } => {
-                            let typ: FixedSize = typ
-                                .clone()
-                                .try_into()
-                                .expect("abi_encode non-fixedsize type");
                             yulfns.push(functions::abi::encode(&[typ.as_abi_type(adb)]));
                         }
                         CallType::BuiltinAssociatedFunction { contract, .. } => {

--- a/crates/yulgen/src/mappers/assignments.rs
+++ b/crates/yulgen/src/mappers/assignments.rs
@@ -2,8 +2,9 @@ use crate::context::FnContext;
 use crate::mappers::expressions;
 use crate::operations::data as data_operations;
 use crate::operations::structs as struct_operations;
+use crate::types::AsEvmSized;
 use fe_analyzer::context::Location;
-use fe_analyzer::namespace::types::{FixedSize, Type};
+use fe_analyzer::namespace::types::Type;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use yultsur::yul::FunctionCall;
@@ -20,8 +21,7 @@ pub fn assign(context: &mut FnContext, stmt: &Node<fe::FuncStmt>) -> yul::Statem
         let value = expressions::expr(context, value_node);
 
         let target_attributes = context.expression_attributes(target_node);
-        let typ = FixedSize::try_from(target_attributes.typ.clone()).expect("invalid attributes");
-
+        let typ = target_attributes.typ.as_evm_sized();
         let value_attributes = context.expression_attributes(value_node);
 
         return match (

--- a/crates/yulgen/src/mappers/declarations.rs
+++ b/crates/yulgen/src/mappers/declarations.rs
@@ -2,7 +2,7 @@ use crate::context::FnContext;
 use crate::mappers::expressions;
 use crate::names;
 use crate::types::EvmSized;
-use fe_analyzer::namespace::types::FixedSize;
+use fe_analyzer::namespace::types::Type;
 use fe_parser::ast as fe;
 use fe_parser::node::Node;
 use yultsur::*;
@@ -19,8 +19,9 @@ pub fn var_decl(context: &mut FnContext, stmt: &Node<fe::FuncStmt>) -> yul::Stat
             statement! { let [target] := [value] }
         } else {
             match decl_type {
-                FixedSize::Base(_) => statement! { let [target] := 0 },
+                Type::Base(_) => statement! { let [target] := 0 },
                 typ => {
+                    let typ: Box<dyn EvmSized> = typ.clone().try_into().expect("Invalid type");
                     let size = literal_expression! { (typ.size()) };
                     statement! { let [target] := alloc([size]) }
                 }

--- a/crates/yulgen/src/operations/data.rs
+++ b/crates/yulgen/src/operations/data.rs
@@ -4,14 +4,14 @@ use fe_analyzer::namespace::types::Array;
 use yultsur::*;
 
 /// Loads a value of the given type from storage.
-pub fn sload<T: EvmSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
+pub fn sload(typ: Box<dyn EvmSized>, sptr: yul::Expression) -> yul::Expression {
     let size = literal_expression! { (typ.size()) };
     expression! { bytes_sloadn([sptr], [size]) }
 }
 
 /// Stores a value of the given type in storage.
-pub fn sstore<T: EvmSized>(
-    typ: T,
+pub fn sstore(
+    typ: Box<dyn EvmSized>,
     sptr: yul::Expression,
     value: yul::Expression,
 ) -> yul::Statement {
@@ -20,14 +20,14 @@ pub fn sstore<T: EvmSized>(
 }
 
 /// Loads a value of the given type from memory.
-pub fn mload<T: EvmSized>(typ: T, mptr: yul::Expression) -> yul::Expression {
+pub fn mload(typ: Box<dyn EvmSized>, mptr: yul::Expression) -> yul::Expression {
     let size = literal_expression! { (typ.size()) };
     expression! { mloadn([mptr], [size]) }
 }
 
 /// Stores a value of the given type in memory.
-pub fn mstore<T: EvmSized>(
-    typ: T,
+pub fn mstore(
+    typ: Box<dyn EvmSized>,
     mptr: yul::Expression,
     value: yul::Expression,
 ) -> yul::Statement {
@@ -36,7 +36,11 @@ pub fn mstore<T: EvmSized>(
 }
 
 /// Copies a segment of memory into storage.
-pub fn mcopys<T: EvmSized>(typ: T, sptr: yul::Expression, mptr: yul::Expression) -> yul::Statement {
+pub fn mcopys(
+    typ: Box<dyn EvmSized>,
+    sptr: yul::Expression,
+    mptr: yul::Expression,
+) -> yul::Statement {
     let size = literal_expression! { (typ.size()) };
     let word_ptr = expression! { div([sptr], 32) };
     statement! { mcopys([mptr], [word_ptr], [size]) }
@@ -45,15 +49,15 @@ pub fn mcopys<T: EvmSized>(typ: T, sptr: yul::Expression, mptr: yul::Expression)
 /// Copies a segment of storage into memory.
 ///
 /// Returns the address of the data in memory.
-pub fn scopym<T: EvmSized>(typ: T, sptr: yul::Expression) -> yul::Expression {
+pub fn scopym(typ: Box<dyn EvmSized>, sptr: yul::Expression) -> yul::Expression {
     let size = literal_expression! { (typ.size()) };
     let word_ptr = expression! { div([sptr], 32) };
     expression! { scopym([word_ptr], [size]) }
 }
 
 /// Copies a segment of storage to another segment of storage.
-pub fn scopys<T: EvmSized>(
-    typ: T,
+pub fn scopys(
+    typ: Box<dyn EvmSized>,
     dest_ptr: yul::Expression,
     origin_ptr: yul::Expression,
 ) -> yul::Statement {
@@ -64,7 +68,7 @@ pub fn scopys<T: EvmSized>(
 }
 
 /// Copies a segment of memory to another segment of memory.
-pub fn mcopym<T: EvmSized>(typ: T, ptr: yul::Expression) -> yul::Expression {
+pub fn mcopym(typ: Box<dyn EvmSized>, ptr: yul::Expression) -> yul::Expression {
     let size = literal_expression! { (typ.size()) };
     expression! { mcopym([ptr], [size]) }
 }


### PR DESCRIPTION
### What was wrong?

FixedSize makes the type system more complex which makes it harder to add new features.

### How was it fixed?

- Removed `FixedSize` type
- Introduced a `has_fixed_size()` API directly on Type
- Using this in a bunch of places where we would previously *try*  to convert a `Type` into a `FixedSize`

I'm not really happy with this. It does remove complexity from our type system but it also introduces new weaknesses. There's probably a better approach hiding somewhere that I haven't found yet...
