### PR TITLE
Add missing newsfragments

### DIFF
--- a/newsfragments/249.feature.md
+++ b/newsfragments/249.feature.md
@@ -1,0 +1,1 @@
+Optimized access of struct fields in storage

--- a/newsfragments/442.feature.md
+++ b/newsfragments/442.feature.md
@@ -1,0 +1,1 @@
+Unit type `()` is now ABI encodable

--- a/newsfragments/590.bugfix.md
+++ b/newsfragments/590.bugfix.md
@@ -1,0 +1,7 @@
+Fixed a crash caused by certain memory to memory assignments.
+
+E.g. the following code would previously lead to a compiler crash:
+
+```
+my_struct.x = my_struct.y
+```

--- a/newsfragments/681.bugfix.md
+++ b/newsfragments/681.bugfix.md
@@ -1,0 +1,13 @@
+Fixed crash when passing a struct that contains an array
+
+E.g. the following would previously result in a compiler crash:
+
+```
+struct MyArray:
+    pub x: Array<i32, 2>
+    
+    
+contract Foo:
+    pub fn bar(my_arr: MyArray):
+        pass
+```

--- a/newsfragments/709.bugfix.md
+++ b/newsfragments/709.bugfix.md
@@ -1,0 +1,14 @@
+Resolve compiler crash when using certain reserved YUL words as struct field names.
+
+E.g. the following would previously lead to a compiler crash because `numer` is
+a reserved keyword in YUL.
+
+```
+struct Foo:
+  pub number: u256
+
+contract Meh:
+
+  pub fn yay() -> Foo:
+    return Foo(number:2)
+```


### PR DESCRIPTION
### What was wrong?

#676 was so epic that nobody cared for the missing newsfragments

### How was it fixed?

Added the missing newsfragments

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
