### PR TITLE
Remove lowering cruft from ingot/module items

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ The most advanced example that we can provide at this point is an implementation
 
 The Fe implementation is split into several crates. Crates that depend on the
 solidity compiler (directly or indirectly) are licensed GPL-3.0-or-later. This
-includes the `fe` CLI tool, compiler "back end" (yulgen, yulc), driver, tests,
-and test-utils.
+includes the `fe` CLI tool, yulc, driver, tests, and test-utils.
 
-The remaining crates are licensed Apache-2.0. This includes the compiler
-"front end" (parser, analyzer, lowering), abi, and common.
+The remaining crates are licensed Apache-2.0. This includes the parser,
+analyzer, mir, abi, and common.

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -374,10 +374,6 @@ pub struct FunctionBody {
     pub string_literals: IndexSet<SmolStr>, // for yulgen
     // Map lhs of variable declaration to type.
     pub var_types: IndexMap<NodeId, Type>,
-
-    // This is the id of the VarDecl TypeDesc node
-    // TODO: Do we really need this?
-    pub var_decl_types: IndexMap<NodeId, Type>,
     pub calls: IndexMap<NodeId, CallType>,
     pub spans: HashMap<NodeId, Span>,
 }

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -6,7 +6,7 @@ use crate::namespace::items::{
 };
 use crate::namespace::types;
 use fe_common::db::{SourceDb, SourceDbStorage, Upcast, UpcastMut};
-use fe_common::Span;
+use fe_common::{SourceFileId, Span};
 use fe_parser::ast;
 use indexmap::map::IndexMap;
 use smol_str::SmolStr;
@@ -39,16 +39,15 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     // Ingot
 
     // These are inputs so that the (future) language server can add
-    // and remove files/dependencies. Set via eg `db.set_ingot_modules`.
+    // and remove files/dependencies. Set via eg `db.set_ingot_files`.
     // If an input is used before it's set, salsa will panic.
-    // Ideally, `ingot_files` would be the input instead, but in order to support analysis
-    // of the post-lowering-phase stuff, we need to be able to construct a new
-    // lowered ingot, and give it a set of lowered modules.
     #[salsa::input]
-    fn ingot_modules(&self, ingot: IngotId) -> Rc<[ModuleId]>;
+    fn ingot_files(&self, ingot: IngotId) -> Rc<[SourceFileId]>;
     #[salsa::input]
     fn ingot_external_ingots(&self, ingot: IngotId) -> Rc<IndexMap<SmolStr, IngotId>>;
 
+    #[salsa::invoke(queries::ingots::ingot_modules)]
+    fn ingot_modules(&self, ingot: IngotId) -> Rc<[ModuleId]>;
     #[salsa::invoke(queries::ingots::ingot_root_module)]
     fn ingot_root_module(&self, ingot: IngotId) -> Option<ModuleId>;
 

--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -356,7 +356,7 @@ pub fn function_dependency_graph(db: &dyn AnalyzerDb, function: FunctionId) -> D
             .values()
             .map(|event| (root, Item::Event(*event), DepLocality::Local)),
     );
-    directs.extend(body.var_decl_types.values().filter_map(|typ| match typ {
+    directs.extend(body.var_types.values().filter_map(|typ| match typ {
         Type::Contract(Contract { id, .. }) => Some((
             root,
             Item::Type(TypeDef::Contract(*id)),

--- a/crates/analyzer/src/db/queries/ingots.rs
+++ b/crates/analyzer/src/db/queries/ingots.rs
@@ -39,7 +39,7 @@ pub fn ingot_modules(db: &dyn AnalyzerDb, ingot: IngotId) -> Rc<[ModuleId]> {
         .iter()
         .flat_map(|(_file, path)| {
             path.strip_prefix(&file_path_prefix.as_str())
-                .unwrap_or_else(|_| path)
+                .unwrap_or(path)
                 .ancestors()
                 .skip(1) // first elem of .ancestors() is the path itself
         })
@@ -52,7 +52,7 @@ pub fn ingot_modules(db: &dyn AnalyzerDb, ingot: IngotId) -> Rc<[ModuleId]> {
                 .iter()
                 .map(|(_file, path)| {
                     path.strip_prefix(&file_path_prefix.as_str())
-                        .unwrap_or_else(|_| path)
+                        .unwrap_or(path)
                         .as_str()
                         .trim_end_matches(".fe")
                         .into()

--- a/crates/analyzer/src/db/queries/ingots.rs
+++ b/crates/analyzer/src/db/queries/ingots.rs
@@ -1,5 +1,72 @@
-use crate::namespace::items::{IngotId, IngotMode, ModuleId};
+use crate::namespace::items::{IngotId, IngotMode, ModuleId, ModuleSource};
 use crate::AnalyzerDb;
+use fe_common::files::{SourceFileId, Utf8Path, Utf8PathBuf};
+use indexmap::IndexSet;
+use std::rc::Rc;
+
+pub fn ingot_modules(db: &dyn AnalyzerDb, ingot: IngotId) -> Rc<[ModuleId]> {
+    let files: Vec<(SourceFileId, Rc<Utf8PathBuf>)> = db
+        .ingot_files(ingot)
+        .iter()
+        .map(|f| (*f, f.path(db.upcast())))
+        .collect();
+
+    // Create a module for every .fe source file.
+    let file_mods = files
+        .iter()
+        .map(|(file, path)| {
+            ModuleId::new(
+                db,
+                path.file_stem().unwrap(),
+                ModuleSource::File(*file),
+                ingot,
+            )
+        })
+        .collect();
+
+    // We automatically build a module hierarchy that matches the directory
+    // structure. We don't (yet?) require a .fe file for each directory like
+    // rust does. (eg `a/b.fe` alongside `a/b/`), but we do allow it (the
+    // module's items will be everything inside the .fe file, and the
+    // submodules inside the dir).
+    //
+    // Collect the set of all directories in the file hierarchy
+    // (after stripping the common prefix from all paths).
+    // eg given ["src/lib.fe", "src/a/b/x.fe", "src/a/c/d/y.fe"],
+    // the dir set is {"a", "a/b", "a/c", "a/c/d"}.
+    let file_path_prefix = &ingot.data(db).src_dir;
+    let dirs = files
+        .iter()
+        .flat_map(|(_file, path)| {
+            path.strip_prefix(&file_path_prefix.as_str())
+                .unwrap_or_else(|_| path)
+                .ancestors()
+                .skip(1) // first elem of .ancestors() is the path itself
+        })
+        .collect::<IndexSet<&Utf8Path>>();
+
+    let dir_mods = dirs
+        // Skip the dirs that have an associated fe file; eg skip "a/b" if "a/b.fe" exists.
+        .difference(
+            &files
+                .iter()
+                .map(|(_file, path)| {
+                    path.strip_prefix(&file_path_prefix.as_str())
+                        .unwrap_or_else(|_| path)
+                        .as_str()
+                        .trim_end_matches(".fe")
+                        .into()
+                })
+                .collect::<IndexSet<&Utf8Path>>(),
+        )
+        .filter_map(|dir| {
+            dir.file_name()
+                .map(|name| ModuleId::new(db, name, ModuleSource::Dir(dir.as_str().into()), ingot))
+        })
+        .collect::<Vec<_>>();
+
+    [file_mods, dir_mods].concat().into()
+}
 
 pub fn ingot_root_module(db: &dyn AnalyzerDb, ingot: IngotId) -> Option<ModuleId> {
     let filename = match ingot.data(db).mode {

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -21,7 +21,6 @@ pub fn module_file_path(db: &dyn AnalyzerDb, module: ModuleId) -> SmolStr {
     let full_path = match &module.data(db).source {
         ModuleSource::File(file) => file.path(db.upcast()).as_str().into(),
         ModuleSource::Dir(path) => path.clone(),
-        ModuleSource::Lowered { original, .. } => return db.module_file_path(*original),
     };
 
     let src_prefix = &module.ingot(db).data(db).src_dir;
@@ -43,7 +42,6 @@ pub fn module_parse(db: &dyn AnalyzerDb, module: ModuleId) -> Analysis<Rc<ast::M
             // Directory with no corresponding source file. Return empty ast.
             Analysis::new(ast::Module { body: vec![] }.into(), vec![].into())
         }
-        ModuleSource::Lowered { .. } => panic!("module_parse called on lowered module"),
     }
 }
 

--- a/crates/analyzer/src/errors.rs
+++ b/crates/analyzer/src/errors.rs
@@ -124,10 +124,6 @@ pub struct AlreadyDefined;
 #[derive(Debug)]
 pub struct CannotMove;
 
-/// Error indicating that a [`Type`] does not have a fixed size.
-#[derive(Debug)]
-pub struct NotFixedSize;
-
 /// Errors that can result from indexing
 #[derive(Debug, PartialEq)]
 pub enum IndexingError {
@@ -144,9 +140,6 @@ pub enum BinaryOperationError {
     RightIsSigned,
     NotEqualAndUnsigned,
 }
-
-#[derive(Debug)]
-pub struct AnalyzerError(pub Vec<Diagnostic>);
 
 impl From<TypeError> for FatalError {
     fn from(err: TypeError) -> Self {

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -214,14 +214,6 @@ impl Item {
         }
     }
 
-    /// Downcast utility function
-    pub fn as_contract(&self) -> Option<ContractId> {
-        match self {
-            Item::Type(TypeDef::Contract(id)) => Some(*id),
-            _ => None,
-        }
-    }
-
     pub fn sink_diagnostics(&self, db: &dyn AnalyzerDb, sink: &mut impl DiagnosticSink) {
         match self {
             Item::Type(id) => id.sink_diagnostics(db, sink),
@@ -641,11 +633,6 @@ impl ModuleId {
         items
     }
 
-    /// All structs, including duplicatecrates/analyzer/src/db.rss
-    pub fn all_structs(&self, db: &dyn AnalyzerDb) -> Rc<[StructId]> {
-        db.module_structs(*self)
-    }
-
     /// All module constants.
     pub fn all_constants(&self, db: &dyn AnalyzerDb) -> Rc<Vec<ModuleConstantId>> {
         db.module_constants(*self)
@@ -978,11 +965,6 @@ impl ContractId {
         db.contract_public_function_map(*self)
     }
 
-    /// Get a function that takes self by its name.
-    pub fn self_function(&self, db: &dyn AnalyzerDb, name: &str) -> Option<FunctionId> {
-        self.function(db, name).filter(|f| f.takes_self(db))
-    }
-
     /// Lookup an event by name.
     pub fn event(&self, db: &dyn AnalyzerDb, name: &str) -> Option<EventId> {
         self.events(db).get(name).copied()
@@ -1196,12 +1178,6 @@ impl Class {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum MemberFunction {
-    BuiltIn(builtins::ValueMethod),
-    Function(FunctionId),
-}
-
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Struct {
     pub ast: Node<ast::Struct>,
@@ -1256,10 +1232,6 @@ impl StructId {
         matches!(self.field_type(db, name), Some(Ok(types::Type::Base(_))))
     }
 
-    pub fn field_index(&self, db: &dyn AnalyzerDb, name: &str) -> Option<usize> {
-        self.fields(db).get_index_of(name)
-    }
-
     pub fn has_complex_fields(&self, db: &dyn AnalyzerDb) -> bool {
         self.fields(db)
             .iter()
@@ -1279,9 +1251,6 @@ impl StructId {
     }
     pub fn function(&self, db: &dyn AnalyzerDb, name: &str) -> Option<FunctionId> {
         self.functions(db).get(name).copied()
-    }
-    pub fn self_function(&self, db: &dyn AnalyzerDb, name: &str) -> Option<FunctionId> {
-        self.function(db, name).filter(|f| f.takes_self(db))
     }
     pub fn parent(&self, db: &dyn AnalyzerDb) -> Item {
         Item::Module(self.data(db).module)

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -188,20 +188,6 @@ impl<'a> FunctionScope<'a> {
             .expect_none("emit statement attributes already exist");
     }
 
-    /// Attribute contextual information to a declaration node.
-    ///
-    /// # Panics
-    ///
-    /// Panics if an entry already exists for the node id.
-    pub fn add_declaration(&self, node: &Node<ast::TypeDesc>, typ: Type) {
-        self.add_node(node);
-        self.body
-            .borrow_mut()
-            .var_decl_types
-            .insert(node.id, typ)
-            .expect_none("declaration attributes already exist");
-    }
-
     pub fn map_variable_type<T>(&self, node: &Node<T>, typ: Type) {
         self.add_node(node);
         self.body

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -380,21 +380,6 @@ pub struct EventField {
 }
 
 impl FunctionSignature {
-    /// # Panics
-    /// Panics if any param type is an `Err`
-    pub fn param_types(&self) -> Vec<Type> {
-        self.params
-            .iter()
-            .map(|param| param.typ.clone().expect("fn param type error"))
-            .collect()
-    }
-
-    /// # Panics
-    /// Panics if the return type is an `Err`
-    pub fn expect_return_type(&self) -> Type {
-        self.return_type.clone().expect("fn return type error")
-    }
-
     /// Parameters without `ctx`, if it is a contract function that declares it.
     ///
     /// This is used when calling a contract method externally.
@@ -489,21 +474,6 @@ impl Type {
 
     pub fn int(int_type: Integer) -> Self {
         Type::Base(Base::Numeric(int_type))
-    }
-
-    pub fn generic_arg_type(&self, idx: usize) -> Option<Type> {
-        match self {
-            Type::Map(Map { key, value }) => match idx {
-                0 => Some(Type::Base(*key)),
-                1 => Some((**value).clone()),
-                _ => None,
-            },
-            Type::Array(array) => match idx {
-                0 => Some(Type::Base(array.inner)),
-                _ => None,
-            },
-            _ => None,
-        }
     }
 
     pub fn has_fixed_size(&self) -> bool {

--- a/crates/analyzer/src/traversal/declarations.rs
+++ b/crates/analyzer/src/traversal/declarations.rs
@@ -33,7 +33,6 @@ pub fn var_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(),
             }
         }
 
-        scope.root.add_declaration(typ, declared_type.clone());
         add_var(scope, target, declared_type)?;
         return Ok(());
     }
@@ -70,7 +69,6 @@ pub fn const_decl(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(
         // Perform constant evaluation.
         let const_value = const_expr::eval_expr(scope, value)?;
 
-        scope.root.add_declaration(typ, declared_type.clone());
         scope.root.map_variable_type(name, declared_type.clone());
         // this logs a message on err, so it's safe to ignore here.
         let _ = scope.add_var(name.kind.as_str(), declared_type, true, name.span);

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -416,7 +416,7 @@ fn function_diagnostics(fun: items::FunctionId, db: &dyn AnalyzerDb) -> Vec<Diag
         // signature
         build_debug_diagnostics(&[(fun.data(db).ast.span, &fun.signature(db))]),
         // declarations
-        label_in_non_overlapping_groups(&lookup_spans(&body.var_decl_types, &body.spans)),
+        label_in_non_overlapping_groups(&lookup_spans(&body.var_types, &body.spans)),
         // expressions
         label_in_non_overlapping_groups(&lookup_spans(&body.expressions, &body.spans)),
         // emits

--- a/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
+++ b/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
@@ -742,10 +742,10 @@ note:
      }
 
 note: 
-   ┌─ aug_assign.fe:66:23
+   ┌─ aug_assign.fe:66:13
    │
 66 │         let my_array: Array<u256, 10>
-   │                       ^^^^^^^^^^^^^^^ Array<u256, 10>
+   │             ^^^^^^^^ Array<u256, 10>
 
 note: 
    ┌─ aug_assign.fe:67:9

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -281,10 +281,10 @@ note:
      }
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:37:28
+   ┌─ ingots/basic_ingot/src/main.fe:37:13
    │
 37 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
-   │                            ^^^^^^^^^^^^ BingContract
+   │             ^^^^^^^^^^^^^ BingContract
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:37:63

--- a/crates/analyzer/tests/snapshots/analysis__const_generics.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_generics.snap
@@ -27,75 +27,75 @@ note:
      }
 
 note: 
-   ┌─ const_generics.fe:4:24
+   ┌─ const_generics.fe:4:13
    │
  4 │         let array_lit: Array<i32, 8>
-   │                        ^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
  5 │         let array_lit2: Array<i32, { 8 }>
-   │                         ^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^ Array<i32, 8>
    ·
  8 │         let array_ternary: Array<i32, { 3 if false else 8 }>
-   │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^^^^ Array<i32, 8>
    ·
 11 │         let array_logical_or: Array<i32, { 8 if (true or false) else 0 }>
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^^^^^^^ Array<i32, 8>
 12 │         let array_logical_and: Array<i32, { 0 if (true and false) else 8 }>
-   │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^^^^^^^^ Array<i32, 8>
    ·
 15 │         let array_add: Array<i32, { 5 + 3 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 16 │         let array_sub: Array<i32, { 10 -  2 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 17 │         let array_mul: Array<i32, { 2 * 4 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 18 │         let array_div: Array<i32, { 16 / 2 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 19 │         let array_mod: Array<i32, { 26 % 9 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 20 │         let array_pow: Array<i32, { 2 ** 3 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 21 │         let array_shl: Array<i32, { 0b0010 << 2 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 22 │         let array_shr: Array<i32, { 0b100000 >> 2 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 23 │         let array_bitor: Array<i32, { 0b1000 |  0b0000 }>
-   │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^^ Array<i32, 8>
 24 │         let array_xor: Array<i32, { 0b1111 ^ 0b0111 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 25 │         let array_bitand: Array<i32, { 0b1010 & 0b1101 }>
-   │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^^^ Array<i32, 8>
    ·
 28 │         let array_eq: Array<i32, { 8 if 10 == 10 else 0 }>
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^ Array<i32, 8>
 29 │         let array_ne: Array<i32, { 8 if 10 != 0 else 0 }>
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^ Array<i32, 8>
 30 │         let array_lt1: Array<i32, { 8 if 0 < 10 else 0 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 31 │         let array_lt2: Array<i32, { 0 if 10 < 10 else 8 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 32 │         let array_lte: Array<i32, { 8 if 0 <= 10 else 0 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 33 │         let array_lte2: Array<i32, { 8 if 10 <= 10 else 0 }>
-   │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^ Array<i32, 8>
 34 │         let array_gt: Array<i32, { 8 if 10 > 0 else 0 }>
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^ Array<i32, 8>
 35 │         let array_gt2: Array<i32, { 1 if 10 > 10 else 8 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 36 │         let array_gte: Array<i32, { 1 if 0 >= 10 else 8 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
 37 │         let array_gte2: Array<i32, { 8 if 10 >= 10 else 0 }>
-   │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^ Array<i32, 8>
    ·
 40 │         let array_not: Array<i32, { 8 if not false else 0 }>
-   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^ Array<i32, 8>
    ·
 43 │         const DOUBLE_ARRAY_LENGTH: u64 = 16
-   │                                    ^^^ u64
+   │               ^^^^^^^^^^^^^^^^^^^ u64
 44 │         const TWO: u64 = 2
-   │                    ^^^ u64
+   │               ^^^ u64
 45 │ 
 46 │         let array_with_const: Array<i32, { DOUBLE_ARRAY_LENGTH / TWO }>
-   │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 8>
+   │             ^^^^^^^^^^^^^^^^ Array<i32, 8>
 
 note: 
   ┌─ const_generics.fe:5:38

--- a/crates/analyzer/tests/snapshots/analysis__const_local.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_local.snap
@@ -29,32 +29,32 @@ note:
      }
 
 note: 
-   ┌─ const_local.fe:3:19
+   ┌─ const_local.fe:3:15
    │
  3 │         const C1: i64 = 1
-   │                   ^^^ i64
+   │               ^^ i64
  4 │         const C2: i64 = 2
-   │                   ^^^ i64
+   │               ^^ i64
  5 │         const C3: i64 = 10
-   │                   ^^^ i64
+   │               ^^ i64
  6 │         const C4: i64 = (C1 * C2) + C3 # 12
-   │                   ^^^ i64
+   │               ^^ i64
  7 │         const EXP: u8 = 2
-   │                    ^^ u8
+   │               ^^^ u8
  8 │         const C5: i64 = (C2 ** EXP) # 4
-   │                   ^^^ i64
+   │               ^^ i64
  9 │         const C6: i64 = (C5 << 1) # 8
-   │                   ^^^ i64
+   │               ^^ i64
 10 │         const C7: bool = (C5 < C6) and (C4 > C5) # true
-   │                   ^^^^ bool
+   │               ^^ bool
 11 │         const C8: bool = false
-   │                   ^^^^ bool
+   │               ^^ bool
 12 │         const C9: bool = C8 < C7 # true
-   │                   ^^^^ bool
+   │               ^^ bool
 13 │         const C10: u256 = 42 if C9 else 0 # 42
-   │                    ^^^^ u256
+   │               ^^^ u256
 14 │         let _arr: Array<bool, { C10 }>
-   │                   ^^^^^^^^^^^^^^^^^^^^ Array<bool, 42>
+   │             ^^^^ Array<bool, 42>
 
 note: 
   ┌─ const_local.fe:3:25

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -66,10 +66,10 @@ note:
      }
 
 note: 
-   ┌─ create2_contract.fe:11:18
+   ┌─ create2_contract.fe:11:13
    │
 11 │         let foo: Foo = Foo.create2(ctx, 0, 52)
-   │                  ^^^ Foo
+   │             ^^^ Foo
 
 note: 
    ┌─ create2_contract.fe:11:36

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -66,10 +66,10 @@ note:
      }
 
 note: 
-   ┌─ create_contract.fe:11:18
+   ┌─ create_contract.fe:11:13
    │
 11 │         let foo: Foo = Foo.create(ctx, 0)
-   │                  ^^^ Foo
+   │             ^^^ Foo
 
 note: 
    ┌─ create_contract.fe:11:35

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -237,12 +237,12 @@ note:
      }
 
 note: 
-   ┌─ data_copying_stress.fe:29:27
+   ┌─ data_copying_stress.fe:29:13
    │
 29 │         let my_2nd_array: Array<u256, 10> = my_array
-   │                           ^^^^^^^^^^^^^^^ Array<u256, 10>
+   │             ^^^^^^^^^^^^ Array<u256, 10>
 30 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
-   │                           ^^^^^^^^^^^^^^^ Array<u256, 10>
+   │             ^^^^^^^^^^^^ Array<u256, 10>
 
 note: 
    ┌─ data_copying_stress.fe:29:45
@@ -606,10 +606,10 @@ note:
      }
 
 note: 
-   ┌─ data_copying_stress.fe:57:26
+   ┌─ data_copying_stress.fe:57:13
    │
 57 │         let my_nums_mem: Array<u256, 5>
-   │                          ^^^^^^^^^^^^^^ Array<u256, 5>
+   │             ^^^^^^^^^^^ Array<u256, 5>
 
 note: 
    ┌─ data_copying_stress.fe:58:9

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -379,10 +379,10 @@ note:
      }
 
 note: 
-   ┌─ events.fe:38:20
+   ┌─ events.fe:38:13
    │
 38 │         let addrs: Array<address, 2>
-   │                    ^^^^^^^^^^^^^^^^^ Array<address, 2>
+   │             ^^^^^ Array<address, 2>
 
 note: 
    ┌─ events.fe:39:9

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -189,10 +189,10 @@ note:
      }
 
 note: 
-   ┌─ external_contract.fe:15:23
+   ┌─ external_contract.fe:15:13
    │
 15 │         let my_array: Array<u256, 3>
-   │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+   │             ^^^^^^^^ Array<u256, 3>
 
 note: 
    ┌─ external_contract.fe:16:9
@@ -322,10 +322,10 @@ note:
      }
 
 note: 
-   ┌─ external_contract.fe:25:18
+   ┌─ external_contract.fe:25:13
    │
 25 │         let foo: Foo = Foo(ctx, foo_address)
-   │                  ^^^ Foo
+   │             ^^^ Foo
 
 note: 
    ┌─ external_contract.fe:25:28
@@ -425,10 +425,10 @@ note:
      }
 
 note: 
-   ┌─ external_contract.fe:30:18
+   ┌─ external_contract.fe:30:13
    │
 30 │         let foo: Foo = Foo(ctx, foo_address)
-   │                  ^^^ Foo
+   │             ^^^ Foo
 
 note: 
    ┌─ external_contract.fe:30:28

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
@@ -29,13 +29,15 @@ note:
      }
 
 note: 
-  ┌─ for_loop_with_break.fe:3:23
+  ┌─ for_loop_with_break.fe:3:13
   │
 3 │         let my_array: Array<u256, 3>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+  │             ^^^^^^^^ Array<u256, 3>
   ·
 7 │         let sum: u256 = 0
-  │                  ^^^^ u256
+  │             ^^^ u256
+8 │         for i in my_array {
+  │             ^ u256
 
 note: 
   ┌─ for_loop_with_break.fe:4:9

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
@@ -29,13 +29,15 @@ note:
      }
 
 note: 
-  ┌─ for_loop_with_continue.fe:3:23
-  │
-3 │         let my_array: Array<u256, 5>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 5>
-  ·
-9 │         let sum: u256 = 0
-  │                  ^^^^ u256
+   ┌─ for_loop_with_continue.fe:3:13
+   │
+ 3 │         let my_array: Array<u256, 5>
+   │             ^^^^^^^^ Array<u256, 5>
+   ·
+ 9 │         let sum: u256 = 0
+   │             ^^^ u256
+10 │         for i in my_array {
+   │             ^ u256
 
 note: 
   ┌─ for_loop_with_continue.fe:4:9

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
@@ -29,13 +29,15 @@ note:
      }
 
 note: 
-  ┌─ for_loop_with_static_array.fe:3:23
+  ┌─ for_loop_with_static_array.fe:3:13
   │
 3 │         let my_array: Array<u256, 3>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+  │             ^^^^^^^^ Array<u256, 3>
   ·
 7 │         let sum: u256 = 0
-  │                  ^^^^ u256
+  │             ^^^ u256
+8 │         for i in my_array {
+  │             ^ u256
 
 note: 
   ┌─ for_loop_with_static_array.fe:4:9

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
@@ -29,13 +29,13 @@ note:
      }
 
 note: 
-  ┌─ if_statement_with_block_declaration.fe:4:20
+  ┌─ if_statement_with_block_declaration.fe:4:17
   │
 4 │             let y: u256 = 1
-  │                    ^^^^ u256
+  │                 ^ u256
   ·
 7 │             let y: u256 = 1
-  │                    ^^^^ u256
+  │                 ^ u256
 
 note: 
   ┌─ if_statement_with_block_declaration.fe:3:12

--- a/crates/analyzer/tests/snapshots/analysis__math.snap
+++ b/crates/analyzer/tests/snapshots/analysis__math.snap
@@ -41,13 +41,13 @@ note:
      }
 
 note: 
-  ┌─ math.fe:3:16
+  ┌─ math.fe:3:13
   │
 3 │         let z: u256
-  │                ^^^^ u256
+  │             ^ u256
   ·
 6 │             let x: u256 = val / 2 + 1
-  │                    ^^^^ u256
+  │                 ^ u256
 
 note: 
   ┌─ math.fe:4:12

--- a/crates/analyzer/tests/snapshots/analysis__module_const.snap
+++ b/crates/analyzer/tests/snapshots/analysis__module_const.snap
@@ -59,16 +59,16 @@ note:
      }
 
 note: 
-   ┌─ module_const.fe:10:28
+   ┌─ module_const.fe:10:15
    │
 10 │         const LOCAL_CONST: i32 = C3 * 2
-   │                            ^^^ i32
+   │               ^^^^^^^^^^^ i32
 11 │         let _arr1: Array<i32, { C2 }>
-   │                    ^^^^^^^^^^^^^^^^^^ Array<i32, 3>
+   │             ^^^^^ Array<i32, 3>
 12 │         let _arr2: Array<i32, { LOCAL_CONST }>
-   │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<i32, 88>
+   │             ^^^^^ Array<i32, 88>
 13 │         let _my_array: MY_ARRAY
-   │                        ^^^^^^^^ Array<bool, 42>
+   │             ^^^^^^^^^ Array<bool, 42>
 
 note: 
    ┌─ module_const.fe:10:34

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -66,10 +66,10 @@ note:
     }
 
 note: 
-  ┌─ multi_param.fe:3:23
+  ┌─ multi_param.fe:3:13
   │
 3 │         let my_array: Array<u256, 3>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 3>
+  │             ^^^^^^^^ Array<u256, 3>
 
 note: 
   ┌─ multi_param.fe:4:9

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -215,10 +215,10 @@ note:
      }
 
 note: 
-   ┌─ pure_fn_standalone.fe:18:16
+   ┌─ pure_fn_standalone.fe:18:13
    │
 18 │         let a: address = address(x)
-   │                ^^^^^^^ address
+   │             ^ address
 
 note: 
    ┌─ pure_fn_standalone.fe:18:34

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -42,10 +42,10 @@ note:
     }
 
 note: 
-  ┌─ return_array.fe:3:23
+  ┌─ return_array.fe:3:13
   │
 3 │         let my_array: Array<u256, 5>
-  │                       ^^^^^^^^^^^^^^ Array<u256, 5>
+  │             ^^^^^^^^ Array<u256, 5>
 
 note: 
   ┌─ return_array.fe:4:9

--- a/crates/analyzer/tests/snapshots/analysis__simple_open_auction.snap
+++ b/crates/analyzer/tests/snapshots/analysis__simple_open_auction.snap
@@ -321,10 +321,10 @@ note:
      }
 
 note: 
-   ┌─ simple_open_auction.fe:59:21
+   ┌─ simple_open_auction.fe:59:13
    │
 59 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
-   │                     ^^^^ u256
+   │             ^^^^^^ u256
 
 note: 
    ┌─ simple_open_auction.fe:59:28

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -151,10 +151,10 @@ note:
      }
 
 note: 
-   ┌─ strings.fe:31:16
+   ┌─ strings.fe:31:13
    │
 31 │         let s: String<18> = "fe"
-   │                ^^^^^^^^^^ String<18>
+   │             ^ String<18>
 
 note: 
    ┌─ strings.fe:31:29

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -181,10 +181,10 @@ note:
      }
 
 note: 
-   ┌─ struct_fns.fe:18:18
+   ┌─ struct_fns.fe:18:13
    │
 18 │         let old: u64 = self.x
-   │                  ^^^ u64
+   │             ^^^ u64
 
 note: 
    ┌─ struct_fns.fe:18:24
@@ -235,12 +235,12 @@ note:
      }
 
 note: 
-   ┌─ struct_fns.fe:24:16
+   ┌─ struct_fns.fe:24:13
    │
 24 │         let x: u64 = self.x
-   │                ^^^ u64
+   │             ^ u64
 25 │         let y: u64 = self.y
-   │                ^^^ u64
+   │             ^ u64
 
 note: 
    ┌─ struct_fns.fe:24:22
@@ -393,12 +393,12 @@ note:
      }
 
 note: 
-   ┌─ struct_fns.fe:36:16
+   ┌─ struct_fns.fe:36:13
    │
 36 │         let x: u64 = self.x + other.x
-   │                ^^^ u64
+   │             ^ u64
 37 │         let y: u64 = self.y + other.y
-   │                ^^^ u64
+   │             ^ u64
 
 note: 
    ┌─ struct_fns.fe:36:22
@@ -482,15 +482,15 @@ note:
      }
 
 note: 
-   ┌─ struct_fns.fe:43:13
+   ┌─ struct_fns.fe:43:9
    │
 43 │     let p1: Point = Point::origin()
-   │             ^^^^^ Point
+   │         ^^ Point
 44 │     p1.translate(x: 5, y: 10)
 45 │     let p2: Point = Point(x: 1, y: 2)
-   │             ^^^^^ Point
+   │         ^^ Point
 46 │     let p3: Point = p1.add(p2)
-   │             ^^^^^ Point
+   │         ^^ Point
 
 note: 
    ┌─ struct_fns.fe:43:21
@@ -616,10 +616,10 @@ note:
      }
 
 note: 
-   ┌─ struct_fns.fe:53:16
+   ┌─ struct_fns.fe:53:13
    │
 53 │         let p: Point = Point::new(x, y)
-   │                ^^^^^ Point
+   │             ^ Point
 
 note: 
    ┌─ struct_fns.fe:52:9

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -1097,10 +1097,10 @@ note:
       }
 
 note: 
-   ┌─ structs.fe:83:18
+   ┌─ structs.fe:83:13
    │
 83 │         let val: Bar = Bar(name: "foo", numbers: [1, 2], point: Point(x: 100, y: 200), something: (1, true))
-   │                  ^^^ Bar
+   │             ^^^ Bar
 
 note: 
    ┌─ structs.fe:83:34
@@ -1715,10 +1715,10 @@ note:
       }
 
 note: 
-    ┌─ structs.fe:115:20
+    ┌─ structs.fe:115:13
     │
 115 │         let mixed: Mixed = Mixed::new(val: 1)
-    │                    ^^^^^ Mixed
+    │             ^^^^^ Mixed
 
 note: 
     ┌─ structs.fe:115:44
@@ -2435,10 +2435,10 @@ note:
       }
 
 note: 
-    ┌─ structs.fe:156:23
+    ┌─ structs.fe:156:13
     │
 156 │         let building: House = House(price: 300, size: 500, rooms: u8(20), vacant: true)
-    │                       ^^^^^ House
+    │             ^^^^^^^^ House
 
 note: 
     ┌─ structs.fe:156:44
@@ -2715,10 +2715,10 @@ note:
       }
 
 note: 
-    ┌─ structs.fe:176:20
+    ┌─ structs.fe:176:13
     │
 176 │         let house: House = House(price: 300, size: 500, rooms: u8(20), vacant: true)
-    │                    ^^^^^ House
+    │             ^^^^^ House
 
 note: 
     ┌─ structs.fe:176:41
@@ -2774,10 +2774,10 @@ note:
       }
 
 note: 
-    ┌─ structs.fe:181:20
+    ┌─ structs.fe:181:13
     │
 181 │         let house: House = House(price: 300, size: 500, rooms: u8(20), vacant: true)
-    │                    ^^^^^ House
+    │             ^^^^^ House
 
 note: 
     ┌─ structs.fe:181:41

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -676,12 +676,12 @@ note:
      }
 
 note: 
-   ┌─ tuple_stress.fe:44:21
+   ┌─ tuple_stress.fe:44:13
    │
 44 │         let my_num: u256 = self.my_sto_tuple.item0
-   │                     ^^^^ u256
+   │             ^^^^^^ u256
 45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
-   │                       ^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address)
+   │             ^^^^^^^^ (u256, bool, address)
 
 note: 
    ┌─ tuple_stress.fe:44:28

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -106,10 +106,10 @@ note:
      }
 
 note: 
-   ┌─ type_aliases.fe:23:17
+   ┌─ type_aliases.fe:23:13
    │
 23 │         let id: PostId = 0
-   │                 ^^^^^^ u256
+   │             ^^ u256
 
 note: 
    ┌─ type_aliases.fe:23:26
@@ -213,10 +213,10 @@ note:
      }
 
 note: 
-   ┌─ type_aliases.fe:30:20
+   ┌─ type_aliases.fe:30:13
    │
 30 │         let score: Score = self.scoreboard[id] + 1
-   │                    ^^^^^ u64
+   │             ^^^^^ u64
 
 note: 
    ┌─ type_aliases.fe:30:28

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -1666,12 +1666,12 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:149:30
+    ┌─ uniswap.fe:149:13
     │
 149 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
-    │                              ^^^^ u256
+    │             ^^^^^^^^^^^^^^^ u256
 150 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
-    │                           ^^^^ u256
+    │             ^^^^^^^^^^^^ u256
 
 note: 
     ┌─ uniswap.fe:149:37
@@ -1980,26 +1980,26 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:162:21
+    ┌─ uniswap.fe:162:13
     │
 162 │         let fee_to: address = UniswapV2Factory(ctx, self.factory).fee_to()
-    │                     ^^^^^^^ address
+    │             ^^^^^^ address
 163 │         let fee_on: bool = fee_to != address(0)
-    │                     ^^^^ bool
+    │             ^^^^^^ bool
 164 │         let k_last: u256 = self.k_last
-    │                     ^^^^ u256
+    │             ^^^^^^ u256
     ·
 167 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
-    │                             ^^^^ u256
+    │                     ^^^^^^ u256
 168 │                 let root_k_last: u256 = sqrt(k_last)
-    │                                  ^^^^ u256
+    │                     ^^^^^^^^^^^ u256
 169 │                 if root_k > root_k_last {
 170 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
-    │                                    ^^^^ u256
+    │                         ^^^^^^^^^ u256
 171 │                     let denominator: u256 = root_k * 5 + root_k_last
-    │                                      ^^^^ u256
+    │                         ^^^^^^^^^^^ u256
 172 │                     let liquidity: u256 = numerator / denominator
-    │                                    ^^^^ u256
+    │                         ^^^^^^^^^ u256
 
 note: 
     ┌─ uniswap.fe:162:48
@@ -2247,28 +2247,28 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:186:32
+    ┌─ uniswap.fe:186:13
     │
 186 │         let MINIMUM_LIQUIDITY: u256 = 1000
-    │                                ^^^^ u256
+    │             ^^^^^^^^^^^^^^^^^ u256
 187 │         let reserve0: u256 = self.reserve0
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 188 │         let reserve1: u256 = self.reserve1
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 189 │         let balance0: u256 = ERC20(ctx, self.token0).balanceOf(ctx.self_address())
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 190 │         let balance1: u256 = ERC20(ctx, self.token1).balanceOf(ctx.self_address())
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 191 │         let amount0: u256 = balance0 - self.reserve0
-    │                      ^^^^ u256
+    │             ^^^^^^^ u256
 192 │         let amount1: u256 = balance1 - self.reserve1
-    │                      ^^^^ u256
+    │             ^^^^^^^ u256
 193 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
-    │                     ^^^^ bool
+    │             ^^^^^^ bool
 194 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
-    │                           ^^^^ u256
+    │             ^^^^^^^^^^^^ u256
 195 │         let liquidity: u256 = 0
-    │                        ^^^^ u256
+    │             ^^^^^^^^^ u256
 
 note: 
     ┌─ uniswap.fe:186:39
@@ -2683,31 +2683,31 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:214:23
+    ┌─ uniswap.fe:214:13
     │
 214 │         let reserve0: u256 = self.reserve0
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 215 │         let reserve1: u256 = self.reserve1
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 216 │         let token0: ERC20 = ERC20(ctx, self.token0)
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 217 │         let token1: ERC20 = ERC20(ctx, self.token1)
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 218 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 219 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 220 │         let liquidity: u256 = self.balances[ctx.self_address()]
-    │                        ^^^^ u256
+    │             ^^^^^^^^^ u256
 221 │ 
 222 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
-    │                     ^^^^ bool
+    │             ^^^^^^ bool
 223 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-    │                           ^^^^ u256
+    │             ^^^^^^^^^^^^ u256
 224 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-    │                      ^^^^ u256
+    │             ^^^^^^^ u256
 225 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
-    │                      ^^^^ u256
+    │             ^^^^^^^ u256
 
 note: 
     ┌─ uniswap.fe:214:30
@@ -3156,32 +3156,32 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:245:23
+    ┌─ uniswap.fe:245:13
     │
 245 │         let reserve0: u256 = self.reserve0
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 246 │         let reserve1: u256 = self.reserve1
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
     ·
 249 │         let token0: ERC20 = ERC20(ctx, self.token0)
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 250 │         let token1: ERC20 = ERC20(ctx, self.token1)
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
     ·
 265 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 266 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
-    │                       ^^^^ u256
+    │             ^^^^^^^^ u256
 267 │ 
 268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
-    │                         ^^^^ u256
+    │             ^^^^^^^^^^ u256
 269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
-    │                         ^^^^ u256
+    │             ^^^^^^^^^^ u256
     ·
 273 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
-    │                                ^^^^ u256
+    │             ^^^^^^^^^^^^^^^^^ u256
 274 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
-    │                                ^^^^ u256
+    │             ^^^^^^^^^^^^^^^^^ u256
 
 note: 
     ┌─ uniswap.fe:244:16
@@ -3771,12 +3771,12 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:284:21
+    ┌─ uniswap.fe:284:13
     │
 284 │         let token0: ERC20 = ERC20(ctx, self.token0) # gas savings
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 285 │         let token1: ERC20 = ERC20(ctx, self.token1) # gas savings
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 
 note: 
     ┌─ uniswap.fe:284:35
@@ -3931,12 +3931,12 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:292:21
+    ┌─ uniswap.fe:292:13
     │
 292 │         let token0: ERC20 = ERC20(ctx, self.token0)
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 293 │         let token1: ERC20 = ERC20(ctx, self.token1)
-    │                     ^^^^^ ERC20
+    │             ^^^^^^ ERC20
 
 note: 
     ┌─ uniswap.fe:292:35
@@ -4228,17 +4228,17 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:337:21
+    ┌─ uniswap.fe:337:13
     │
 337 │         let token0: address = token_a if token_a < token_b else token_b
-    │                     ^^^^^^^ address
+    │             ^^^^^^ address
 338 │         let token1: address = token_a if token_a > token_b else token_b
-    │                     ^^^^^^^ address
+    │             ^^^^^^ address
     ·
 342 │         let salt: u256 = keccak256((token0, token1).abi_encode())
-    │                   ^^^^ u256
+    │             ^^^^ u256
 343 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
-    │                   ^^^^^^^^^^^^^ UniswapV2Pair
+    │             ^^^^ UniswapV2Pair
 
 note: 
     ┌─ uniswap.fe:335:16
@@ -4798,13 +4798,13 @@ note:
       }
 
 note: 
-    ┌─ uniswap.fe:367:12
+    ┌─ uniswap.fe:367:9
     │
 367 │     let z: u256
-    │            ^^^^ u256
+    │         ^ u256
     ·
 370 │         let x: u256 = val / 2 + 1
-    │                ^^^^ u256
+    │             ^ u256
 
 note: 
     ┌─ uniswap.fe:368:8

--- a/crates/analyzer/tests/snapshots/analysis__while_loop.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop.snap
@@ -29,10 +29,10 @@ note:
      }
 
 note: 
-  ┌─ while_loop.fe:3:18
+  ┌─ while_loop.fe:3:13
   │
 3 │         let val: u256 = 0
-  │                  ^^^^ u256
+  │             ^^^ u256
 
 note: 
   ┌─ while_loop.fe:3:25

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
@@ -29,10 +29,10 @@ note:
     }
 
 note: 
-  ┌─ while_loop_with_break.fe:3:18
+  ┌─ while_loop_with_break.fe:3:13
   │
 3 │         let val: u256 = 0
-  │                  ^^^^ u256
+  │             ^^^ u256
 
 note: 
   ┌─ while_loop_with_break.fe:3:25

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
@@ -29,10 +29,10 @@ note:
      }
 
 note: 
-  ┌─ while_loop_with_break_2.fe:3:18
+  ┌─ while_loop_with_break_2.fe:3:13
   │
 3 │         let val: u256 = 0
-  │                  ^^^^ u256
+  │             ^^^ u256
 
 note: 
   ┌─ while_loop_with_break_2.fe:3:25

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
@@ -29,12 +29,12 @@ note:
      }
 
 note: 
-  ┌─ while_loop_with_continue.fe:3:16
+  ┌─ while_loop_with_continue.fe:3:13
   │
 3 │         let i: u256 = 0
-  │                ^^^^ u256
+  │             ^ u256
 4 │         let counter: u256 = 0
-  │                      ^^^^ u256
+  │             ^^^^^^^ u256
 
 note: 
   ┌─ while_loop_with_continue.fe:3:23

--- a/crates/common/src/files.rs
+++ b/crates/common/src/files.rs
@@ -107,7 +107,7 @@ impl SourceFileId {
     }
 
     pub fn dummy_file() -> Self {
-        // Used by lowering::ZeroSpanNode, unit tests, and benchmarks
+        // Used by unit tests and benchmarks
         Self(u32::MAX)
     }
     pub fn is_dummy(self) -> bool {

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -382,15 +382,6 @@ impl Node<Field> {
     }
 }
 
-impl Function {
-    pub fn is_pub(&self) -> bool {
-        self.pub_.is_some()
-    }
-    pub fn is_unsafe(&self) -> bool {
-        self.unsafe_.is_some()
-    }
-}
-
 impl Node<Function> {
     pub fn name(&self) -> &str {
         &self.kind.name.kind

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -45,9 +45,7 @@ pub fn parse_module_stmt(par: &mut Parser) -> ParseResult<ModuleStmt> {
         TokenKind::Type => ModuleStmt::TypeAlias(parse_type_alias(par, None)?),
         TokenKind::Const => ModuleStmt::Constant(parse_constant(par, None)?),
 
-        // Let these be parse errors for now:
         TokenKind::Event => ModuleStmt::Event(parse_event_def(par, None)?),
-        // TokenKind::Name if par.peeked_text() == "from" => parse_from_import(par),
         TokenKind::Pub => {
             let pub_span = par.next()?.span;
             match par.peek_or_err()? {

--- a/crates/parser/src/node.rs
+++ b/crates/parser/src/node.rs
@@ -25,30 +25,13 @@ pub struct Node<T> {
     pub kind: T,
     #[serde(skip_serializing, skip_deserializing)]
     pub id: NodeId,
-    #[serde(skip_serializing, skip_deserializing)]
-    pub original_id: NodeId,
     pub span: Span,
 }
 
 impl<T> Node<T> {
     pub fn new(kind: T, span: Span) -> Self {
         let id = NodeId::create();
-        Self {
-            kind,
-            id,
-            original_id: id,
-            span,
-        }
-    }
-
-    pub fn with_original_id(kind: T, span: Span, original_id: NodeId) -> Self {
-        let id = NodeId::create();
-        Self {
-            kind,
-            id,
-            original_id,
-            span,
-        }
+        Self { kind, id, span }
     }
 }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -118,19 +118,6 @@ impl<'a> Parser<'a> {
         self.peek_raw()
     }
 
-    /// Peek at the text of the next token, without consuming it. This is useful
-    /// for words that are keywords in some contexts, but not others. E.g.
-    /// `from` can be used as a variable or field name, but it's the leading
-    /// keyword of a `from x import y` statement.
-    ///
-    /// # Panics
-    /// This function must only be used in cases where the kind of the next
-    /// token has already been [`Parser::peek`]ed. If there is no next token, it
-    /// will panic.
-    pub fn peeked_text(&mut self) -> &'a str {
-        self.buffered.last().unwrap().text
-    }
-
     fn peek_raw(&mut self) -> Option<TokenKind> {
         if self.buffered.is_empty() {
             if let Some(tok) = self.lexer.next() {


### PR DESCRIPTION
### What was wrong?

Closes #720 (I think; @Y-Nak, are you aware of any other leftorovers?)

The only functional change is that `db.set_ingot_modules` has been replaced with `db.set_ingot_files`. The former was a compromise to work with lowered modules. Now the latter will be used by the (imaginary) language server to update the list of files in a project.

### How was it fixed?
:brain:

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
