### PR TITLE
Fix wrong safemath lowering

### DIFF
--- a/crates/mir/src/ir/value.rs
+++ b/crates/mir/src/ir/value.rs
@@ -42,6 +42,10 @@ impl Value {
             | Self::Constant { ty, .. } => *ty,
         }
     }
+
+    pub fn is_imm(&self) -> bool {
+        matches!(self, Self::Immediate { .. })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/newsfragments/723.bugfix.md
+++ b/newsfragments/723.bugfix.md
@@ -1,0 +1,2 @@
+* Properly lower right shift operation to yul's `sar` if operand is signed type
+* Properly lower negate operation to call `safe_sub`


### PR DESCRIPTION
### What was wrong?
1. Right shift operation isn't lowered `sar` when operands are signed type
2. negate operation isn't lowered into `safe_sub` call.


### How was it fixed?
🔪 

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
