### PR TITLE
Implement traits, impls and generic functions with trait bounds

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -508,7 +508,7 @@ impl CallType {
             // check that this is the `Context` struct defined in `std`
             // this should be deleted once associated functions are supported and we can
             // define unsafe constructors in Fe
-            struct_.name == "Context" && struct_.id.module(db).ingot(db).name(db) == "std"
+            struct_.name == "Context" && struct_.id.module(db).is_in_std(db)
         } else {
             self.function().map(|id| id.is_unsafe(db)).unwrap_or(false)
         }

--- a/crates/analyzer/src/db/queries.rs
+++ b/crates/analyzer/src/db/queries.rs
@@ -4,4 +4,5 @@ pub mod functions;
 pub mod ingots;
 pub mod module;
 pub mod structs;
+pub mod traits;
 pub mod types;

--- a/crates/analyzer/src/db/queries.rs
+++ b/crates/analyzer/src/db/queries.rs
@@ -1,6 +1,7 @@
 pub mod contracts;
 pub mod events;
 pub mod functions;
+pub mod impls;
 pub mod ingots;
 pub mod module;
 pub mod structs;

--- a/crates/analyzer/src/db/queries/impls.rs
+++ b/crates/analyzer/src/db/queries/impls.rs
@@ -1,0 +1,54 @@
+use indexmap::map::Entry;
+use indexmap::IndexMap;
+use smol_str::SmolStr;
+
+use crate::context::{Analysis, AnalyzerContext};
+use crate::namespace::items::{Class, Function, FunctionId, ImplId};
+use crate::namespace::scopes::ItemScope;
+use crate::AnalyzerDb;
+use std::rc::Rc;
+
+pub fn impl_all_functions(db: &dyn AnalyzerDb, impl_: ImplId) -> Rc<[FunctionId]> {
+    let impl_data = impl_.data(db);
+    impl_data
+        .ast
+        .kind
+        .functions
+        .iter()
+        .map(|node| {
+            db.intern_function(Rc::new(Function::new(
+                db,
+                node,
+                Some(Class::Impl(impl_)),
+                impl_data.module,
+            )))
+        })
+        .collect()
+}
+
+pub fn impl_function_map(
+    db: &dyn AnalyzerDb,
+    impl_: ImplId,
+) -> Analysis<Rc<IndexMap<SmolStr, FunctionId>>> {
+    let scope = ItemScope::new(db, impl_.module(db));
+    let mut map = IndexMap::<SmolStr, FunctionId>::new();
+
+    for func in db.impl_all_functions(impl_).iter() {
+        let def_name = func.name(db);
+
+        match map.entry(def_name) {
+            Entry::Occupied(entry) => {
+                scope.duplicate_name_error(
+                    "duplicate function names in `impl` block",
+                    entry.key(),
+                    entry.get().name_span(db),
+                    func.name_span(db),
+                );
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(*func);
+            }
+        }
+    }
+    Analysis::new(Rc::new(map), scope.diagnostics.take().into())
+}

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -3,8 +3,8 @@ use crate::context::AnalyzerContext;
 use crate::db::Analysis;
 use crate::errors::TypeError;
 use crate::namespace::items::{
-    self, DepGraph, DepGraphWrapper, DepLocality, Function, FunctionId, Item, StructField,
-    StructFieldId, StructId, TypeDef,
+    self, DepGraph, DepGraphWrapper, DepLocality, FunctionId, Item, StructField, StructFieldId,
+    StructId, TypeDef,
 };
 use crate::namespace::scopes::ItemScope;
 use crate::namespace::types::{self, Contract, Struct, Type};
@@ -121,11 +121,12 @@ pub fn struct_all_functions(db: &dyn AnalyzerDb, struct_: StructId) -> Rc<[Funct
         .functions
         .iter()
         .map(|node| {
-            db.intern_function(Rc::new(Function {
-                ast: node.clone(),
-                module: struct_data.module,
-                parent: Some(items::Class::Struct(struct_)),
-            }))
+            db.intern_function(Rc::new(items::Function::new(
+                db,
+                node,
+                Some(items::Class::Struct(struct_)),
+                struct_data.module,
+            )))
         })
         .collect()
 }
@@ -150,7 +151,7 @@ pub fn struct_function_map(
                 def_name,
                 &named_item,
                 named_item.name_span(db),
-                def.kind.name.span,
+                func.name_span(db),
             );
             continue;
         }
@@ -161,7 +162,7 @@ pub fn struct_function_map(
                     "function name `{}` conflicts with built-in function",
                     def_name
                 ),
-                def.kind.name.span,
+                func.name_span(db),
                 &format!("`{}` is a built-in function", def_name),
             );
             continue;

--- a/crates/analyzer/src/db/queries/traits.rs
+++ b/crates/analyzer/src/db/queries/traits.rs
@@ -1,0 +1,11 @@
+use crate::namespace::items::TraitId;
+use crate::namespace::types;
+use crate::AnalyzerDb;
+use std::rc::Rc;
+
+pub fn trait_type(db: &dyn AnalyzerDb, trait_: TraitId) -> Rc<types::Trait> {
+    Rc::new(types::Trait {
+        name: trait_.name(db),
+        id: trait_,
+    })
+}

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -309,6 +309,8 @@ impl<'a> AnalyzerContext for FunctionScope<'a> {
                     .data(self.db)
                     .ast
                     .kind
+                    .sig
+                    .kind
                     .args
                     .iter()
                     .find_map(|param| (param.name() == name).then(|| param.name_span()))

--- a/crates/analyzer/src/operations.rs
+++ b/crates/analyzer/src/operations.rs
@@ -15,6 +15,8 @@ pub fn index(value: Type, index: Type) -> Result<Type, IndexingError> {
         | Type::String(_)
         | Type::Contract(_)
         | Type::SelfContract(_)
+        | Type::Trait(_)
+        | Type::Generic(_)
         | Type::Struct(_) => Err(IndexingError::NotSubscriptable),
     }
 }

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -178,7 +178,7 @@ pub fn assignable_expr(
                 attributes.move_location = Some(Location::Value);
             }
         }
-        Array(_) | Tuple(_) | String(_) | Struct(_) => {
+        Array(_) | Tuple(_) | String(_) | Struct(_) | Trait(_) | Generic(_) => {
             if attributes.final_location() != Location::Memory {
                 context.fancy_error(
                     "value must be copied to memory",
@@ -1120,27 +1120,18 @@ fn expr_call_type_constructor(
         Type::Struct(struct_type) => {
             return expr_call_struct_constructor(context, name_span, struct_type, args)
         }
-        Type::Base(Base::Bool) => {
+        Type::Base(Base::Bool)
+        | Type::Array(_)
+        | Type::Map(_)
+        | Type::Generic(_)
+        | Type::Trait(_) => {
             return Err(FatalError::new(context.error(
-                "`bool` type is not callable",
+                &format!("`{}` type is not callable", typ.name()),
                 name_span,
                 "",
             )))
         }
-        Type::Map(_) => {
-            return Err(FatalError::new(context.error(
-                "`Map` type is not callable",
-                name_span,
-                "",
-            )))
-        }
-        Type::Array(_) => {
-            return Err(FatalError::new(context.error(
-                "`Array` type is not callable",
-                name_span,
-                "",
-            )))
-        }
+
         _ => {}
     }
 
@@ -1220,6 +1211,8 @@ fn expr_call_type_constructor(
         Type::Struct(_) => unreachable!(),        // handled above
         Type::Map(_) => unreachable!(),           // handled above
         Type::Array(_) => unreachable!(),         // handled above
+        Type::Trait(_) => unreachable!(),         // handled above
+        Type::Generic(_) => unreachable!(),       // handled above
         Type::SelfContract(_) => unreachable!(),  /* unnameable; contract names all become
                                                     * Type::Contract */
     };

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -345,7 +345,13 @@ fn build_snapshot(db: &dyn AnalyzerDb, module: items::ModuleId) -> String {
                     .collect(),
             ]
             .concat(),
-            Item::Type(TypeDef::Trait(_)) => vec![], // TODO: fill in when traits are allowed to have functions
+            Item::Type(TypeDef::Trait(val)) => val
+                .all_functions(db)
+                .iter()
+                .flat_map(|fun| {
+                    build_debug_diagnostics(&[(fun.data(db).ast.span, &fun.signature(db))])
+                })
+                .collect::<Vec<_>>(),
             Item::Function(id) => function_diagnostics(*id, db),
             Item::Constant(id) => vec![build_display_diagnostic(id.span(db), &id.typ(db).unwrap())],
             Item::Event(id) => event_diagnostics(*id, db),

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -345,7 +345,7 @@ fn build_snapshot(db: &dyn AnalyzerDb, module: items::ModuleId) -> String {
                     .collect(),
             ]
             .concat(),
-
+            Item::Type(TypeDef::Trait(_)) => vec![], // TODO: fill in when traits are allowed to have functions
             Item::Function(id) => function_diagnostics(*id, db),
             Item::Constant(id) => vec![build_display_diagnostic(id.span(db), &id.typ(db).unwrap())],
             Item::Event(id) => event_diagnostics(*id, db),

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -215,6 +215,7 @@ test_file! { bad_string }
 test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }
 test_file! { bad_tuple_attr3 }
+test_file! { call_generic_function_with_unsatisfied_bound}
 test_file! { call_builtin_object }
 test_file! { call_create_with_wrong_type }
 test_file! { call_create2_with_wrong_type }
@@ -246,11 +247,15 @@ test_file! { duplicate_var_in_for_loop }
 test_file! { emit_bad_args }
 test_file! { external_call_type_error }
 test_file! { external_call_wrong_number_of_params }
+test_file! { contract_function_with_generic_params }
 test_file! { indexed_event }
 test_file! { invalid_compiler_version }
 test_file! { invalid_block_field }
 test_file! { invalid_chain_field }
 test_file! { invalid_contract_field }
+test_file! { invalid_generic_bound }
+test_file! { invalid_impl_type }
+test_file! { invalid_impl_location }
 test_file! { invalid_msg_field }
 test_file! { invalid_string_field }
 test_file! { invalid_struct_field }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -244,6 +244,7 @@ test_file! { duplicate_typedef_in_module }
 test_file! { duplicate_var_in_child_scope }
 test_file! { duplicate_var_in_contract_method }
 test_file! { duplicate_var_in_for_loop }
+test_file! { duplicate_generic_params }
 test_file! { emit_bad_args }
 test_file! { external_call_type_error }
 test_file! { external_call_wrong_number_of_params }
@@ -293,6 +294,12 @@ test_file! { struct_private_constructor }
 test_file! { struct_call_bad_args }
 test_file! { struct_call_without_kw_args }
 test_file! { struct_recursive_cycles }
+test_file! { trait_impl_mismatch }
+test_file! { trait_fn_without_self }
+test_file! { trait_fn_with_generic_params }
+test_file! { traits_as_fields }
+test_file! { trait_conflicting_impls }
+test_file! { traits_with_wrong_bounds }
 test_file! { non_pub_init }
 test_file! { init_wrong_return_type }
 test_file! { init_duplicate_def }

--- a/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
@@ -4,9 +4,9 @@ expression: error_string_ingot(&path)
 
 ---
 error: the type `MyInt` is private
-  ┌─ compile_errors/bad_visibility/src/main.fe:5:33
+  ┌─ compile_errors/bad_visibility/src/main.fe:8:33
   │
-5 │     pub fn priv_type_alias() -> MyInt {
+8 │     pub fn priv_type_alias() -> MyInt {
   │                                 ^^^^^ this type is not `pub`
   │
   ┌─ compile_errors/bad_visibility/src/foo.fe:1:6
@@ -18,9 +18,9 @@ error: the type `MyInt` is private
   = Hint: use `pub` to make `MyInt` visible from outside of `foo`
 
 error: the type `MyInt` is private
-  ┌─ compile_errors/bad_visibility/src/main.fe:6:16
+  ┌─ compile_errors/bad_visibility/src/main.fe:9:16
   │
-6 │         let x: MyInt = 1
+9 │         let x: MyInt = 1
   │                ^^^^^ this type is not `pub`
   │
   ┌─ compile_errors/bad_visibility/src/foo.fe:1:6
@@ -32,9 +32,9 @@ error: the type `MyInt` is private
   = Hint: use `pub` to make `MyInt` visible from outside of `foo`
 
 error: the constant `MY_CONST` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:11:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:14:16
    │
-11 │         return MY_CONST
+14 │         return MY_CONST
    │                ^^^^^^^^ this constant is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:3:7
@@ -46,9 +46,9 @@ error: the constant `MY_CONST` is private
    = Hint: use `pub` to make `MY_CONST` visible from outside of `foo`
 
 error: the constant `MY_CONST` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:11:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:14:16
    │
-11 │         return MY_CONST
+14 │         return MY_CONST
    │                ^^^^^^^^ this constant is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:3:1
@@ -60,131 +60,140 @@ error: the constant `MY_CONST` is private
    = Hint: use `pub const MY_CONST` to make `MY_CONST` visible from outside of `foo`
 
 error: the event `MyEvent` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:15:14
+   ┌─ compile_errors/bad_visibility/src/main.fe:18:14
    │
-15 │         emit MyEvent(ctx, x: 1)
+18 │         emit MyEvent(ctx, x: 1)
    │              ^^^^^^^ this event is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:5:7
+   ┌─ compile_errors/bad_visibility/src/foo.fe:7:7
    │
- 5 │ event MyEvent {
+ 7 │ event MyEvent {
    │       ------- `MyEvent` is defined here
    │
    = `MyEvent` can only be used within `foo`
    = Hint: use `pub` to make `MyEvent` visible from outside of `foo`
 
 error: the event `MyEvent` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:15:14
+   ┌─ compile_errors/bad_visibility/src/main.fe:18:14
    │
-15 │         emit MyEvent(ctx, x: 1)
+18 │         emit MyEvent(ctx, x: 1)
    │              ^^^^^^^ this event is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:5:1
+   ┌─ compile_errors/bad_visibility/src/foo.fe:7:1
    │  
- 5 │ ╭ event MyEvent {
- 6 │ │     x: i32
- 7 │ │ }
+ 7 │ ╭ event MyEvent {
+ 8 │ │     x: i32
+ 9 │ │ }
    │ ╰─' `MyEvent` is defined here
    │  
    = `MyEvent` can only be used within `foo`
    = Hint: use `pub event MyEvent` to make `MyEvent` visible from outside of `foo`
 
 error: cannot find value `ctx` in this scope
-   ┌─ compile_errors/bad_visibility/src/main.fe:15:22
+   ┌─ compile_errors/bad_visibility/src/main.fe:18:22
    │
-15 │         emit MyEvent(ctx, x: 1)
+18 │         emit MyEvent(ctx, x: 1)
    │                      ^^^ undefined
 
 error: the type `MyStruct` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:19:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:22:16
    │
-19 │         let s: MyStruct = MyStruct(x: 1)
+22 │         let s: MyStruct = MyStruct(x: 1)
    │                ^^^^^^^^ this type is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:9:8
+   ┌─ compile_errors/bad_visibility/src/foo.fe:11:8
    │
- 9 │ struct MyStruct {
+11 │ struct MyStruct {
    │        -------- `MyStruct` is defined here
    │
    = `MyStruct` can only be used within `foo`
    = Hint: use `pub` to make `MyStruct` visible from outside of `foo`
 
 error: the type `MyStruct` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:19:27
+   ┌─ compile_errors/bad_visibility/src/main.fe:22:27
    │
-19 │         let s: MyStruct = MyStruct(x: 1)
+22 │         let s: MyStruct = MyStruct(x: 1)
    │                           ^^^^^^^^ this type is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:9:8
+   ┌─ compile_errors/bad_visibility/src/foo.fe:11:8
    │
- 9 │ struct MyStruct {
+11 │ struct MyStruct {
    │        -------- `MyStruct` is defined here
    │
    = `MyStruct` can only be used within `foo`
    = Hint: use `pub` to make `MyStruct` visible from outside of `foo`
 
 error: Can not call private constructor of struct `MyStruct` 
-   ┌─ compile_errors/bad_visibility/src/foo.fe:10:5
+   ┌─ compile_errors/bad_visibility/src/foo.fe:12:5
    │
-10 │     x: i32
+12 │     x: i32
    │     ^^^^^^ Field `x` is private
    │
    = Suggestion: implement a method `new(...)` on struct `MyStruct` to call the constructor and return the struct
 
 error: the function `my_func` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:23:9
+   ┌─ compile_errors/bad_visibility/src/main.fe:26:9
    │
-23 │         my_func()
+26 │         my_func()
    │         ^^^^^^^ this function is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:13:4
+   ┌─ compile_errors/bad_visibility/src/foo.fe:15:4
    │
-13 │ fn my_func() {}
+15 │ fn my_func() {}
    │    ------- `my_func` is defined here
    │
    = `my_func` can only be used within `foo`
    = Hint: use `pub` to make `my_func` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:27:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:30:16
    │
-27 │         let _: MyContract = MyContract(addr)
+30 │         let _: MyContract = MyContract(addr)
    │                ^^^^^^^^^^ this type is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:15:10
+   ┌─ compile_errors/bad_visibility/src/foo.fe:17:10
    │
-15 │ contract MyContract {
+17 │ contract MyContract {
    │          ---------- `MyContract` is defined here
    │
    = `MyContract` can only be used within `foo`
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:27:29
+   ┌─ compile_errors/bad_visibility/src/main.fe:30:29
    │
-27 │         let _: MyContract = MyContract(addr)
+30 │         let _: MyContract = MyContract(addr)
    │                             ^^^^^^^^^^ this type is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:15:10
+   ┌─ compile_errors/bad_visibility/src/foo.fe:17:10
    │
-15 │ contract MyContract {
+17 │ contract MyContract {
    │          ---------- `MyContract` is defined here
    │
    = `MyContract` can only be used within `foo`
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:28:9
+   ┌─ compile_errors/bad_visibility/src/main.fe:31:9
    │
-28 │         MyContract.create(ctx, 1)
+31 │         MyContract.create(ctx, 1)
    │         ^^^^^^^^^^ this type is not `pub`
    │
-   ┌─ compile_errors/bad_visibility/src/foo.fe:15:10
+   ┌─ compile_errors/bad_visibility/src/foo.fe:17:10
    │
-15 │ contract MyContract {
+17 │ contract MyContract {
    │          ---------- `MyContract` is defined here
    │
    = `MyContract` can only be used within `foo`
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
+
+error: the trait `MyTrait` is private
+  ┌─ compile_errors/bad_visibility/src/foo.fe:5:7
+  │
+5 │ trait MyTrait {}
+  │       ^^^^^^^ this trait is not `pub`
+  │
+  = `MyTrait` can only be used within `foo`
+  = Hint: use `pub trait MyTrait` to make `MyTrait` visible from outside of `foo`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_generic_function_with_unsatisfied_bound.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_generic_function_with_unsatisfied_bound.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: the trait bound `bool: IsNumeric` is not satisfied
+   ┌─ compile_errors/call_generic_function_with_unsatisfied_bound.fe:14:13
+   │
+14 │     foo.bar(true)
+   │             ^^^^ the trait `IsNumeric` is not implemented for `bool`
+
+error: incorrect type for `bar` argument at position 0
+   ┌─ compile_errors/call_generic_function_with_unsatisfied_bound.fe:14:13
+   │
+14 │     foo.bar(true)
+   │             ^^^^ this has type `bool`; expected type `T`
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_generic_function_with_unsatisfied_bound.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_generic_function_with_unsatisfied_bound.snap
@@ -3,16 +3,16 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: the trait bound `bool: IsNumeric` is not satisfied
-   ┌─ compile_errors/call_generic_function_with_unsatisfied_bound.fe:14:13
+error: the trait bound `Bar: Dummy` is not satisfied
+   ┌─ compile_errors/call_generic_function_with_unsatisfied_bound.fe:16:13
    │
-14 │     foo.bar(true)
-   │             ^^^^ the trait `IsNumeric` is not implemented for `bool`
+16 │     foo.bar(Bar())
+   │             ^^^^^ the trait `Dummy` is not implemented for `Bar`
 
 error: incorrect type for `bar` argument at position 0
-   ┌─ compile_errors/call_generic_function_with_unsatisfied_bound.fe:14:13
+   ┌─ compile_errors/call_generic_function_with_unsatisfied_bound.fe:16:13
    │
-14 │     foo.bar(true)
-   │             ^^^^ this has type `bool`; expected type `T`
+16 │     foo.bar(Bar())
+   │             ^^^^^ this has type `Bar`; expected type `T`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
@@ -5,13 +5,11 @@ expression: "error_string(&path, test_files::fixture(path))"
 ---
 error: the function `do_private_thingz` on `contract Foo` is private
    ┌─ compile_errors/call_non_pub_fn_on_external_contract.fe:13:25
-   │  
- 6 │ ╭     fn do_private_thingz(self) {
- 7 │ │         self.val = 100
- 8 │ │     }
-   │ ╰─────' `do_private_thingz` is defined here
-   · │
-13 │           Foo(address(0)).do_private_thingz()
-   │                           ^^^^^^^^^^^^^^^^^ this function is not `pub`
+   │
+ 6 │     fn do_private_thingz(self) {
+   │     -------------------------- `do_private_thingz` is defined here
+   ·
+13 │         Foo(address(0)).do_private_thingz()
+   │                         ^^^^^^^^^^^^^^^^^ this function is not `pub`
 
 

--- a/crates/analyzer/tests/snapshots/errors__contract_function_with_generic_params.snap
+++ b/crates/analyzer/tests/snapshots/errors__contract_function_with_generic_params.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: generic function parameters aren't yet supported in contract functions
+  ┌─ compile_errors/contract_function_with_generic_params.fe:4:15
+  │
+4 │     pub fn bar<T: IsNumeric>(val: T) {}
+  │               ^^^^^^^^^^^^^^ This can not appear here
+  │
+  = Hint: Struct functions can have generic parameters
+
+

--- a/crates/analyzer/tests/snapshots/errors__duplicate_generic_params.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_generic_params.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: duplicate generic parameter
+   ┌─ compile_errors/duplicate_generic_params.fe:10:10
+   │
+10 │   fn foo<T: Computable, T: Computable2>(val1: T, val2: T) {
+   │          ^              - `T` redefined here
+   │          │               
+   │          `T` first defined here
+
+

--- a/crates/analyzer/tests/snapshots/errors__invalid_generic_bound.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_generic_bound.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: expected trait, found type `bool`
+  ┌─ compile_errors/invalid_generic_bound.fe:2:19
+  │
+2 │     pub fn bar<T: bool>(val: T) {}
+  │                   ^^^^ not a trait
+
+

--- a/crates/analyzer/tests/snapshots/errors__invalid_impl_location.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_impl_location.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: illegal `impl`. Either type or trait must be in the same ingot as the `impl`
+  ┌─ compile_errors/invalid_impl_location.fe:3:1
+  │
+3 │ impl IsNumeric for u8 {}
+  │ ^^^^^^^^^^^^^^^^^^^^^ Neither `u8` nor `IsNumeric` are in the ingot of the `impl` block
+
+

--- a/crates/analyzer/tests/snapshots/errors__invalid_impl_location.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_impl_location.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: illegal `impl`. Either type or trait must be in the same ingot as the `impl`
-  ┌─ compile_errors/invalid_impl_location.fe:3:1
+  ┌─ compile_errors/invalid_impl_location.fe:4:1
   │
-3 │ impl IsNumeric for u8 {}
-  │ ^^^^^^^^^^^^^^^^^^^^^ Neither `u8` nor `IsNumeric` are in the ingot of the `impl` block
+4 │ impl Dummy for Context {}
+  │ ^^^^^^^^^^^^^^^^^^^^^^ Neither `Context` nor `Dummy` are in the ingot of the `impl` block
 
 

--- a/crates/analyzer/tests/snapshots/errors__invalid_impl_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_impl_type.snap
@@ -1,0 +1,12 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: `impl` blocks aren't allowed for Map<u8, u8>
+  ┌─ compile_errors/invalid_impl_type.fe:3:1
+  │
+3 │ impl SomeTrait for Map<u8, u8> {}
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ illegal `impl` block
+
+

--- a/crates/analyzer/tests/snapshots/errors__map_constructor.snap
+++ b/crates/analyzer/tests/snapshots/errors__map_constructor.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(\"[snippet]\", &src)"
 
 ---
-error: `Map` type is not callable
+error: `Map<u8, u8>` type is not callable
   ┌─ [snippet]:3:3
   │
 3 │   Map<u8, u8>()

--- a/crates/analyzer/tests/snapshots/errors__trait_conflicting_impls.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_conflicting_impls.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: duplicate `impl` blocks for trait `Foo` for type `Bar`
+  ┌─ compile_errors/trait_conflicting_impls.fe:6:1
+  │
+6 │ impl Foo for Bar {}
+  │ ^^^^^^^^^^^^^^^^ `` first defined here
+7 │ impl Foo for Bar {}
+  │ ---------------- `` redefined here
+
+

--- a/crates/analyzer/tests/snapshots/errors__trait_fn_with_generic_params.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_fn_with_generic_params.snap
@@ -4,10 +4,10 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: generic function parameters aren't yet supported outside of struct functions
-  ┌─ compile_errors/contract_function_with_generic_params.fe:4:15
+  ┌─ compile_errors/trait_fn_with_generic_params.fe:4:18
   │
-4 │     pub fn bar<T: Dummy>(val: T) {}
-  │               ^^^^^^^^^^ This can not appear here
+4 │     fn generic_fn<T: Bar>(self, val: T);
+  │                  ^^^^^^^^ This can not appear here
   │
   = Hint: Struct functions can have generic parameters
 

--- a/crates/analyzer/tests/snapshots/errors__trait_fn_without_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_fn_without_self.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: associated functions aren't yet supported in traits
+  ┌─ compile_errors/trait_fn_without_self.fe:2:5
+  │
+2 │     fn this_has_no_self();
+  │     ^^^^^^^^^^^^^^^^^^^^^ function doesn't take `self`
+  │
+  = Hint: add a `self` param to this function
+
+

--- a/crates/analyzer/tests/snapshots/errors__trait_impl_mismatch.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_impl_mismatch.snap
@@ -1,0 +1,36 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: method `this_has_wrong_args_in_impl` has incompatible parameters for `this_has_wrong_args_in_impl` of trait `Foo`
+   ┌─ compile_errors/trait_impl_mismatch.fe:3:5
+   │
+ 3 │     fn this_has_wrong_args_in_impl(self, val: u8, val2: bool);
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in trait `Foo`
+   ·
+11 │     fn this_has_wrong_args_in_impl(self, val: u16, val2: Array<u8, 10>) {}
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in `impl` block
+
+error: method `this_has_wrong_return_type_in_impl` has an incompatible return type for `this_has_wrong_return_type_in_impl` of trait `Foo`
+   ┌─ compile_errors/trait_impl_mismatch.fe:4:5
+   │
+ 4 │     fn this_has_wrong_return_type_in_impl(self) -> bool;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in trait `Foo`
+   ·
+12 │     fn this_has_wrong_return_type_in_impl(self) -> u8 {
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in `impl` block
+
+error: method `this_does_not_exist_in_trait` is not a member of trait `Foo`
+   ┌─ compile_errors/trait_impl_mismatch.fe:15:5
+   │
+15 │     fn this_does_not_exist_in_trait() {}
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Foo`
+
+error: not all members of trait `Foo` implemented, missing: `this_misses_in_impl`
+  ┌─ compile_errors/trait_impl_mismatch.fe:2:5
+  │
+2 │     fn this_misses_in_impl(self);
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this trait function is missing in `impl` block
+
+

--- a/crates/analyzer/tests/snapshots/errors__traits_as_fields.snap
+++ b/crates/analyzer/tests/snapshots/errors__traits_as_fields.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: struct field type must have a fixed size
+  ┌─ compile_errors/traits_as_fields.fe:4:5
+  │
+4 │     val: Foo
+  │     ^^^^^^^^ this can't be used as an struct field
+
+error: traits can not be used as contract fields
+  ┌─ compile_errors/traits_as_fields.fe:8:5
+  │
+8 │     val: Foo
+  │     ^^^^^^^^ trait `Foo` can not appear here
+
+

--- a/crates/analyzer/tests/snapshots/errors__traits_with_wrong_bounds.snap
+++ b/crates/analyzer/tests/snapshots/errors__traits_with_wrong_bounds.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: unbounded generic parameters aren't yet supported
+  ┌─ compile_errors/traits_with_wrong_bounds.fe:4:22
+  │
+4 │     pub fn no_bounds<T>(val: T) {}
+  │                      ^ `T` needs to be bound by some trait
+  │
+  = Hint: Change `T` to `T: SomeTrait`
+
+

--- a/crates/library/std/src/traits.fe
+++ b/crates/library/std/src/traits.fe
@@ -1,15 +1,3 @@
-# Marker trait that all numeric types implement
-pub trait IsNumeric {}
+# Dummy trait used in testing. We can remove this once we have more useful traits
 
-impl IsNumeric for u8 {}
-impl IsNumeric for u16 {}
-impl IsNumeric for u32 {}
-impl IsNumeric for u64 {}
-impl IsNumeric for u128 {}
-impl IsNumeric for u256 {}
-impl IsNumeric for i8 {}
-impl IsNumeric for i16 {}
-impl IsNumeric for i32 {}
-impl IsNumeric for i64 {}
-impl IsNumeric for i128 {}
-impl IsNumeric for i256 {}
+pub trait Dummy {}

--- a/crates/library/std/src/traits.fe
+++ b/crates/library/std/src/traits.fe
@@ -1,0 +1,15 @@
+# Marker trait that all numeric types implement
+pub trait IsNumeric {}
+
+impl IsNumeric for u8 {}
+impl IsNumeric for u16 {}
+impl IsNumeric for u32 {}
+impl IsNumeric for u64 {}
+impl IsNumeric for u128 {}
+impl IsNumeric for u256 {}
+impl IsNumeric for i8 {}
+impl IsNumeric for i16 {}
+impl IsNumeric for i32 {}
+impl IsNumeric for i64 {}
+impl IsNumeric for i128 {}
+impl IsNumeric for i256 {}

--- a/crates/mir/src/db.rs
+++ b/crates/mir/src/db.rs
@@ -51,6 +51,12 @@ pub trait MirDb: AnalyzerDb + Upcast<dyn AnalyzerDb> + UpcastMut<dyn AnalyzerDb>
         &self,
         analyzer_func: analyzer_items::FunctionId,
     ) -> ir::FunctionId;
+    #[salsa::invoke(queries::function::mir_lowered_monomorphized_func_signature)]
+    fn mir_lowered_monomorphized_func_signature(
+        &self,
+        analyzer_func: analyzer_items::FunctionId,
+        concrete_args: Vec<analyzer_types::Type>,
+    ) -> ir::FunctionId;
     #[salsa::invoke(queries::function::mir_lowered_func_body)]
     fn mir_lowered_func_body(&self, func: ir::FunctionId) -> Rc<ir::FunctionBody>;
 }

--- a/crates/mir/src/db/queries/types.rs
+++ b/crates/mir/src/db/queries/types.rs
@@ -27,6 +27,10 @@ impl TypeId {
         db.lookup_mir_intern_type(self)
     }
 
+    pub fn analyzer_ty(self, db: &dyn MirDb) -> Option<analyzer_types::Type> {
+        self.data(db).analyzer_ty.clone()
+    }
+
     pub fn projection_ty(self, db: &dyn MirDb, access: &Value) -> TypeId {
         let ty = self.deref(db);
         match &ty.data(db).as_ref().kind {

--- a/crates/mir/src/graphviz/function.rs
+++ b/crates/mir/src/graphviz/function.rs
@@ -52,7 +52,7 @@ impl FunctionNode {
         let body = self.func.body(db);
 
         let sig_data = self.func.signature(db);
-        let mut sig = format!("fn {}(", self.func.name_with_class(db));
+        let mut sig = format!("fn {}(", self.func.debug_name(db));
 
         let params = &sig_data.params;
         let param_len = params.len();

--- a/crates/mir/src/ir/function.rs
+++ b/crates/mir/src/ir/function.rs
@@ -1,9 +1,11 @@
 use fe_analyzer::namespace::items as analyzer_items;
+use fe_analyzer::namespace::types as analyzer_types;
 use fe_common::impl_intern_key;
 use fxhash::FxHashMap;
 use id_arena::Arena;
 use num_bigint::BigInt;
 use smol_str::SmolStr;
+use std::collections::BTreeMap;
 
 use crate::db::MirDb;
 
@@ -20,6 +22,7 @@ use super::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FunctionSignature {
     pub params: Vec<FunctionParam>,
+    pub resolved_generics: BTreeMap<analyzer_types::Generic, analyzer_types::Type>,
     pub return_type: Option<TypeId>,
     pub module_id: analyzer_items::ModuleId,
     pub analyzer_func_id: analyzer_items::FunctionId,

--- a/crates/mir/src/lower/types.rs
+++ b/crates/mir/src/lower/types.rs
@@ -18,6 +18,12 @@ pub fn lower_type(db: &dyn MirDb, analyzer_ty: &analyzer_types::Type) -> TypeId 
         analyzer_types::Type::Contract(_) => TypeKind::Address,
         analyzer_types::Type::SelfContract(contract) => lower_contract(db, contract),
         analyzer_types::Type::Struct(struct_) => lower_struct(db, struct_),
+        analyzer_types::Type::Trait(_) => {
+            panic!("traits should only appear in generic bounds for now")
+        }
+        analyzer_types::Type::Generic(_) => {
+            panic!("should be lowered in `lower_types_in_functions`")
+        }
     };
 
     intern_type(db, ty_kind, Some(analyzer_ty))

--- a/crates/mir/src/pretty_print/inst.rs
+++ b/crates/mir/src/pretty_print/inst.rs
@@ -99,7 +99,7 @@ impl PrettyPrint for InstId {
                 args,
                 call_type,
             } => {
-                let name = func.name_with_class(db);
+                let name = func.debug_name(db);
                 write!(w, "{}@{}(", name, call_type)?;
                 args.as_slice().pretty_print(db, store, w)?;
                 write!(w, ")")

--- a/crates/parser/src/grammar/functions.rs
+++ b/crates/parser/src/grammar/functions.rs
@@ -3,7 +3,7 @@ use super::types::parse_type_desc;
 
 use crate::ast::{
     BinOperator, Expr, FuncStmt, Function, FunctionArg, GenericParameter, RegularFunctionArg,
-    VarDeclTarget,
+    TypeDesc, VarDeclTarget,
 };
 use crate::node::{Node, Span};
 use crate::{Label, ParseFailed, ParseResult, Parser, TokenKind};
@@ -115,7 +115,12 @@ pub fn parse_generic_param(par: &mut Parser) -> ParseResult<GenericParameter> {
             let bound = par.assert(Name);
             Ok(GenericParameter::Bounded {
                 name: Node::new(name.text.into(), name.span),
-                bound: Node::new(bound.text.into(), bound.span),
+                bound: Node::new(
+                    TypeDesc::Base {
+                        base: bound.text.into(),
+                    },
+                    bound.span,
+                ),
             })
         }
         None => Ok(GenericParameter::Unbounded(Node::new(

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -2,7 +2,8 @@ use super::contracts::parse_contract_def;
 use super::expressions::parse_expr;
 use super::functions::parse_fn_def;
 use super::types::{
-    parse_event_def, parse_path_tail, parse_struct_def, parse_type_alias, parse_type_desc,
+    parse_event_def, parse_impl_def, parse_path_tail, parse_struct_def, parse_trait_def,
+    parse_type_alias, parse_type_desc,
 };
 use crate::ast::{ConstantDecl, Module, ModuleStmt, Pragma, Use, UseTree};
 use crate::node::{Node, Span};
@@ -42,6 +43,8 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
         TokenKind::Use => ModuleStmt::Use(parse_use(par)?),
         TokenKind::Contract => ModuleStmt::Contract(parse_contract_def(par, None)?),
         TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par, None)?),
+        TokenKind::Trait => ModuleStmt::Trait(parse_trait_def(par, None)?),
+        TokenKind::Impl => ModuleStmt::Impl(parse_impl_def(par)?),
         TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par, None)?),
         TokenKind::Const => ModuleStmt::Constant(parse_constant(par, None)?),
 
@@ -54,6 +57,7 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
                     ModuleStmt::Function(parse_fn_def(par, Some(pub_span))?)
                 }
                 TokenKind::Struct => ModuleStmt::Struct(parse_struct_def(par, Some(pub_span))?),
+                TokenKind::Trait => ModuleStmt::Trait(parse_trait_def(par, Some(pub_span))?),
                 TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par, Some(pub_span))?),
                 TokenKind::Const => ModuleStmt::Constant(parse_constant(par, Some(pub_span))?),
                 TokenKind::Contract => {

--- a/crates/parser/src/lexer/token.rs
+++ b/crates/parser/src/lexer/token.rs
@@ -261,7 +261,7 @@ impl TokenKind {
             Colon => "symbol `:`",
             ColonColon => "symbol `::`",
             Comma => "symbol `,`",
-            Semi => "symbol ``",
+            Semi => "symbol `;`",
             Plus => "symbol `+`",
             Minus => "symbol `-`",
             Star => "symbol `*`",

--- a/crates/parser/src/lexer/token.rs
+++ b/crates/parser/src/lexer/token.rs
@@ -79,6 +79,8 @@ pub enum TokenKind {
     Idx,
     #[token("if")]
     If,
+    #[token("impl")]
+    Impl,
     #[token("pragma")]
     Pragma,
     #[token("for")]
@@ -93,6 +95,8 @@ pub enum TokenKind {
     SelfValue,
     #[token("struct")]
     Struct,
+    #[token("trait")]
+    Trait,
     #[token("type")]
     Type,
     #[token("unsafe")]
@@ -230,6 +234,7 @@ impl TokenKind {
             Event => "keyword `event`",
             Idx => "keyword `idx`",
             If => "keyword `if`",
+            Impl => "keyword `impl`",
             Pragma => "keyword `pragma`",
             For => "keyword `for`",
             Pub => "keyword `pub`",
@@ -237,6 +242,7 @@ impl TokenKind {
             Revert => "keyword `revert`",
             SelfValue => "keyword `self`",
             Struct => "keyword `struct`",
+            Trait => "keyword `trait`",
             Type => "keyword `type`",
             Unsafe => "keyword `unsafe`",
             While => "keyword `while`",

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__contract_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(contract_def), try_parse_module,\n           r#\"contract Foo {\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n\n  pub fn foo() -> u8 {\n    return 10\n  }\n  event Bar {\n    idx from: address\n  }\n}\n\"#)"
+expression: "ast_string(stringify!(contract_def), try_parse_module,\n    r#\"contract Foo {\n  x: address\n  pub y: u8\n  pub const z: Map<u8, address>\n\n  pub fn foo() -> u8 {\n    return 10\n  }\n  event Bar {\n    idx from: address\n  }\n}\n\"#)"
 
 ---
 Node(
@@ -133,35 +133,43 @@ Node(
           body: [
             Function(Node(
               kind: Function(
-                pub_: Some(Span(
-                  start: 75,
-                  end: 78,
-                )),
-                unsafe_: None,
-                name: Node(
-                  kind: "foo",
-                  span: Span(
-                    start: 82,
-                    end: 85,
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: Some(Span(
+                      start: 75,
+                      end: 78,
+                    )),
+                    unsafe_: None,
+                    name: Node(
+                      kind: "foo",
+                      span: Span(
+                        start: 82,
+                        end: 85,
+                      ),
+                    ),
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 82,
+                        end: 85,
+                      ),
+                    ),
+                    args: [],
+                    return_type: Some(Node(
+                      kind: Base(
+                        base: "u8",
+                      ),
+                      span: Span(
+                        start: 91,
+                        end: 93,
+                      ),
+                    )),
                   ),
-                ),
-                generic_params: Node(
-                  kind: [],
                   span: Span(
-                    start: 82,
-                    end: 85,
-                  ),
-                ),
-                args: [],
-                return_type: Some(Node(
-                  kind: Base(
-                    base: "u8",
-                  ),
-                  span: Span(
-                    start: 91,
+                    start: 75,
                     end: 93,
                   ),
-                )),
+                ),
                 body: [
                   Node(
                     kind: Return(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def), try_parse_module,\n           \"fn transfer(from sender: address, to recip: address, _ val: u64) -> bool {\\n false \\n}\")"
+expression: "ast_string(stringify!(fn_def), try_parse_module,\n    \"fn transfer(from sender: address, to recip: address, _ val: u64) -> bool {\\n false \\n}\")"
 
 ---
 Node(
@@ -8,126 +8,134 @@ Node(
     body: [
       Function(Node(
         kind: Function(
-          pub_: None,
-          unsafe_: None,
-          name: Node(
-            kind: "transfer",
-            span: Span(
-              start: 3,
-              end: 11,
-            ),
-          ),
-          generic_params: Node(
-            kind: [],
-            span: Span(
-              start: 3,
-              end: 11,
-            ),
-          ),
-          args: [
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: Some(Node(
-                  kind: "from",
-                  span: Span(
-                    start: 12,
-                    end: 16,
-                  ),
-                )),
-                name: Node(
-                  kind: "sender",
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: None,
+              unsafe_: None,
+              name: Node(
+                kind: "transfer",
+                span: Span(
+                  start: 3,
+                  end: 11,
+                ),
+              ),
+              generic_params: Node(
+                kind: [],
+                span: Span(
+                  start: 3,
+                  end: 11,
+                ),
+              ),
+              args: [
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: Some(Node(
+                      kind: "from",
+                      span: Span(
+                        start: 12,
+                        end: 16,
+                      ),
+                    )),
+                    name: Node(
+                      kind: "sender",
+                      span: Span(
+                        start: 17,
+                        end: 23,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "address",
+                      ),
+                      span: Span(
+                        start: 25,
+                        end: 32,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 17,
-                    end: 23,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "address",
-                  ),
-                  span: Span(
-                    start: 25,
                     end: 32,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 17,
-                end: 32,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: Some(Node(
-                  kind: "to",
-                  span: Span(
-                    start: 34,
-                    end: 36,
-                  ),
-                )),
-                name: Node(
-                  kind: "recip",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: Some(Node(
+                      kind: "to",
+                      span: Span(
+                        start: 34,
+                        end: 36,
+                      ),
+                    )),
+                    name: Node(
+                      kind: "recip",
+                      span: Span(
+                        start: 37,
+                        end: 42,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "address",
+                      ),
+                      span: Span(
+                        start: 44,
+                        end: 51,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 37,
-                    end: 42,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "address",
-                  ),
-                  span: Span(
-                    start: 44,
                     end: 51,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 37,
-                end: 51,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: Some(Node(
-                  kind: "_",
-                  span: Span(
-                    start: 53,
-                    end: 54,
-                  ),
-                )),
-                name: Node(
-                  kind: "val",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: Some(Node(
+                      kind: "_",
+                      span: Span(
+                        start: 53,
+                        end: 54,
+                      ),
+                    )),
+                    name: Node(
+                      kind: "val",
+                      span: Span(
+                        start: 55,
+                        end: 58,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "u64",
+                      ),
+                      span: Span(
+                        start: 60,
+                        end: 63,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 55,
-                    end: 58,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "u64",
-                  ),
-                  span: Span(
-                    start: 60,
                     end: 63,
                   ),
                 ),
+              ],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "bool",
+                ),
+                span: Span(
+                  start: 68,
+                  end: 72,
+                ),
               )),
-              span: Span(
-                start: 55,
-                end: 63,
-              ),
-            ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "bool",
             ),
             span: Span(
-              start: 68,
+              start: 0,
               end: 72,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Expr(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_generic.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_generic.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_generic), try_parse_module,\n           \"fn foo<T, R: Event>(this: T, that: R, _ val: u64) -> bool { false }\")"
+expression: "ast_string(stringify!(fn_def_generic), try_parse_module,\n    \"fn foo<T, R: Event>(this: T, that: R, _ val: u64) -> bool { false }\")"
 
 ---
 Node(
@@ -35,7 +35,9 @@ Node(
                   ),
                 ),
                 bound: Node(
-                  kind: "Event",
+                  kind: Base(
+                    base: "Event",
+                  ),
                   span: Span(
                     start: 13,
                     end: 18,

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_generic.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_generic.snap
@@ -8,140 +8,148 @@ Node(
     body: [
       Function(Node(
         kind: Function(
-          pub_: None,
-          unsafe_: None,
-          name: Node(
-            kind: "foo",
-            span: Span(
-              start: 3,
-              end: 6,
-            ),
-          ),
-          generic_params: Node(
-            kind: [
-              Unbounded(Node(
-                kind: "T",
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: None,
+              unsafe_: None,
+              name: Node(
+                kind: "foo",
                 span: Span(
-                  start: 7,
-                  end: 8,
-                ),
-              )),
-              Bounded(
-                name: Node(
-                  kind: "R",
-                  span: Span(
-                    start: 10,
-                    end: 11,
-                  ),
-                ),
-                bound: Node(
-                  kind: Base(
-                    base: "Event",
-                  ),
-                  span: Span(
-                    start: 13,
-                    end: 18,
-                  ),
+                  start: 3,
+                  end: 6,
                 ),
               ),
-            ],
-            span: Span(
-              start: 6,
-              end: 19,
-            ),
-          ),
-          args: [
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "this",
+              generic_params: Node(
+                kind: [
+                  Unbounded(Node(
+                    kind: "T",
+                    span: Span(
+                      start: 7,
+                      end: 8,
+                    ),
+                  )),
+                  Bounded(
+                    name: Node(
+                      kind: "R",
+                      span: Span(
+                        start: 10,
+                        end: 11,
+                      ),
+                    ),
+                    bound: Node(
+                      kind: Base(
+                        base: "Event",
+                      ),
+                      span: Span(
+                        start: 13,
+                        end: 18,
+                      ),
+                    ),
+                  ),
+                ],
+                span: Span(
+                  start: 6,
+                  end: 19,
+                ),
+              ),
+              args: [
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "this",
+                      span: Span(
+                        start: 20,
+                        end: 24,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "T",
+                      ),
+                      span: Span(
+                        start: 26,
+                        end: 27,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 20,
-                    end: 24,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "T",
-                  ),
-                  span: Span(
-                    start: 26,
                     end: 27,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 20,
-                end: 27,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "that",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "that",
+                      span: Span(
+                        start: 29,
+                        end: 33,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "R",
+                      ),
+                      span: Span(
+                        start: 35,
+                        end: 36,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 29,
-                    end: 33,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "R",
-                  ),
-                  span: Span(
-                    start: 35,
                     end: 36,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 29,
-                end: 36,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: Some(Node(
-                  kind: "_",
-                  span: Span(
-                    start: 38,
-                    end: 39,
-                  ),
-                )),
-                name: Node(
-                  kind: "val",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: Some(Node(
+                      kind: "_",
+                      span: Span(
+                        start: 38,
+                        end: 39,
+                      ),
+                    )),
+                    name: Node(
+                      kind: "val",
+                      span: Span(
+                        start: 40,
+                        end: 43,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "u64",
+                      ),
+                      span: Span(
+                        start: 45,
+                        end: 48,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 40,
-                    end: 43,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "u64",
-                  ),
-                  span: Span(
-                    start: 45,
                     end: 48,
                   ),
                 ),
+              ],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "bool",
+                ),
+                span: Span(
+                  start: 53,
+                  end: 57,
+                ),
               )),
-              span: Span(
-                start: 40,
-                end: 48,
-              ),
-            ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "bool",
             ),
             span: Span(
-              start: 53,
+              start: 0,
               end: 57,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Expr(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_pub), try_parse_module,\n           \"pub fn foo21(x: bool, y: address,) -> bool { x }\")"
+expression: "ast_string(stringify!(fn_def_pub), try_parse_module,\n    \"pub fn foo21(x: bool, y: address,) -> bool { x }\")"
 
 ---
 Node(
@@ -8,86 +8,94 @@ Node(
     body: [
       Function(Node(
         kind: Function(
-          pub_: Some(Span(
-            start: 0,
-            end: 3,
-          )),
-          unsafe_: None,
-          name: Node(
-            kind: "foo21",
-            span: Span(
-              start: 7,
-              end: 12,
-            ),
-          ),
-          generic_params: Node(
-            kind: [],
-            span: Span(
-              start: 7,
-              end: 12,
-            ),
-          ),
-          args: [
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "x",
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: Some(Span(
+                start: 0,
+                end: 3,
+              )),
+              unsafe_: None,
+              name: Node(
+                kind: "foo21",
+                span: Span(
+                  start: 7,
+                  end: 12,
+                ),
+              ),
+              generic_params: Node(
+                kind: [],
+                span: Span(
+                  start: 7,
+                  end: 12,
+                ),
+              ),
+              args: [
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "x",
+                      span: Span(
+                        start: 13,
+                        end: 14,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "bool",
+                      ),
+                      span: Span(
+                        start: 16,
+                        end: 20,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 13,
-                    end: 14,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "bool",
-                  ),
-                  span: Span(
-                    start: 16,
                     end: 20,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 13,
-                end: 20,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "y",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "y",
+                      span: Span(
+                        start: 22,
+                        end: 23,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "address",
+                      ),
+                      span: Span(
+                        start: 25,
+                        end: 32,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 22,
-                    end: 23,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "address",
-                  ),
-                  span: Span(
-                    start: 25,
                     end: 32,
                   ),
                 ),
+              ],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "bool",
+                ),
+                span: Span(
+                  start: 38,
+                  end: 42,
+                ),
               )),
-              span: Span(
-                start: 22,
-                end: 32,
-              ),
-            ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "bool",
             ),
             span: Span(
-              start: 38,
+              start: 0,
               end: 42,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Expr(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub_unsafe.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_pub_unsafe.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_pub_unsafe), try_parse_module,\n           \"pub unsafe fn foo21(x: bool, y: address,) -> bool{x}\")"
+expression: "ast_string(stringify!(fn_def_pub_unsafe), try_parse_module,\n    \"pub unsafe fn foo21(x: bool, y: address,) -> bool{x}\")"
 
 ---
 Node(
@@ -8,89 +8,97 @@ Node(
     body: [
       Function(Node(
         kind: Function(
-          pub_: Some(Span(
-            start: 0,
-            end: 3,
-          )),
-          unsafe_: Some(Span(
-            start: 4,
-            end: 10,
-          )),
-          name: Node(
-            kind: "foo21",
-            span: Span(
-              start: 14,
-              end: 19,
-            ),
-          ),
-          generic_params: Node(
-            kind: [],
-            span: Span(
-              start: 14,
-              end: 19,
-            ),
-          ),
-          args: [
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "x",
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: Some(Span(
+                start: 0,
+                end: 3,
+              )),
+              unsafe_: Some(Span(
+                start: 4,
+                end: 10,
+              )),
+              name: Node(
+                kind: "foo21",
+                span: Span(
+                  start: 14,
+                  end: 19,
+                ),
+              ),
+              generic_params: Node(
+                kind: [],
+                span: Span(
+                  start: 14,
+                  end: 19,
+                ),
+              ),
+              args: [
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "x",
+                      span: Span(
+                        start: 20,
+                        end: 21,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "bool",
+                      ),
+                      span: Span(
+                        start: 23,
+                        end: 27,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 20,
-                    end: 21,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "bool",
-                  ),
-                  span: Span(
-                    start: 23,
                     end: 27,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 20,
-                end: 27,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "y",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "y",
+                      span: Span(
+                        start: 29,
+                        end: 30,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "address",
+                      ),
+                      span: Span(
+                        start: 32,
+                        end: 39,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 29,
-                    end: 30,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "address",
-                  ),
-                  span: Span(
-                    start: 32,
                     end: 39,
                   ),
                 ),
+              ],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "bool",
+                ),
+                span: Span(
+                  start: 45,
+                  end: 49,
+                ),
               )),
-              span: Span(
-                start: 29,
-                end: 39,
-              ),
-            ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "bool",
             ),
             span: Span(
-              start: 45,
+              start: 0,
               end: 49,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Expr(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_unsafe.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__fn_def_unsafe.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(fn_def_unsafe), try_parse_module,\n           \"unsafe fn foo21(x: bool, y: address,) -> bool {\\n x\\n}\")"
+expression: "ast_string(stringify!(fn_def_unsafe), try_parse_module,\n    \"unsafe fn foo21(x: bool, y: address,) -> bool {\\n x\\n}\")"
 
 ---
 Node(
@@ -8,86 +8,94 @@ Node(
     body: [
       Function(Node(
         kind: Function(
-          pub_: None,
-          unsafe_: Some(Span(
-            start: 0,
-            end: 6,
-          )),
-          name: Node(
-            kind: "foo21",
-            span: Span(
-              start: 10,
-              end: 15,
-            ),
-          ),
-          generic_params: Node(
-            kind: [],
-            span: Span(
-              start: 10,
-              end: 15,
-            ),
-          ),
-          args: [
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "x",
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: None,
+              unsafe_: Some(Span(
+                start: 0,
+                end: 6,
+              )),
+              name: Node(
+                kind: "foo21",
+                span: Span(
+                  start: 10,
+                  end: 15,
+                ),
+              ),
+              generic_params: Node(
+                kind: [],
+                span: Span(
+                  start: 10,
+                  end: 15,
+                ),
+              ),
+              args: [
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "x",
+                      span: Span(
+                        start: 16,
+                        end: 17,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "bool",
+                      ),
+                      span: Span(
+                        start: 19,
+                        end: 23,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 16,
-                    end: 17,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "bool",
-                  ),
-                  span: Span(
-                    start: 19,
                     end: 23,
                   ),
                 ),
-              )),
-              span: Span(
-                start: 16,
-                end: 23,
-              ),
-            ),
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "y",
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "y",
+                      span: Span(
+                        start: 25,
+                        end: 26,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "address",
+                      ),
+                      span: Span(
+                        start: 28,
+                        end: 35,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 25,
-                    end: 26,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "address",
-                  ),
-                  span: Span(
-                    start: 28,
                     end: 35,
                   ),
                 ),
+              ],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "bool",
+                ),
+                span: Span(
+                  start: 41,
+                  end: 45,
+                ),
               )),
-              span: Span(
-                start: 25,
-                end: 35,
-              ),
-            ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "bool",
             ),
             span: Span(
-              start: 41,
+              start: 0,
               end: 45,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Expr(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__guest_book.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(guest_book), try_parse_module,\n           r#\"\ntype BookMsg = Array<bytes, 100>\n\ncontract GuestBook {\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed {\n        idx book_msg: BookMsg\n    }\n\n    pub fn sign(self, book_msg: BookMsg) {\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg: book_msg)\n    }\n    pub fn get_msg(self, addr: address) -> BookMsg {\n        return self.guest_book[addr]\n    }\n}\"#)"
+expression: "ast_string(stringify!(guest_book), try_parse_module,\n    r#\"\ntype BookMsg = Array<bytes, 100>\n\ncontract GuestBook {\n    pub guest_book: Map<address, BookMsg>\n\n    event Signed {\n        idx book_msg: BookMsg\n    }\n\n    pub fn sign(self, book_msg: BookMsg) {\n        self.guest_book[msg.sender] = book_msg\n\n        emit Signed(book_msg: book_msg)\n    }\n    pub fn get_msg(self, addr: address) -> BookMsg {\n        return self.guest_book[addr]\n    }\n}\"#)"
 
 ---
 Node(
@@ -177,60 +177,68 @@ Node(
             )),
             Function(Node(
               kind: Function(
-                pub_: Some(Span(
-                  start: 159,
-                  end: 162,
-                )),
-                unsafe_: None,
-                name: Node(
-                  kind: "sign",
-                  span: Span(
-                    start: 166,
-                    end: 170,
-                  ),
-                ),
-                generic_params: Node(
-                  kind: [],
-                  span: Span(
-                    start: 166,
-                    end: 170,
-                  ),
-                ),
-                args: [
-                  Node(
-                    kind: Self_,
-                    span: Span(
-                      start: 171,
-                      end: 175,
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: Some(Span(
+                      start: 159,
+                      end: 162,
+                    )),
+                    unsafe_: None,
+                    name: Node(
+                      kind: "sign",
+                      span: Span(
+                        start: 166,
+                        end: 170,
+                      ),
                     ),
-                  ),
-                  Node(
-                    kind: Regular(RegularFunctionArg(
-                      label: None,
-                      name: Node(
-                        kind: "book_msg",
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 166,
+                        end: 170,
+                      ),
+                    ),
+                    args: [
+                      Node(
+                        kind: Self_,
                         span: Span(
-                          start: 177,
-                          end: 185,
+                          start: 171,
+                          end: 175,
                         ),
                       ),
-                      typ: Node(
-                        kind: Base(
-                          base: "BookMsg",
-                        ),
+                      Node(
+                        kind: Regular(RegularFunctionArg(
+                          label: None,
+                          name: Node(
+                            kind: "book_msg",
+                            span: Span(
+                              start: 177,
+                              end: 185,
+                            ),
+                          ),
+                          typ: Node(
+                            kind: Base(
+                              base: "BookMsg",
+                            ),
+                            span: Span(
+                              start: 187,
+                              end: 194,
+                            ),
+                          ),
+                        )),
                         span: Span(
-                          start: 187,
+                          start: 177,
                           end: 194,
                         ),
                       ),
-                    )),
-                    span: Span(
-                      start: 177,
-                      end: 194,
-                    ),
+                    ],
+                    return_type: None,
                   ),
-                ],
-                return_type: None,
+                  span: Span(
+                    start: 159,
+                    end: 195,
+                  ),
+                ),
                 body: [
                   Node(
                     kind: Assign(
@@ -353,68 +361,76 @@ Node(
             )),
             Function(Node(
               kind: Function(
-                pub_: Some(Span(
-                  start: 296,
-                  end: 299,
-                )),
-                unsafe_: None,
-                name: Node(
-                  kind: "get_msg",
-                  span: Span(
-                    start: 303,
-                    end: 310,
-                  ),
-                ),
-                generic_params: Node(
-                  kind: [],
-                  span: Span(
-                    start: 303,
-                    end: 310,
-                  ),
-                ),
-                args: [
-                  Node(
-                    kind: Self_,
-                    span: Span(
-                      start: 311,
-                      end: 315,
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: Some(Span(
+                      start: 296,
+                      end: 299,
+                    )),
+                    unsafe_: None,
+                    name: Node(
+                      kind: "get_msg",
+                      span: Span(
+                        start: 303,
+                        end: 310,
+                      ),
                     ),
-                  ),
-                  Node(
-                    kind: Regular(RegularFunctionArg(
-                      label: None,
-                      name: Node(
-                        kind: "addr",
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 303,
+                        end: 310,
+                      ),
+                    ),
+                    args: [
+                      Node(
+                        kind: Self_,
                         span: Span(
-                          start: 317,
-                          end: 321,
+                          start: 311,
+                          end: 315,
                         ),
                       ),
-                      typ: Node(
-                        kind: Base(
-                          base: "address",
-                        ),
+                      Node(
+                        kind: Regular(RegularFunctionArg(
+                          label: None,
+                          name: Node(
+                            kind: "addr",
+                            span: Span(
+                              start: 317,
+                              end: 321,
+                            ),
+                          ),
+                          typ: Node(
+                            kind: Base(
+                              base: "address",
+                            ),
+                            span: Span(
+                              start: 323,
+                              end: 330,
+                            ),
+                          ),
+                        )),
                         span: Span(
-                          start: 323,
+                          start: 317,
                           end: 330,
                         ),
                       ),
+                    ],
+                    return_type: Some(Node(
+                      kind: Base(
+                        base: "BookMsg",
+                      ),
+                      span: Span(
+                        start: 335,
+                        end: 342,
+                      ),
                     )),
-                    span: Span(
-                      start: 317,
-                      end: 330,
-                    ),
-                  ),
-                ],
-                return_type: Some(Node(
-                  kind: Base(
-                    base: "BookMsg",
                   ),
                   span: Span(
-                    start: 335,
+                    start: 296,
                     end: 342,
                   ),
-                )),
+                ),
                 body: [
                   Node(
                     kind: Return(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_level_events), try_parse_module,\n           r#\"\nuse std::context::Context\n\nevent Transfer {\n    idx sender: address\n    idx receiver: address\n    value: u256\n}\ncontract Foo {\n    fn transfer(ctx: Context, to: address, value: u256) {\n        emit Transfer(ctx, sender: msg.sender, receiver: to, value)\n    }\n}\n\"#)"
+expression: "ast_string(stringify!(module_level_events), try_parse_module,\n    r#\"\nuse std::context::Context\n\nevent Transfer {\n    idx sender: address\n    idx receiver: address\n    value: u256\n}\ncontract Foo {\n    fn transfer(ctx: Context, to: address, value: u256) {\n        emit Transfer(ctx, sender: msg.sender, receiver: to, value)\n    }\n}\n\"#)"
 
 ---
 Node(
@@ -154,100 +154,108 @@ Node(
           body: [
             Function(Node(
               kind: Function(
-                pub_: None,
-                unsafe_: None,
-                name: Node(
-                  kind: "transfer",
-                  span: Span(
-                    start: 135,
-                    end: 143,
-                  ),
-                ),
-                generic_params: Node(
-                  kind: [],
-                  span: Span(
-                    start: 135,
-                    end: 143,
-                  ),
-                ),
-                args: [
-                  Node(
-                    kind: Regular(RegularFunctionArg(
-                      label: None,
-                      name: Node(
-                        kind: "ctx",
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: None,
+                    unsafe_: None,
+                    name: Node(
+                      kind: "transfer",
+                      span: Span(
+                        start: 135,
+                        end: 143,
+                      ),
+                    ),
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 135,
+                        end: 143,
+                      ),
+                    ),
+                    args: [
+                      Node(
+                        kind: Regular(RegularFunctionArg(
+                          label: None,
+                          name: Node(
+                            kind: "ctx",
+                            span: Span(
+                              start: 144,
+                              end: 147,
+                            ),
+                          ),
+                          typ: Node(
+                            kind: Base(
+                              base: "Context",
+                            ),
+                            span: Span(
+                              start: 149,
+                              end: 156,
+                            ),
+                          ),
+                        )),
                         span: Span(
                           start: 144,
-                          end: 147,
-                        ),
-                      ),
-                      typ: Node(
-                        kind: Base(
-                          base: "Context",
-                        ),
-                        span: Span(
-                          start: 149,
                           end: 156,
                         ),
                       ),
-                    )),
-                    span: Span(
-                      start: 144,
-                      end: 156,
-                    ),
-                  ),
-                  Node(
-                    kind: Regular(RegularFunctionArg(
-                      label: None,
-                      name: Node(
-                        kind: "to",
+                      Node(
+                        kind: Regular(RegularFunctionArg(
+                          label: None,
+                          name: Node(
+                            kind: "to",
+                            span: Span(
+                              start: 158,
+                              end: 160,
+                            ),
+                          ),
+                          typ: Node(
+                            kind: Base(
+                              base: "address",
+                            ),
+                            span: Span(
+                              start: 162,
+                              end: 169,
+                            ),
+                          ),
+                        )),
                         span: Span(
                           start: 158,
-                          end: 160,
-                        ),
-                      ),
-                      typ: Node(
-                        kind: Base(
-                          base: "address",
-                        ),
-                        span: Span(
-                          start: 162,
                           end: 169,
                         ),
                       ),
-                    )),
-                    span: Span(
-                      start: 158,
-                      end: 169,
-                    ),
-                  ),
-                  Node(
-                    kind: Regular(RegularFunctionArg(
-                      label: None,
-                      name: Node(
-                        kind: "value",
+                      Node(
+                        kind: Regular(RegularFunctionArg(
+                          label: None,
+                          name: Node(
+                            kind: "value",
+                            span: Span(
+                              start: 171,
+                              end: 176,
+                            ),
+                          ),
+                          typ: Node(
+                            kind: Base(
+                              base: "u256",
+                            ),
+                            span: Span(
+                              start: 178,
+                              end: 182,
+                            ),
+                          ),
+                        )),
                         span: Span(
                           start: 171,
-                          end: 176,
-                        ),
-                      ),
-                      typ: Node(
-                        kind: Base(
-                          base: "u256",
-                        ),
-                        span: Span(
-                          start: 178,
                           end: 182,
                         ),
                       ),
-                    )),
-                    span: Span(
-                      start: 171,
-                      end: 182,
-                    ),
+                    ],
+                    return_type: None,
                   ),
-                ],
-                return_type: None,
+                  span: Span(
+                    start: 132,
+                    end: 183,
+                  ),
+                ),
                 body: [
                   Node(
                     kind: Emit(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_stmts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_stmts), try_parse_module,\n           r#\"\npragma 0.5.0\n\nuse foo::bar::{\n    bing as bong,\n    food::*\n}\n\ntype X = Map<u8, u16>\n\npub fn double(x: u8) -> u8 {\n    return x * 2\n}\n\nfn secret() -> u8 { return 0xBEEF }\n\ncontract A {\n    pub const x: u256 = 10\n}\n\ncontract B {\n    pub x: X\n}\"#)"
+expression: "ast_string(stringify!(module_stmts), try_parse_module,\n    r#\"\npragma 0.5.0\n\nuse foo::bar::{\n    bing as bong,\n    food::*\n}\n\ntype X = Map<u8, u16>\n\npub fn double(x: u8) -> u8 {\n    return x * 2\n}\n\nfn secret() -> u8 { return 0xBEEF }\n\ncontract A {\n    pub const x: u256 = 10\n}\n\ncontract B {\n    pub x: X\n}\"#)"
 
 ---
 Node(
@@ -161,61 +161,69 @@ Node(
       )),
       Function(Node(
         kind: Function(
-          pub_: Some(Span(
-            start: 87,
-            end: 90,
-          )),
-          unsafe_: None,
-          name: Node(
-            kind: "double",
-            span: Span(
-              start: 94,
-              end: 100,
-            ),
-          ),
-          generic_params: Node(
-            kind: [],
-            span: Span(
-              start: 94,
-              end: 100,
-            ),
-          ),
-          args: [
-            Node(
-              kind: Regular(RegularFunctionArg(
-                label: None,
-                name: Node(
-                  kind: "x",
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: Some(Span(
+                start: 87,
+                end: 90,
+              )),
+              unsafe_: None,
+              name: Node(
+                kind: "double",
+                span: Span(
+                  start: 94,
+                  end: 100,
+                ),
+              ),
+              generic_params: Node(
+                kind: [],
+                span: Span(
+                  start: 94,
+                  end: 100,
+                ),
+              ),
+              args: [
+                Node(
+                  kind: Regular(RegularFunctionArg(
+                    label: None,
+                    name: Node(
+                      kind: "x",
+                      span: Span(
+                        start: 101,
+                        end: 102,
+                      ),
+                    ),
+                    typ: Node(
+                      kind: Base(
+                        base: "u8",
+                      ),
+                      span: Span(
+                        start: 104,
+                        end: 106,
+                      ),
+                    ),
+                  )),
                   span: Span(
                     start: 101,
-                    end: 102,
-                  ),
-                ),
-                typ: Node(
-                  kind: Base(
-                    base: "u8",
-                  ),
-                  span: Span(
-                    start: 104,
                     end: 106,
                   ),
                 ),
+              ],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "u8",
+                ),
+                span: Span(
+                  start: 111,
+                  end: 113,
+                ),
               )),
-              span: Span(
-                start: 101,
-                end: 106,
-              ),
-            ),
-          ],
-          return_type: Some(Node(
-            kind: Base(
-              base: "u8",
             ),
             span: Span(
-              start: 111,
+              start: 87,
               end: 113,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Return(
@@ -263,32 +271,40 @@ Node(
       )),
       Function(Node(
         kind: Function(
-          pub_: None,
-          unsafe_: None,
-          name: Node(
-            kind: "secret",
-            span: Span(
-              start: 139,
-              end: 145,
+          sig: Node(
+            kind: FunctionSignature(
+              pub_: None,
+              unsafe_: None,
+              name: Node(
+                kind: "secret",
+                span: Span(
+                  start: 139,
+                  end: 145,
+                ),
+              ),
+              generic_params: Node(
+                kind: [],
+                span: Span(
+                  start: 139,
+                  end: 145,
+                ),
+              ),
+              args: [],
+              return_type: Some(Node(
+                kind: Base(
+                  base: "u8",
+                ),
+                span: Span(
+                  start: 151,
+                  end: 153,
+                ),
+              )),
             ),
-          ),
-          generic_params: Node(
-            kind: [],
             span: Span(
-              start: 139,
-              end: 145,
-            ),
-          ),
-          args: [],
-          return_type: Some(Node(
-            kind: Base(
-              base: "u8",
-            ),
-            span: Span(
-              start: 151,
+              start: 136,
               end: 153,
             ),
-          )),
+          ),
           body: [
             Node(
               kind: Return(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__pub_contract_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(pub_contract_def), try_parse_module,\n           r#\"\npub contract Foo {\n    pub fn foo() -> u8 {\n      return 10\n    }\n}\"#)"
+expression: "ast_string(stringify!(pub_contract_def), try_parse_module,\n    r#\"\npub contract Foo {\n    pub fn foo() -> u8 {\n      return 10\n    }\n}\"#)"
 
 ---
 Node(
@@ -19,35 +19,43 @@ Node(
           body: [
             Function(Node(
               kind: Function(
-                pub_: Some(Span(
-                  start: 24,
-                  end: 27,
-                )),
-                unsafe_: None,
-                name: Node(
-                  kind: "foo",
-                  span: Span(
-                    start: 31,
-                    end: 34,
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: Some(Span(
+                      start: 24,
+                      end: 27,
+                    )),
+                    unsafe_: None,
+                    name: Node(
+                      kind: "foo",
+                      span: Span(
+                        start: 31,
+                        end: 34,
+                      ),
+                    ),
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 31,
+                        end: 34,
+                      ),
+                    ),
+                    args: [],
+                    return_type: Some(Node(
+                      kind: Base(
+                        base: "u8",
+                      ),
+                      span: Span(
+                        start: 40,
+                        end: 42,
+                      ),
+                    )),
                   ),
-                ),
-                generic_params: Node(
-                  kind: [],
                   span: Span(
-                    start: 31,
-                    end: 34,
-                  ),
-                ),
-                args: [],
-                return_type: Some(Node(
-                  kind: Base(
-                    base: "u8",
-                  ),
-                  span: Span(
-                    start: 40,
+                    start: 24,
                     end: 42,
                   ),
-                )),
+                ),
                 body: [
                   Node(
                     kind: Return(

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__struct_def.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(struct_def), try_parse_module,\n           r#\"struct S {\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8 {\n    return self.z + self.y\n  }\n  unsafe fn bar() {}\n}\"#)"
+expression: "ast_string(stringify!(struct_def), try_parse_module,\n    r#\"struct S {\n  x: address\n  pub y: u8\n  z: u8\n  pub a: Map<u8, foo>\n\n  pub fn foo(self) -> u8 {\n    return self.z + self.y\n  }\n  unsafe fn bar() {}\n}\"#)"
 
 ---
 Node(
@@ -160,43 +160,51 @@ Node(
           functions: [
             Node(
               kind: Function(
-                pub_: Some(Span(
-                  start: 69,
-                  end: 72,
-                )),
-                unsafe_: None,
-                name: Node(
-                  kind: "foo",
-                  span: Span(
-                    start: 76,
-                    end: 79,
-                  ),
-                ),
-                generic_params: Node(
-                  kind: [],
-                  span: Span(
-                    start: 76,
-                    end: 79,
-                  ),
-                ),
-                args: [
-                  Node(
-                    kind: Self_,
-                    span: Span(
-                      start: 80,
-                      end: 84,
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: Some(Span(
+                      start: 69,
+                      end: 72,
+                    )),
+                    unsafe_: None,
+                    name: Node(
+                      kind: "foo",
+                      span: Span(
+                        start: 76,
+                        end: 79,
+                      ),
                     ),
-                  ),
-                ],
-                return_type: Some(Node(
-                  kind: Base(
-                    base: "u8",
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 76,
+                        end: 79,
+                      ),
+                    ),
+                    args: [
+                      Node(
+                        kind: Self_,
+                        span: Span(
+                          start: 80,
+                          end: 84,
+                        ),
+                      ),
+                    ],
+                    return_type: Some(Node(
+                      kind: Base(
+                        base: "u8",
+                      ),
+                      span: Span(
+                        start: 89,
+                        end: 91,
+                      ),
+                    )),
                   ),
                   span: Span(
-                    start: 89,
+                    start: 69,
                     end: 91,
                   ),
-                )),
+                ),
                 body: [
                   Node(
                     kind: Return(
@@ -274,27 +282,35 @@ Node(
             ),
             Node(
               kind: Function(
-                pub_: None,
-                unsafe_: Some(Span(
-                  start: 127,
-                  end: 133,
-                )),
-                name: Node(
-                  kind: "bar",
+                sig: Node(
+                  kind: FunctionSignature(
+                    pub_: None,
+                    unsafe_: Some(Span(
+                      start: 127,
+                      end: 133,
+                    )),
+                    name: Node(
+                      kind: "bar",
+                      span: Span(
+                        start: 137,
+                        end: 140,
+                      ),
+                    ),
+                    generic_params: Node(
+                      kind: [],
+                      span: Span(
+                        start: 137,
+                        end: 140,
+                      ),
+                    ),
+                    args: [],
+                    return_type: None,
+                  ),
                   span: Span(
-                    start: 137,
-                    end: 140,
+                    start: 127,
+                    end: 142,
                   ),
                 ),
-                generic_params: Node(
-                  kind: [],
-                  span: Span(
-                    start: 137,
-                    end: 140,
-                  ),
-                ),
-                args: [],
-                return_type: None,
                 body: [],
               ),
               span: Span(

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/foo.fe
@@ -2,6 +2,8 @@ type MyInt = i32
 
 const MY_CONST: MyInt = 1
 
+trait MyTrait {}
+
 event MyEvent {
     x: i32
 }

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
@@ -1,5 +1,8 @@
-use foo::{MyInt, MY_CONST, MyEvent, MyStruct, my_func, MyContract}
+use foo::{MyInt, MY_CONST, MyEvent, MyStruct, MyTrait, my_func, MyContract}
 use std::context::Context
+
+struct SomeThing {}
+impl MyTrait for SomeThing {}
 
 contract Main {
     pub fn priv_type_alias() -> MyInt {

--- a/crates/test-files/fixtures/compile_errors/call_generic_function_with_unsatisfied_bound.fe
+++ b/crates/test-files/fixtures/compile_errors/call_generic_function_with_unsatisfied_bound.fe
@@ -1,8 +1,10 @@
-use std::traits::IsNumeric
+trait Dummy {}
+
+struct Bar {}
 
 struct Foo {
 
-  pub fn bar<T: IsNumeric>(self, _ x: T) -> bool {
+  pub fn bar<T: Dummy>(self, _ x: T) -> bool {
     return true
   }
 }
@@ -11,6 +13,6 @@ contract Meh {
 
   pub fn call_bar(self) {
     let foo: Foo = Foo();
-    foo.bar(true)
+    foo.bar(Bar())
   }
 }

--- a/crates/test-files/fixtures/compile_errors/call_generic_function_with_unsatisfied_bound.fe
+++ b/crates/test-files/fixtures/compile_errors/call_generic_function_with_unsatisfied_bound.fe
@@ -1,0 +1,16 @@
+use std::traits::IsNumeric
+
+struct Foo {
+
+  pub fn bar<T: IsNumeric>(self, _ x: T) -> bool {
+    return true
+  }
+}
+
+contract Meh {
+
+  pub fn call_bar(self) {
+    let foo: Foo = Foo();
+    foo.bar(true)
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/contract_function_with_generic_params.fe
+++ b/crates/test-files/fixtures/compile_errors/contract_function_with_generic_params.fe
@@ -1,0 +1,5 @@
+use std::traits::IsNumeric
+
+contract Foo {
+    pub fn bar<T: IsNumeric>(val: T) {}
+}

--- a/crates/test-files/fixtures/compile_errors/contract_function_with_generic_params.fe
+++ b/crates/test-files/fixtures/compile_errors/contract_function_with_generic_params.fe
@@ -1,5 +1,5 @@
-use std::traits::IsNumeric
+trait Dummy {}
 
 contract Foo {
-    pub fn bar<T: IsNumeric>(val: T) {}
+    pub fn bar<T: Dummy>(val: T) {}
 }

--- a/crates/test-files/fixtures/compile_errors/duplicate_generic_params.fe
+++ b/crates/test-files/fixtures/compile_errors/duplicate_generic_params.fe
@@ -1,0 +1,13 @@
+trait Computable {
+  fn compute(self, val: u256) -> u256;
+}
+
+trait Computable2 {
+  fn compute2(self, val: u256) -> u256;
+}
+
+struct Yay {
+  fn foo<T: Computable, T: Computable2>(val1: T, val2: T) {
+      return
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/invalid_generic_bound.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_generic_bound.fe
@@ -1,0 +1,3 @@
+struct Foo {
+    pub fn bar<T: bool>(val: T) {}
+}

--- a/crates/test-files/fixtures/compile_errors/invalid_impl_location.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_impl_location.fe
@@ -1,0 +1,3 @@
+use std::traits::IsNumeric
+
+impl IsNumeric for u8 {}

--- a/crates/test-files/fixtures/compile_errors/invalid_impl_location.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_impl_location.fe
@@ -1,3 +1,4 @@
-use std::traits::IsNumeric
+use std::traits::Dummy
+use std::context::Context
 
-impl IsNumeric for u8 {}
+impl Dummy for Context {}

--- a/crates/test-files/fixtures/compile_errors/invalid_impl_type.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_impl_type.fe
@@ -1,0 +1,3 @@
+trait SomeTrait {}
+
+impl SomeTrait for Map<u8, u8> {}

--- a/crates/test-files/fixtures/compile_errors/trait_conflicting_impls.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_conflicting_impls.fe
@@ -1,0 +1,7 @@
+trait Foo {}
+
+struct Bar {
+}
+
+impl Foo for Bar {}
+impl Foo for Bar {}

--- a/crates/test-files/fixtures/compile_errors/trait_fn_with_generic_params.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_fn_with_generic_params.fe
@@ -1,0 +1,5 @@
+trait Bar {}
+
+trait Foo {
+    fn generic_fn<T: Bar>(self, val: T);
+}

--- a/crates/test-files/fixtures/compile_errors/trait_fn_without_self.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_fn_without_self.fe
@@ -1,0 +1,3 @@
+trait Foo {
+    fn this_has_no_self();
+}

--- a/crates/test-files/fixtures/compile_errors/trait_impl_mismatch.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_impl_mismatch.fe
@@ -1,0 +1,16 @@
+trait Foo {
+    fn this_misses_in_impl(self);
+    fn this_has_wrong_args_in_impl(self, val: u8, val2: bool);
+    fn this_has_wrong_return_type_in_impl(self) -> bool;
+}
+
+struct Bar {}
+
+impl Foo for Bar {
+
+    fn this_has_wrong_args_in_impl(self, val: u16, val2: Array<u8, 10>) {}
+    fn this_has_wrong_return_type_in_impl(self) -> u8 {
+        return 0
+    }
+    fn this_does_not_exist_in_trait() {}
+}

--- a/crates/test-files/fixtures/compile_errors/traits_as_fields.fe
+++ b/crates/test-files/fixtures/compile_errors/traits_as_fields.fe
@@ -1,0 +1,9 @@
+trait Foo {}
+
+struct Bar {
+    val: Foo
+}
+
+contract Nope {
+    val: Foo
+}

--- a/crates/test-files/fixtures/compile_errors/traits_with_wrong_bounds.fe
+++ b/crates/test-files/fixtures/compile_errors/traits_with_wrong_bounds.fe
@@ -1,0 +1,5 @@
+trait Some {}
+
+struct Bar {
+    pub fn no_bounds<T>(val: T) {}
+}

--- a/crates/test-files/fixtures/features/generic_functions.fe
+++ b/crates/test-files/fixtures/features/generic_functions.fe
@@ -1,0 +1,23 @@
+use std::traits::IsNumeric
+
+struct Bar {
+
+  pub fn bar<T: IsNumeric>(self, x: T, y: u256) -> bool {
+    return true
+  }
+
+  pub fn call_me_maybe(self) {
+    self.bar(x: 1, y: 1)
+    self.bar(x: i8(-1), y:1)
+  }
+}
+
+
+contract Foo {
+
+  pub fn call_me_maybe(self) {
+    let bar: Bar = Bar();
+    bar.bar(x: 1, y: 1)
+    bar.bar(x: i8(-1), y:1)
+  }
+}

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -2042,7 +2042,7 @@ fn ctx_init_in_call() {
 #[test]
 fn generics() {
     with_executor(&|mut executor| {
-        // This isn't testing much yet. It soon will when traits and impls are fully implemented
-        deploy_contract(&mut executor, "generic_functions.fe", "Foo", &[]);
+        let harness = deploy_contract(&mut executor, "generic_functions.fe", "Example", &[]);
+        harness.test_function(&mut executor, "generic_compute", &[], None);
     });
 }

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -2038,3 +2038,11 @@ fn ctx_init_in_call() {
         }
     });
 }
+
+#[test]
+fn generics() {
+    with_executor(&|mut executor| {
+        // This isn't testing much yet. It soon will when traits and impls are fully implemented
+        deploy_contract(&mut executor, "generic_functions.fe", "Foo", &[]);
+    });
+}

--- a/newsfragments/710.feature.md
+++ b/newsfragments/710.feature.md
@@ -1,15 +1,17 @@
+traits and generic function parameter
+
+Traits can now be defined, e.g:
+
+```
 trait Computable {
   fn compute(self, val: u256) -> u256;
 }
+```
 
-struct Mac {}
+For now, traits can only be implemented for structs.
+The mechanism to implement a trait is via an `impl` block e.g:
 
-impl Computable for Mac {
-  fn compute(self, val: u256) -> u256 {
-    return 1 + val
-  }
-}
-
+```
 struct Linux {
   pub counter: u256
   pub fn get_counter(self) -> u256 {
@@ -25,18 +27,29 @@ impl Computable for Linux {
     return val + Linux::something_static() + self.get_counter()
   }
 }
+```
 
+Traits can only appear as bounds for generic functions e.g.:
+
+```
 struct Runner {
 
   pub fn run<T: Computable>(self, _ val: T) -> u256 {
     return val.compute(val: 1000)
   }
 }
+```
 
+Only `struct` functions (not `contract` functions) can have generic parameters.
+The `run` method of `Runner` can be called with any type that implements `Computable` e.g.
+
+```
 contract Example {
+
   pub fn generic_compute(self) {
     let runner: Runner = Runner();
     assert runner.run(Mac()) == 1001
     assert runner.run(Linux(counter: 10)) == 1015
   }
 }
+```


### PR DESCRIPTION
### Abstract

We want to have traits as well as generic functions with trait bounds. One of the main motivations is to properly implement `emit` on the `Context` struct as `pub fn emit<T: Event>(val: T) { ... }`

### How was it fixed?

Working example below:

https://github.com/ethereum/fe/blob/f97afea7937202e32b40de5f866b960b60d84c0a/crates/test-files/fixtures/features/generic_functions.fe#L1-L42

Some notes:

- Generic functions a currently monomorphized at MIR lowering
- Because trait functions are usually (and currently only) defined without body the signature part was ripped out of `FunctionId` and into `FunctionSigId` to allow traits to reuse a bunch of code that doesn't care about the body anyway.
- There are certain limitations that can potentially be improved in the future e.g.
  - support traits for non-struct types
  - allow trait methods to define a body as a default implementation
  - support generic functions in traits (e.g. `trait PartialEq { pub fun eq<T>(self, other: T); }`)
  - support multiple bounds
  - support unbounded generics
  - support trait associated functions (e.g. `SomeTrait::some_fun()`
  