### PR TITLE
GH actions: run test coverage on merge-to-master, but not prs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+name: test-coverage
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - v*
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-all-dev
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v1
+      - name: install cargo-tarpaulin
+        run: |
+          cargo install cargo-quickinstall
+          cargo quickinstall cargo-tarpaulin
+      - name: coverage with tarpaulin
+        run: |
+          make coverage
+          bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,32 +14,6 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  coverage:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libboost-all-dev
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
-      - name: install cargo-tarpaulin
-        run: |
-          cargo install cargo-quickinstall
-          cargo quickinstall cargo-tarpaulin
-      - name: coverage with tarpaulin
-        run: |
-          make coverage
-          bash <(curl -s https://codecov.io/bash)
-
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What was wrong?

The cargo-tarpaulin check takes 20+ minutes. The rest are usually done in <4 minutes. Fast checks and not wasting compute resources are nice things. Our test coverage never changes much; someone should make a concerted effort to improve it, but they can run cargo-tarpaulin locally and/or make the code coverage check run on their pr by changing the workflow file.

### How was it fixed?

Moved the code coverage check into a new workflow file that only runs when something is pushed to master.