### PR TITLE
Detect cyclic field definitions in struct dependency graph

### DIFF
--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -154,8 +154,9 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     fn struct_all_functions(&self, id: StructId) -> Rc<[FunctionId]>;
     #[salsa::invoke(queries::structs::struct_function_map)]
     fn struct_function_map(&self, id: StructId) -> Analysis<Rc<IndexMap<SmolStr, FunctionId>>>;
+    #[salsa::cycle(queries::structs::struct_cycle)]
     #[salsa::invoke(queries::structs::struct_dependency_graph)]
-    fn struct_dependency_graph(&self, id: StructId) -> DepGraphWrapper;
+    fn struct_dependency_graph(&self, id: StructId) -> Analysis<DepGraphWrapper>;
 
     // Event
     #[salsa::invoke(queries::events::event_type)]

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -1340,10 +1340,12 @@ impl StructId {
         )
     }
     pub fn dependency_graph(&self, db: &dyn AnalyzerDb) -> Rc<DepGraph> {
-        db.struct_dependency_graph(*self).0
+        db.struct_dependency_graph(*self).value.0
     }
     pub fn sink_diagnostics(&self, db: &dyn AnalyzerDb, sink: &mut impl DiagnosticSink) {
         sink.push_all(db.struct_field_map(*self).diagnostics.iter());
+        sink.push_all(db.struct_dependency_graph(*self).diagnostics.iter());
+
         db.struct_all_fields(*self)
             .iter()
             .for_each(|id| id.sink_diagnostics(db, sink));

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -306,6 +306,7 @@ test_file! { strict_boolean_if_else }
 test_file! { struct_private_constructor }
 test_file! { struct_call_bad_args }
 test_file! { struct_call_without_kw_args }
+test_file! { struct_recursive_cycles }
 test_file! { non_pub_init }
 test_file! { init_wrong_return_type }
 test_file! { init_duplicate_def }

--- a/crates/analyzer/tests/snapshots/errors__struct_recursive_cycles.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_recursive_cycles.snap
@@ -1,0 +1,23 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+---
+error: recursive struct `Foo`
+  ┌─ compile_errors/struct_recursive_cycles.fe:4:8
+  │
+4 │ struct Foo:
+  │        ^^^ struct `Foo` has infinite size due to recursive definition
+
+error: recursive struct `Bar`
+  ┌─ compile_errors/struct_recursive_cycles.fe:8:8
+  │
+8 │ struct Bar:
+  │        ^^^ struct `Bar` has infinite size due to recursive definition
+
+error: recursive struct `Foo2`
+   ┌─ compile_errors/struct_recursive_cycles.fe:12:8
+   │
+12 │ struct Foo2:
+   │        ^^^^ struct `Foo2` has infinite size due to recursive definition
+
+

--- a/crates/test-files/fixtures/compile_errors/struct_recursive_cycles.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_recursive_cycles.fe
@@ -1,0 +1,22 @@
+
+# structs `Foo` and `Bar` contains indirect recursion
+# struct Foo depends on `Bar`
+struct Foo:
+    x: Bar
+
+# struct Bar depends on `Foo`
+struct Bar:
+    x: Foo
+
+# struct `Foo2` depends on itself - contains direct recursion
+struct Foo2:
+    x: Foo2
+
+# struct `Bar2` has no recursion
+struct Bar2:
+    x: Foo
+    y: Bar
+
+contract MyContract:
+    pub fn func(foo: Foo, foo2: Foo2, bar2: Bar2):
+       pass

--- a/newsfragments/682.bugfix.md
+++ b/newsfragments/682.bugfix.md
@@ -1,0 +1,3 @@
+reject infinite size struct definitions.
+
+Fe `structs` having infinite size due to recursive definitions were not rejected earlier and would cause ICE in the analyzer since they were not properly handled. Now `structs` having infinite size are properly identified by detecting cycles in the dependency graph of the struct field definitions and an error is thrown by the analyzer.


### PR DESCRIPTION
### What was wrong?
As stated by @Y-Nak in the issue #682 
### How was it fixed?
By adding `struct_cycles` as salsa cycle callback that throws an error when cycles are detected.