### PR TITLE
Temporary default stateMutability to payable in ABI

### DIFF
--- a/crates/abi/src/builder.rs
+++ b/crates/abi/src/builder.rs
@@ -1,6 +1,6 @@
 use crate::elements::{
     Component, Contract, Event, EventField, FuncInput, FuncOutput, FuncType, Function, JsonAbi,
-    ModuleAbis,
+    ModuleAbis, StateMutability,
 };
 use crate::AbiError;
 use fe_analyzer::namespace::items::{ContractId, FunctionId, ModuleId};
@@ -97,6 +97,7 @@ fn function_def(db: &dyn AnalyzerDb, name: &str, fn_id: FunctionId, typ: FuncTyp
         typ,
         inputs,
         outputs,
+        state_mutability: StateMutability::Payable,
     }
 }
 

--- a/crates/abi/src/elements.rs
+++ b/crates/abi/src/elements.rs
@@ -173,6 +173,7 @@ pub struct EventField {
 
 /// A function interface.
 #[derive(Serialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Function {
     /// The function's name.
     pub name: String,
@@ -183,6 +184,8 @@ pub struct Function {
     pub inputs: Vec<FuncInput>,
     /// All function outputs.
     pub outputs: Vec<FuncOutput>,
+    /// Mutability of the function
+    pub state_mutability: StateMutability,
 }
 
 /// Component of an ABI tuple.
@@ -250,7 +253,6 @@ pub enum FuncType {
 }
 
 /// The mutability of a public function.
-#[allow(dead_code)]
 #[derive(Serialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum StateMutability {
@@ -262,7 +264,9 @@ pub enum StateMutability {
 
 #[cfg(test)]
 mod tests {
-    use crate::elements::{Contract, Event, EventField, FuncInput, FuncOutput, FuncType, Function};
+    use crate::elements::{
+        Contract, Event, EventField, FuncInput, FuncOutput, FuncType, Function, StateMutability,
+    };
 
     #[test]
     fn contract_json() {
@@ -291,6 +295,7 @@ mod tests {
                     typ: "uint256".to_string(),
                     components: vec![],
                 }],
+                state_mutability: StateMutability::Payable,
             }],
         };
 
@@ -313,7 +318,8 @@ mod tests {
                     "name":"function_name",
                     "type":"function",
                     "inputs":[{"name":"input_name","type":"address"}],
-                    "outputs":[{"name":"output_name","type":"uint256"}]
+                    "outputs":[{"name":"output_name","type":"uint256"}],
+                    "stateMutability":"payable"
                 }
             ]"#
             .split_whitespace()

--- a/newsfragments/705.feature.md
+++ b/newsfragments/705.feature.md
@@ -1,0 +1,5 @@
+Temporary default stateMutability to payable in ABI
+
+The ABI metadata that the compiler currently generates does not include the `stateMutability` field. This piece of information is important for tooling such as hardhat because it determines whether a function needs to be called with or without sending a transaction.
+
+As soon as we have support for `mut self` and `mut ctx` we will be able to derive that information from the function signature. In the meantime we now default to `payable`.


### PR DESCRIPTION
### What was wrong?

The ABI metadata that we generate does currently not include the `stateMutability` field. This piece of information is important for tooling such as hardhat because it determines whether a function needs to be called with or without sending a transaction.

As soon as we have support for `mut self` and `mut ctx` we will be able to derive that information from the function signature. In the meantime we should default to `payable`. 

### How was it fixed?

Add `stateMutability` field and default it to `payable`.