### PR TITLE
Allow using a complex type as an array element type

### DIFF
--- a/crates/abi/src/types.rs
+++ b/crates/abi/src/types.rs
@@ -59,16 +59,15 @@ impl AbiType {
     pub fn header_size(&self) -> usize {
         match self {
             Self::UInt(_) | Self::Int(_) | Self::Address | Self::Bool | Self::Function => 32,
-            Self::Array { elem_ty, len } => elem_ty.header_size() * len,
-            Self::Tuple(fields) => {
-                if self.is_static() {
-                    fields
-                        .iter()
-                        .fold(0, |acc, field| field.ty.header_size() + acc)
-                } else {
-                    32
-                }
-            }
+
+            Self::Array { elem_ty, len } if elem_ty.is_static() => elem_ty.header_size() * len,
+            Self::Array { .. } => 32,
+
+            Self::Tuple(fields) if self.is_static() => fields
+                .iter()
+                .fold(0, |acc, field| field.ty.header_size() + acc),
+            Self::Tuple(_) => 32,
+
             Self::Bytes | Self::String => 32,
         }
     }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -95,7 +95,7 @@ pub const U256: Base = Base::Numeric(Integer::U256);
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Array {
     pub size: usize,
-    pub inner: Base,
+    pub inner: Box<Type>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -217,7 +217,7 @@ impl GenericType {
             GenericType::Array => vec![
                 GenericParam {
                     name: "element type".into(),
-                    kind: GenericParamKind::PrimitiveType,
+                    kind: GenericParamKind::AnyType,
                 },
                 GenericParam {
                     name: "size".into(),
@@ -246,7 +246,7 @@ impl GenericType {
             GenericType::Array => match args {
                 [GenericArg::Type(element), GenericArg::Int(size)] => Some(Type::Array(Array {
                     size: *size,
-                    inner: element.as_primitive()?,
+                    inner: Box::new(element.clone()),
                 })),
                 _ => None,
             },

--- a/crates/analyzer/src/operations.rs
+++ b/crates/analyzer/src/operations.rs
@@ -24,7 +24,7 @@ fn index_array(array: Array, index: Type) -> Result<Type, IndexingError> {
         return Err(IndexingError::WrongIndexType);
     }
 
-    Ok(Type::Base(array.inner))
+    Ok(array.inner.as_ref().clone())
 }
 
 fn index_map(map: Map, index: Type) -> Result<Type, IndexingError> {
@@ -125,12 +125,15 @@ mod tests {
     use crate::operations;
     use rstest::rstest;
 
-    const U256_ARRAY_TYPE: Type = Type::Array(Array {
-        inner: U256,
-        size: 100,
-    });
     const U256_TYPE: Type = Type::Base(U256);
     const BOOL_TYPE: Type = Type::Base(Base::Bool);
+
+    fn u256_array_type() -> Type {
+        Type::Array(Array {
+            inner: Box::new(U256.into()),
+            size: 100,
+        })
+    }
 
     fn u256_bool_map() -> Type {
         Type::Map(Map {
@@ -143,7 +146,7 @@ mod tests {
         value,
         index,
         expected,
-        case(U256_ARRAY_TYPE, U256_TYPE, U256_TYPE),
+        case(u256_array_type(), U256_TYPE, U256_TYPE),
         case(u256_bool_map(), U256_TYPE, BOOL_TYPE)
     )]
     fn basic_index(value: Type, index: Type, expected: Type) {
@@ -154,9 +157,9 @@ mod tests {
     #[rstest(
         value,
         index,
-        case(U256_ARRAY_TYPE, BOOL_TYPE),
+        case(u256_array_type(), BOOL_TYPE),
         case(u256_bool_map(), BOOL_TYPE),
-        case(u256_bool_map(), U256_ARRAY_TYPE)
+        case(u256_bool_map(), u256_array_type())
     )]
     fn type_error_index(value: Type, index: Type) {
         let actual = operations::index(value, index).expect_err("didn't fail");

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -47,7 +47,7 @@ fn for_loop(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), Fat
             // Make sure iter is in the function scope & it should be an array.
             let iter_type = expressions::assignable_expr(scope, iter, None)?.typ;
             let target_type = if let Type::Array(array) = iter_type {
-                Type::Base(array.inner)
+                array.inner
             } else {
                 return Err(FatalError::new(scope.type_error(
                     "invalid `for` loop iterator type",
@@ -57,11 +57,18 @@ fn for_loop(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), Fat
                 )));
             };
 
-            scope.root.map_variable_type(target, target_type.clone());
+            scope
+                .root
+                .map_variable_type(target, target_type.as_ref().clone());
 
             let mut body_scope = scope.new_child(BlockScopeType::Loop);
             // add_var emits a msg on err; we can ignore the Result.
-            let _ = body_scope.add_var(&target.kind, target_type, false, target.span);
+            let _ = body_scope.add_var(
+                &target.kind,
+                target_type.as_ref().clone(),
+                false,
+                target.span,
+            );
 
             // Traverse the statements within the `for loop` body scope.
             traverse_statements(&mut body_scope, body)

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -96,7 +96,6 @@ macro_rules! test_stmt {
     };
 }
 
-test_stmt! { array_non_primitive, "let x: Array<(u8, u8), 10>" }
 test_stmt! { array_mixed_types, "let x: Array<u16, 3> = [1, address(0), \"hi\"]" }
 test_stmt! { array_size_mismatch, "let x: Array<u8, 3> = []\nlet y: Array<u8, 3> = [1, 2]" }
 test_stmt! { array_constructor_call, "u8[3]([1, 2, 3])" }

--- a/crates/analyzer/tests/snapshots/analysis__abi_decode_complex.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_decode_complex.snap
@@ -167,45 +167,147 @@ note:
    │                ^ NestedDynamicComplex: Memory
 
 note: 
-   ┌─ abi_decode_complex.fe:20:5
+   ┌─ abi_decode_complex.fe:18:5
+   │  
+18 │ ╭     pub fn decode_static_complex_elem_array(arr: Array<StaticComplex, 3>) -> Array<StaticComplex, 3> {
+19 │ │         return arr
+20 │ │     }
+   │ ╰─────^ attributes hash: 14814063204670221852
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         ctx_decl: None,
+         params: [
+             FunctionParam {
+                 label: None,
+                 name: "arr",
+                 typ: Ok(
+                     Array(
+                         Array {
+                             size: 3,
+                             inner: Struct(
+                                 Struct {
+                                     name: "StaticComplex",
+                                     field_count: 2,
+                                 },
+                             ),
+                         },
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Array(
+                 Array {
+                     size: 3,
+                     inner: Struct(
+                         Struct {
+                             name: "StaticComplex",
+                             field_count: 2,
+                         },
+                     ),
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ abi_decode_complex.fe:19:16
    │
-20 │     pub inner_x: i32
+19 │         return arr
+   │                ^^^ Array<StaticComplex, 3>: Memory
+
+note: 
+   ┌─ abi_decode_complex.fe:22:5
+   │  
+22 │ ╭     pub fn decode_dynamic_complex_elem_array(arr: Array<NestedDynamicComplex, 3>) -> Array<NestedDynamicComplex, 3> {
+23 │ │         return arr
+24 │ │     }
+   │ ╰─────^ attributes hash: 26751994078138639
+   │  
+   = FunctionSignature {
+         self_decl: None,
+         ctx_decl: None,
+         params: [
+             FunctionParam {
+                 label: None,
+                 name: "arr",
+                 typ: Ok(
+                     Array(
+                         Array {
+                             size: 3,
+                             inner: Struct(
+                                 Struct {
+                                     name: "NestedDynamicComplex",
+                                     field_count: 3,
+                                 },
+                             ),
+                         },
+                     ),
+                 ),
+             },
+         ],
+         return_type: Ok(
+             Array(
+                 Array {
+                     size: 3,
+                     inner: Struct(
+                         Struct {
+                             name: "NestedDynamicComplex",
+                             field_count: 3,
+                         },
+                     ),
+                 },
+             ),
+         ),
+     }
+
+note: 
+   ┌─ abi_decode_complex.fe:23:16
+   │
+23 │         return arr
+   │                ^^^ Array<NestedDynamicComplex, 3>: Memory
+
+note: 
+   ┌─ abi_decode_complex.fe:28:5
+   │
+28 │     pub inner_x: i32
    │     ^^^^^^^^^^^^^^^^ i32
-21 │     pub inner_y: i32
+29 │     pub inner_y: i32
    │     ^^^^^^^^^^^^^^^^ i32
 
 note: 
-   ┌─ abi_decode_complex.fe:25:5
+   ┌─ abi_decode_complex.fe:33:5
    │
-25 │     pub inner: StaticInner
+33 │     pub inner: StaticInner
    │     ^^^^^^^^^^^^^^^^^^^^^^ StaticInner
-26 │     pub outer_x: i256
+34 │     pub outer_x: i256
    │     ^^^^^^^^^^^^^^^^^ i256
 
 note: 
-   ┌─ abi_decode_complex.fe:30:5
+   ┌─ abi_decode_complex.fe:38:5
    │
-30 │     pub string: String<8>
+38 │     pub string: String<8>
    │     ^^^^^^^^^^^^^^^^^^^^^ String<8>
-31 │     pub outer_x: i32
+39 │     pub outer_x: i32
    │     ^^^^^^^^^^^^^^^^ i32
 
 note: 
-   ┌─ abi_decode_complex.fe:35:5
+   ┌─ abi_decode_complex.fe:43:5
    │
-35 │     pub bytes: Array<u8, 8>
+43 │     pub bytes: Array<u8, 8>
    │     ^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 8>
-36 │     pub outer_x: i32
+44 │     pub outer_x: i32
    │     ^^^^^^^^^^^^^^^^ i32
 
 note: 
-   ┌─ abi_decode_complex.fe:40:5
+   ┌─ abi_decode_complex.fe:48:5
    │
-40 │     pub bytes_complex: BytesComplex
+48 │     pub bytes_complex: BytesComplex
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ BytesComplex
-41 │     pub static_complex: StaticComplex
+49 │     pub static_complex: StaticComplex
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StaticComplex
-42 │     pub string_complex: StringComplex
+50 │     pub string_complex: StringComplex
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ StringComplex
 
 

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ abi_encoding_stress.fe:4:5
@@ -53,7 +52,7 @@ note:
 27 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 5>) {
 28 │ │         self.my_addrs = my_addrs
 29 │ │     }
-   │ ╰─────^ attributes hash: 8893819222299525150
+   │ ╰─────^ attributes hash: 6651617854478011991
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -68,7 +67,9 @@ note:
                      Array(
                          Array {
                              size: 5,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),
@@ -101,7 +102,7 @@ note:
 31 │ ╭     pub fn get_my_addrs(self) -> Array<address, 5> {
 32 │ │         return self.my_addrs.to_mem()
 33 │ │     }
-   │ ╰─────^ attributes hash: 1736881624347502724
+   │ ╰─────^ attributes hash: 3503941160400696207
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -113,7 +114,9 @@ note:
              Array(
                  Array {
                      size: 5,
-                     inner: Address,
+                     inner: Base(
+                         Address,
+                     ),
                  },
              ),
          ),
@@ -313,7 +316,7 @@ note:
 51 │ ╭     pub fn set_my_u16s(self, my_u16s: Array<u16, 255>) {
 52 │ │         self.my_u16s = my_u16s
 53 │ │     }
-   │ ╰─────^ attributes hash: 15015381430419725173
+   │ ╰─────^ attributes hash: 15373408821262001670
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -328,8 +331,10 @@ note:
                      Array(
                          Array {
                              size: 255,
-                             inner: Numeric(
-                                 U16,
+                             inner: Base(
+                                 Numeric(
+                                     U16,
+                                 ),
                              ),
                          },
                      ),
@@ -363,7 +368,7 @@ note:
 55 │ ╭     pub fn get_my_u16s(self) -> Array<u16, 255> {
 56 │ │         return self.my_u16s.to_mem()
 57 │ │     }
-   │ ╰─────^ attributes hash: 14119474618304681318
+   │ ╰─────^ attributes hash: 7191948642218091354
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -375,8 +380,10 @@ note:
              Array(
                  Array {
                      size: 255,
-                     inner: Numeric(
-                         U16,
+                     inner: Base(
+                         Numeric(
+                             U16,
+                         ),
                      ),
                  },
              ),
@@ -485,7 +492,7 @@ note:
 67 │ ╭     pub fn set_my_bytes(self, my_bytes: Array<u8, 100>) {
 68 │ │         self.my_bytes = my_bytes
 69 │ │     }
-   │ ╰─────^ attributes hash: 11573101353594183790
+   │ ╰─────^ attributes hash: 12615116636431196289
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -500,8 +507,10 @@ note:
                      Array(
                          Array {
                              size: 100,
-                             inner: Numeric(
-                                 U8,
+                             inner: Base(
+                                 Numeric(
+                                     U8,
+                                 ),
                              ),
                          },
                      ),
@@ -535,7 +544,7 @@ note:
 71 │ ╭     pub fn get_my_bytes(self) -> Array<u8, 100> {
 72 │ │         return self.my_bytes.to_mem()
 73 │ │     }
-   │ ╰─────^ attributes hash: 157798734366762321
+   │ ╰─────^ attributes hash: 1930284060814414607
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -547,8 +556,10 @@ note:
              Array(
                  Array {
                      size: 100,
-                     inner: Numeric(
-                         U8,
+                     inner: Base(
+                         Numeric(
+                             U8,
+                         ),
                      ),
                  },
              ),
@@ -839,7 +850,7 @@ note:
    ┌─ abi_encoding_stress.fe:88:9
    │
 88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 2185685122923697263
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6413258942580560070
    │
    = Event {
          name: "MyEvent",
@@ -850,7 +861,9 @@ note:
                      Array(
                          Array {
                              size: 5,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),
@@ -884,8 +897,10 @@ note:
                      Array(
                          Array {
                              size: 255,
-                             inner: Numeric(
-                                 U16,
+                             inner: Base(
+                                 Numeric(
+                                     U16,
+                                 ),
                              ),
                          },
                      ),
@@ -907,8 +922,10 @@ note:
                      Array(
                          Array {
                              size: 100,
-                             inner: Numeric(
-                                 U8,
+                             inner: Base(
+                                 Numeric(
+                                     U8,
+                                 ),
                              ),
                          },
                      ),

--- a/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ address_bytes10_map.fe:2:5
@@ -15,7 +14,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: address) -> Array<u8, 10> {
 5 │ │         return self.bar[key].to_mem()
 6 │ │     }
-  │ ╰─────^ attributes hash: 7365261960972751402
+  │ ╰─────^ attributes hash: 14715984257538758536
   │  
   = FunctionSignature {
         self_decl: Some(
@@ -37,8 +36,10 @@ note:
             Array(
                 Array {
                     size: 10,
-                    inner: Numeric(
-                        U8,
+                    inner: Base(
+                        Numeric(
+                            U8,
+                        ),
                     ),
                 },
             ),
@@ -77,7 +78,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: address, value: Array<u8, 10>) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 10331226497424577374
+   │ ╰─────^ attributes hash: 14916033339844523953
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -101,8 +102,10 @@ note:
                      Array(
                          Array {
                              size: 10,
-                             inner: Numeric(
-                                 U8,
+                             inner: Base(
+                                 Numeric(
+                                     U8,
+                                 ),
                              ),
                          },
                      ),

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ data_copying_stress.fe:4:5
@@ -208,7 +207,7 @@ note:
    · │
 39 │ │         assert my_3rd_array[3] == 50
 40 │ │     }
-   │ ╰─────^ attributes hash: 16237067187800993503
+   │ ╰─────^ attributes hash: 17752007532841141815
    │  
    = FunctionSignature {
          self_decl: None,
@@ -221,8 +220,10 @@ note:
                      Array(
                          Array {
                              size: 10,
-                             inner: Numeric(
-                                 U256,
+                             inner: Base(
+                                 Numeric(
+                                     U256,
+                                 ),
                              ),
                          },
                      ),
@@ -409,7 +410,7 @@ note:
 43 │ │         my_array[3] = 5
 44 │ │         return my_array
 45 │ │     }
-   │ ╰─────^ attributes hash: 15461468619504661037
+   │ ╰─────^ attributes hash: 92188389337515101
    │  
    = FunctionSignature {
          self_decl: None,
@@ -422,8 +423,10 @@ note:
                      Array(
                          Array {
                              size: 10,
-                             inner: Numeric(
-                                 U256,
+                             inner: Base(
+                                 Numeric(
+                                     U256,
+                                 ),
                              ),
                          },
                      ),
@@ -434,8 +437,10 @@ note:
              Array(
                  Array {
                      size: 10,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),
@@ -466,7 +471,7 @@ note:
 47 │ ╭     pub fn clone_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
 48 │ │         return my_array.clone()
 49 │ │     }
-   │ ╰─────^ attributes hash: 15461468619504661037
+   │ ╰─────^ attributes hash: 92188389337515101
    │  
    = FunctionSignature {
          self_decl: None,
@@ -479,8 +484,10 @@ note:
                      Array(
                          Array {
                              size: 10,
-                             inner: Numeric(
-                                 U256,
+                             inner: Base(
+                                 Numeric(
+                                     U256,
+                                 ),
                              ),
                          },
                      ),
@@ -491,8 +498,10 @@ note:
              Array(
                  Array {
                      size: 10,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),
@@ -518,7 +527,7 @@ note:
 52 │ │         my_array.clone()[3] = 5
 53 │ │         return my_array
 54 │ │     }
-   │ ╰─────^ attributes hash: 15461468619504661037
+   │ ╰─────^ attributes hash: 92188389337515101
    │  
    = FunctionSignature {
          self_decl: None,
@@ -531,8 +540,10 @@ note:
                      Array(
                          Array {
                              size: 10,
-                             inner: Numeric(
-                                 U256,
+                             inner: Base(
+                                 Numeric(
+                                     U256,
+                                 ),
                              ),
                          },
                      ),
@@ -543,8 +554,10 @@ note:
              Array(
                  Array {
                      size: 10,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),
@@ -585,7 +598,7 @@ note:
    · │
 64 │ │         return my_nums_mem
 65 │ │     }
-   │ ╰─────^ attributes hash: 13146367689365512086
+   │ ╰─────^ attributes hash: 14329847023405603454
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -597,8 +610,10 @@ note:
              Array(
                  Array {
                      size: 5,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),
@@ -902,7 +917,7 @@ note:
 75 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>) {
 76 │ │         self.my_addrs = my_addrs
 77 │ │     }
-   │ ╰─────^ attributes hash: 1347763946351267085
+   │ ╰─────^ attributes hash: 6379907192890628947
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -917,7 +932,9 @@ note:
                      Array(
                          Array {
                              size: 3,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ events.fe:5:9
@@ -204,7 +203,7 @@ note:
 33 │ ╭     pub fn emit_mix(ctx: Context, addr: address, my_bytes: Array<u8, 100>) {
 34 │ │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
 35 │ │     }
-   │ ╰─────^ attributes hash: 9652612436637375041
+   │ ╰─────^ attributes hash: 17632983073889485939
    │  
    = FunctionSignature {
          self_decl: None,
@@ -240,8 +239,10 @@ note:
                      Array(
                          Array {
                              size: 100,
-                             inner: Numeric(
-                                 U8,
+                             inner: Base(
+                                 Numeric(
+                                     U8,
+                                 ),
                              ),
                          },
                      ),
@@ -270,7 +271,7 @@ note:
    ┌─ events.fe:34:9
    │
 34 │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12006518826467385253
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14467559009864244124
    │
    = Event {
          name: "Mix",
@@ -312,8 +313,10 @@ note:
                      Array(
                          Array {
                              size: 100,
-                             inner: Numeric(
-                                 U8,
+                             inner: Base(
+                                 Numeric(
+                                     U8,
+                                 ),
                              ),
                          },
                      ),
@@ -420,7 +423,7 @@ note:
    ┌─ events.fe:41:9
    │
 41 │         emit Addresses(ctx, addrs)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17766225573703958283
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13530689072905293596
    │
    = Event {
          name: "Addresses",
@@ -431,7 +434,9 @@ note:
                      Array(
                          Array {
                              size: 2,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ external_contract.fe:5:9
@@ -19,7 +18,7 @@ note:
 10 │ ╭     pub fn emit_event(ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
 11 │ │         emit MyEvent(ctx, my_num, my_addrs, my_string)
 12 │ │     }
-   │ ╰─────^ attributes hash: 14584319691445179306
+   │ ╰─────^ attributes hash: 3754416609002139684
    │  
    = FunctionSignature {
          self_decl: None,
@@ -57,7 +56,9 @@ note:
                      Array(
                          Array {
                              size: 5,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),
@@ -95,7 +96,7 @@ note:
    ┌─ external_contract.fe:11:9
    │
 11 │         emit MyEvent(ctx, my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3872046667435269452
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14493411523883858336
    │
    = Event {
          name: "MyEvent",
@@ -117,7 +118,9 @@ note:
                      Array(
                          Array {
                              size: 5,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),
@@ -147,7 +150,7 @@ note:
 18 │ │         my_array[2] = b
 19 │ │         return my_array
 20 │ │     }
-   │ ╰─────^ attributes hash: 14276910879408601208
+   │ ╰─────^ attributes hash: 8432779812067699525
    │  
    = FunctionSignature {
          self_decl: None,
@@ -180,8 +183,10 @@ note:
              Array(
                  Array {
                      size: 3,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),
@@ -250,7 +255,7 @@ note:
 25 │ │         let foo: Foo = Foo(foo_address)
 26 │ │         foo.emit_event(ctx, my_num, my_addrs, my_string)
 27 │ │     }
-   │ ╰─────^ attributes hash: 11744736773867210426
+   │ ╰─────^ attributes hash: 14242721142940057862
    │  
    = FunctionSignature {
          self_decl: None,
@@ -297,7 +302,9 @@ note:
                      Array(
                          Array {
                              size: 5,
-                             inner: Address,
+                             inner: Base(
+                                 Address,
+                             ),
                          },
                      ),
                  ),
@@ -359,7 +366,7 @@ note:
 30 │ │         let foo: Foo = Foo(foo_address)
 31 │ │         return foo.build_array(a, b)
 32 │ │     }
-   │ ╰─────^ attributes hash: 4627171240003453976
+   │ ╰─────^ attributes hash: 6675851927406831661
    │  
    = FunctionSignature {
          self_decl: None,
@@ -401,8 +408,10 @@ note:
              Array(
                  Array {
                      size: 3,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ keccak.fe:2:5
@@ -9,7 +8,7 @@ note:
 2 │ ╭     pub fn return_hash_from_u8(val: Array<u8, 1>) -> u256 {
 3 │ │         return keccak256(val)
 4 │ │     }
-  │ ╰─────^ attributes hash: 6936681782057010951
+  │ ╰─────^ attributes hash: 13665051569980032928
   │  
   = FunctionSignature {
         self_decl: None,
@@ -22,8 +21,10 @@ note:
                     Array(
                         Array {
                             size: 1,
-                            inner: Numeric(
-                                U8,
+                            inner: Base(
+                                Numeric(
+                                    U8,
+                                ),
                             ),
                         },
                     ),
@@ -57,7 +58,7 @@ note:
 6 │ ╭     pub fn return_hash_from_foo(val: Array<u8, 3>) -> u256 {
 7 │ │         return keccak256(val)
 8 │ │     }
-  │ ╰─────^ attributes hash: 10874278598381710302
+  │ ╰─────^ attributes hash: 14115249111516313873
   │  
   = FunctionSignature {
         self_decl: None,
@@ -70,8 +71,10 @@ note:
                     Array(
                         Array {
                             size: 3,
-                            inner: Numeric(
-                                U8,
+                            inner: Base(
+                                Numeric(
+                                    U8,
+                                ),
                             ),
                         },
                     ),
@@ -105,7 +108,7 @@ note:
 10 │ ╭     pub fn return_hash_from_u256(val: Array<u8, 32>) -> u256 {
 11 │ │         return keccak256(val)
 12 │ │     }
-   │ ╰─────^ attributes hash: 1385099984461119772
+   │ ╰─────^ attributes hash: 3591219705610392773
    │  
    = FunctionSignature {
          self_decl: None,
@@ -118,8 +121,10 @@ note:
                      Array(
                          Array {
                              size: 32,
-                             inner: Numeric(
-                                 U8,
+                             inner: Base(
+                                 Numeric(
+                                     U8,
+                                 ),
                              ),
                          },
                      ),

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ multi_param.fe:2:5
@@ -13,7 +12,7 @@ note:
 6 │ │         my_array[2] = z
 7 │ │         return my_array
 8 │ │     }
-  │ ╰─────^ attributes hash: 10778435134172267300
+  │ ╰─────^ attributes hash: 10696147843982229344
   │  
   = FunctionSignature {
         self_decl: None,
@@ -57,8 +56,10 @@ note:
             Array(
                 Array {
                     size: 3,
-                    inner: Numeric(
-                        U256,
+                    inner: Base(
+                        Numeric(
+                            U256,
+                        ),
                     ),
                 },
             ),

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ return_array.fe:2:5
@@ -11,7 +10,7 @@ note:
 4 │ │         my_array[3] = x
 5 │ │         return my_array
 6 │ │     }
-  │ ╰─────^ attributes hash: 5752237891839439208
+  │ ╰─────^ attributes hash: 4865772778354002151
   │  
   = FunctionSignature {
         self_decl: None,
@@ -33,8 +32,10 @@ note:
             Array(
                 Array {
                     size: 5,
-                    inner: Numeric(
-                        U256,
+                    inner: Base(
+                        Numeric(
+                            U256,
+                        ),
                     ),
                 },
             ),

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ sized_vals_in_sto.fe:4:5
@@ -111,7 +110,7 @@ note:
 22 │ ╭     pub fn write_nums(self, x: Array<u256, 42>) {
 23 │ │         self.nums = x
 24 │ │     }
-   │ ╰─────^ attributes hash: 15243923981938152137
+   │ ╰─────^ attributes hash: 3795910266468030735
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -126,8 +125,10 @@ note:
                      Array(
                          Array {
                              size: 42,
-                             inner: Numeric(
-                                 U256,
+                             inner: Base(
+                                 Numeric(
+                                     U256,
+                                 ),
                              ),
                          },
                      ),
@@ -161,7 +162,7 @@ note:
 26 │ ╭     pub fn read_nums(self) -> Array<u256, 42> {
 27 │ │         return self.nums.to_mem()
 28 │ │     }
-   │ ╰─────^ attributes hash: 7235961322057554817
+   │ ╰─────^ attributes hash: 7198573459523579428
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -173,8 +174,10 @@ note:
              Array(
                  Array {
                      size: 42,
-                     inner: Numeric(
-                         U256,
+                     inner: Base(
+                         Numeric(
+                             U256,
+                         ),
                      ),
                  },
              ),
@@ -369,7 +372,7 @@ note:
    ┌─ sized_vals_in_sto.fe:39:9
    │
 39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 9998967556022527347
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11879127803411427086
    │
    = Event {
          name: "MyEvent",
@@ -391,8 +394,10 @@ note:
                      Array(
                          Array {
                              size: 42,
-                             inner: Numeric(
-                                 U256,
+                             inner: Base(
+                                 Numeric(
+                                     U256,
+                                 ),
                              ),
                          },
                      ),

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ structs.fe:2:5
@@ -97,7 +96,7 @@ note:
 28 │ ╭     pub fn encode(self) -> Array<u8, 128> {
 29 │ │         return self.abi_encode()
 30 │ │     }
-   │ ╰─────^ attributes hash: 2052929893622941907
+   │ ╰─────^ attributes hash: 374785682862794405
    │  
    = FunctionSignature {
          self_decl: Some(
@@ -109,8 +108,10 @@ note:
              Array(
                  Array {
                      size: 128,
-                     inner: Numeric(
-                         U8,
+                     inner: Base(
+                         Numeric(
+                             U8,
+                         ),
                      ),
                  },
              ),
@@ -2696,7 +2697,7 @@ note:
 176 │ │         let house: House = House(price: 300, size: 500, rooms: u8(20), vacant: true)
 177 │ │         return house.encode()
 178 │ │     }
-    │ ╰─────^ attributes hash: 9174136327042912890
+    │ ╰─────^ attributes hash: 7483658980613368648
     │  
     = FunctionSignature {
           self_decl: None,
@@ -2706,8 +2707,10 @@ note:
               Array(
                   Array {
                       size: 128,
-                      inner: Numeric(
-                          U8,
+                      inner: Base(
+                          Numeric(
+                              U8,
+                          ),
                       ),
                   },
               ),

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
-
 ---
 note: 
   ┌─ tuple_stress.fe:4:5
@@ -754,7 +753,7 @@ note:
 49 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> Array<u8, 96> {
 50 │ │         return my_tuple.abi_encode()
 51 │ │     }
-   │ ╰─────^ attributes hash: 3539305055628398466
+   │ ╰─────^ attributes hash: 10651188962262222621
    │  
    = FunctionSignature {
          self_decl: None,
@@ -788,8 +787,10 @@ note:
              Array(
                  Array {
                      size: 96,
-                     inner: Numeric(
-                         U8,
+                     inner: Base(
+                         Numeric(
+                             U8,
+                         ),
                      ),
                  },
              ),

--- a/crates/codegen/src/yul/runtime/abi.rs
+++ b/crates/codegen/src/yul/runtime/abi.rs
@@ -117,7 +117,7 @@ pub(super) fn make_abi_encode_dynamic_array_type(
                 ([enc_size.ident()] := add([provider.abi_encode(db, src.expr(), data_ptr.expr(), elem_ptr_ty, is_dst_storage)], [enc_size.expr()]))
                 ([header_ptr.ident()] := add([header_ptr.expr()], [literal_expression!{(elem_header_size)}]))
                 ([data_ptr.ident()] := add([dst.expr()], [enc_size.expr()]))
-                 ([src.ident()] := add([src.expr()], [literal_expression!{(elem_ty_size)}]))
+                ([src.ident()] := add([src.expr()], [literal_expression!{(elem_ty_size)}]))
              })
          }
     };
@@ -449,7 +449,7 @@ impl DefaultRuntimeProvider {
         debug_assert!(abi_ty.is_static());
 
         let func_name_postfix = match abi_loc {
-            AbiSrcLocation::CallData => "call_data",
+            AbiSrcLocation::CallData => "calldata",
             AbiSrcLocation::Memory => "memory",
         };
 
@@ -485,7 +485,7 @@ impl DefaultRuntimeProvider {
         debug_assert!(!abi_ty.is_static());
 
         let func_name_postfix = match abi_loc {
-            AbiSrcLocation::CallData => "call_data",
+            AbiSrcLocation::CallData => "calldata",
             AbiSrcLocation::Memory => "memory",
         };
 
@@ -502,6 +502,7 @@ impl DefaultRuntimeProvider {
                     make_abi_decode_string_type(provider, db, &name, abi_loc)
                 })
             }
+
             AbiType::Bytes => {
                 let len = match &ty.data(db.upcast()).kind {
                     TypeKind::Array(ArrayDef { len, .. }) => *len,
@@ -513,8 +514,10 @@ impl DefaultRuntimeProvider {
                     make_abi_decode_bytes_type(provider, db, &name, abi_loc)
                 })
             }
+
             AbiType::Array { .. } => {
-                let name = format! {"$abi_decode_dynamic_array_from_{}", func_name_postfix};
+                let name =
+                    format! {"$abi_decode_dynamic_array_{}_from_{}", ty.0, func_name_postfix};
                 self.create_then_call(&name, args, |provider| {
                     make_abi_decode_dynamic_elem_array_type(provider, db, &name, ty, abi_loc)
                 })

--- a/crates/mir/src/lower/types.rs
+++ b/crates/mir/src/lower/types.rs
@@ -79,7 +79,7 @@ fn lower_base(base: &analyzer_types::Base) -> TypeKind {
 
 fn lower_array(db: &dyn MirDb, arr: &analyzer_types::Array) -> TypeKind {
     let len = arr.size;
-    let elem_ty = db.mir_lowered_type(arr.inner.into());
+    let elem_ty = db.mir_lowered_type(arr.inner.as_ref().clone());
 
     let def = ArrayDef { elem_ty, len };
     TypeKind::Array(def)

--- a/crates/test-files/fixtures/features/abi_decode_complex.fe
+++ b/crates/test-files/fixtures/features/abi_decode_complex.fe
@@ -14,6 +14,14 @@ contract Foo {
     pub fn decode_nested_dynamic_complex(s: NestedDynamicComplex) -> NestedDynamicComplex {
         return s
     }
+
+    pub fn decode_static_complex_elem_array(arr: Array<StaticComplex, 3>) -> Array<StaticComplex, 3> {
+        return arr
+    }
+
+    pub fn decode_dynamic_complex_elem_array(arr: Array<NestedDynamicComplex, 3>) -> Array<NestedDynamicComplex, 3> {
+        return arr
+    }
 }
 
 pub struct StaticInner {

--- a/crates/test-files/fixtures/features/for_loop_with_complex_elem_array.fe
+++ b/crates/test-files/fixtures/features/for_loop_with_complex_elem_array.fe
@@ -1,0 +1,33 @@
+contract Foo {
+    pub fn bar() -> i256 {
+        let my_array: Array<Pair, 3> = [Pair::new(-1, 1), Pair::new(10, -10), Pair::new(-100, 100)]
+
+        let sum: i256 = 0
+        for pair in my_array {
+            sum += pair.l1_norm()
+        }
+
+        return sum
+    }
+}
+
+struct Pair {
+    pub x: i256
+    pub y: i256
+    
+    pub fn new(_ x: i256, _ y: i256) -> Pair {
+        return Pair(x, y)
+    }
+    
+    pub fn l1_norm(self) -> i256 {
+        return abs(self.x) + abs(self.y)
+    }
+}
+
+fn abs(_ val: i256) -> i256 {
+    if val < 0 {
+        return -val
+    } else {
+        return val
+    }
+}

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -438,6 +438,7 @@ fn test_arrays() {
     case::associated_fns("associated_fns.fe", &[uint_token(12)], uint_token(144)),
     case::struct_fns("struct_fns.fe", &[uint_token(10), uint_token(20)], uint_token(100)),
     case::cast_address_to_u256("cast_address_to_u256.fe", &[address_token(SOME_ADDRESS)], address_token(SOME_ADDRESS)),
+    case("for_loop_with_complex_elem_array.fe", &[], int_token(222)),
 )]
 fn test_method_return(fixture_file: &str, input: &[ethabi::Token], expected: ethabi::Token) {
     with_executor(&|mut executor| {
@@ -1859,12 +1860,32 @@ fn abi_decode_complex() {
             Some(&bytes_complex),
         );
 
-        let nested_dynamic_complex = tuple_token(&[bytes_complex, static_complex, string_complex]);
+        let nested_dynamic_complex =
+            tuple_token(&[bytes_complex, static_complex.clone(), string_complex]);
         harness.test_function(
             &mut executor,
             "decode_nested_dynamic_complex",
             &[nested_dynamic_complex.clone()],
             Some(&nested_dynamic_complex),
+        );
+
+        let static_complex_array =
+            ethabi::Token::FixedArray(std::iter::repeat(static_complex).take(3).collect());
+        harness.test_function(
+            &mut executor,
+            "decode_static_complex_elem_array",
+            &[static_complex_array.clone()],
+            Some(&static_complex_array),
+        );
+
+        let dynamic_complex_array =
+            ethabi::Token::FixedArray(std::iter::repeat(nested_dynamic_complex).take(3).collect());
+        dbg!(ethabi::encode(&[dynamic_complex_array.clone()]).len());
+        harness.test_function(
+            &mut executor,
+            "decode_dynamic_complex_elem_array",
+            &[dynamic_complex_array.clone()],
+            Some(&dynamic_complex_array),
         );
 
         assert_harness_gas_report!(harness);

--- a/crates/tests/src/snapshots/fe_compiler_tests__demo_uniswap__uniswap_contracts.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__demo_uniswap__uniswap_contracts.snap
@@ -11,7 +11,7 @@ balanceOf([Address(0x0000000000000000000000000000000000000000)]) used 628 gas
 get_reserves([]) used 801 gas
 swap([Uint(1993), Uint(0), Address(0x0000000000000000000000000000000000000042)]) used 36368 gas
 get_reserves([]) used 801 gas
-transfer([Address(0x08c3f5f1f2d9c71814275b0f4056b255defada7a), Uint(141421356237309503880)]) used 5802 gas
+transfer([Address(0x5544753c1deedce3cb267ca69ea62c24711b786f), Uint(141421356237309503880)]) used 5802 gas
 burn([Address(0x1000000000000000000000000000000000000001)]) used 3650 gas
 get_reserves([]) used 801 gas
 

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__abi_decode_complex.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__abi_decode_complex.snap
@@ -2,8 +2,10 @@
 source: crates/tests/src/features.rs
 expression: "format!(\"{}\", harness.gas_reporter)"
 ---
-decode_static_complex([Tuple([Tuple([Int(10), Int(20)]), Int(30)])]) used 756 gas
+decode_static_complex([Tuple([Tuple([Int(10), Int(20)]), Int(30)])]) used 783 gas
 decode_string_complex([Tuple([String("Hello"), Int(30)])]) used 1438 gas
 decode_bytes_complex([Tuple([Bytes([1, 2, 3, 4, 5, 6, 7, 8]), Int(30)])]) used 1000 gas
-decode_nested_dynamic_complex([Tuple([Tuple([Bytes([1, 2, 3, 4, 5, 6, 7, 8]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([String("Hello"), Int(30)])])]) used 3539 gas
+decode_nested_dynamic_complex([Tuple([Tuple([Bytes([1, 2, 3, 4, 5, 6, 7, 8]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([String("Hello"), Int(30)])])]) used 3622 gas
+decode_static_complex_elem_array([FixedArray([Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)])])]) used 3061 gas
+decode_dynamic_complex_elem_array([FixedArray([Tuple([Tuple([Bytes([1, 2, 3, 4, 5, 6, 7, 8]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([String("Hello"), Int(30)])]), Tuple([Tuple([Bytes([1, 2, 3, 4, 5, 6, 7, 8]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([String("Hello"), Int(30)])]), Tuple([Tuple([Bytes([1, 2, 3, 4, 5, 6, 7, 8]), Int(30)]), Tuple([Tuple([Int(10), Int(20)]), Int(30)]), Tuple([String("Hello"), Int(30)])])])]) used 12597 gas
 

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_163.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_163.snap
@@ -1,0 +1,6 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+---
+bar([]) used 4083 gas
+

--- a/newsfragments/730.feature.md
+++ b/newsfragments/730.feature.md
@@ -1,0 +1,26 @@
+Allow using complex type as array element type.
+
+Example:
+```
+contract Foo {
+    pub fn bar() -> i256 {
+        let my_array: Array<Pair, 3> = [Pair::new(1, 0), Pair::new(2, 0), Pair::new(3, 0)]
+
+        let sum: i256 = 0
+        for pair in my_array {
+            sum += pair.x
+        }
+
+        return sum
+    }
+}
+
+struct Pair {
+    pub x: i256
+    pub y: i256
+    
+    pub fn new(_ x: i256, _ y: i256) -> Pair {
+        return Pair(x, y)
+    }
+}
+```

--- a/newsfragments/734.bugfix.md
+++ b/newsfragments/734.bugfix.md
@@ -1,0 +1,1 @@
+Fix a bug that incorrect instruction is selected when the operands of a comp instruction are a signed type.


### PR DESCRIPTION
close #730 
1. Allow using a complex type as an array element type
2. Fix a bug that incorrect instruction is selected when the operands of a comp instruction are a signed type.

Example: 
```
contract Foo {
    pub fn bar() -> i256 {
        let my_array: Array<Pair, 3> = [Pair::new(-1, 1), Pair::new(10, -10), Pair::new(-100, 100)]

        let sum: i256 = 0
        for pair in my_array {
            sum += pair.l1_norm()
        }

        return sum
    }
}

struct Pair {
    pub x: i256
    pub y: i256

    pub fn new(_ x: i256, _ y: i256) -> Pair {
        return Pair(x, y)
    }

    pub fn l1_norm(self) -> i256 {
        return abs(self.x) + abs(self.y)
    }
}

fn abs(_ val: i256) -> i256 {
    if val < 0 {
        return -val
    } else {
        return val
    }
}
```

NOTE: 
Please start reviewing this after #729 is merged.


[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
