### PR TITLE
Intern analyzer Types (TypeId)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,6 @@ dependencies = [
  "smallvec",
  "smol_str",
  "strum",
- "vec1",
  "wasm-bindgen-test",
 ]
 

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -15,7 +15,6 @@ hex = "0.4"
 num-bigint = "0.4.3"
 num-traits = "0.2.14"
 strum = { version = "0.23.0", features = ["derive"] }
-vec1 = "1.8.0"
 semver = "1.0.0"
 salsa = "0.16.1"
 parking_lot_core = { version = "=0.8.0" } # used by salsa; version pinned for wasm compatibility

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -1,7 +1,9 @@
+use crate::display::Displayable;
+
 use crate::namespace::items::{
     Class, ContractId, DiagnosticSink, EventId, FunctionId, FunctionSigId, Item, TraitId,
 };
-use crate::namespace::types::{Generic, SelfDecl, Struct, Type};
+use crate::namespace::types::{Generic, SelfDecl, Type, TypeId};
 use crate::AnalyzerDb;
 use crate::{
     builtins::{ContractTypeMethod, GlobalFunction, Intrinsic, ValueMethod},
@@ -17,10 +19,10 @@ use fe_common::Span;
 use fe_parser::ast;
 use fe_parser::node::{Node, NodeId};
 
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 use num_bigint::BigInt;
 use smol_str::SmolStr;
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -136,14 +138,6 @@ pub trait AnalyzerContext {
     /// to determine whether a context is in a function.
     fn add_call(&self, node: &Node<ast::Expr>, call_type: CallType);
 
-    /// Store string literal to the current context.
-    ///
-    /// # Panics
-    ///
-    /// Panics if a context is not in a function. Use [`Self::is_in_function`]
-    /// to determine whether a context is in a function.
-    fn add_string(&self, str_lit: SmolStr);
-
     /// Returns `true` if the context is in function scope.
     fn is_in_function(&self) -> bool;
 
@@ -151,16 +145,21 @@ pub trait AnalyzerContext {
     fn inherits_type(&self, typ: BlockScopeType) -> bool;
 
     /// Returns the `Context` type, if it is defined.
-    fn get_context_type(&self) -> Option<Struct>;
+    fn get_context_type(&self) -> Option<TypeId>;
 
     fn type_error(
         &self,
         message: &str,
         span: Span,
-        expected: &dyn Display,
-        actual: &dyn Display,
+        expected: TypeId,
+        actual: TypeId,
     ) -> DiagnosticVoucher {
-        self.register_diag(errors::type_error(message, span, expected, actual))
+        self.register_diag(errors::type_error(
+            message,
+            span,
+            expected.display(self.db()),
+            actual.display(self.db()),
+        ))
     }
 
     fn not_yet_implemented(&self, feature: &str, span: Span) -> DiagnosticVoucher {
@@ -226,7 +225,7 @@ pub enum NamedThing {
     // SelfType // when/if we add a `Self` type keyword
     Variable {
         name: String,
-        typ: Result<Type, TypeError>,
+        typ: Result<TypeId, TypeError>,
         is_const: bool,
         span: Span,
     },
@@ -324,10 +323,6 @@ impl AnalyzerContext for TempContext {
         panic!("TempContext can't add call");
     }
 
-    fn add_string(&self, _str_lit: SmolStr) {
-        panic!("TempContext can't store string literal")
-    }
-
     fn is_in_function(&self) -> bool {
         false
     }
@@ -340,7 +335,7 @@ impl AnalyzerContext for TempContext {
         self.diagnostics.borrow_mut().push(diag)
     }
 
-    fn get_context_type(&self) -> Option<Struct> {
+    fn get_context_type(&self) -> Option<TypeId> {
         panic!("TempContext can't resolve Context")
     }
 }
@@ -369,7 +364,7 @@ impl Location {
             | Type::String(_)
             | Type::Struct(_)
             | Type::Generic(_) => Location::Memory,
-            other => panic!("Type {other} can not be assigned, returned or passed"),
+            _ => panic!("Type can not be assigned, returned or passed"),
         }
     }
 }
@@ -378,9 +373,8 @@ impl Location {
 pub struct FunctionBody {
     pub expressions: IndexMap<NodeId, ExpressionAttributes>,
     pub emits: IndexMap<NodeId, EventId>,
-    pub string_literals: IndexSet<SmolStr>, // for yulgen
     // Map lhs of variable declaration to type.
-    pub var_types: IndexMap<NodeId, Type>,
+    pub var_types: IndexMap<NodeId, TypeId>,
     pub calls: IndexMap<NodeId, CallType>,
     pub spans: HashMap<NodeId, Span>,
 }
@@ -388,7 +382,7 @@ pub struct FunctionBody {
 /// Contains contextual information relating to an expression AST node.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExpressionAttributes {
-    pub typ: Type,
+    pub typ: TypeId,
     pub location: Location,
     pub move_location: Option<Location>,
     // Evaluated constant value of const local definition.
@@ -396,7 +390,7 @@ pub struct ExpressionAttributes {
 }
 
 impl ExpressionAttributes {
-    pub fn new(typ: Type, location: Location) -> Self {
+    pub fn new(typ: TypeId, location: Location) -> Self {
         Self {
             typ,
             location,
@@ -412,8 +406,8 @@ impl ExpressionAttributes {
     }
 
     /// Adds a move to value, if it is in storage or memory.
-    pub fn into_loaded(mut self) -> Result<Self, CannotMove> {
-        match self.typ {
+    pub fn into_loaded(mut self, db: &dyn AnalyzerDb) -> Result<Self, CannotMove> {
+        match self.typ.typ(db) {
             Type::Base(_) | Type::Contract(_) => {
                 if self.location != Location::Value {
                     self.move_location = Some(Location::Value);
@@ -427,20 +421,17 @@ impl ExpressionAttributes {
 
     /// The final location of an expression after a possible move.
     pub fn final_location(&self) -> Location {
-        if let Some(location) = self.move_location {
-            return location;
-        }
-        self.location
+        self.move_location.unwrap_or(self.location)
     }
 }
 
-impl fmt::Display for ExpressionAttributes {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+impl crate::display::DisplayWithDb for ExpressionAttributes {
+    fn format(&self, db: &dyn AnalyzerDb, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "{}: {:?}", self.typ.display(db), self.location)?;
         if let Some(move_to) = self.move_location {
-            write!(f, "{}: {:?} => {:?}", self.typ, self.location, move_to)
-        } else {
-            write!(f, "{}: {:?}", self.typ, self.location)
+            write!(f, " => {:?}", move_to)?;
         }
+        Ok(())
     }
 }
 
@@ -451,7 +442,7 @@ pub enum CallType {
     Intrinsic(Intrinsic),
     BuiltinValueMethod {
         method: ValueMethod,
-        typ: Type,
+        typ: TypeId,
     },
 
     // create, create2 (will be methods of the context struct soon)
@@ -485,7 +476,7 @@ pub enum CallType {
         function: FunctionId,
     },
     Pure(FunctionId),
-    TypeConstructor(Type),
+    TypeConstructor(TypeId),
 }
 
 impl CallType {
@@ -516,18 +507,22 @@ impl CallType {
             | CallType::External { function: id, .. }
             | CallType::Pure(id) => id.name(db),
             CallType::TraitValueMethod { method: id, .. } => id.name(db),
-            CallType::TypeConstructor(typ) => typ.name(),
+            CallType::TypeConstructor(typ) => typ.display(db).to_string().into(),
         }
     }
 
     pub fn is_unsafe(&self, db: &dyn AnalyzerDb) -> bool {
         if let CallType::Intrinsic(_) = self {
             true
-        } else if let CallType::TypeConstructor(Type::Struct(struct_)) = self {
+        } else if let CallType::TypeConstructor(type_id) = self {
             // check that this is the `Context` struct defined in `std`
             // this should be deleted once associated functions are supported and we can
             // define unsafe constructors in Fe
-            struct_.name == "Context" && struct_.id.module(db).is_in_std(db)
+            if let Type::Struct(struct_) = type_id.typ(db) {
+                struct_.name(db) == "Context" && struct_.module(db).ingot(db).name(db) == "std"
+            } else {
+                false
+            }
         } else {
             self.function().map(|id| id.is_unsafe(db)).unwrap_or(false)
         }

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -4,7 +4,7 @@ use crate::namespace::items::{
     self, ContractFieldId, ContractId, DepGraphWrapper, EventId, FunctionId, FunctionSigId, ImplId,
     IngotId, Item, ModuleConstantId, ModuleId, StructFieldId, StructId, TraitId, TypeAliasId,
 };
-use crate::namespace::types::{self, Type};
+use crate::namespace::types::{self, Type, TypeId};
 use fe_common::db::{SourceDb, SourceDbStorage, Upcast, UpcastMut};
 use fe_common::{SourceFileId, Span};
 use fe_parser::ast;
@@ -41,6 +41,8 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     fn intern_function(&self, data: Rc<items::Function>) -> FunctionId;
     #[salsa::interned]
     fn intern_event(&self, data: Rc<items::Event>) -> EventId;
+    #[salsa::interned]
+    fn intern_type(&self, data: Type) -> TypeId;
 
     // Ingot
 
@@ -71,7 +73,10 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     #[salsa::invoke(queries::module::module_item_map)]
     fn module_item_map(&self, module: ModuleId) -> Analysis<Rc<IndexMap<SmolStr, Item>>>;
     #[salsa::invoke(queries::module::module_impl_map)]
-    fn module_impl_map(&self, module: ModuleId) -> Analysis<Rc<IndexMap<(TraitId, Type), ImplId>>>;
+    fn module_impl_map(
+        &self,
+        module: ModuleId,
+    ) -> Analysis<Rc<IndexMap<(TraitId, TypeId), ImplId>>>;
     #[salsa::invoke(queries::module::module_contracts)]
     fn module_contracts(&self, module: ModuleId) -> Rc<[ContractId]>;
     #[salsa::invoke(queries::module::module_structs)]
@@ -91,10 +96,7 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     // Module Constant
     #[salsa::cycle(queries::module::module_constant_type_cycle)]
     #[salsa::invoke(queries::module::module_constant_type)]
-    fn module_constant_type(
-        &self,
-        id: ModuleConstantId,
-    ) -> Analysis<Result<types::Type, TypeError>>;
+    fn module_constant_type(&self, id: ModuleConstantId) -> Analysis<Result<TypeId, TypeError>>;
     #[salsa::cycle(queries::module::module_constant_value_cycle)]
     #[salsa::invoke(queries::module::module_constant_value)]
     fn module_constant_value(
@@ -127,10 +129,7 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
         id: ContractId,
     ) -> Analysis<Rc<IndexMap<SmolStr, ContractFieldId>>>;
     #[salsa::invoke(queries::contracts::contract_field_type)]
-    fn contract_field_type(
-        &self,
-        field: ContractFieldId,
-    ) -> Analysis<Result<types::Type, TypeError>>;
+    fn contract_field_type(&self, field: ContractFieldId) -> Analysis<Result<TypeId, TypeError>>;
     #[salsa::cycle(queries::contracts::contract_dependency_graph_cycle)]
     #[salsa::invoke(queries::contracts::contract_dependency_graph)]
     fn contract_dependency_graph(&self, id: ContractId) -> DepGraphWrapper;
@@ -148,14 +147,12 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     fn function_dependency_graph(&self, id: FunctionId) -> DepGraphWrapper;
 
     // Struct
-    #[salsa::invoke(queries::structs::struct_type)]
-    fn struct_type(&self, id: StructId) -> Rc<types::Struct>;
     #[salsa::invoke(queries::structs::struct_all_fields)]
     fn struct_all_fields(&self, id: StructId) -> Rc<[StructFieldId]>;
     #[salsa::invoke(queries::structs::struct_field_map)]
     fn struct_field_map(&self, id: StructId) -> Analysis<Rc<IndexMap<SmolStr, StructFieldId>>>;
     #[salsa::invoke(queries::structs::struct_field_type)]
-    fn struct_field_type(&self, field: StructFieldId) -> Analysis<Result<types::Type, TypeError>>;
+    fn struct_field_type(&self, field: StructFieldId) -> Analysis<Result<TypeId, TypeError>>;
     #[salsa::invoke(queries::structs::struct_all_functions)]
     fn struct_all_functions(&self, id: StructId) -> Rc<[FunctionId]>;
     #[salsa::invoke(queries::structs::struct_function_map)]
@@ -165,12 +162,12 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     fn struct_dependency_graph(&self, id: StructId) -> Analysis<DepGraphWrapper>;
 
     // Trait
-    #[salsa::invoke(queries::traits::trait_type)]
-    fn trait_type(&self, id: TraitId) -> Rc<types::Trait>;
     #[salsa::invoke(queries::traits::trait_all_functions)]
     fn trait_all_functions(&self, id: TraitId) -> Rc<[FunctionSigId]>;
     #[salsa::invoke(queries::traits::trait_function_map)]
     fn trait_function_map(&self, id: TraitId) -> Analysis<Rc<IndexMap<SmolStr, FunctionSigId>>>;
+    #[salsa::invoke(queries::traits::trait_is_implemented_for)]
+    fn trait_is_implemented_for(&self, id: TraitId, typ: TypeId) -> bool;
 
     // Impl
     #[salsa::invoke(queries::impls::impl_all_functions)]
@@ -185,7 +182,7 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     // Type alias
     #[salsa::invoke(queries::types::type_alias_type)]
     #[salsa::cycle(queries::types::type_alias_type_cycle)]
-    fn type_alias_type(&self, id: TypeAliasId) -> Analysis<Result<types::Type, TypeError>>;
+    fn type_alias_type(&self, id: TypeAliasId) -> Analysis<Result<TypeId, TypeError>>;
 }
 
 #[salsa::database(AnalyzerDbStorage, SourceDbStorage)]

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -40,7 +40,7 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
             } = &field.kind;
 
             let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
-                typ if typ.has_fixed_size() => Ok(typ),
+                typ if typ.has_fixed_size(scope.db()) => Ok(typ),
                 _ => Err(TypeError::new(scope.error(
                     "event field type must have a fixed size",
                     typ_node.span,

--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -1,11 +1,12 @@
 use crate::context::{AnalyzerContext, CallType, FunctionBody};
 use crate::db::{Analysis, AnalyzerDb};
+use crate::display::Displayable;
 use crate::errors::TypeError;
 use crate::namespace::items::{
     Class, DepGraph, DepGraphWrapper, DepLocality, FunctionId, FunctionSigId, Item, TypeDef,
 };
 use crate::namespace::scopes::{BlockScope, BlockScopeType, FunctionScope, ItemScope};
-use crate::namespace::types::{self, Contract, CtxDecl, Generic, SelfDecl, Struct, Type};
+use crate::namespace::types::{self, CtxDecl, Generic, SelfDecl, Type, TypeId};
 use crate::traversal::functions::traverse_statements;
 use crate::traversal::types::{type_desc, type_desc_to_trait};
 use fe_common::diagnostics::Label;
@@ -106,16 +107,16 @@ pub fn function_signature(
             }
             ast::FunctionArg::Regular(reg) => {
                 let typ = resolve_function_param_type(db, function, &mut scope, &reg.typ).and_then(|typ| match typ {
-                    typ if typ.has_fixed_size() => Ok(typ),
+                    typ if typ.has_fixed_size(db) => Ok(typ),
                     _ => Err(TypeError::new(scope.error(
                         "function parameter types must have fixed size",
                         reg.typ.span,
-                        &format!("`{}` type can't be used as a function parameter", typ.name()),
+                        &format!("`{}` type can't be used as a function parameter", typ.display(db)),
                     ))),
                 });
 
                 if let Some(context_type) = scope.get_context_type() {
-                    if typ == Ok(Type::Struct(context_type)) {
+                    if typ == Ok(context_type) {
                         if arg.name() != "ctx" {
                             scope.error(
                                 "invalid `Context` instance name",
@@ -213,15 +214,10 @@ pub fn function_signature(
                         ],
                     );
                 }
-                Ok(Type::unit())
+                Ok(TypeId::unit(scope.db()))
             } else {
                 match type_desc(&mut scope, type_node)? {
-                    Type::Struct(val)
-                        if val.id.has_complex_fields(db) && function.is_public(db) =>
-                    {
-                        Ok(Type::Struct(val))
-                    }
-                    typ if typ.has_fixed_size() => Ok(typ),
+                    typ if typ.has_fixed_size(scope.db()) => Ok(typ),
                     _ => Err(TypeError::new(scope.error(
                         "function return type must have a fixed size",
                         type_node.span,
@@ -230,7 +226,7 @@ pub fn function_signature(
                 }
             }
         })
-        .unwrap_or_else(|| Ok(Type::unit()));
+        .unwrap_or_else(|| Ok(TypeId::unit(db)));
 
     Analysis {
         value: Rc::new(types::FunctionSignature {
@@ -248,22 +244,22 @@ pub fn resolve_function_param_type(
     function: FunctionSigId,
     context: &mut dyn AnalyzerContext,
     desc: &Node<ast::TypeDesc>,
-) -> Result<Type, TypeError> {
+) -> Result<TypeId, TypeError> {
     // First check if the param type is a local generic of the function. This won't hold when in the future
     // generics can appear on the contract, struct or module level but it could be good enough for now.
     if let ast::TypeDesc::Base { base } = &desc.kind {
         if let Some(val) = function.generic_param(db, base) {
             let bounds = match val {
-                ast::GenericParameter::Unbounded(_) => vec![],
+                ast::GenericParameter::Unbounded(_) => vec![].into(),
                 ast::GenericParameter::Bounded { bound, .. } => {
-                    vec![type_desc_to_trait(context, &bound)?]
+                    vec![type_desc_to_trait(context, &bound)?].into()
                 }
             };
 
-            return Ok(Type::Generic(Generic {
+            return Ok(db.intern_type(Type::Generic(Generic {
                 name: base.clone(),
                 bounds,
-            }));
+            })));
         }
     }
     type_desc(context, desc)
@@ -279,7 +275,7 @@ pub fn function_body(db: &dyn AnalyzerDb, function: FunctionId) -> Analysis<Rc<F
     // If the return type is anything else, we need to ensure that all code paths
     // return or revert.
     if let Ok(return_type) = &function.signature(db).return_type {
-        if !return_type.is_unit() && !all_paths_return_or_revert(&def.body) {
+        if !return_type.typ(db).is_unit() && !all_paths_return_or_revert(&def.body) {
             scope.fancy_error(
                 "function body is missing a return or revert statement",
                 vec![
@@ -289,7 +285,7 @@ pub fn function_body(db: &dyn AnalyzerDb, function: FunctionId) -> Analysis<Rc<F
                     ),
                     Label::secondary(
                         def.sig.kind.return_type.as_ref().unwrap().span,
-                        format!("expected function to return `{}`", return_type),
+                        format!("expected function to return `{}`", return_type.display(db)),
                     ),
                 ],
                 vec![],
@@ -356,8 +352,8 @@ pub fn function_dependency_graph(db: &dyn AnalyzerDb, function: FunctionId) -> D
             .clone()
             .into_iter()
             .chain(sig.params.iter().filter_map(|param| param.typ.clone().ok()))
-            .filter_map(|typ| match typ {
-                Type::Contract(Contract { id, .. }) => {
+            .filter_map(|id| match id.typ(db) {
+                Type::Contract(id) => {
                     // Contract types that are taken as (non-self) args or returned are "external",
                     // meaning that they're addresses of other contracts, so we don't have direct
                     // access to their fields, etc.
@@ -367,7 +363,7 @@ pub fn function_dependency_graph(db: &dyn AnalyzerDb, function: FunctionId) -> D
                         DepLocality::External,
                     ))
                 }
-                Type::Struct(Struct { id, .. }) => {
+                Type::Struct(id) => {
                     Some((root, Item::Type(TypeDef::Struct(id)), DepLocality::Local))
                 }
                 _ => None,
@@ -404,17 +400,17 @@ pub fn function_dependency_graph(db: &dyn AnalyzerDb, function: FunctionId) -> D
                     DepLocality::External,
                 ));
             }
-            CallType::TypeConstructor(Type::Struct(Struct { id, .. })) => {
-                directs.push((root, Item::Type(TypeDef::Struct(*id)), DepLocality::Local));
-            }
-            CallType::TypeConstructor(Type::Contract(Contract { id, .. })) => {
-                directs.push((
+            CallType::TypeConstructor(type_id) => match type_id.typ(db) {
+                Type::Struct(id) => {
+                    directs.push((root, Item::Type(TypeDef::Struct(id)), DepLocality::Local))
+                }
+                Type::Contract(id) => directs.push((
                     root,
-                    Item::Type(TypeDef::Contract(*id)),
+                    Item::Type(TypeDef::Contract(id)),
                     DepLocality::External,
-                ));
-            }
-            CallType::TypeConstructor(_) => {}
+                )),
+                _ => {}
+            },
             CallType::BuiltinAssociatedFunction { contract, .. } => {
                 // create/create2 call. The contract type is "external" for dependency graph
                 // purposes.
@@ -436,17 +432,21 @@ pub fn function_dependency_graph(db: &dyn AnalyzerDb, function: FunctionId) -> D
             .values()
             .map(|event| (root, Item::Event(*event), DepLocality::Local)),
     );
-    directs.extend(body.var_types.values().filter_map(|typ| match typ {
-        Type::Contract(Contract { id, .. }) => Some((
-            root,
-            Item::Type(TypeDef::Contract(*id)),
-            DepLocality::External,
-        )),
-        Type::Struct(Struct { id, .. }) => {
-            Some((root, Item::Type(TypeDef::Struct(*id)), DepLocality::Local))
-        }
-        _ => None,
-    }));
+    directs.extend(
+        body.var_types
+            .values()
+            .filter_map(|typid| match typid.typ(db) {
+                Type::Contract(id) => Some((
+                    root,
+                    Item::Type(TypeDef::Contract(id)),
+                    DepLocality::External,
+                )),
+                Type::Struct(id) => {
+                    Some((root, Item::Type(TypeDef::Struct(id)), DepLocality::Local))
+                }
+                _ => None,
+            }),
+    );
 
     let mut graph = DepGraph::from_edges(directs.iter());
     for (_, item, _) in directs {

--- a/crates/analyzer/src/db/queries/traits.rs
+++ b/crates/analyzer/src/db/queries/traits.rs
@@ -5,16 +5,9 @@ use smol_str::SmolStr;
 use crate::context::{Analysis, AnalyzerContext};
 use crate::namespace::items::{FunctionSig, FunctionSigId, TraitId};
 use crate::namespace::scopes::ItemScope;
-use crate::namespace::types;
+use crate::namespace::types::TypeId;
 use crate::AnalyzerDb;
 use std::rc::Rc;
-
-pub fn trait_type(db: &dyn AnalyzerDb, trait_: TraitId) -> Rc<types::Trait> {
-    Rc::new(types::Trait {
-        name: trait_.name(db),
-        id: trait_,
-    })
-}
 
 pub fn trait_all_functions(db: &dyn AnalyzerDb, trait_: TraitId) -> Rc<[FunctionSigId]> {
     let trait_data = trait_.data(db);
@@ -58,4 +51,12 @@ pub fn trait_function_map(
         }
     }
     Analysis::new(Rc::new(map), scope.diagnostics.take().into())
+}
+
+pub fn trait_is_implemented_for(db: &dyn AnalyzerDb, trait_: TraitId, ty: TypeId) -> bool {
+    trait_
+        .module(db)
+        .all_impls(db)
+        .iter()
+        .any(|val| val.trait_id(db) == trait_ && val.receiver(db) == ty)
 }

--- a/crates/analyzer/src/db/queries/types.rs
+++ b/crates/analyzer/src/db/queries/types.rs
@@ -10,7 +10,7 @@ use crate::AnalyzerDb;
 pub fn type_alias_type(
     db: &dyn AnalyzerDb,
     alias: TypeAliasId,
-) -> Analysis<Result<types::Type, TypeError>> {
+) -> Analysis<Result<types::TypeId, TypeError>> {
     let mut scope = ItemScope::new(db, alias.data(db).module);
     let typ = type_desc(&mut scope, &alias.data(db).ast.kind.typ);
 
@@ -21,7 +21,7 @@ pub fn type_alias_type_cycle(
     db: &dyn AnalyzerDb,
     _cycle: &[String],
     alias: &TypeAliasId,
-) -> Analysis<Result<types::Type, TypeError>> {
+) -> Analysis<Result<types::TypeId, TypeError>> {
     let mut context = TempContext::default();
     let err = Err(TypeError::new(context.error(
         "recursive type definition",

--- a/crates/analyzer/src/display.rs
+++ b/crates/analyzer/src/display.rs
@@ -1,0 +1,41 @@
+use crate::AnalyzerDb;
+use std::fmt;
+
+pub trait Displayable: DisplayWithDb {
+    fn display<'a, 'b>(&'a self, db: &'b dyn AnalyzerDb) -> DisplayableWrapper<'b, &'a Self> {
+        DisplayableWrapper::new(db, self)
+    }
+}
+impl<T: DisplayWithDb> Displayable for T {}
+
+pub trait DisplayWithDb {
+    fn format(&self, db: &dyn AnalyzerDb, f: &mut fmt::Formatter<'_>) -> fmt::Result;
+}
+
+impl<T: ?Sized> DisplayWithDb for &T
+where
+    T: DisplayWithDb,
+{
+    fn format(&self, db: &dyn AnalyzerDb, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (*self).format(db, f)
+    }
+}
+
+pub struct DisplayableWrapper<'a, T> {
+    db: &'a dyn AnalyzerDb,
+    inner: T,
+}
+impl<'a, T> DisplayableWrapper<'a, T> {
+    pub fn new(db: &'a dyn AnalyzerDb, inner: T) -> Self {
+        Self { db, inner }
+    }
+    pub fn child(&self, inner: T) -> Self {
+        Self { db: self.db, inner }
+    }
+}
+
+impl<T: DisplayWithDb> fmt::Display for DisplayableWrapper<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.format(self.db, f)
+    }
+}

--- a/crates/analyzer/src/lib.rs
+++ b/crates/analyzer/src/lib.rs
@@ -8,14 +8,15 @@ pub mod builtins;
 pub mod constants;
 pub mod context;
 pub mod db;
+pub mod display;
 pub mod errors;
 pub mod namespace;
 mod operations;
 mod traversal;
 
-use crate::namespace::items::{IngotId, ModuleId};
 pub use db::{AnalyzerDb, TestDb};
 use fe_common::diagnostics::Diagnostic;
+use namespace::items::{IngotId, ModuleId};
 
 pub fn analyze_ingot(db: &dyn AnalyzerDb, ingot_id: IngotId) -> Result<(), Vec<Diagnostic>> {
     let diagnostics = ingot_id.diagnostics(db);

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -1,13 +1,12 @@
-use crate::context;
-use fe_common::diagnostics::Label;
-
-use crate::context::{Analysis, Constant};
+use crate::context::{self, Analysis, Constant};
+use crate::display::Displayable;
 use crate::errors::{self, IncompleteItem, TypeError};
-use crate::namespace::types::{self, GenericType};
+use crate::namespace::types::{self, GenericType, Type, TypeDowncast, TypeId};
 use crate::traversal::pragma::check_pragma_version;
 use crate::AnalyzerDb;
 use crate::{builtins, errors::ConstEvalError};
 use fe_common::diagnostics::Diagnostic;
+use fe_common::diagnostics::Label;
 use fe_common::files::{common_prefix, Utf8Path};
 use fe_common::{impl_intern_key, FileKind, SourceFileId};
 use fe_parser::ast::GenericParameter;
@@ -17,10 +16,7 @@ use indexmap::{indexmap, IndexMap};
 use smol_str::SmolStr;
 use std::ops::Deref;
 use std::rc::Rc;
-
 use strum::IntoEnumIterator;
-
-use super::types::{Type, TypeDowncast};
 
 /// A named item. This does not include things inside of
 /// a function body.
@@ -497,7 +493,7 @@ impl ModuleId {
         db.module_all_impls(*self)
     }
 
-    pub fn impls(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<(TraitId, Type), ImplId>> {
+    pub fn impls(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<(TraitId, TypeId), ImplId>> {
         db.module_impl_map(*self).value
     }
 
@@ -729,12 +725,8 @@ impl ModuleConstantId {
     pub fn span(&self, db: &dyn AnalyzerDb) -> Span {
         self.data(db).ast.span
     }
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::Type, TypeError> {
+    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::TypeId, TypeError> {
         db.module_constant_type(*self).value
-    }
-
-    pub fn is_base_type(&self, db: &dyn AnalyzerDb) -> bool {
-        matches!(self.typ(db), Ok(types::Type::Base(_)))
     }
 
     pub fn name(&self, db: &dyn AnalyzerDb) -> SmolStr {
@@ -826,20 +818,17 @@ impl TypeDef {
         }
     }
 
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::Type, TypeError> {
+    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<Type, TypeError> {
         match self {
-            TypeDef::Alias(id) => id.typ(db),
-            TypeDef::Struct(id) => Ok(types::Type::Struct(types::Struct {
-                id: *id,
-                name: id.name(db),
-                field_count: id.fields(db).len(), // for the EvmSized trait
-            })),
-            TypeDef::Contract(id) => Ok(types::Type::Contract(types::Contract {
-                id: *id,
-                name: id.name(db),
-            })),
-            TypeDef::Primitive(base) => Ok(types::Type::Base(*base)),
+            TypeDef::Alias(id) => Ok(id.type_id(db)?.typ(db)),
+            TypeDef::Struct(id) => Ok(Type::Struct(*id)),
+            TypeDef::Contract(id) => Ok(Type::Contract(*id)),
+            TypeDef::Primitive(base) => Ok(Type::Base(*base)),
         }
+    }
+
+    pub fn type_id(&self, db: &dyn AnalyzerDb) -> Result<TypeId, TypeError> {
+        Ok(db.intern_type(self.typ(db)?))
     }
 
     pub fn is_public(&self, db: &dyn AnalyzerDb) -> bool {
@@ -896,7 +885,7 @@ impl TypeAliasId {
     pub fn is_public(&self, db: &dyn AnalyzerDb) -> bool {
         self.data(db).ast.kind.pub_qual.is_some()
     }
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::Type, TypeError> {
+    pub fn type_id(&self, db: &dyn AnalyzerDb) -> Result<types::TypeId, TypeError> {
         db.type_alias_type(*self).value
     }
     pub fn parent(&self, db: &dyn AnalyzerDb) -> Item {
@@ -933,9 +922,6 @@ impl ContractId {
     pub fn is_public(&self, db: &dyn AnalyzerDb) -> bool {
         self.data(db).ast.kind.pub_qual.is_some()
     }
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> types::Type {
-        types::Type::Contract(types::Contract::from_id(*self, db))
-    }
     pub fn name_span(&self, db: &dyn AnalyzerDb) -> Span {
         self.data(db).ast.kind.name.span
     }
@@ -952,7 +938,7 @@ impl ContractId {
         &self,
         db: &dyn AnalyzerDb,
         name: &str,
-    ) -> Option<(Result<types::Type, TypeError>, usize)> {
+    ) -> Option<(Result<types::TypeId, TypeError>, usize)> {
         let fields = db.contract_field_map(*self).value;
         let (index, _, field) = fields.get_full(name)?;
         Some((field.typ(db), index))
@@ -1070,7 +1056,7 @@ impl ContractFieldId {
     pub fn data(&self, db: &dyn AnalyzerDb) -> Rc<ContractField> {
         db.lookup_intern_contract_field(*self)
     }
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::Type, TypeError> {
+    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::TypeId, TypeError> {
         db.contract_field_type(*self).value
     }
     pub fn sink_diagnostics(&self, db: &dyn AnalyzerDb, sink: &mut impl DiagnosticSink) {
@@ -1103,14 +1089,10 @@ impl FunctionSigId {
         self.signature(db).self_decl.is_some()
     }
 
-    pub fn self_typ(&self, db: &dyn AnalyzerDb) -> Option<types::Type> {
+    pub fn self_type(&self, db: &dyn AnalyzerDb) -> Option<types::TypeId> {
         match self.parent(db) {
-            Item::Type(TypeDef::Contract(cid)) => {
-                Some(types::Type::SelfContract(types::Contract::from_id(cid, db)))
-            }
-            Item::Type(TypeDef::Struct(sid)) => {
-                Some(types::Type::Struct(types::Struct::from_id(sid, db)))
-            }
+            Item::Type(TypeDef::Contract(cid)) => Some(types::Type::SelfContract(cid).id(db)),
+            Item::Type(TypeDef::Struct(sid)) => Some(types::Type::Struct(sid).id(db)),
             _ => None,
         }
     }
@@ -1244,8 +1226,8 @@ impl FunctionId {
     pub fn class(&self, db: &dyn AnalyzerDb) -> Option<Class> {
         self.sig(db).class(db)
     }
-    pub fn self_typ(&self, db: &dyn AnalyzerDb) -> Option<types::Type> {
-        self.sig(db).self_typ(db)
+    pub fn self_type(&self, db: &dyn AnalyzerDb) -> Option<types::TypeId> {
+        self.sig(db).self_type(db)
     }
     pub fn parent(&self, db: &dyn AnalyzerDb) -> Item {
         self.sig(db).parent(db)
@@ -1348,8 +1330,9 @@ impl Class {
             // be addressed when we get rid of `Class`.
             Class::Impl(id) => id
                 .receiver(db)
+                .typ(db)
                 .as_struct()
-                .map(|val| Item::Type(TypeDef::Struct(val.id)))
+                .map(|id| Item::Type(TypeDef::Struct(id)))
                 .expect("missing receiver"),
         }
     }
@@ -1386,40 +1369,23 @@ impl StructId {
         self.data(db).module
     }
 
+    pub fn as_type(&self, db: &dyn AnalyzerDb) -> TypeId {
+        db.intern_type(Type::Struct(*self))
+    }
+
     pub fn get_impl_for(&self, db: &dyn AnalyzerDb, trait_: TraitId) -> Option<ImplId> {
         self.module(db)
             .impls(db)
-            .get(&(trait_, Type::Struct((*self.typ(db)).clone())))
+            .get(&(trait_, db.intern_type(Type::Struct(*self))))
             .cloned()
     }
 
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Rc<types::Struct> {
-        db.struct_type(*self)
-    }
-
     pub fn has_private_field(&self, db: &dyn AnalyzerDb) -> bool {
-        self.private_fields(db).iter().count() > 0
+        self.fields(db).values().any(|field| !field.is_public(db))
     }
 
     pub fn field(&self, db: &dyn AnalyzerDb, name: &str) -> Option<StructFieldId> {
         self.fields(db).get(name).copied()
-    }
-    pub fn field_type(
-        &self,
-        db: &dyn AnalyzerDb,
-        name: &str,
-    ) -> Option<Result<types::Type, TypeError>> {
-        Some(self.field(db, name)?.typ(db))
-    }
-
-    pub fn is_base_type(&self, db: &dyn AnalyzerDb, name: &str) -> bool {
-        matches!(self.field_type(db, name), Some(Ok(types::Type::Base(_))))
-    }
-
-    pub fn has_complex_fields(&self, db: &dyn AnalyzerDb) -> bool {
-        self.fields(db)
-            .iter()
-            .any(|(name, _)| !self.is_base_type(db, name.as_str()))
     }
 
     pub fn fields(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<SmolStr, StructFieldId>> {
@@ -1438,20 +1404,6 @@ impl StructId {
     }
     pub fn parent(&self, db: &dyn AnalyzerDb) -> Item {
         Item::Module(self.data(db).module)
-    }
-    pub fn private_fields(&self, db: &dyn AnalyzerDb) -> Rc<IndexMap<SmolStr, StructFieldId>> {
-        Rc::new(
-            self.fields(db)
-                .iter()
-                .filter_map(|(name, field)| {
-                    if field.is_public(db) {
-                        None
-                    } else {
-                        Some((name.clone(), *field))
-                    }
-                })
-                .collect(),
-        )
     }
     pub fn dependency_graph(&self, db: &dyn AnalyzerDb) -> Rc<DepGraph> {
         db.struct_dependency_graph(*self).value.0
@@ -1489,11 +1441,8 @@ impl StructFieldId {
     pub fn data(&self, db: &dyn AnalyzerDb) -> Rc<StructField> {
         db.lookup_intern_struct_field(*self)
     }
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::Type, TypeError> {
+    pub fn typ(&self, db: &dyn AnalyzerDb) -> Result<types::TypeId, TypeError> {
         db.struct_field_type(*self).value
-    }
-    pub fn is_base_type(&self, db: &dyn AnalyzerDb) -> bool {
-        matches!(self.typ(db), Ok(types::Type::Base(_)))
     }
     pub fn is_public(&self, db: &dyn AnalyzerDb) -> bool {
         self.data(db).ast.kind.is_pub
@@ -1507,7 +1456,7 @@ impl StructFieldId {
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Impl {
     pub trait_id: TraitId,
-    pub receiver: Type,
+    pub receiver: TypeId,
     pub module: ModuleId,
     pub ast: Node<ast::Impl>,
 }
@@ -1535,8 +1484,8 @@ impl ImplId {
         self.data(db).trait_id
     }
 
-    pub fn receiver(&self, db: &dyn AnalyzerDb) -> Type {
-        self.data(db).receiver.clone()
+    pub fn receiver(&self, db: &dyn AnalyzerDb) -> TypeId {
+        self.data(db).receiver
     }
 
     pub fn ast(&self, db: &dyn AnalyzerDb) -> Node<ast::Impl> {
@@ -1556,7 +1505,7 @@ impl ImplId {
         format!(
             "{}_{}",
             self.trait_id(db).name(db),
-            self.receiver(db).name()
+            self.receiver(db).display(db)
         )
         .into()
     }
@@ -1580,7 +1529,7 @@ impl ImplId {
                     self.data(db).ast.span,
                     format!(
                         "Neither `{}` nor `{}` are in the ingot of the `impl` block",
-                        self.data(db).receiver,
+                        self.data(db).receiver.display(db),
                         self.data(db).trait_id.name(db)
                     ),
                 )],
@@ -1590,7 +1539,7 @@ impl ImplId {
     }
 
     pub fn sink_diagnostics(&self, db: &dyn AnalyzerDb, sink: &mut impl DiagnosticSink) {
-        match &self.data(db).receiver {
+        match &self.data(db).receiver.typ(db) {
             Type::Contract(_)
             | Type::Map(_)
             | Type::SelfContract(_)
@@ -1603,7 +1552,7 @@ impl ImplId {
             | Type::String(_) => sink.push(&errors::fancy_error(
                 format!(
                     "`impl` blocks aren't allowed for {}",
-                    self.data(db).receiver
+                    self.data(db).receiver.display(db)
                 ),
                 vec![Label::primary(
                     self.data(db).ast.span,
@@ -1611,8 +1560,8 @@ impl ImplId {
                 )],
                 vec![],
             )),
-            Type::Struct(val) => {
-                self.validate_type_or_trait_is_in_ingot(db, sink, Some(val.id.module(db)))
+            Type::Struct(id) => {
+                self.validate_type_or_trait_is_in_ingot(db, sink, Some(id.module(db)))
             }
         }
 
@@ -1755,16 +1704,13 @@ impl TraitId {
         self.data(db).module
     }
 
-    pub fn is_implemented_for(&self, db: &dyn AnalyzerDb, ty: &Type) -> bool {
+    pub fn is_implemented_for(&self, db: &dyn AnalyzerDb, ty: TypeId) -> bool {
         self.module(db)
             .all_impls(db)
             .iter()
-            .any(|val| &val.trait_id(db) == self && &val.receiver(db) == ty)
+            .any(|val| &val.trait_id(db) == self && val.receiver(db) == ty)
     }
 
-    pub fn typ(&self, db: &dyn AnalyzerDb) -> Rc<types::Trait> {
-        db.trait_type(*self)
-    }
     pub fn is_in_std(&self, db: &dyn AnalyzerDb) -> bool {
         self.module(db).is_in_std(db)
     }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -1,16 +1,19 @@
 use crate::context::AnalyzerContext;
+use crate::display::DisplayWithDb;
+use crate::display::Displayable;
 use crate::errors::TypeError;
 use crate::namespace::items::{Class, ContractId, StructId, TraitId};
 use crate::AnalyzerDb;
 
+use fe_common::impl_intern_key;
 use fe_common::Span;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use smol_str::SmolStr;
 use std::fmt;
+use std::rc::Rc;
 use std::str::FromStr;
 use strum::{AsRefStr, EnumIter, EnumString};
-use vec1::Vec1;
 
 pub fn u256_min() -> BigInt {
     BigInt::from(0)
@@ -42,12 +45,57 @@ pub enum Type {
     Tuple(Tuple),
     String(FeString),
     /// An "external" contract. Effectively just a `newtype`d address.
-    Contract(Contract),
+    Contract(ContractId),
     /// The type of a contract while it's being executed. Ie. the type
     /// of `self` within a contract function.
-    SelfContract(Contract),
-    Struct(Struct),
+    SelfContract(ContractId),
+    Struct(StructId),
     Generic(Generic),
+}
+#[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
+pub struct TypeId(pub(crate) u32);
+impl_intern_key!(TypeId);
+impl TypeId {
+    pub fn unit(db: &dyn AnalyzerDb) -> Self {
+        db.intern_type(Type::unit())
+    }
+    pub fn bool(db: &dyn AnalyzerDb) -> Self {
+        db.intern_type(Type::bool())
+    }
+    pub fn int(db: &dyn AnalyzerDb, int: Integer) -> Self {
+        db.intern_type(Type::int(int))
+    }
+    pub fn address(db: &dyn AnalyzerDb) -> Self {
+        db.intern_type(Type::Base(Base::Address))
+    }
+    pub fn base(db: &dyn AnalyzerDb, t: Base) -> Self {
+        db.intern_type(Type::Base(t))
+    }
+
+    pub fn typ(&self, db: &dyn AnalyzerDb) -> Type {
+        db.lookup_intern_type(*self)
+    }
+    pub fn has_fixed_size(&self, db: &dyn AnalyzerDb) -> bool {
+        self.typ(db).has_fixed_size()
+    }
+    pub fn is_base(&self, db: &dyn AnalyzerDb) -> bool {
+        self.typ(db).is_base()
+    }
+    pub fn is_bool(&self, db: &dyn AnalyzerDb) -> bool {
+        matches!(self.typ(db), Type::Base(Base::Bool))
+    }
+    pub fn is_integer(&self, db: &dyn AnalyzerDb) -> bool {
+        self.typ(db).is_integer()
+    }
+    pub fn is_string(&self, db: &dyn AnalyzerDb) -> bool {
+        self.typ(db).as_string().is_some()
+    }
+    pub fn as_struct(&self, db: &dyn AnalyzerDb) -> Option<StructId> {
+        self.typ(db).as_struct()
+    }
+    pub fn as_class(&self, db: &dyn AnalyzerDb) -> Option<Class> {
+        self.typ(db).as_class()
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -93,71 +141,27 @@ pub enum Integer {
 
 pub const U256: Base = Base::Numeric(Integer::U256);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Array {
     pub size: usize,
-    pub inner: Box<Type>,
+    pub inner: TypeId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Map {
-    pub key: Base,
-    pub value: Box<Type>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Tuple {
-    pub items: Vec1<Type>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Struct {
-    pub name: SmolStr,
-    pub id: StructId,
-    pub field_count: usize,
-}
-impl Struct {
-    pub fn from_id(id: StructId, db: &dyn AnalyzerDb) -> Self {
-        Self {
-            name: id.name(db),
-            id,
-            field_count: id.fields(db).len(),
-        }
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Trait {
-    pub name: SmolStr,
-    pub id: TraitId,
-}
-impl Trait {
-    pub fn from_id(id: TraitId, db: &dyn AnalyzerDb) -> Self {
-        Self {
-            name: id.name(db),
-            id,
-        }
-    }
+    pub key: TypeId,
+    pub value: TypeId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Generic {
     pub name: SmolStr,
-    pub bounds: Vec<TraitId>,
+    pub bounds: Rc<[TraitId]>,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Contract {
-    pub name: SmolStr,
-    pub id: ContractId,
-}
-impl Contract {
-    pub fn from_id(id: ContractId, db: &dyn AnalyzerDb) -> Self {
-        Self {
-            name: id.name(db),
-            id,
-        }
-    }
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Tuple {
+    pub items: Rc<[TypeId]>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
@@ -170,7 +174,7 @@ pub struct FunctionSignature {
     pub self_decl: Option<SelfDecl>,
     pub ctx_decl: Option<CtxDecl>,
     pub params: Vec<FunctionParam>,
-    pub return_type: Result<Type, TypeError>,
+    pub return_type: Result<TypeId, TypeError>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
@@ -187,10 +191,10 @@ pub enum CtxDecl {
 pub struct FunctionParam {
     label: Option<SmolStr>,
     pub name: SmolStr,
-    pub typ: Result<Type, TypeError>,
+    pub typ: Result<TypeId, TypeError>,
 }
 impl FunctionParam {
-    pub fn new(label: Option<&str>, name: &str, typ: Result<Type, TypeError>) -> Self {
+    pub fn new(label: Option<&str>, name: &str, typ: Result<TypeId, TypeError>) -> Self {
         Self {
             label: label.map(SmolStr::new),
             name: name.into(),
@@ -249,8 +253,8 @@ impl GenericType {
     }
 
     // see traversal::types::apply_generic_type_args for error checking
-    pub fn apply(&self, args: &[GenericArg]) -> Option<Type> {
-        match self {
+    pub fn apply(&self, db: &dyn AnalyzerDb, args: &[GenericArg]) -> Option<TypeId> {
+        let typ = match self {
             GenericType::String => match args {
                 [GenericArg::Int(max_size)] => Some(Type::String(FeString {
                     max_size: *max_size,
@@ -259,19 +263,20 @@ impl GenericType {
             },
             GenericType::Map => match args {
                 [GenericArg::Type(key), GenericArg::Type(value)] => Some(Type::Map(Map {
-                    key: key.as_primitive()?,
-                    value: Box::new(value.clone()),
+                    key: *key,
+                    value: *value,
                 })),
                 _ => None,
             },
             GenericType::Array => match args {
                 [GenericArg::Type(element), GenericArg::Int(size)] => Some(Type::Array(Array {
                     size: *size,
-                    inner: Box::new(element.clone()),
+                    inner: *element,
                 })),
                 _ => None,
             },
-        }
+        }?;
+        Some(db.intern_type(typ))
     }
 }
 
@@ -293,7 +298,7 @@ pub enum GenericParamKind {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum GenericArg {
     Int(usize),
-    Type(Type),
+    Type(TypeId),
 }
 
 impl Integer {
@@ -328,7 +333,7 @@ impl Integer {
 
     /// Returns `true` if the integer is at least the same size (or larger) than
     /// `other`
-    pub fn can_hold(&self, other: &Integer) -> bool {
+    pub fn can_hold(&self, other: Integer) -> bool {
         self.size() >= other.size()
     }
 
@@ -396,28 +401,25 @@ pub struct Event {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EventField {
     pub name: SmolStr,
-    pub typ: Result<Type, TypeError>,
+    pub typ: Result<TypeId, TypeError>,
     pub is_indexed: bool,
 }
 
 impl Type {
-    pub fn name(&self) -> SmolStr {
+    pub fn id(&self, db: &dyn AnalyzerDb) -> TypeId {
+        db.intern_type(self.clone())
+    }
+    pub fn name(&self, db: &dyn AnalyzerDb) -> SmolStr {
         match self {
             Type::Base(inner) => inner.name(),
-            Type::Array(inner) => inner.to_string().into(),
-            Type::Map(inner) => inner.to_string().into(),
-            Type::Tuple(inner) => inner.to_string().into(),
-            Type::String(inner) => inner.to_string().into(),
-            Type::Struct(inner) => inner.name.clone(),
-            Type::Generic(inner) => inner.name.clone(),
-            Type::Contract(inner) | Type::SelfContract(inner) => inner.name.clone(),
+            _ => self.display(db).to_string().into(),
         }
     }
 
     pub fn def_span(&self, context: &dyn AnalyzerContext) -> Option<Span> {
         match self {
-            Self::Struct(inner) => Some(inner.id.span(context.db())),
-            Self::Contract(inner) | Self::SelfContract(inner) => Some(inner.id.span(context.db())),
+            Self::Struct(id) => Some(id.span(context.db())),
+            Self::Contract(id) | Self::SelfContract(id) => Some(id.span(context.db())),
             _ => None,
         }
     }
@@ -493,8 +495,8 @@ pub trait TypeDowncast {
     fn as_int(&self) -> Option<Integer>;
     fn as_primitive(&self) -> Option<Base>;
     fn as_class(&self) -> Option<Class>;
-    fn as_generic(&self) -> Option<Generic>;
-    fn as_struct(&self) -> Option<Struct>;
+    fn as_generic(&self) -> Option<&Generic>;
+    fn as_struct(&self) -> Option<StructId>;
 }
 
 impl TypeDowncast for Type {
@@ -536,8 +538,8 @@ impl TypeDowncast for Type {
     }
     fn as_class(&self) -> Option<Class> {
         match self {
-            Type::Struct(inner) => Some(Class::Struct(inner.id)),
-            Type::Contract(inner) | Type::SelfContract(inner) => Some(Class::Contract(inner.id)),
+            Type::Struct(id) => Some(Class::Struct(*id)),
+            Type::Contract(id) | Type::SelfContract(id) => Some(Class::Contract(*id)),
             Type::Generic(inner) if !inner.bounds.is_empty() => {
                 // FIXME: This won't hold when we support multiple bounds or traits can be implemented for non-struct types
                 inner.bounds.first().map(TraitId::as_class)
@@ -545,15 +547,15 @@ impl TypeDowncast for Type {
             _ => None,
         }
     }
-    fn as_struct(&self) -> Option<Struct> {
+    fn as_struct(&self) -> Option<StructId> {
         match self {
-            Type::Struct(val) => Some(val.clone()),
+            Type::Struct(id) => Some(*id),
             _ => None,
         }
     }
-    fn as_generic(&self) -> Option<Generic> {
+    fn as_generic(&self) -> Option<&Generic> {
         match self {
-            Type::Generic(generic) => Some(generic.clone()),
+            Type::Generic(inner) => Some(inner),
             _ => None,
         }
     }
@@ -581,10 +583,10 @@ impl TypeDowncast for Option<&Type> {
     fn as_class(&self) -> Option<Class> {
         self.and_then(TypeDowncast::as_class)
     }
-    fn as_struct(&self) -> Option<Struct> {
+    fn as_struct(&self) -> Option<StructId> {
         self.and_then(TypeDowncast::as_struct)
     }
-    fn as_generic(&self) -> Option<Generic> {
+    fn as_generic(&self) -> Option<&Generic> {
         self.and_then(TypeDowncast::as_generic)
     }
 }
@@ -595,97 +597,37 @@ impl From<Base> for Type {
     }
 }
 
-impl SafeNames for Type {
-    fn lower_snake(&self) -> String {
-        match self {
-            Type::Array(array) => array.lower_snake(),
-            Type::Base(base) => base.lower_snake(),
-            Type::Tuple(tuple) => tuple.lower_snake(),
-            Type::String(string) => string.lower_snake(),
-            Type::Contract(contract) => contract.lower_snake(),
-            Type::Struct(val) => val.lower_snake(),
-            _ => panic!("Can not construct safe name for {self}"),
-        }
-    }
-}
-
-impl SafeNames for Base {
-    fn lower_snake(&self) -> String {
-        match self {
-            Base::Numeric(Integer::U256) => "u256".to_string(),
-            Base::Numeric(Integer::U128) => "u128".to_string(),
-            Base::Numeric(Integer::U64) => "u64".to_string(),
-            Base::Numeric(Integer::U32) => "u32".to_string(),
-            Base::Numeric(Integer::U16) => "u16".to_string(),
-            Base::Numeric(Integer::U8) => "u8".to_string(),
-            Base::Numeric(Integer::I256) => "i256".to_string(),
-            Base::Numeric(Integer::I128) => "i128".to_string(),
-            Base::Numeric(Integer::I64) => "i64".to_string(),
-            Base::Numeric(Integer::I32) => "i32".to_string(),
-            Base::Numeric(Integer::I16) => "i16".to_string(),
-            Base::Numeric(Integer::I8) => "i8".to_string(),
-            Base::Address => "address".to_string(),
-            Base::Bool => "bool".to_string(),
-            Base::Unit => "unit".to_string(),
-        }
-    }
-}
-
-impl SafeNames for Array {
-    fn lower_snake(&self) -> String {
-        format!("array_{}_{}", self.inner.lower_snake(), self.size)
-    }
-}
-
-impl SafeNames for Struct {
-    fn lower_snake(&self) -> String {
-        format!("struct_{}", self.name)
-    }
-}
-
-impl SafeNames for Tuple {
-    fn lower_snake(&self) -> String {
-        let field_names = self
-            .items
-            .iter()
-            .map(SafeNames::lower_snake)
-            .collect::<Vec<String>>();
-        let joined_names = field_names.join("_");
-
-        // The trailing `_` denotes the end of the tuple, to differentiate between
-        // different tuple nestings. Eg
-        // (A, (B, C), D) => tuple_A_tuple_B_C__D_
-        // (A, (B, C, D)) => tuple_A_tuple_B_C_D__
-        // Conceptually, each paren and comma is replaced with an underscore.
-        format!("tuple_{}_", joined_names)
-    }
-}
-
-impl SafeNames for Contract {
-    fn lower_snake(&self) -> String {
-        unimplemented!();
-    }
-}
-
-impl SafeNames for FeString {
-    fn lower_snake(&self) -> String {
-        format!("string_{}", self.max_size)
-    }
-}
-
-impl fmt::Display for Type {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl DisplayWithDb for Type {
+    fn format(&self, db: &dyn AnalyzerDb, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use std::fmt::Display;
         match self {
             Type::Base(inner) => inner.fmt(f),
-            Type::Array(inner) => inner.fmt(f),
-            Type::Map(inner) => inner.fmt(f),
-            Type::Tuple(inner) => inner.fmt(f),
             Type::String(inner) => inner.fmt(f),
-            Type::Contract(inner) => inner.fmt(f),
-            Type::SelfContract(inner) => inner.fmt(f),
-            Type::Struct(inner) => inner.fmt(f),
+            Type::Array(arr) => {
+                write!(f, "Array<{}, {}>", arr.inner.display(db), arr.size)
+            }
+            Type::Map(map) => {
+                let Map { key, value } = map;
+                write!(f, "Map<{}, {}>", key.display(db), value.display(db),)
+            }
+            Type::Tuple(id) => {
+                write!(f, "(")?;
+                let mut delim = "";
+                for item in id.items.iter() {
+                    write!(f, "{}{}", delim, item.display(db))?;
+                    delim = ", ";
+                }
+                write!(f, ")")
+            }
+            Type::Contract(id) | Type::SelfContract(id) => write!(f, "{}", id.name(db)),
+            Type::Struct(id) => write!(f, "{}", id.name(db)),
             Type::Generic(inner) => inner.fmt(f),
         }
+    }
+}
+impl DisplayWithDb for TypeId {
+    fn format(&self, db: &dyn AnalyzerDb, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.typ(db).format(db, f)
     }
 }
 
@@ -721,71 +663,36 @@ impl fmt::Display for Integer {
     }
 }
 
-impl fmt::Display for Array {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Array<{}, {}>", self.inner, self.size)
-    }
-}
-
-impl fmt::Display for Map {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Map<{}, {}>", self.key, self.value)
-    }
-}
-
-impl fmt::Display for Tuple {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(")?;
-        let mut delim = "";
-        for item in &self.items {
-            write!(f, "{}{}", delim, item)?;
-            delim = ", ";
-        }
-        write!(f, ")")
-    }
-}
-
 impl fmt::Display for FeString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "String<{}>", self.max_size)
     }
 }
 
-impl fmt::Display for Contract {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-impl fmt::Debug for Contract {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Contract")
-            .field("name", &self.name)
-            .finish()
-    }
-}
+impl DisplayWithDb for FunctionSignature {
+    fn format(&self, db: &dyn AnalyzerDb, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let FunctionSignature {
+            self_decl,
+            ctx_decl: _,
+            params,
+            return_type,
+        } = self;
 
-impl fmt::Display for Struct {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-impl fmt::Debug for Struct {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Struct")
-            .field("name", &self.name)
-            .field("field_count", &self.field_count)
-            .finish()
-    }
-}
-
-impl fmt::Display for Trait {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-impl fmt::Debug for Trait {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Struct").field("name", &self.name).finish()
+        write!(f, "self: {:?}, ", self_decl)?;
+        write!(f, "params: [")?;
+        let mut delim = "";
+        for p in params {
+            write!(
+                f,
+                "{}{{ label: {:?}, name: {}, typ: {} }}",
+                delim,
+                p.label,
+                p.name,
+                p.typ.as_ref().unwrap().display(db),
+            )?;
+            delim = ", ";
+        }
+        write!(f, "] -> {}", return_type.as_ref().unwrap().display(db))
     }
 }
 

--- a/crates/analyzer/src/operations.rs
+++ b/crates/analyzer/src/operations.rs
@@ -1,15 +1,16 @@
 use crate::errors::{BinaryOperationError, IndexingError};
-use crate::namespace::types::{Array, Base, Map, Type, U256};
+use crate::namespace::types::{Array, Base, Integer, Map, Type, TypeId};
+use crate::AnalyzerDb;
 
 use fe_parser::ast as fe;
 
 /// Finds the type of an index operation and checks types.
 ///
 /// e.g. `foo[42]`
-pub fn index(value: Type, index: Type) -> Result<Type, IndexingError> {
-    match value {
-        Type::Array(array) => index_array(array, index),
-        Type::Map(map) => index_map(map, index),
+pub fn index(db: &dyn AnalyzerDb, value: TypeId, index: TypeId) -> Result<TypeId, IndexingError> {
+    match value.typ(db) {
+        Type::Array(array) => index_array(db, &array, index),
+        Type::Map(map) => index_map(&map, index),
         Type::Base(_)
         | Type::Tuple(_)
         | Type::String(_)
@@ -20,150 +21,97 @@ pub fn index(value: Type, index: Type) -> Result<Type, IndexingError> {
     }
 }
 
-fn index_array(array: Array, index: Type) -> Result<Type, IndexingError> {
-    if index != Type::Base(U256) {
+fn index_array(db: &dyn AnalyzerDb, array: &Array, index: TypeId) -> Result<TypeId, IndexingError> {
+    if index.typ(db) != Type::u256() {
         return Err(IndexingError::WrongIndexType);
     }
 
-    Ok(array.inner.as_ref().clone())
+    Ok(array.inner)
 }
 
-fn index_map(map: Map, index: Type) -> Result<Type, IndexingError> {
-    if index != Type::Base(map.key) {
+fn index_map(map: &Map, index: TypeId) -> Result<TypeId, IndexingError> {
+    let Map { key, value } = map;
+    if index != *key {
         return Err(IndexingError::WrongIndexType);
     }
-
-    Ok(*map.value)
+    Ok(*value)
 }
 
 /// Finds the type of a binary operation and checks types.
-pub fn bin(left: &Type, op: &fe::BinOperator, right: &Type) -> Result<Type, BinaryOperationError> {
-    match op {
-        fe::BinOperator::Add
-        | fe::BinOperator::Sub
-        | fe::BinOperator::Mult
-        | fe::BinOperator::Div
-        | fe::BinOperator::Mod => bin_arithmetic(left, right),
-        fe::BinOperator::Pow => bin_pow(left, right),
-        fe::BinOperator::LShift | fe::BinOperator::RShift => bin_bit_shift(left, right),
-        fe::BinOperator::BitOr | fe::BinOperator::BitXor | fe::BinOperator::BitAnd => {
-            bin_bit(left, right)
-        }
-    }
-}
-
-fn bin_arithmetic(left: &Type, right: &Type) -> Result<Type, BinaryOperationError> {
-    if let (Type::Base(Base::Numeric(left)), Type::Base(Base::Numeric(right))) = (left, right) {
-        if left == right {
-            // For now, we require that the types be numeric and equal. In the future, we
-            // will want to loosen this up such that arithmetic operations can be performed
-            // on different types.
-            //
-            // The rules should be:
-            // - Any combination of numeric types can be operated on.
-            // - If either number is signed, we return a signed type.
-            // - The larger type is returned.
-            Ok(Type::Base(Base::Numeric(*left)))
-        } else {
-            // The types are not equal. Again, there is no need to be this strict.
-            Err(BinaryOperationError::TypesNotEqual)
-        }
+pub fn bin(
+    db: &dyn AnalyzerDb,
+    left: TypeId,
+    op: fe::BinOperator,
+    right: TypeId,
+) -> Result<TypeId, BinaryOperationError> {
+    if let (Type::Base(Base::Numeric(left)), Type::Base(Base::Numeric(right))) =
+        (left.typ(db), right.typ(db))
+    {
+        let int = match op {
+            fe::BinOperator::Add
+            | fe::BinOperator::Sub
+            | fe::BinOperator::Mult
+            | fe::BinOperator::Div
+            | fe::BinOperator::Mod => bin_arithmetic(left, right),
+            fe::BinOperator::Pow => bin_pow(left, right),
+            fe::BinOperator::LShift | fe::BinOperator::RShift => bin_bit_shift(left, right),
+            fe::BinOperator::BitOr | fe::BinOperator::BitXor | fe::BinOperator::BitAnd => {
+                bin_bit(left, right)
+            }
+        }?;
+        Ok(TypeId::int(db, int))
     } else {
         Err(BinaryOperationError::TypesNotNumeric)
     }
 }
 
-fn bin_pow(left: &Type, right: &Type) -> Result<Type, BinaryOperationError> {
-    if let (Type::Base(Base::Numeric(left)), Type::Base(Base::Numeric(right))) = (left, right) {
-        // The exponent is not allowed to be a signed integer. To allow calculations
-        // such as -2 ** 3 we allow the right hand side to be an unsigned integer
-        // even if the left side is a signed integer. It is allowed as long as the
-        // right side is the same size or smaller than the left side (e.g. i16 ** u16
-        // but not i16 ** u32). The type of the result will be the type of the left
-        // side and under/overflow checks are based on that type.
-        if right.is_signed() {
-            Err(BinaryOperationError::RightIsSigned)
-        } else if left.can_hold(right) {
-            Ok(Type::Base(Base::Numeric(*left)))
-        } else {
-            Err(BinaryOperationError::RightTooLarge)
-        }
+fn bin_arithmetic(left: Integer, right: Integer) -> Result<Integer, BinaryOperationError> {
+    if left == right {
+        // For now, we require that the types be numeric and equal. In the future, we
+        // will want to loosen this up such that arithmetic operations can be performed
+        // on different types.
+        //
+        // The rules should be:
+        // - Any combination of numeric types can be operated on.
+        // - If either number is signed, we return a signed type.
+        // - The larger type is returned.
+        Ok(left)
     } else {
-        Err(BinaryOperationError::TypesNotNumeric)
+        // The types are not equal. Again, there is no need to be this strict.
+        Err(BinaryOperationError::TypesNotEqual)
     }
 }
 
-fn bin_bit_shift(left: &Type, right: &Type) -> Result<Type, BinaryOperationError> {
-    if let (Type::Base(Base::Numeric(left)), Type::Base(Base::Numeric(right))) = (left, right) {
-        // The right side must be unsigned.
-        if right.is_signed() {
-            Err(BinaryOperationError::RightIsSigned)
-        } else {
-            Ok(Type::Base(Base::Numeric(*left)))
-        }
+fn bin_pow(left: Integer, right: Integer) -> Result<Integer, BinaryOperationError> {
+    // The exponent is not allowed to be a signed integer. To allow calculations
+    // such as -2 ** 3 we allow the right hand side to be an unsigned integer
+    // even if the left side is a signed integer. It is allowed as long as the
+    // right side is the same size or smaller than the left side (e.g. i16 ** u16
+    // but not i16 ** u32). The type of the result will be the type of the left
+    // side and under/overflow checks are based on that type.
+    if right.is_signed() {
+        Err(BinaryOperationError::RightIsSigned)
+    } else if left.can_hold(right) {
+        Ok(left)
     } else {
-        Err(BinaryOperationError::TypesNotNumeric)
+        Err(BinaryOperationError::RightTooLarge)
     }
 }
 
-fn bin_bit(left: &Type, right: &Type) -> Result<Type, BinaryOperationError> {
-    if let (Type::Base(Base::Numeric(left)), Type::Base(Base::Numeric(right))) = (left, right) {
-        // We require that both numbers be unsigned and equal in size.
-        if !left.is_signed() && left == right {
-            Ok(Type::Base(Base::Numeric(*left)))
-        } else {
-            Err(BinaryOperationError::NotEqualAndUnsigned)
-        }
+fn bin_bit_shift(left: Integer, right: Integer) -> Result<Integer, BinaryOperationError> {
+    // The right side must be unsigned.
+    if right.is_signed() {
+        Err(BinaryOperationError::RightIsSigned)
     } else {
-        Err(BinaryOperationError::TypesNotNumeric)
+        Ok(left)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::errors::IndexingError;
-    use crate::namespace::types::{Array, Base, Map, Type, U256};
-    use crate::operations;
-    use rstest::rstest;
-
-    const U256_TYPE: Type = Type::Base(U256);
-    const BOOL_TYPE: Type = Type::Base(Base::Bool);
-
-    fn u256_array_type() -> Type {
-        Type::Array(Array {
-            inner: Box::new(U256.into()),
-            size: 100,
-        })
-    }
-
-    fn u256_bool_map() -> Type {
-        Type::Map(Map {
-            key: U256,
-            value: Box::new(Type::Base(Base::Bool)),
-        })
-    }
-
-    #[rstest(
-        value,
-        index,
-        expected,
-        case(u256_array_type(), U256_TYPE, U256_TYPE),
-        case(u256_bool_map(), U256_TYPE, BOOL_TYPE)
-    )]
-    fn basic_index(value: Type, index: Type, expected: Type) {
-        let actual = operations::index(value, index).expect("failed to get expected type");
-        assert_eq!(actual, expected)
-    }
-
-    #[rstest(
-        value,
-        index,
-        case(u256_array_type(), BOOL_TYPE),
-        case(u256_bool_map(), BOOL_TYPE),
-        case(u256_bool_map(), u256_array_type())
-    )]
-    fn type_error_index(value: Type, index: Type) {
-        let actual = operations::index(value, index).expect_err("didn't fail");
-        assert_eq!(actual, IndexingError::WrongIndexType)
+fn bin_bit(left: Integer, right: Integer) -> Result<Integer, BinaryOperationError> {
+    // We require that both numbers be unsigned and equal in size.
+    if !left.is_signed() && left == right {
+        Ok(left)
+    } else {
+        Err(BinaryOperationError::NotEqualAndUnsigned)
     }
 }

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -1,12 +1,13 @@
 use crate::context::{AnalyzerContext, ExpressionAttributes, Location, NamedThing};
-use crate::errors::FatalError;
+use crate::display::Displayable;
+use crate::errors::{self, FatalError};
 use crate::namespace::items::Item;
 use crate::namespace::scopes::{BlockScope, BlockScopeType};
-use crate::namespace::types::{Base, EventField, Type};
+use crate::namespace::types::{EventField, Type, TypeId};
 use crate::traversal::{assignments, call_args, declarations, expressions};
 use fe_common::diagnostics::Label;
 use fe_parser::ast as fe;
-use fe_parser::node::Node;
+use fe_parser::node::{Node, Span};
 
 pub fn traverse_statements(
     scope: &mut BlockScope,
@@ -46,29 +47,22 @@ fn for_loop(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), Fat
         fe::FuncStmt::For { target, iter, body } => {
             // Make sure iter is in the function scope & it should be an array.
             let iter_type = expressions::assignable_expr(scope, iter, None)?.typ;
-            let target_type = if let Type::Array(array) = iter_type {
+            let target_type = if let Type::Array(array) = iter_type.typ(scope.db()) {
                 array.inner
             } else {
-                return Err(FatalError::new(scope.type_error(
+                return Err(FatalError::new(scope.register_diag(errors::type_error(
                     "invalid `for` loop iterator type",
                     iter.span,
                     &"array",
-                    &iter_type,
-                )));
+                    &iter_type.display(scope.db()),
+                ))));
             };
 
-            scope
-                .root
-                .map_variable_type(target, target_type.as_ref().clone());
+            scope.root.map_variable_type(target, target_type);
 
             let mut body_scope = scope.new_child(BlockScopeType::Loop);
             // add_var emits a msg on err; we can ignore the Result.
-            let _ = body_scope.add_var(
-                &target.kind,
-                target_type.as_ref().clone(),
-                false,
-                target.span,
-            );
+            let _ = body_scope.add_var(&target.kind, target_type, false, target.span);
 
             // Traverse the statements within the `for loop` body scope.
             traverse_statements(&mut body_scope, body)
@@ -103,20 +97,23 @@ fn if_statement(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(),
             or_else,
         } => {
             let test_type = expressions::value_expr(scope, test, None)?.typ;
-            if test_type != Type::Base(Base::Bool) {
-                scope.type_error(
-                    "`if` statement condition is not bool",
-                    test.span,
-                    &Base::Bool,
-                    &test_type,
-                );
-            }
-
+            error_if_not_bool(
+                scope,
+                test_type,
+                test.span,
+                "`if` statement condition is not bool",
+            );
             traverse_statements(&mut scope.new_child(BlockScopeType::IfElse), body)?;
             traverse_statements(&mut scope.new_child(BlockScopeType::IfElse), or_else)?;
             Ok(())
         }
         _ => unreachable!(),
+    }
+}
+
+fn error_if_not_bool(scope: &mut BlockScope, typ: TypeId, span: Span, msg: &str) {
+    if typ.typ(scope.db()) != Type::bool() {
+        scope.type_error(msg, span, scope.db().intern_type(Type::bool()), typ);
     }
 }
 
@@ -140,15 +137,12 @@ fn while_loop(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), F
     match &stmt.kind {
         fe::FuncStmt::While { test, body } => {
             let test_type = expressions::value_expr(scope, test, None)?.typ;
-            if test_type != Type::Base(Base::Bool) {
-                scope.type_error(
-                    "`while` loop condition is not bool",
-                    test.span,
-                    &Base::Bool,
-                    &test_type,
-                );
-            }
-
+            error_if_not_bool(
+                scope,
+                test_type,
+                test.span,
+                "`while` loop condition is not bool",
+            );
             traverse_statements(&mut scope.new_child(BlockScopeType::Loop), body)?;
             Ok(())
         }
@@ -195,7 +189,7 @@ fn emit(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalEr
                     let params_with_ctx = [
                         vec![EventField {
                             name: "ctx".into(),
-                            typ: Ok(Type::Struct(context_type)),
+                            typ: Ok(context_type),
                             is_indexed: false,
                         }],
                         event.typ(scope.db()).fields.clone(),
@@ -252,22 +246,23 @@ fn emit(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalEr
 fn assert(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalError> {
     if let fe::FuncStmt::Assert { test, msg } = &stmt.kind {
         let test_type = expressions::value_expr(scope, test, None)?.typ;
-        if test_type != Type::Base(Base::Bool) {
-            scope.type_error(
-                "`assert` condition is not bool",
-                test.span,
-                &Base::Bool,
-                &test_type,
-            );
-        }
+        error_if_not_bool(
+            scope,
+            test_type,
+            test.span,
+            "`assert` condition is not bool",
+        );
 
         if let Some(msg) = msg {
             let msg_attributes = expressions::assignable_expr(scope, msg, None)?;
-            if !matches!(msg_attributes.typ, Type::String(_)) {
+            if !matches!(msg_attributes.typ.typ(scope.db()), Type::String(_)) {
                 scope.error(
                     "`assert` reason must be a string",
                     msg.span,
-                    &format!("this has type `{}`; expected a string", msg_attributes.typ),
+                    &format!(
+                        "this has type `{}`; expected a string",
+                        msg_attributes.typ.display(scope.db())
+                    ),
                 );
             }
         }
@@ -282,13 +277,13 @@ fn revert(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), Fatal
     if let fe::FuncStmt::Revert { error } = &stmt.kind {
         if let Some(error_expr) = error {
             let error_attributes = expressions::assignable_expr(scope, error_expr, None)?;
-            if !matches!(error_attributes.typ, Type::Struct(_)) {
+            if error_attributes.typ.as_struct(scope.db()).is_none() {
                 scope.error(
                     "`revert` error must be a struct",
                     error_expr.span,
                     &format!(
                         "this has type `{}`; expected a struct",
-                        error_attributes.typ
+                        error_attributes.typ.display(scope.db())
                     ),
                 );
             }
@@ -305,15 +300,16 @@ fn func_return(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), 
         let expected_type = scope.root.function_return_type()?;
 
         let attributes = match value {
-            Some(val) => expressions::assignable_expr(scope, val, Some(&expected_type))?,
-            None => ExpressionAttributes::new(Type::unit(), Location::Value),
+            Some(val) => expressions::assignable_expr(scope, val, Some(expected_type))?,
+            None => ExpressionAttributes::new(TypeId::unit(scope.db()), Location::Value),
         };
 
         if attributes.typ != expected_type {
             scope.error(
                 &format!(
                     "expected function to return `{}` but was `{}`",
-                    expected_type, attributes.typ
+                    expected_type.display(scope.db()),
+                    attributes.typ.display(scope.db())
                 ),
                 stmt.span,
                 "",

--- a/crates/analyzer/src/traversal/utils.rs
+++ b/crates/analyzer/src/traversal/utils.rs
@@ -2,26 +2,30 @@ use fe_common::diagnostics::Label;
 use fe_common::Span;
 
 use crate::context::{AnalyzerContext, DiagnosticVoucher};
+use crate::display::Displayable;
 use crate::errors::BinaryOperationError;
-use crate::namespace::types::Type;
+use crate::namespace::types::TypeId;
+use crate::AnalyzerDb;
 use std::fmt::Display;
+
+fn type_label(db: &dyn AnalyzerDb, span: Span, typ: TypeId) -> Label {
+    Label::primary(span, &format!("this has type `{}`", typ.display(db)))
+}
 
 pub fn add_bin_operations_errors(
     context: &mut dyn AnalyzerContext,
     op: &dyn Display,
-    left_span: Span,
-    left_type: &Type,
-    right_span: Span,
-    right_type: &Type,
+    lspan: Span,
+    ltype: TypeId,
+    rspan: Span,
+    rtype: TypeId,
     error: BinaryOperationError,
 ) -> DiagnosticVoucher {
+    let db = context.db();
     match error {
         BinaryOperationError::NotEqualAndUnsigned => context.fancy_error(
             &format!("`{}` operand types must be equal and unsigned", op),
-            vec![
-                Label::primary(left_span, &format!("this has type `{}`", left_type)),
-                Label::primary(right_span, &format!("this has type `{}`", right_type)),
-            ],
+            vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![],
         ),
         BinaryOperationError::RightIsSigned => context.fancy_error(
@@ -30,36 +34,27 @@ pub fn add_bin_operations_errors(
                 op
             ),
             vec![Label::primary(
-                right_span,
-                &format!("this has signed type `{}`", right_type),
+                rspan,
+                &format!("this has signed type `{}`", rtype.display(db)),
             )],
             vec![],
         ),
         BinaryOperationError::RightTooLarge => context.fancy_error(
             &format!("incompatible `{}` operand types", op),
-            vec![
-                Label::primary(left_span, &format!("this has type `{}`", left_type)),
-                Label::primary(right_span, &format!("this has type `{}`", right_type)),
-            ],
+            vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![format!(
                 "The type of the right hand side cannot be larger than the left (`{}`)",
-                left_type
+                ltype.display(db)
             )],
         ),
         BinaryOperationError::TypesNotEqual => context.fancy_error(
             &format!("`{}` operand types must be equal", op),
-            vec![
-                Label::primary(left_span, &format!("this has type `{}`", left_type)),
-                Label::primary(right_span, &format!("this has type `{}`", right_type)),
-            ],
+            vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![],
         ),
         BinaryOperationError::TypesNotNumeric => context.fancy_error(
             &format!("`{}` operands must be numeric", op),
-            vec![
-                Label::primary(left_span, &format!("this has type `{}`", left_type)),
-                Label::primary(right_span, &format!("this has type `{}`", right_type)),
-            ],
+            vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![],
         ),
     }

--- a/crates/analyzer/tests/snapshots/analysis__abi_decode_complex.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_decode_complex.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ abi_decode_complex.fe:2:5
@@ -8,34 +9,7 @@ note:
 2 │ ╭     pub fn decode_static_complex(s: StaticComplex) -> StaticComplex {
 3 │ │         return s
 4 │ │     }
-  │ ╰─────^ attributes hash: 13546101684275548970
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "s",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "StaticComplex",
-                            field_count: 2,
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Struct(
-                Struct {
-                    name: "StaticComplex",
-                    field_count: 2,
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: s, typ: StaticComplex }] -> StaticComplex
 
 note: 
   ┌─ abi_decode_complex.fe:3:16
@@ -49,34 +23,7 @@ note:
 6 │ ╭     pub fn decode_string_complex(s: StringComplex) -> StringComplex {
 7 │ │         return s
 8 │ │     }
-  │ ╰─────^ attributes hash: 9213499526282989909
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "s",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "StringComplex",
-                            field_count: 2,
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Struct(
-                Struct {
-                    name: "StringComplex",
-                    field_count: 2,
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: s, typ: StringComplex }] -> StringComplex
 
 note: 
   ┌─ abi_decode_complex.fe:7:16
@@ -90,34 +37,7 @@ note:
 10 │ ╭     pub fn decode_bytes_complex(s: BytesComplex) -> BytesComplex {
 11 │ │         return s
 12 │ │     }
-   │ ╰─────^ attributes hash: 9262156959297131687
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "s",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "BytesComplex",
-                             field_count: 2,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "BytesComplex",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: s, typ: BytesComplex }] -> BytesComplex
 
 note: 
    ┌─ abi_decode_complex.fe:11:16
@@ -131,34 +51,7 @@ note:
 14 │ ╭     pub fn decode_nested_dynamic_complex(s: NestedDynamicComplex) -> NestedDynamicComplex {
 15 │ │         return s
 16 │ │     }
-   │ ╰─────^ attributes hash: 3503331736540589795
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "s",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "NestedDynamicComplex",
-                             field_count: 3,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "NestedDynamicComplex",
-                     field_count: 3,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: s, typ: NestedDynamicComplex }] -> NestedDynamicComplex
 
 note: 
    ┌─ abi_decode_complex.fe:15:16
@@ -172,44 +65,7 @@ note:
 18 │ ╭     pub fn decode_static_complex_elem_array(arr: Array<StaticComplex, 3>) -> Array<StaticComplex, 3> {
 19 │ │         return arr
 20 │ │     }
-   │ ╰─────^ attributes hash: 14814063204670221852
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "arr",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 3,
-                             inner: Struct(
-                                 Struct {
-                                     name: "StaticComplex",
-                                     field_count: 2,
-                                 },
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 3,
-                     inner: Struct(
-                         Struct {
-                             name: "StaticComplex",
-                             field_count: 2,
-                         },
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: arr, typ: Array<StaticComplex, 3> }] -> Array<StaticComplex, 3>
 
 note: 
    ┌─ abi_decode_complex.fe:19:16
@@ -223,44 +79,7 @@ note:
 22 │ ╭     pub fn decode_dynamic_complex_elem_array(arr: Array<NestedDynamicComplex, 3>) -> Array<NestedDynamicComplex, 3> {
 23 │ │         return arr
 24 │ │     }
-   │ ╰─────^ attributes hash: 26751994078138639
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "arr",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 3,
-                             inner: Struct(
-                                 Struct {
-                                     name: "NestedDynamicComplex",
-                                     field_count: 3,
-                                 },
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 3,
-                     inner: Struct(
-                         Struct {
-                             name: "NestedDynamicComplex",
-                             field_count: 3,
-                         },
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: arr, typ: Array<NestedDynamicComplex, 3> }] -> Array<NestedDynamicComplex, 3>
 
 note: 
    ┌─ abi_decode_complex.fe:23:16

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ abi_encoding_stress.fe:4:5
@@ -52,35 +53,7 @@ note:
 27 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 5>) {
 28 │ │         self.my_addrs = my_addrs
 29 │ │     }
-   │ ╰─────^ attributes hash: 6651617854478011991
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 5,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_addrs, typ: Array<address, 5> }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:28:9
@@ -102,25 +75,7 @@ note:
 31 │ ╭     pub fn get_my_addrs(self) -> Array<address, 5> {
 32 │ │         return self.my_addrs.to_mem()
 33 │ │     }
-   │ ╰─────^ attributes hash: 3503941160400696207
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 5,
-                     inner: Base(
-                         Address,
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> Array<address, 5>
 
 note: 
    ┌─ abi_encoding_stress.fe:32:16
@@ -146,32 +101,7 @@ note:
 35 │ ╭     pub fn set_my_u128(self, my_u128: u128) {
 36 │ │         self.my_u128 = my_u128
 37 │ │     }
-   │ ╰─────^ attributes hash: 15199964699853061770
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_u128",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U128,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_u128, typ: u128 }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:36:9
@@ -193,22 +123,7 @@ note:
 39 │ ╭     pub fn get_my_u128(self) -> u128 {
 40 │ │         return self.my_u128
 41 │ │     }
-   │ ╰─────^ attributes hash: 15343208064821852867
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U128,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u128
 
 note: 
    ┌─ abi_encoding_stress.fe:40:16
@@ -228,32 +143,7 @@ note:
 43 │ ╭     pub fn set_my_string(self, my_string: String<10>) {
 44 │ │         self.my_string = my_string
 45 │ │     }
-   │ ╰─────^ attributes hash: 241116312146617781
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 10,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_string, typ: String<10> }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:44:9
@@ -275,22 +165,7 @@ note:
 47 │ ╭     pub fn get_my_string(self) -> String<10> {
 48 │ │         return self.my_string.to_mem()
 49 │ │     }
-   │ ╰─────^ attributes hash: 1556448784000816371
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 10,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> String<10>
 
 note: 
    ┌─ abi_encoding_stress.fe:48:16
@@ -316,37 +191,7 @@ note:
 51 │ ╭     pub fn set_my_u16s(self, my_u16s: Array<u16, 255>) {
 52 │ │         self.my_u16s = my_u16s
 53 │ │     }
-   │ ╰─────^ attributes hash: 15373408821262001670
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_u16s",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 255,
-                             inner: Base(
-                                 Numeric(
-                                     U16,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_u16s, typ: Array<u16, 255> }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:52:9
@@ -368,27 +213,7 @@ note:
 55 │ ╭     pub fn get_my_u16s(self) -> Array<u16, 255> {
 56 │ │         return self.my_u16s.to_mem()
 57 │ │     }
-   │ ╰─────^ attributes hash: 7191948642218091354
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 255,
-                     inner: Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> Array<u16, 255>
 
 note: 
    ┌─ abi_encoding_stress.fe:56:16
@@ -414,30 +239,7 @@ note:
 59 │ ╭     pub fn set_my_bool(self, my_bool: bool) {
 60 │ │         self.my_bool = my_bool
 61 │ │     }
-   │ ╰─────^ attributes hash: 3845928701529339179
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_bool",
-                 typ: Ok(
-                     Base(
-                         Bool,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_bool, typ: bool }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:60:9
@@ -459,20 +261,7 @@ note:
 63 │ ╭     pub fn get_my_bool(self) -> bool {
 64 │ │         return self.my_bool
 65 │ │     }
-   │ ╰─────^ attributes hash: 2163156009319630199
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> bool
 
 note: 
    ┌─ abi_encoding_stress.fe:64:16
@@ -492,37 +281,7 @@ note:
 67 │ ╭     pub fn set_my_bytes(self, my_bytes: Array<u8, 100>) {
 68 │ │         self.my_bytes = my_bytes
 69 │ │     }
-   │ ╰─────^ attributes hash: 12615116636431196289
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_bytes",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 100,
-                             inner: Base(
-                                 Numeric(
-                                     U8,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_bytes, typ: Array<u8, 100> }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:68:9
@@ -544,27 +303,7 @@ note:
 71 │ ╭     pub fn get_my_bytes(self) -> Array<u8, 100> {
 72 │ │         return self.my_bytes.to_mem()
 73 │ │     }
-   │ ╰─────^ attributes hash: 1930284060814414607
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 100,
-                     inner: Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> Array<u8, 100>
 
 note: 
    ┌─ abi_encoding_stress.fe:72:16
@@ -590,21 +329,7 @@ note:
 75 │ ╭     pub fn get_my_struct() -> MyStruct {
 76 │ │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
 77 │ │     }
-   │ ╰─────^ attributes hash: 16166951200114277325
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "MyStruct",
-                     field_count: 4,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> MyStruct
 
 note: 
    ┌─ abi_encoding_stress.fe:76:33
@@ -645,34 +370,7 @@ note:
 83 │ │         my_struct.my_addr = address(9999)
 84 │ │         return my_struct
 85 │ │     }
-   │ ╰─────^ attributes hash: 11747697140833990696
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_struct",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "MyStruct",
-                             field_count: 4,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "MyStruct",
-                     field_count: 4,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_struct, typ: MyStruct }] -> MyStruct
 
 note: 
    ┌─ abi_encoding_stress.fe:80:9
@@ -738,35 +436,7 @@ note:
 87 │ ╭     pub fn emit_my_event(self, ctx: Context) {
 88 │ │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
 89 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ abi_encoding_stress.fe:88:22
@@ -845,94 +515,5 @@ note:
    │
 88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                                                                                                                         ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
-
-note: 
-   ┌─ abi_encoding_stress.fe:88:9
-   │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 6413258942580560070
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 5,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_u128",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U128,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 10,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_u16s",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 255,
-                             inner: Base(
-                                 Numeric(
-                                     U16,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_bool",
-                 typ: Ok(
-                     Base(
-                         Bool,
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_bytes",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 100,
-                             inner: Base(
-                                 Numeric(
-                                     U8,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__address_bytes10_map.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ address_bytes10_map.fe:2:5
@@ -14,37 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: address) -> Array<u8, 10> {
 5 │ │         return self.bar[key].to_mem()
 6 │ │     }
-  │ ╰─────^ attributes hash: 14715984257538758536
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Address,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Array(
-                Array {
-                    size: 10,
-                    inner: Base(
-                        Numeric(
-                            U8,
-                        ),
-                    ),
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: address }] -> Array<u8, 10>
 
 note: 
   ┌─ address_bytes10_map.fe:5:16
@@ -78,46 +49,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: address, value: Array<u8, 10>) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 14916033339844523953
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 10,
-                             inner: Base(
-                                 Numeric(
-                                     U8,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: address }, { label: None, name: value, typ: Array<u8, 10> }] -> ()
 
 note: 
   ┌─ address_bytes10_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__assert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__assert.snap
@@ -17,30 +17,7 @@ note:
 5 │ ╭     pub fn bar(baz: u256) {
 6 │ │         assert baz > 5
 7 │ │     }
-  │ ╰─────^ attributes hash: 2614610269237134179
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "baz",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: baz, typ: u256 }] -> ()
 
 note: 
   ┌─ assert.fe:6:16
@@ -62,30 +39,7 @@ note:
  9 │ ╭     pub fn revert_with_static_string(baz: u256) {
 10 │ │         assert baz > 5, "Must be greater than five"
 11 │ │     }
-   │ ╰─────^ attributes hash: 2614610269237134179
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "baz",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: baz, typ: u256 }] -> ()
 
 note: 
    ┌─ assert.fe:10:16
@@ -109,41 +63,7 @@ note:
 13 │ ╭     pub fn revert_with(baz: u256, reason: String<1000>) {
 14 │ │         assert baz > 5, reason
 15 │ │     }
-   │ ╰─────^ attributes hash: 10044481770469626577
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "baz",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "reason",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 1000,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: baz, typ: u256 }, { label: None, name: reason, typ: String<1000> }] -> ()
 
 note: 
    ┌─ assert.fe:14:16
@@ -168,20 +88,7 @@ note:
 18 │ │         self.my_bool = false
 19 │ │         assert self.my_bool
 20 │ │     }
-   │ ╰─────^ attributes hash: 18235041182630809162
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
    ┌─ assert.fe:18:9
@@ -212,20 +119,7 @@ note:
 23 │ │         self.my_string = "hello"
 24 │ │         assert false, self.my_string.to_mem()
 25 │ │     }
-   │ ╰─────^ attributes hash: 18235041182630809162
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
    ┌─ assert.fe:23:9

--- a/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__associated_fns.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn square(x: u256) -> u256 {
 3 │ │         return x * x
 4 │ │     }
-  │ ╰─────^ attributes hash: 6622018637299644818
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }] -> u256
 
 note: 
   ┌─ associated_fns.fe:3:16
@@ -62,33 +37,7 @@ note:
 10 │ ╭     pub fn new(x: u256) -> MyStruct {
 11 │ │         return MyStruct(x)
 12 │ │     }
-   │ ╰─────^ attributes hash: 2145703897684373991
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "MyStruct",
-                     field_count: 1,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }] -> MyStruct
 
 note: 
    ┌─ associated_fns.fe:11:25
@@ -115,34 +64,7 @@ note:
 19 │ │         self.my_struct = MyStruct::new(x: val)
 20 │ │         return Lib::square(x: self.my_struct.x)
 21 │ │     }
-   │ ╰─────^ attributes hash: 2950430758151367369
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "val",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: val, typ: u256 }] -> u256
 
 note: 
    ┌─ associated_fns.fe:19:9

--- a/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
+++ b/crates/analyzer/tests/snapshots/analysis__aug_assign.snap
@@ -16,43 +16,7 @@ note:
 5 │ │         a += b
 6 │ │         return a
 7 │ │     }
-  │ ╰─────^ attributes hash: 14373109651426912995
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "a",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "b",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
   ┌─ aug_assign.fe:5:9
@@ -71,43 +35,7 @@ note:
 10 │ │         a -= b
 11 │ │         return a
 12 │ │     }
-   │ ╰─────^ attributes hash: 14373109651426912995
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:10:9
@@ -126,43 +54,7 @@ note:
 15 │ │         a *= b
 16 │ │         return a
 17 │ │     }
-   │ ╰─────^ attributes hash: 14373109651426912995
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:15:9
@@ -181,43 +73,7 @@ note:
 20 │ │         a /= b
 21 │ │         return a
 22 │ │     }
-   │ ╰─────^ attributes hash: 14373109651426912995
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:20:9
@@ -236,43 +92,7 @@ note:
 25 │ │         a %= b
 26 │ │         return a
 27 │ │     }
-   │ ╰─────^ attributes hash: 14373109651426912995
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:25:9
@@ -291,43 +111,7 @@ note:
 30 │ │         a **= b
 31 │ │         return a
 32 │ │     }
-   │ ╰─────^ attributes hash: 14373109651426912995
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:30:9
@@ -346,43 +130,7 @@ note:
 35 │ │         a <<= b
 36 │ │         return a
 37 │ │     }
-   │ ╰─────^ attributes hash: 3365128954177167387
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u8 }, { label: None, name: b, typ: u8 }] -> u8
 
 note: 
    ┌─ aug_assign.fe:35:9
@@ -401,43 +149,7 @@ note:
 40 │ │         a >>= b
 41 │ │         return a
 42 │ │     }
-   │ ╰─────^ attributes hash: 3365128954177167387
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u8 }, { label: None, name: b, typ: u8 }] -> u8
 
 note: 
    ┌─ aug_assign.fe:40:9
@@ -456,43 +168,7 @@ note:
 45 │ │         a |= b
 46 │ │         return a
 47 │ │     }
-   │ ╰─────^ attributes hash: 3365128954177167387
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u8 }, { label: None, name: b, typ: u8 }] -> u8
 
 note: 
    ┌─ aug_assign.fe:45:9
@@ -511,43 +187,7 @@ note:
 50 │ │         a ^= b
 51 │ │         return a
 52 │ │     }
-   │ ╰─────^ attributes hash: 3365128954177167387
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u8 }, { label: None, name: b, typ: u8 }] -> u8
 
 note: 
    ┌─ aug_assign.fe:50:9
@@ -566,43 +206,7 @@ note:
 55 │ │         a &= b
 56 │ │         return a
 57 │ │     }
-   │ ╰─────^ attributes hash: 3365128954177167387
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u8 }, { label: None, name: b, typ: u8 }] -> u8
 
 note: 
    ┌─ aug_assign.fe:55:9
@@ -622,45 +226,7 @@ note:
 61 │ │         self.my_num += b
 62 │ │         return self.my_num
 63 │ │     }
-   │ ╰─────^ attributes hash: 3506345928150766050
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:60:9
@@ -703,43 +269,7 @@ note:
 68 │ │         my_array[7] += b
 69 │ │         return my_array[7]
 70 │ │     }
-   │ ╰─────^ attributes hash: 14373109651426912995
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> u256
 
 note: 
    ┌─ aug_assign.fe:66:13

--- a/crates/analyzer/tests/snapshots/analysis__balances.snap
+++ b/crates/analyzer/tests/snapshots/analysis__balances.snap
@@ -9,37 +9,7 @@ note:
 5 │ ╭     pub fn my_balance(self, ctx: Context) -> u256 {
 6 │ │         return ctx.self_balance()
 7 │ │     }
-  │ ╰─────^ attributes hash: 3247318976601732237
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: Some(
-            Mutable,
-        ),
-        params: [
-            FunctionParam {
-                label: None,
-                name: "ctx",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "Context",
-                            field_count: 0,
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
   ┌─ balances.fe:6:16
@@ -59,46 +29,7 @@ note:
  9 │ ╭     pub fn other_balance(self, ctx: Context, someone: address) -> u256 {
 10 │ │         return ctx.balance_of(someone)
 11 │ │     }
-   │ ╰─────^ attributes hash: 7590750053308816492
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "someone",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: someone, typ: address }] -> u256
 
 note: 
    ┌─ balances.fe:10:16

--- a/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__base_tuple.snap
@@ -9,50 +9,7 @@ note:
 2 │ ╭     pub fn bar(my_num: u256, my_bool: bool) -> (u256, bool) {
 3 │ │         return (my_num, my_bool)
 4 │ │     }
-  │ ╰─────^ attributes hash: 10319049298189511667
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "my_num",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "my_bool",
-                typ: Ok(
-                    Base(
-                        Bool,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Tuple(
-                Tuple {
-                    items: [
-                        Base(
-                            Numeric(
-                                U256,
-                            ),
-                        ),
-                        Base(
-                            Bool,
-                        ),
-                    ],
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: my_num, typ: u256 }, { label: None, name: my_bool, typ: bool }] -> (u256, bool)
 
 note: 
   ┌─ base_tuple.fe:3:17

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -10,21 +10,7 @@ note:
 11 │ │         assert file_items_work()
 12 │ │         return Baz(my_bool: true, my_u256: 26)
 13 │ │     }
-   │ ╰─────^ attributes hash: 12617626076609670469
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Baz",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> Baz
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:11:16
@@ -48,21 +34,7 @@ note:
 15 │ ╭     pub fn get_my_bing() -> Bong {
 16 │ │         return Bong(my_address: address(42))
 17 │ │     }
-   │ ╰─────^ attributes hash: 10335209349982667488
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Bing",
-                     field_count: 1,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> Bing
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:16:41
@@ -88,20 +60,7 @@ note:
 19 │ ╭     pub fn get_42() -> u256 {
 20 │ │         return get_42_backend()
 21 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:20:16
@@ -115,20 +74,7 @@ note:
 23 │ ╭     pub fn get_26() -> u256 {
 24 │ │         return std::evm::add(13, 13)
 25 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:24:30
@@ -151,18 +97,7 @@ note:
 28 │ │         assert bar::mee::Mee::kawum() == 1
 29 │ │         assert bar::mee::Mee().rums() == 1
 30 │ │     }
-   │ ╰─────^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> ()
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:28:16
@@ -200,21 +135,7 @@ note:
 32 │ ╭     pub fn get_my_dyng() -> dong::Dyng {
 33 │ │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
 34 │ │     }
-   │ ╰─────^ attributes hash: 13186223862505072309
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Dyng",
-                     field_count: 3,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> Dyng
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:33:47
@@ -250,35 +171,7 @@ note:
 37 │ │         let bing_contract: BingContract = BingContract.create(ctx, 0)
 38 │ │         return bing_contract.add(40, 50)
 39 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ ingots/basic_ingot/src/main.fe:37:13
@@ -318,18 +211,7 @@ note:
 1 │ ╭ pub fn file_items_work() -> bool {
 2 │ │     return true
 3 │ │ }
-  │ ╰─^ attributes hash: 5583437014632790429
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─^ self: None, params: [] -> bool
 
 note: 
   ┌─ ingots/basic_ingot/src/bar.fe:2:12
@@ -350,20 +232,7 @@ note:
 7 │ ╭ pub fn get_42_backend() -> u256 {
 8 │ │     return std::evm::add(21, 21)
 9 │ │ }
-  │ ╰─^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─^ self: None, params: [] -> u256
 
 note: 
   ┌─ ingots/basic_ingot/src/bing.fe:8:26
@@ -385,47 +254,7 @@ note:
 12 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
 13 │ │         return x + y
 14 │ │     }
-   │ ╰─────^ attributes hash: 4448606202021980030
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "y",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
    ┌─ ingots/basic_ingot/src/bing.fe:13:16
@@ -458,20 +287,7 @@ note:
 2 │ ╭     pub fn kawum() -> u256 {
 3 │ │         return 1
 4 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ ingots/basic_ingot/src/bar/mee.fe:3:16
@@ -485,22 +301,7 @@ note:
 6 │ ╭     pub fn rums(self) -> u256 {
 7 │ │         return 1
 8 │ │     }
-  │ ╰─────^ attributes hash: 11773348765973600208
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
   ┌─ ingots/basic_ingot/src/bar/mee.fe:7:16
@@ -532,21 +333,7 @@ note:
  9 │ ╭ fn get_bing() -> Bing {
 10 │ │     return Bing(my_address: address(0))
 11 │ │ }
-   │ ╰─^ attributes hash: 10335209349982667488
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Bing",
-                     field_count: 1,
-                 },
-             ),
-         ),
-     }
+   │ ╰─^ self: None, params: [] -> Bing
 
 note: 
    ┌─ ingots/basic_ingot/src/ding/dong.fe:10:37

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     fn assign(self, _ val: u256) {
 5 │ │         self.baz[0] = val
 6 │ │     }
-  │ ╰─────^ attributes hash: 15254234582808678866
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "val",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: val, typ: u256 }] -> ()
 
 note: 
   ┌─ call_statement_with_args.fe:5:9
@@ -73,22 +46,7 @@ note:
  9 │ │         self.assign(100)
 10 │ │         return self.baz[0]
 11 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
   ┌─ call_statement_with_args.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_with_args_2.snap
@@ -16,36 +16,7 @@ note:
 5 │ │         self.baz[0] = val
 6 │ │         return val
 7 │ │     }
-  │ ╰─────^ attributes hash: 11102768331449211201
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "val",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: val, typ: u256 }] -> u256
 
 note: 
   ┌─ call_statement_with_args_2.fe:5:9
@@ -78,22 +49,7 @@ note:
 10 │ │         self.assign(100)
 11 │ │         return self.baz[0]
 12 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ call_statement_with_args_2.fe:10:9

--- a/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__call_statement_without_args.snap
@@ -15,20 +15,7 @@ note:
 4 │ ╭     fn assign(self) {
 5 │ │         self.baz[0] = 100
 6 │ │     }
-  │ ╰─────^ attributes hash: 18235041182630809162
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
   ┌─ call_statement_without_args.fe:5:9
@@ -59,22 +46,7 @@ note:
  9 │ │         self.assign()
 10 │ │         return self.baz[0]
 11 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
   ┌─ call_statement_without_args.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
+++ b/crates/analyzer/tests/snapshots/analysis__checked_arithmetic.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn add_u256(left: u256, right: u256) -> u256 {
 3 │ │         return left + right
 4 │ │     }
-  │ ╰─────^ attributes hash: 8877497213208027149
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "left",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "right",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u256 }, { label: None, name: right, typ: u256 }] -> u256
 
 note: 
   ┌─ checked_arithmetic.fe:3:16
@@ -67,43 +31,7 @@ note:
 6 │ ╭     pub fn add_u128(left: u128, right: u128) -> u128 {
 7 │ │         return left + right
 8 │ │     }
-  │ ╰─────^ attributes hash: 11187416061572591496
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "left",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "right",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u128 }, { label: None, name: right, typ: u128 }] -> u128
 
 note: 
   ┌─ checked_arithmetic.fe:7:16
@@ -125,43 +53,7 @@ note:
 10 │ ╭     pub fn add_u64(left: u64, right: u64) -> u64 {
 11 │ │         return left + right
 12 │ │     }
-   │ ╰─────^ attributes hash: 9316585824156398552
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u64 }, { label: None, name: right, typ: u64 }] -> u64
 
 note: 
    ┌─ checked_arithmetic.fe:11:16
@@ -183,43 +75,7 @@ note:
 14 │ ╭     pub fn add_u32(left: u32, right: u32) -> u32 {
 15 │ │         return left + right
 16 │ │     }
-   │ ╰─────^ attributes hash: 6948562809403003686
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U32,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U32,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u32 }, { label: None, name: right, typ: u32 }] -> u32
 
 note: 
    ┌─ checked_arithmetic.fe:15:16
@@ -241,43 +97,7 @@ note:
 18 │ ╭     pub fn add_u16(left: u16, right: u16) -> u16 {
 19 │ │         return left + right
 20 │ │     }
-   │ ╰─────^ attributes hash: 4214429573900255413
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u16 }, { label: None, name: right, typ: u16 }] -> u16
 
 note: 
    ┌─ checked_arithmetic.fe:19:16
@@ -299,43 +119,7 @@ note:
 22 │ ╭     pub fn add_u8(left: u8, right: u8) -> u8 {
 23 │ │         return left + right
 24 │ │     }
-   │ ╰─────^ attributes hash: 3749617961046563034
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u8 }, { label: None, name: right, typ: u8 }] -> u8
 
 note: 
    ┌─ checked_arithmetic.fe:23:16
@@ -357,43 +141,7 @@ note:
 26 │ ╭     pub fn add_i256(left: i256, right: i256) -> i256 {
 27 │ │         return left + right
 28 │ │     }
-   │ ╰─────^ attributes hash: 17908204859155721295
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i256 }, { label: None, name: right, typ: i256 }] -> i256
 
 note: 
    ┌─ checked_arithmetic.fe:27:16
@@ -415,43 +163,7 @@ note:
 30 │ ╭     pub fn add_i128(left: i128, right: i128) -> i128 {
 31 │ │         return left + right
 32 │ │     }
-   │ ╰─────^ attributes hash: 1332431709112937827
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I128,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I128,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I128,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i128 }, { label: None, name: right, typ: i128 }] -> i128
 
 note: 
    ┌─ checked_arithmetic.fe:31:16
@@ -473,43 +185,7 @@ note:
 34 │ ╭     pub fn add_i64(left: i64, right: i64) -> i64 {
 35 │ │         return left + right
 36 │ │     }
-   │ ╰─────^ attributes hash: 3549113083347694903
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i64 }, { label: None, name: right, typ: i64 }] -> i64
 
 note: 
    ┌─ checked_arithmetic.fe:35:16
@@ -531,43 +207,7 @@ note:
 38 │ ╭     pub fn add_i32(left: i32, right: i32) -> i32 {
 39 │ │         return left + right
 40 │ │     }
-   │ ╰─────^ attributes hash: 15117649447142800500
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I32,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I32,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i32 }, { label: None, name: right, typ: i32 }] -> i32
 
 note: 
    ┌─ checked_arithmetic.fe:39:16
@@ -589,43 +229,7 @@ note:
 42 │ ╭     pub fn add_i16(left: i16, right: i16) -> i16 {
 43 │ │         return left + right
 44 │ │     }
-   │ ╰─────^ attributes hash: 16520261699954225452
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I16,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I16,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i16 }, { label: None, name: right, typ: i16 }] -> i16
 
 note: 
    ┌─ checked_arithmetic.fe:43:16
@@ -647,43 +251,7 @@ note:
 46 │ ╭     pub fn add_i8(left: i8, right: i8) -> i8 {
 47 │ │         return left + right
 48 │ │     }
-   │ ╰─────^ attributes hash: 2984879578165475690
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i8 }, { label: None, name: right, typ: i8 }] -> i8
 
 note: 
    ┌─ checked_arithmetic.fe:47:16
@@ -705,43 +273,7 @@ note:
 50 │ ╭     pub fn sub_u256(left: u256, right: u256) -> u256 {
 51 │ │         return left - right
 52 │ │     }
-   │ ╰─────^ attributes hash: 8877497213208027149
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u256 }, { label: None, name: right, typ: u256 }] -> u256
 
 note: 
    ┌─ checked_arithmetic.fe:51:16
@@ -763,43 +295,7 @@ note:
 54 │ ╭     pub fn sub_u128(left: u128, right: u128) -> u128 {
 55 │ │         return left - right
 56 │ │     }
-   │ ╰─────^ attributes hash: 11187416061572591496
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U128,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U128,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U128,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u128 }, { label: None, name: right, typ: u128 }] -> u128
 
 note: 
    ┌─ checked_arithmetic.fe:55:16
@@ -821,43 +317,7 @@ note:
 58 │ ╭     pub fn sub_u64(left: u64, right: u64) -> u64 {
 59 │ │         return left - right
 60 │ │     }
-   │ ╰─────^ attributes hash: 9316585824156398552
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u64 }, { label: None, name: right, typ: u64 }] -> u64
 
 note: 
    ┌─ checked_arithmetic.fe:59:16
@@ -879,43 +339,7 @@ note:
 62 │ ╭     pub fn sub_u32(left: u32, right: u32) -> u32 {
 63 │ │         return left - right
 64 │ │     }
-   │ ╰─────^ attributes hash: 6948562809403003686
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U32,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U32,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u32 }, { label: None, name: right, typ: u32 }] -> u32
 
 note: 
    ┌─ checked_arithmetic.fe:63:16
@@ -937,43 +361,7 @@ note:
 66 │ ╭     pub fn sub_u16(left: u16, right: u16) -> u16 {
 67 │ │         return left - right
 68 │ │     }
-   │ ╰─────^ attributes hash: 4214429573900255413
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u16 }, { label: None, name: right, typ: u16 }] -> u16
 
 note: 
    ┌─ checked_arithmetic.fe:67:16
@@ -995,43 +383,7 @@ note:
 70 │ ╭     pub fn sub_u8(left: u8, right: u8) -> u8 {
 71 │ │         return left - right
 72 │ │     }
-   │ ╰─────^ attributes hash: 3749617961046563034
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u8 }, { label: None, name: right, typ: u8 }] -> u8
 
 note: 
    ┌─ checked_arithmetic.fe:71:16
@@ -1053,43 +405,7 @@ note:
 74 │ ╭     pub fn sub_i256(left: i256, right: i256) -> i256 {
 75 │ │         return left - right
 76 │ │     }
-   │ ╰─────^ attributes hash: 17908204859155721295
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i256 }, { label: None, name: right, typ: i256 }] -> i256
 
 note: 
    ┌─ checked_arithmetic.fe:75:16
@@ -1111,43 +427,7 @@ note:
 78 │ ╭     pub fn sub_i128(left: i128, right: i128) -> i128 {
 79 │ │         return left - right
 80 │ │     }
-   │ ╰─────^ attributes hash: 1332431709112937827
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I128,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I128,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I128,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i128 }, { label: None, name: right, typ: i128 }] -> i128
 
 note: 
    ┌─ checked_arithmetic.fe:79:16
@@ -1169,43 +449,7 @@ note:
 82 │ ╭     pub fn sub_i64(left: i64, right: i64) -> i64 {
 83 │ │         return left - right
 84 │ │     }
-   │ ╰─────^ attributes hash: 3549113083347694903
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i64 }, { label: None, name: right, typ: i64 }] -> i64
 
 note: 
    ┌─ checked_arithmetic.fe:83:16
@@ -1227,43 +471,7 @@ note:
 86 │ ╭     pub fn sub_i32(left: i32, right: i32) -> i32 {
 87 │ │         return left - right
 88 │ │     }
-   │ ╰─────^ attributes hash: 15117649447142800500
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I32,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I32,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i32 }, { label: None, name: right, typ: i32 }] -> i32
 
 note: 
    ┌─ checked_arithmetic.fe:87:16
@@ -1285,43 +493,7 @@ note:
 90 │ ╭     pub fn sub_i16(left: i16, right: i16) -> i16 {
 91 │ │         return left - right
 92 │ │     }
-   │ ╰─────^ attributes hash: 16520261699954225452
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I16,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I16,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i16 }, { label: None, name: right, typ: i16 }] -> i16
 
 note: 
    ┌─ checked_arithmetic.fe:91:16
@@ -1343,43 +515,7 @@ note:
 94 │ ╭     pub fn sub_i8(left: i8, right: i8) -> i8 {
 95 │ │         return left - right
 96 │ │     }
-   │ ╰─────^ attributes hash: 2984879578165475690
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "left",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "right",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i8 }, { label: None, name: right, typ: i8 }] -> i8
 
 note: 
    ┌─ checked_arithmetic.fe:95:16
@@ -1401,43 +537,7 @@ note:
  98 │ ╭     pub fn div_u256(left: u256, right: u256) -> u256 {
  99 │ │         return left / right
 100 │ │     }
-    │ ╰─────^ attributes hash: 8877497213208027149
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u256 }, { label: None, name: right, typ: u256 }] -> u256
 
 note: 
    ┌─ checked_arithmetic.fe:99:16
@@ -1459,43 +559,7 @@ note:
 102 │ ╭     pub fn div_u128(left: u128, right: u128) -> u128 {
 103 │ │         return left / right
 104 │ │     }
-    │ ╰─────^ attributes hash: 11187416061572591496
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u128 }, { label: None, name: right, typ: u128 }] -> u128
 
 note: 
     ┌─ checked_arithmetic.fe:103:16
@@ -1517,43 +581,7 @@ note:
 106 │ ╭     pub fn div_u64(left: u64, right: u64) -> u64 {
 107 │ │         return left / right
 108 │ │     }
-    │ ╰─────^ attributes hash: 9316585824156398552
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u64 }, { label: None, name: right, typ: u64 }] -> u64
 
 note: 
     ┌─ checked_arithmetic.fe:107:16
@@ -1575,43 +603,7 @@ note:
 110 │ ╭     pub fn div_u32(left: u32, right: u32) -> u32 {
 111 │ │         return left / right
 112 │ │     }
-    │ ╰─────^ attributes hash: 6948562809403003686
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u32 }, { label: None, name: right, typ: u32 }] -> u32
 
 note: 
     ┌─ checked_arithmetic.fe:111:16
@@ -1633,43 +625,7 @@ note:
 114 │ ╭     pub fn div_u16(left: u16, right: u16) -> u16 {
 115 │ │         return left / right
 116 │ │     }
-    │ ╰─────^ attributes hash: 4214429573900255413
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u16 }, { label: None, name: right, typ: u16 }] -> u16
 
 note: 
     ┌─ checked_arithmetic.fe:115:16
@@ -1691,43 +647,7 @@ note:
 118 │ ╭     pub fn div_u8(left: u8, right: u8) -> u8 {
 119 │ │         return left / right
 120 │ │     }
-    │ ╰─────^ attributes hash: 3749617961046563034
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u8 }, { label: None, name: right, typ: u8 }] -> u8
 
 note: 
     ┌─ checked_arithmetic.fe:119:16
@@ -1749,43 +669,7 @@ note:
 122 │ ╭     pub fn div_i256(left: i256, right: i256) -> i256 {
 123 │ │         return left / right
 124 │ │     }
-    │ ╰─────^ attributes hash: 17908204859155721295
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i256 }, { label: None, name: right, typ: i256 }] -> i256
 
 note: 
     ┌─ checked_arithmetic.fe:123:16
@@ -1807,43 +691,7 @@ note:
 126 │ ╭     pub fn div_i128(left: i128, right: i128) -> i128 {
 127 │ │         return left / right
 128 │ │     }
-    │ ╰─────^ attributes hash: 1332431709112937827
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i128 }, { label: None, name: right, typ: i128 }] -> i128
 
 note: 
     ┌─ checked_arithmetic.fe:127:16
@@ -1865,43 +713,7 @@ note:
 130 │ ╭     pub fn div_i64(left: i64, right: i64) -> i64 {
 131 │ │         return left / right
 132 │ │     }
-    │ ╰─────^ attributes hash: 3549113083347694903
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i64 }, { label: None, name: right, typ: i64 }] -> i64
 
 note: 
     ┌─ checked_arithmetic.fe:131:16
@@ -1923,43 +735,7 @@ note:
 134 │ ╭     pub fn div_i32(left: i32, right: i32) -> i32 {
 135 │ │         return left / right
 136 │ │     }
-    │ ╰─────^ attributes hash: 15117649447142800500
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i32 }, { label: None, name: right, typ: i32 }] -> i32
 
 note: 
     ┌─ checked_arithmetic.fe:135:16
@@ -1981,43 +757,7 @@ note:
 138 │ ╭     pub fn div_i16(left: i16, right: i16) -> i16 {
 139 │ │         return left / right
 140 │ │     }
-    │ ╰─────^ attributes hash: 16520261699954225452
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i16 }, { label: None, name: right, typ: i16 }] -> i16
 
 note: 
     ┌─ checked_arithmetic.fe:139:16
@@ -2039,43 +779,7 @@ note:
 142 │ ╭     pub fn div_i8(left: i8, right: i8) -> i8 {
 143 │ │         return left / right
 144 │ │     }
-    │ ╰─────^ attributes hash: 2984879578165475690
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i8 }, { label: None, name: right, typ: i8 }] -> i8
 
 note: 
     ┌─ checked_arithmetic.fe:143:16
@@ -2097,43 +801,7 @@ note:
 146 │ ╭     pub fn mul_u256(left: u256, right: u256) -> u256 {
 147 │ │         return left * right
 148 │ │     }
-    │ ╰─────^ attributes hash: 8877497213208027149
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u256 }, { label: None, name: right, typ: u256 }] -> u256
 
 note: 
     ┌─ checked_arithmetic.fe:147:16
@@ -2155,43 +823,7 @@ note:
 150 │ ╭     pub fn mul_u128(left: u128, right: u128) -> u128 {
 151 │ │         return left * right
 152 │ │     }
-    │ ╰─────^ attributes hash: 11187416061572591496
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u128 }, { label: None, name: right, typ: u128 }] -> u128
 
 note: 
     ┌─ checked_arithmetic.fe:151:16
@@ -2213,43 +845,7 @@ note:
 154 │ ╭     pub fn mul_u64(left: u64, right: u64) -> u64 {
 155 │ │         return left * right
 156 │ │     }
-    │ ╰─────^ attributes hash: 9316585824156398552
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u64 }, { label: None, name: right, typ: u64 }] -> u64
 
 note: 
     ┌─ checked_arithmetic.fe:155:16
@@ -2271,43 +867,7 @@ note:
 158 │ ╭     pub fn mul_u32(left: u32, right: u32) -> u32 {
 159 │ │         return left * right
 160 │ │     }
-    │ ╰─────^ attributes hash: 6948562809403003686
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u32 }, { label: None, name: right, typ: u32 }] -> u32
 
 note: 
     ┌─ checked_arithmetic.fe:159:16
@@ -2329,43 +889,7 @@ note:
 162 │ ╭     pub fn mul_u16(left: u16, right: u16) -> u16 {
 163 │ │         return left * right
 164 │ │     }
-    │ ╰─────^ attributes hash: 4214429573900255413
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u16 }, { label: None, name: right, typ: u16 }] -> u16
 
 note: 
     ┌─ checked_arithmetic.fe:163:16
@@ -2387,43 +911,7 @@ note:
 166 │ ╭     pub fn mul_u8(left: u8, right: u8) -> u8 {
 167 │ │         return left * right
 168 │ │     }
-    │ ╰─────^ attributes hash: 3749617961046563034
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u8 }, { label: None, name: right, typ: u8 }] -> u8
 
 note: 
     ┌─ checked_arithmetic.fe:167:16
@@ -2445,43 +933,7 @@ note:
 170 │ ╭     pub fn mul_i256(left: i256, right: i256) -> i256 {
 171 │ │         return left * right
 172 │ │     }
-    │ ╰─────^ attributes hash: 17908204859155721295
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i256 }, { label: None, name: right, typ: i256 }] -> i256
 
 note: 
     ┌─ checked_arithmetic.fe:171:16
@@ -2503,43 +955,7 @@ note:
 174 │ ╭     pub fn mul_i128(left: i128, right: i128) -> i128 {
 175 │ │         return left * right
 176 │ │     }
-    │ ╰─────^ attributes hash: 1332431709112937827
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i128 }, { label: None, name: right, typ: i128 }] -> i128
 
 note: 
     ┌─ checked_arithmetic.fe:175:16
@@ -2561,43 +977,7 @@ note:
 178 │ ╭     pub fn mul_i64(left: i64, right: i64) -> i64 {
 179 │ │         return left * right
 180 │ │     }
-    │ ╰─────^ attributes hash: 3549113083347694903
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i64 }, { label: None, name: right, typ: i64 }] -> i64
 
 note: 
     ┌─ checked_arithmetic.fe:179:16
@@ -2619,43 +999,7 @@ note:
 182 │ ╭     pub fn mul_i32(left: i32, right: i32) -> i32 {
 183 │ │         return left * right
 184 │ │     }
-    │ ╰─────^ attributes hash: 15117649447142800500
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i32 }, { label: None, name: right, typ: i32 }] -> i32
 
 note: 
     ┌─ checked_arithmetic.fe:183:16
@@ -2677,43 +1021,7 @@ note:
 186 │ ╭     pub fn mul_i16(left: i16, right: i16) -> i16 {
 187 │ │         return left * right
 188 │ │     }
-    │ ╰─────^ attributes hash: 16520261699954225452
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i16 }, { label: None, name: right, typ: i16 }] -> i16
 
 note: 
     ┌─ checked_arithmetic.fe:187:16
@@ -2735,43 +1043,7 @@ note:
 190 │ ╭     pub fn mul_i8(left: i8, right: i8) -> i8 {
 191 │ │         return left * right
 192 │ │     }
-    │ ╰─────^ attributes hash: 2984879578165475690
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i8 }, { label: None, name: right, typ: i8 }] -> i8
 
 note: 
     ┌─ checked_arithmetic.fe:191:16
@@ -2793,43 +1065,7 @@ note:
 194 │ ╭     pub fn mod_u256(left: u256, right: u256) -> u256 {
 195 │ │         return left % right
 196 │ │     }
-    │ ╰─────^ attributes hash: 8877497213208027149
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u256 }, { label: None, name: right, typ: u256 }] -> u256
 
 note: 
     ┌─ checked_arithmetic.fe:195:16
@@ -2851,43 +1087,7 @@ note:
 198 │ ╭     pub fn mod_u128(left: u128, right: u128) -> u128 {
 199 │ │         return left % right
 200 │ │     }
-    │ ╰─────^ attributes hash: 11187416061572591496
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u128 }, { label: None, name: right, typ: u128 }] -> u128
 
 note: 
     ┌─ checked_arithmetic.fe:199:16
@@ -2909,43 +1109,7 @@ note:
 202 │ ╭     pub fn mod_u64(left: u64, right: u64) -> u64 {
 203 │ │         return left % right
 204 │ │     }
-    │ ╰─────^ attributes hash: 9316585824156398552
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u64 }, { label: None, name: right, typ: u64 }] -> u64
 
 note: 
     ┌─ checked_arithmetic.fe:203:16
@@ -2967,43 +1131,7 @@ note:
 206 │ ╭     pub fn mod_u32(left: u32, right: u32) -> u32 {
 207 │ │         return left % right
 208 │ │     }
-    │ ╰─────^ attributes hash: 6948562809403003686
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u32 }, { label: None, name: right, typ: u32 }] -> u32
 
 note: 
     ┌─ checked_arithmetic.fe:207:16
@@ -3025,43 +1153,7 @@ note:
 210 │ ╭     pub fn mod_u16(left: u16, right: u16) -> u16 {
 211 │ │         return left % right
 212 │ │     }
-    │ ╰─────^ attributes hash: 4214429573900255413
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u16 }, { label: None, name: right, typ: u16 }] -> u16
 
 note: 
     ┌─ checked_arithmetic.fe:211:16
@@ -3083,43 +1175,7 @@ note:
 214 │ ╭     pub fn mod_u8(left: u8, right: u8) -> u8 {
 215 │ │         return left % right
 216 │ │     }
-    │ ╰─────^ attributes hash: 3749617961046563034
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u8 }, { label: None, name: right, typ: u8 }] -> u8
 
 note: 
     ┌─ checked_arithmetic.fe:215:16
@@ -3141,43 +1197,7 @@ note:
 218 │ ╭     pub fn mod_i256(left: i256, right: i256) -> i256 {
 219 │ │         return left % right
 220 │ │     }
-    │ ╰─────^ attributes hash: 17908204859155721295
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i256 }, { label: None, name: right, typ: i256 }] -> i256
 
 note: 
     ┌─ checked_arithmetic.fe:219:16
@@ -3199,43 +1219,7 @@ note:
 222 │ ╭     pub fn mod_i128(left: i128, right: i128) -> i128 {
 223 │ │         return left % right
 224 │ │     }
-    │ ╰─────^ attributes hash: 1332431709112937827
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i128 }, { label: None, name: right, typ: i128 }] -> i128
 
 note: 
     ┌─ checked_arithmetic.fe:223:16
@@ -3257,43 +1241,7 @@ note:
 226 │ ╭     pub fn mod_i64(left: i64, right: i64) -> i64 {
 227 │ │         return left % right
 228 │ │     }
-    │ ╰─────^ attributes hash: 3549113083347694903
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i64 }, { label: None, name: right, typ: i64 }] -> i64
 
 note: 
     ┌─ checked_arithmetic.fe:227:16
@@ -3315,43 +1263,7 @@ note:
 230 │ ╭     pub fn mod_i32(left: i32, right: i32) -> i32 {
 231 │ │         return left % right
 232 │ │     }
-    │ ╰─────^ attributes hash: 15117649447142800500
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i32 }, { label: None, name: right, typ: i32 }] -> i32
 
 note: 
     ┌─ checked_arithmetic.fe:231:16
@@ -3373,43 +1285,7 @@ note:
 234 │ ╭     pub fn mod_i16(left: i16, right: i16) -> i16 {
 235 │ │         return left % right
 236 │ │     }
-    │ ╰─────^ attributes hash: 16520261699954225452
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i16 }, { label: None, name: right, typ: i16 }] -> i16
 
 note: 
     ┌─ checked_arithmetic.fe:235:16
@@ -3431,43 +1307,7 @@ note:
 238 │ ╭     pub fn mod_i8(left: i8, right: i8) -> i8 {
 239 │ │         return left % right
 240 │ │     }
-    │ ╰─────^ attributes hash: 2984879578165475690
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i8 }, { label: None, name: right, typ: i8 }] -> i8
 
 note: 
     ┌─ checked_arithmetic.fe:239:16
@@ -3489,43 +1329,7 @@ note:
 242 │ ╭     pub fn pow_u256(left: u256, right: u256) -> u256 {
 243 │ │         return left ** right
 244 │ │     }
-    │ ╰─────^ attributes hash: 8877497213208027149
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u256 }, { label: None, name: right, typ: u256 }] -> u256
 
 note: 
     ┌─ checked_arithmetic.fe:243:16
@@ -3547,43 +1351,7 @@ note:
 246 │ ╭     pub fn pow_u128(left: u128, right: u128) -> u128 {
 247 │ │         return left ** right
 248 │ │     }
-    │ ╰─────^ attributes hash: 11187416061572591496
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u128 }, { label: None, name: right, typ: u128 }] -> u128
 
 note: 
     ┌─ checked_arithmetic.fe:247:16
@@ -3605,43 +1373,7 @@ note:
 250 │ ╭     pub fn pow_u64(left: u64, right: u64) -> u64 {
 251 │ │         return left ** right
 252 │ │     }
-    │ ╰─────^ attributes hash: 9316585824156398552
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u64 }, { label: None, name: right, typ: u64 }] -> u64
 
 note: 
     ┌─ checked_arithmetic.fe:251:16
@@ -3663,43 +1395,7 @@ note:
 254 │ ╭     pub fn pow_u32(left: u32, right: u32) -> u32 {
 255 │ │         return left ** right
 256 │ │     }
-    │ ╰─────^ attributes hash: 6948562809403003686
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u32 }, { label: None, name: right, typ: u32 }] -> u32
 
 note: 
     ┌─ checked_arithmetic.fe:255:16
@@ -3721,43 +1417,7 @@ note:
 258 │ ╭     pub fn pow_u16(left: u16, right: u16) -> u16 {
 259 │ │         return left ** right
 260 │ │     }
-    │ ╰─────^ attributes hash: 4214429573900255413
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u16 }, { label: None, name: right, typ: u16 }] -> u16
 
 note: 
     ┌─ checked_arithmetic.fe:259:16
@@ -3779,43 +1439,7 @@ note:
 262 │ ╭     pub fn pow_u8(left: u8, right: u8) -> u8 {
 263 │ │         return left ** right
 264 │ │     }
-    │ ╰─────^ attributes hash: 3749617961046563034
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: u8 }, { label: None, name: right, typ: u8 }] -> u8
 
 note: 
     ┌─ checked_arithmetic.fe:263:16
@@ -3837,43 +1461,7 @@ note:
 266 │ ╭     pub fn pow_i256(left: i256, right: u256) -> i256 {
 267 │ │         return left ** right
 268 │ │     }
-    │ ╰─────^ attributes hash: 10218838230504849711
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i256 }, { label: None, name: right, typ: u256 }] -> i256
 
 note: 
     ┌─ checked_arithmetic.fe:267:16
@@ -3895,43 +1483,7 @@ note:
 270 │ ╭     pub fn pow_i128(left: i128, right: u128) -> i128 {
 271 │ │         return left ** right
 272 │ │     }
-    │ ╰─────^ attributes hash: 8492300797170107874
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I128,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U128,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i128 }, { label: None, name: right, typ: u128 }] -> i128
 
 note: 
     ┌─ checked_arithmetic.fe:271:16
@@ -3953,43 +1505,7 @@ note:
 274 │ ╭     pub fn pow_i64(left: i64, right: u64) -> i64 {
 275 │ │         return left ** right
 276 │ │     }
-    │ ╰─────^ attributes hash: 8175269888119534907
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I64,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U64,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i64 }, { label: None, name: right, typ: u64 }] -> i64
 
 note: 
     ┌─ checked_arithmetic.fe:275:16
@@ -4011,43 +1527,7 @@ note:
 278 │ ╭     pub fn pow_i32(left: i32, right: u32) -> i32 {
 279 │ │         return left ** right
 280 │ │     }
-    │ ╰─────^ attributes hash: 9388330002377862662
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I32,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U32,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i32 }, { label: None, name: right, typ: u32 }] -> i32
 
 note: 
     ┌─ checked_arithmetic.fe:279:16
@@ -4069,43 +1549,7 @@ note:
 282 │ ╭     pub fn pow_i16(left: i16, right: u16) -> i16 {
 283 │ │         return left ** right
 284 │ │     }
-    │ ╰─────^ attributes hash: 8172583117888506116
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I16,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U16,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i16 }, { label: None, name: right, typ: u16 }] -> i16
 
 note: 
     ┌─ checked_arithmetic.fe:283:16
@@ -4127,43 +1571,7 @@ note:
 286 │ ╭     pub fn pow_i8(left: i8, right: u8) -> i8 {
 287 │ │         return left ** right
 288 │ │     }
-    │ ╰─────^ attributes hash: 783967907920544100
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "left",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              I8,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "right",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [{ label: None, name: left, typ: i8 }, { label: None, name: right, typ: u8 }] -> i8
 
 note: 
     ┌─ checked_arithmetic.fe:287:16

--- a/crates/analyzer/tests/snapshots/analysis__const_generics.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_generics.snap
@@ -13,18 +13,7 @@ note:
    · │
 46 │ │         let array_with_const: Array<i32, { DOUBLE_ARRAY_LENGTH / TWO }>
 47 │ │     }
-   │ ╰─────^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> ()
 
 note: 
    ┌─ const_generics.fe:4:13

--- a/crates/analyzer/tests/snapshots/analysis__const_local.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_local.snap
@@ -13,20 +13,7 @@ note:
    · │
 15 │ │         return C10
 16 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ const_local.fe:3:15

--- a/crates/analyzer/tests/snapshots/analysis__constructor.snap
+++ b/crates/analyzer/tests/snapshots/analysis__constructor.snap
@@ -15,22 +15,7 @@ note:
  8 │ ╭     pub fn read_bar(self) -> u256 {
  9 │ │         return self.bar[42]
 10 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
   ┌─ constructor.fe:9:16

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -9,20 +9,7 @@ note:
 4 │ ╭     pub fn get_my_num() -> u256 {
 5 │ │         return 42
 6 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ create2_contract.fe:5:16
@@ -37,33 +24,7 @@ note:
 11 │ │         let foo: Foo = Foo.create2(ctx, 0, 52)
 12 │ │         return address(foo)
 13 │ │     }
-   │ ╰─────^ attributes hash: 9364783648076633772
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
    ┌─ create2_contract.fe:11:13

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -9,20 +9,7 @@ note:
 4 │ ╭     pub fn get_my_num() -> u256 {
 5 │ │         return 42
 6 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ create_contract.fe:5:16
@@ -37,33 +24,7 @@ note:
 11 │ │         let foo: Foo = Foo.create(ctx, 0)
 12 │ │         return address(foo)
 13 │ │     }
-   │ ╰─────^ attributes hash: 9364783648076633772
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
    ┌─ create_contract.fe:11:13

--- a/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
@@ -9,20 +9,7 @@ note:
 4 │ ╭     pub fn get_my_num() -> u256 {
 5 │ │         return 42
 6 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ create_contract_from_init.fe:5:16
@@ -42,20 +29,7 @@ note:
 16 │ ╭     pub fn get_foo_addr(self) -> address {
 17 │ │         return self.foo_addr
 18 │ │     }
-   │ ╰─────^ attributes hash: 227275695522088782
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
    ┌─ create_contract_from_init.fe:17:16

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ data_copying_stress.fe:4:5
@@ -35,65 +36,7 @@ note:
 19 │ │         self.my_u256 = my_u256
 20 │ │         self.my_other_u256 = my_other_u256
 21 │ │     }
-   │ ╰─────^ attributes hash: 8414520425977761339
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 42,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_other_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 42,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_u256",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_other_u256",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_string, typ: String<42> }, { label: None, name: my_other_string, typ: String<42> }, { label: None, name: my_u256, typ: u256 }, { label: None, name: my_other_u256, typ: u256 }] -> ()
 
 note: 
    ┌─ data_copying_stress.fe:17:9
@@ -146,20 +89,7 @@ note:
 24 │ │         self.my_string = self.my_other_string
 25 │ │         self.my_u256 = self.my_other_u256
 26 │ │     }
-   │ ╰─────^ attributes hash: 18235041182630809162
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
    ┌─ data_copying_stress.fe:24:9
@@ -207,35 +137,7 @@ note:
    · │
 39 │ │         assert my_3rd_array[3] == 50
 40 │ │     }
-   │ ╰─────^ attributes hash: 17752007532841141815
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_array",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 10,
-                             inner: Base(
-                                 Numeric(
-                                     U256,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> ()
 
 note: 
    ┌─ data_copying_stress.fe:29:13
@@ -410,42 +312,7 @@ note:
 43 │ │         my_array[3] = 5
 44 │ │         return my_array
 45 │ │     }
-   │ ╰─────^ attributes hash: 92188389337515101
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_array",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 10,
-                             inner: Base(
-                                 Numeric(
-                                     U256,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 10,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> Array<u256, 10>
 
 note: 
    ┌─ data_copying_stress.fe:43:9
@@ -471,42 +338,7 @@ note:
 47 │ ╭     pub fn clone_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
 48 │ │         return my_array.clone()
 49 │ │     }
-   │ ╰─────^ attributes hash: 92188389337515101
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_array",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 10,
-                             inner: Base(
-                                 Numeric(
-                                     U256,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 10,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> Array<u256, 10>
 
 note: 
    ┌─ data_copying_stress.fe:48:16
@@ -527,42 +359,7 @@ note:
 52 │ │         my_array.clone()[3] = 5
 53 │ │         return my_array
 54 │ │     }
-   │ ╰─────^ attributes hash: 92188389337515101
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_array",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 10,
-                             inner: Base(
-                                 Numeric(
-                                     U256,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 10,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> Array<u256, 10>
 
 note: 
    ┌─ data_copying_stress.fe:52:9
@@ -598,27 +395,7 @@ note:
    · │
 64 │ │         return my_nums_mem
 65 │ │     }
-   │ ╰─────^ attributes hash: 14329847023405603454
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 5,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> Array<u256, 5>
 
 note: 
    ┌─ data_copying_stress.fe:57:13
@@ -744,35 +521,7 @@ note:
 67 │ ╭     pub fn emit_my_event(self, ctx: Context) {
 68 │ │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
 69 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ data_copying_stress.fe:68:32
@@ -814,59 +563,7 @@ note:
 71 │ ╭     fn emit_my_event_internal(ctx: Context, _ my_string: String<42>, _ my_u256: u256) {
 72 │ │         emit MyEvent(ctx, my_string, my_u256)
 73 │ │     }
-   │ ╰─────^ attributes hash: 15658342901286022244
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 42,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "my_u256",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: Some("_"), name: my_string, typ: String<42> }, { label: Some("_"), name: my_u256, typ: u256 }] -> ()
 
 note: 
    ┌─ data_copying_stress.fe:72:22
@@ -878,74 +575,12 @@ note:
    │                      Context: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:72:9
-   │
-72 │         emit MyEvent(ctx, my_string, my_u256)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 595206297963940250
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 42,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_u256",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ data_copying_stress.fe:75:5
    │  
 75 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>) {
 76 │ │         self.my_addrs = my_addrs
 77 │ │     }
-   │ ╰─────^ attributes hash: 6379907192890628947
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 3,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_addrs, typ: Array<address, 3> }] -> ()
 
 note: 
    ┌─ data_copying_stress.fe:76:9
@@ -967,20 +602,7 @@ note:
 79 │ ╭     pub fn get_my_second_addr(self) -> address {
 80 │ │         return self.my_addrs[1]
 81 │ │     }
-   │ ╰─────^ attributes hash: 227275695522088782
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
    ┌─ data_copying_stress.fe:80:16

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -45,22 +45,7 @@ note:
 30 │ ╭     pub fn name(self) -> String<100> {
 31 │ │         return self._name.to_mem()
 32 │ │     }
-   │ ╰─────^ attributes hash: 2936475649167061923
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 100,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> String<100>
 
 note: 
    ┌─ erc20_token.fe:31:16
@@ -86,22 +71,7 @@ note:
 34 │ ╭     pub fn symbol(self) -> String<100> {
 35 │ │         return self._symbol.to_mem()
 36 │ │     }
-   │ ╰─────^ attributes hash: 2936475649167061923
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 100,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> String<100>
 
 note: 
    ┌─ erc20_token.fe:35:16
@@ -127,22 +97,7 @@ note:
 38 │ ╭     pub fn decimals(self) -> u8 {
 39 │ │         return self._decimals
 40 │ │     }
-   │ ╰─────^ attributes hash: 11864308689780915279
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u8
 
 note: 
    ┌─ erc20_token.fe:39:16
@@ -162,22 +117,7 @@ note:
 42 │ ╭     pub fn totalSupply(self) -> u256 {
 43 │ │         return self._total_supply
 44 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ erc20_token.fe:43:16
@@ -197,34 +137,7 @@ note:
 46 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
 47 │ │         return self._balances[account]
 48 │ │     }
-   │ ╰─────^ attributes hash: 5993653573135321647
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "account",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
    ┌─ erc20_token.fe:47:16
@@ -253,55 +166,7 @@ note:
 51 │ │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
 52 │ │         return true
 53 │ │     }
-   │ ╰─────^ attributes hash: 9700541873563816287
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "recipient",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: recipient, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
    ┌─ erc20_token.fe:51:9
@@ -335,41 +200,7 @@ note:
 55 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256 {
 56 │ │         return self._allowances[owner][spender]
 57 │ │     }
-   │ ╰─────^ attributes hash: 3316599995530573429
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "owner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: owner, typ: address }, { label: None, name: spender, typ: address }] -> u256
 
 note: 
    ┌─ erc20_token.fe:56:16
@@ -406,55 +237,7 @@ note:
 60 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
 61 │ │         return true
 62 │ │     }
-   │ ╰─────^ attributes hash: 8309406699454253603
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
    ┌─ erc20_token.fe:60:9
@@ -491,64 +274,7 @@ note:
 67 │ │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
 68 │ │         return true
 69 │ │     }
-   │ ╰─────^ attributes hash: 14464733394183378558
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "sender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "recipient",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: sender, typ: address }, { label: None, name: recipient, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
    ┌─ erc20_token.fe:65:16
@@ -670,55 +396,7 @@ note:
 72 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
 73 │ │         return true
 74 │ │     }
-   │ ╰─────^ attributes hash: 14606848714789380929
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "addedValue",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: addedValue, typ: u256 }] -> bool
 
 note: 
    ┌─ erc20_token.fe:72:9
@@ -789,55 +467,7 @@ note:
 77 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
 78 │ │         return true
 79 │ │     }
-   │ ╰─────^ attributes hash: 9154612140799800808
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "spender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "subtractedValue",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: subtractedValue, typ: u256 }] -> bool
 
 note: 
    ┌─ erc20_token.fe:77:9
@@ -911,64 +541,7 @@ note:
    · │
 87 │ │         emit Transfer(ctx, from: sender, to: recipient, value)
 88 │ │     }
-   │ ╰─────^ attributes hash: 10648262769466339085
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "sender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "recipient",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: sender, typ: address }, { label: None, name: recipient, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ erc20_token.fe:82:16
@@ -1104,47 +677,6 @@ note:
    │                       Context: Memory
 
 note: 
-   ┌─ erc20_token.fe:87:9
-   │
-87 │         emit Transfer(ctx, from: sender, to: recipient, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ erc20_token.fe:90:5
    │  
 90 │ ╭     fn _mint(self, ctx: Context, account: address, value: u256) {
@@ -1154,55 +686,7 @@ note:
 94 │ │         self._balances[account] = self._balances[account] + value
 95 │ │         emit Transfer(ctx, from: address(0), to: account, value)
 96 │ │     }
-   │ ╰─────^ attributes hash: 6502254374233415580
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "account",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: account, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ erc20_token.fe:91:16
@@ -1319,47 +803,6 @@ note:
    │                                  address: Value
 
 note: 
-   ┌─ erc20_token.fe:95:9
-   │
-95 │         emit Transfer(ctx, from: address(0), to: account, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
     ┌─ erc20_token.fe:98:5
     │  
  98 │ ╭     fn _burn(self, ctx: Context, account: address, value: u256) {
@@ -1369,55 +812,7 @@ note:
 102 │ │         self._total_supply = self._total_supply - value
 103 │ │         emit Transfer(ctx, from: account, to: address(0), value)
 104 │ │     }
-    │ ╰─────^ attributes hash: 6502254374233415580
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "account",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: account, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ erc20_token.fe:99:16
@@ -1535,47 +930,6 @@ note:
     │                                               address: Value
 
 note: 
-    ┌─ erc20_token.fe:103:9
-    │
-103 │         emit Transfer(ctx, from: account, to: address(0), value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-    │
-    = Event {
-          name: "Transfer",
-          fields: [
-              EventField {
-                  name: "from",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ erc20_token.fe:106:5
     │  
 106 │ ╭     fn _approve(self, ctx: Context, owner: address, spender: address, value: u256) {
@@ -1584,64 +938,7 @@ note:
 109 │ │         self._allowances[owner][spender] = value
 110 │ │         emit Approval(ctx, owner, spender, value)
 111 │ │     }
-    │ ╰─────^ attributes hash: 1630416716014819616
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "owner",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "spender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: owner, typ: address }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
     ┌─ erc20_token.fe:107:16
@@ -1712,80 +1009,12 @@ note:
     │                       Context: Memory
 
 note: 
-    ┌─ erc20_token.fe:110:9
-    │
-110 │         emit Approval(ctx, owner, spender, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8893313742751514912
-    │
-    = Event {
-          name: "Approval",
-          fields: [
-              EventField {
-                  name: "owner",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "spender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ erc20_token.fe:113:5
     │  
 113 │ ╭     fn _setup_decimals(self, _ decimals_: u8) {
 114 │ │         self._decimals = decimals_
 115 │ │     }
-    │ ╰─────^ attributes hash: 2241116105643912660
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "decimals_",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: decimals_, typ: u8 }] -> ()
 
 note: 
     ┌─ erc20_token.fe:114:9
@@ -1805,49 +1034,6 @@ note:
     ┌─ erc20_token.fe:117:5
     │
 117 │     fn _before_token_transfer(from: address, to: address, _ value: u256) {}
-    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10552855728897650120
-    │
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "from",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ self: None, params: [{ label: None, name: from, typ: address }, { label: None, name: to, typ: address }, { label: Some("_"), name: value, typ: u256 }] -> ()
 
 

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ events.fe:5:9
@@ -42,33 +43,7 @@ note:
 25 │ ╭     pub fn emit_nums(ctx: Context) {
 26 │ │         emit Nums(ctx, num1: 26, num2: 42)
 27 │ │     }
-   │ ╰─────^ attributes hash: 5519676733853656531
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ events.fe:26:19
@@ -80,81 +55,12 @@ note:
    │                   Context: Memory
 
 note: 
-   ┌─ events.fe:26:9
-   │
-26 │         emit Nums(ctx, num1: 26, num2: 42)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4681095448721924839
-   │
-   = Event {
-         name: "Nums",
-         fields: [
-             EventField {
-                 name: "num1",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "num2",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ events.fe:29:5
    │  
 29 │ ╭     pub fn emit_bases(ctx: Context, addr: address) {
 30 │ │         emit Bases(ctx, num: 26, addr)
 31 │ │     }
-   │ ╰─────^ attributes hash: 15383426943610850221
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: addr, typ: address }] -> ()
 
 note: 
    ┌─ events.fe:30:20
@@ -166,95 +72,12 @@ note:
    │                    Context: Memory
 
 note: 
-   ┌─ events.fe:30:9
-   │
-30 │         emit Bases(ctx, num: 26, addr)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4407350417102602838
-   │
-   = Event {
-         name: "Bases",
-         fields: [
-             EventField {
-                 name: "num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ events.fe:33:5
    │  
 33 │ ╭     pub fn emit_mix(ctx: Context, addr: address, my_bytes: Array<u8, 100>) {
 34 │ │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
 35 │ │     }
-   │ ╰─────^ attributes hash: 17632983073889485939
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_bytes",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 100,
-                             inner: Base(
-                                 Numeric(
-                                     U8,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: addr, typ: address }, { label: None, name: my_bytes, typ: Array<u8, 100> }] -> ()
 
 note: 
    ┌─ events.fe:34:18
@@ -268,65 +91,6 @@ note:
    │                  Context: Memory
 
 note: 
-   ┌─ events.fe:34:9
-   │
-34 │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14467559009864244124
-   │
-   = Event {
-         name: "Mix",
-         fields: [
-             EventField {
-                 name: "num1",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "num2",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_bytes",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 100,
-                             inner: Base(
-                                 Numeric(
-                                     U8,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ events.fe:37:5
    │  
 37 │ ╭     pub fn emit_addresses(ctx: Context, addr1: address, addr2: address) {
@@ -335,51 +99,7 @@ note:
 40 │ │         addrs[1] = addr2
 41 │ │         emit Addresses(ctx, addrs)
 42 │ │     }
-   │ ╰─────^ attributes hash: 18438233211486921531
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "addr1",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "addr2",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: addr1, typ: address }, { label: None, name: addr2, typ: address }] -> ()
 
 note: 
    ┌─ events.fe:38:13
@@ -418,31 +138,5 @@ note:
    │                        ^^^  ^^^^^ Array<address, 2>: Memory
    │                        │     
    │                        Context: Memory
-
-note: 
-   ┌─ events.fe:41:9
-   │
-41 │         emit Addresses(ctx, addrs)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13530689072905293596
-   │
-   = Event {
-         name: "Addresses",
-         fields: [
-             EventField {
-                 name: "addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 2,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ external_contract.fe:5:9
@@ -18,69 +19,7 @@ note:
 10 │ ╭     pub fn emit_event(ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
 11 │ │         emit MyEvent(ctx, my_num, my_addrs, my_string)
 12 │ │     }
-   │ ╰─────^ attributes hash: 3754416609002139684
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 5,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 11,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
 
 note: 
    ┌─ external_contract.fe:11:22
@@ -93,54 +32,6 @@ note:
    │                      Context: Memory
 
 note: 
-   ┌─ external_contract.fe:11:9
-   │
-11 │         emit MyEvent(ctx, my_num, my_addrs, my_string)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 14493411523883858336
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "my_num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 5,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 11,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ external_contract.fe:14:5
    │  
 14 │ ╭     pub fn build_array(a: u256, b: u256) -> Array<u256, 3> {
@@ -150,48 +41,7 @@ note:
 18 │ │         my_array[2] = b
 19 │ │         return my_array
 20 │ │     }
-   │ ╰─────^ attributes hash: 8432779812067699525
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 3,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
 
 note: 
    ┌─ external_contract.fe:15:13
@@ -255,78 +105,7 @@ note:
 25 │ │         let foo: Foo = Foo(foo_address)
 26 │ │         foo.emit_event(ctx, my_num, my_addrs, my_string)
 27 │ │     }
-   │ ╰─────^ attributes hash: 14242721142940057862
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "foo_address",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_addrs",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 5,
-                             inner: Base(
-                                 Address,
-                             ),
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_string",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 11,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: foo_address, typ: address }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
 
 note: 
    ┌─ external_contract.fe:25:13
@@ -366,57 +145,7 @@ note:
 30 │ │         let foo: Foo = Foo(foo_address)
 31 │ │         return foo.build_array(a, b)
 32 │ │     }
-   │ ╰─────^ attributes hash: 6675851927406831661
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "foo_address",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 3,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: foo_address, typ: address }, { label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
 
 note: 
    ┌─ external_contract.fe:30:13

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_break.snap
@@ -13,20 +13,7 @@ note:
    · │
 14 │ │         return sum
 15 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ for_loop_with_break.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_continue.snap
@@ -13,20 +13,7 @@ note:
    · │
 16 │ │         return sum
 17 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ for_loop_with_continue.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__for_loop_with_static_array.snap
@@ -13,20 +13,7 @@ note:
    · │
 11 │ │         return sum
 12 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ for_loop_with_static_array.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -25,46 +25,7 @@ note:
 18 │ │         # Emit the `Signed` event
 19 │ │         emit Signed(ctx, book_msg)
 20 │ │     }
-   │ ╰─────^ attributes hash: 12497999579229810685
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "book_msg",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: book_msg, typ: String<100> }] -> ()
 
 note: 
    ┌─ guest_book.fe:16:9
@@ -100,29 +61,6 @@ note:
    │                     Context: Memory
 
 note: 
-   ┌─ guest_book.fe:19:9
-   │
-19 │         emit Signed(ctx, book_msg)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 3840771212935086148
-   │
-   = Event {
-         name: "Signed",
-         fields: [
-             EventField {
-                 name: "book_msg",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ guest_book.fe:22:5
    │  
 22 │ ╭     pub fn get_msg(self, addr: address) -> String<100> {
@@ -130,32 +68,7 @@ note:
 24 │ │         # has to be done explicitly via `to_mem()`
 25 │ │         return self.messages[addr].to_mem()
 26 │ │     }
-   │ ╰─────^ attributes hash: 3325224293767249368
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 100,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: addr, typ: address }] -> String<100>
 
 note: 
    ┌─ guest_book.fe:25:16

--- a/crates/analyzer/tests/snapshots/analysis__if_statement.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement.snap
@@ -13,32 +13,7 @@ note:
 6 │ │             return 0
 7 │ │         }
 8 │ │     }
-  │ ╰─────^ attributes hash: 10660199954095577886
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "input",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: input, typ: u256 }] -> u256
 
 note: 
   ┌─ if_statement.fe:3:12

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_2.snap
@@ -13,32 +13,7 @@ note:
   · │
 8 │ │         return 0
 9 │ │     }
-  │ ╰─────^ attributes hash: 12367727332255217641
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "val",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: val, typ: u256 }] -> u256
 
 note: 
   ┌─ if_statement_2.fe:3:12

--- a/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
+++ b/crates/analyzer/tests/snapshots/analysis__if_statement_with_block_declaration.snap
@@ -13,20 +13,7 @@ note:
    · │
  9 │ │         }
 10 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ if_statement_with_block_declaration.fe:4:17

--- a/crates/analyzer/tests/snapshots/analysis__keccak.snap
+++ b/crates/analyzer/tests/snapshots/analysis__keccak.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ keccak.fe:2:5
@@ -8,37 +9,7 @@ note:
 2 │ ╭     pub fn return_hash_from_u8(val: Array<u8, 1>) -> u256 {
 3 │ │         return keccak256(val)
 4 │ │     }
-  │ ╰─────^ attributes hash: 13665051569980032928
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "val",
-                typ: Ok(
-                    Array(
-                        Array {
-                            size: 1,
-                            inner: Base(
-                                Numeric(
-                                    U8,
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: val, typ: Array<u8, 1> }] -> u256
 
 note: 
   ┌─ keccak.fe:3:26
@@ -58,37 +29,7 @@ note:
 6 │ ╭     pub fn return_hash_from_foo(val: Array<u8, 3>) -> u256 {
 7 │ │         return keccak256(val)
 8 │ │     }
-  │ ╰─────^ attributes hash: 14115249111516313873
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "val",
-                typ: Ok(
-                    Array(
-                        Array {
-                            size: 3,
-                            inner: Base(
-                                Numeric(
-                                    U8,
-                                ),
-                            ),
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: val, typ: Array<u8, 3> }] -> u256
 
 note: 
   ┌─ keccak.fe:7:26
@@ -108,37 +49,7 @@ note:
 10 │ ╭     pub fn return_hash_from_u256(val: Array<u8, 32>) -> u256 {
 11 │ │         return keccak256(val)
 12 │ │     }
-   │ ╰─────^ attributes hash: 3591219705610392773
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "val",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 32,
-                             inner: Base(
-                                 Numeric(
-                                     U8,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: val, typ: Array<u8, 32> }] -> u256
 
 note: 
    ┌─ keccak.fe:11:26

--- a/crates/analyzer/tests/snapshots/analysis__math.snap
+++ b/crates/analyzer/tests/snapshots/analysis__math.snap
@@ -13,32 +13,7 @@ note:
    · │
 14 │ │         return z
 15 │ │     }
-   │ ╰─────^ attributes hash: 12367727332255217641
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "val",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: val, typ: u256 }] -> u256
 
 note: 
   ┌─ math.fe:3:13
@@ -150,43 +125,7 @@ note:
 17 │ ╭     pub fn min(x: u256, y: u256) -> u256 {
 18 │ │         return x if x < y else y
 19 │ │     }
-   │ ╰─────^ attributes hash: 6847926207878778580
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "y",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
    ┌─ math.fe:18:21

--- a/crates/analyzer/tests/snapshots/analysis__module_const.snap
+++ b/crates/analyzer/tests/snapshots/analysis__module_const.snap
@@ -43,20 +43,7 @@ note:
 13 │ │         let _my_array: MY_ARRAY
 14 │ │         return C4
 15 │ │     }
-   │ ╰─────^ attributes hash: 18058099208132403133
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> i32
 
 note: 
    ┌─ module_const.fe:10:15

--- a/crates/analyzer/tests/snapshots/analysis__module_level_events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__module_level_events.snap
@@ -19,53 +19,7 @@ note:
 10 │ ╭     fn transfer(ctx: Context, to: address, value: u256) {
 11 │ │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
 12 │ │     }
-   │ ╰─────^ attributes hash: 10847004199357482546
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ module_level_events.fe:11:23
@@ -83,46 +37,5 @@ note:
    │                                    │                           │    
    │                                    │                           address: Value
    │                                    address: Value
-
-note: 
-   ┌─ module_level_events.fe:11:9
-   │
-11 │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 17986960071624595337
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "sender",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "receiver",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__multi_param.snap
+++ b/crates/analyzer/tests/snapshots/analysis__multi_param.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ multi_param.fe:2:5
@@ -12,59 +13,7 @@ note:
 6 │ │         my_array[2] = z
 7 │ │         return my_array
 8 │ │     }
-  │ ╰─────^ attributes hash: 10696147843982229344
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "z",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Array(
-                Array {
-                    size: 3,
-                    inner: Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }, { label: None, name: z, typ: u256 }] -> Array<u256, 3>
 
 note: 
   ┌─ multi_param.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__nested_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__nested_map.snap
@@ -17,41 +17,7 @@ note:
 5 │ ╭     pub fn read_bar(self, a: address, b: address) -> u256 {
 6 │ │         return self.bar[a][b]
 7 │ │     }
-  │ ╰─────^ attributes hash: 17216960098647945084
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "a",
-                typ: Ok(
-                    Base(
-                        Address,
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "b",
-                typ: Ok(
-                    Base(
-                        Address,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: address }, { label: None, name: b, typ: address }] -> u256
 
 note: 
   ┌─ nested_map.fe:6:16
@@ -87,50 +53,7 @@ note:
  9 │ ╭     pub fn write_bar(self, a: address, b: address, value: u256) {
 10 │ │         self.bar[a][b] = value
 11 │ │     }
-   │ ╰─────^ attributes hash: 1717293224155577849
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: address }, { label: None, name: b, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ nested_map.fe:10:9
@@ -168,41 +91,7 @@ note:
 13 │ ╭     pub fn read_baz(self, a: address, b: u256) -> bool {
 14 │ │         return self.baz[a][b]
 15 │ │     }
-   │ ╰─────^ attributes hash: 13548986453815092160
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: address }, { label: None, name: b, typ: u256 }] -> bool
 
 note: 
    ┌─ nested_map.fe:14:16
@@ -238,50 +127,7 @@ note:
 17 │ ╭     pub fn write_baz(self, a: address, b: u256, value: bool) {
 18 │ │         self.baz[a][b] = value
 19 │ │     }
-   │ ╰─────^ attributes hash: 6442389777288668179
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "a",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "b",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Bool,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: address }, { label: None, name: b, typ: u256 }, { label: None, name: value, typ: bool }] -> ()
 
 note: 
    ┌─ nested_map.fe:18:9

--- a/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__numeric_sizes.snap
@@ -153,20 +153,7 @@ note:
 33 │ ╭     pub fn get_u8_min() -> u8 {
 34 │ │         return u8(0)
 35 │ │     }
-   │ ╰─────^ attributes hash: 18193502560299416939
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u8
 
 note: 
    ┌─ numeric_sizes.fe:34:19
@@ -186,20 +173,7 @@ note:
 36 │ ╭     pub fn get_u8_const_min() -> u8 {
 37 │ │         return U8_MIN
 38 │ │     }
-   │ ╰─────^ attributes hash: 18193502560299416939
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u8
 
 note: 
    ┌─ numeric_sizes.fe:37:16
@@ -213,20 +187,7 @@ note:
 40 │ ╭     pub fn get_u16_min() -> u16 {
 41 │ │         return u16(0)
 42 │ │     }
-   │ ╰─────^ attributes hash: 3086088635989474166
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u16
 
 note: 
    ┌─ numeric_sizes.fe:41:20
@@ -246,20 +207,7 @@ note:
 44 │ ╭     pub fn get_u16_const_min() -> u16 {
 45 │ │         return U16_MIN
 46 │ │     }
-   │ ╰─────^ attributes hash: 3086088635989474166
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u16
 
 note: 
    ┌─ numeric_sizes.fe:45:16
@@ -273,20 +221,7 @@ note:
 48 │ ╭     pub fn get_u32_min() -> u32 {
 49 │ │         return u32(0)
 50 │ │     }
-   │ ╰─────^ attributes hash: 1978352585063323439
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u32
 
 note: 
    ┌─ numeric_sizes.fe:49:20
@@ -306,20 +241,7 @@ note:
 52 │ ╭     pub fn get_u32_const_min() -> u32 {
 53 │ │         return U32_MIN
 54 │ │     }
-   │ ╰─────^ attributes hash: 1978352585063323439
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u32
 
 note: 
    ┌─ numeric_sizes.fe:53:16
@@ -333,20 +255,7 @@ note:
 56 │ ╭     pub fn get_u64_min() -> u64 {
 57 │ │         return u64(0)
 58 │ │     }
-   │ ╰─────^ attributes hash: 3966212821348382963
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u64
 
 note: 
    ┌─ numeric_sizes.fe:57:20
@@ -366,20 +275,7 @@ note:
 60 │ ╭     pub fn get_u64_const_min() -> u64 {
 61 │ │         return U64_MIN
 62 │ │     }
-   │ ╰─────^ attributes hash: 3966212821348382963
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u64
 
 note: 
    ┌─ numeric_sizes.fe:61:16
@@ -393,20 +289,7 @@ note:
 64 │ ╭     pub fn get_u128_min() -> u128 {
 65 │ │         return u128(0)
 66 │ │     }
-   │ ╰─────^ attributes hash: 104322826323649285
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U128,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u128
 
 note: 
    ┌─ numeric_sizes.fe:65:21
@@ -426,20 +309,7 @@ note:
 68 │ ╭     pub fn get_u128_const_min() -> u128 {
 69 │ │         return U128_MIN
 70 │ │     }
-   │ ╰─────^ attributes hash: 104322826323649285
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U128,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u128
 
 note: 
    ┌─ numeric_sizes.fe:69:16
@@ -453,20 +323,7 @@ note:
 72 │ ╭     pub fn get_u256_min() -> u256 {
 73 │ │         return u256(0)
 74 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ numeric_sizes.fe:73:21
@@ -486,20 +343,7 @@ note:
 76 │ ╭     pub fn get_u256_const_min() -> u256 {
 77 │ │         return U256_MIN
 78 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ numeric_sizes.fe:77:16
@@ -513,20 +357,7 @@ note:
 80 │ ╭     pub fn get_i8_min() -> i8 {
 81 │ │         return i8(-128)
 82 │ │     }
-   │ ╰─────^ attributes hash: 15762448841602984320
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> i8
 
 note: 
    ┌─ numeric_sizes.fe:81:20
@@ -552,20 +383,7 @@ note:
 84 │ ╭     pub fn get_i8_const_min() -> i8 {
 85 │ │         return I8_MIN
 86 │ │     }
-   │ ╰─────^ attributes hash: 15762448841602984320
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I8,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> i8
 
 note: 
    ┌─ numeric_sizes.fe:85:16
@@ -579,20 +397,7 @@ note:
 88 │ ╭     pub fn get_i16_min() -> i16 {
 89 │ │         return i16(-32768)
 90 │ │     }
-   │ ╰─────^ attributes hash: 1032717434757427850
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> i16
 
 note: 
    ┌─ numeric_sizes.fe:89:21
@@ -618,20 +423,7 @@ note:
 92 │ ╭     pub fn get_i16_const_min() -> i16 {
 93 │ │         return I16_MIN
 94 │ │     }
-   │ ╰─────^ attributes hash: 1032717434757427850
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I16,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> i16
 
 note: 
    ┌─ numeric_sizes.fe:93:16
@@ -645,20 +437,7 @@ note:
 96 │ ╭     pub fn get_i32_min() -> i32 {
 97 │ │         return i32(-2147483648)
 98 │ │     }
-   │ ╰─────^ attributes hash: 18058099208132403133
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     I32,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> i32
 
 note: 
    ┌─ numeric_sizes.fe:97:21
@@ -684,20 +463,7 @@ note:
 100 │ ╭     pub fn get_i32_const_min() -> i32 {
 101 │ │         return I32_MIN
 102 │ │     }
-    │ ╰─────^ attributes hash: 18058099208132403133
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i32
 
 note: 
     ┌─ numeric_sizes.fe:101:16
@@ -711,20 +477,7 @@ note:
 104 │ ╭     pub fn get_i64_min() -> i64 {
 105 │ │         return i64(-9223372036854775808)
 106 │ │     }
-    │ ╰─────^ attributes hash: 6774734901144681103
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i64
 
 note: 
     ┌─ numeric_sizes.fe:105:21
@@ -750,20 +503,7 @@ note:
 108 │ ╭     pub fn get_i64_const_min() -> i64 {
 109 │ │         return I64_MIN
 110 │ │     }
-    │ ╰─────^ attributes hash: 6774734901144681103
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i64
 
 note: 
     ┌─ numeric_sizes.fe:109:16
@@ -777,20 +517,7 @@ note:
 112 │ ╭     pub fn get_i128_min() -> i128 {
 113 │ │         return i128(-170141183460469231731687303715884105728)
 114 │ │     }
-    │ ╰─────^ attributes hash: 155533728466856391
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i128
 
 note: 
     ┌─ numeric_sizes.fe:113:22
@@ -816,20 +543,7 @@ note:
 116 │ ╭     pub fn get_i128_const_min() -> i128 {
 117 │ │         return I128_MIN
 118 │ │     }
-    │ ╰─────^ attributes hash: 155533728466856391
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i128
 
 note: 
     ┌─ numeric_sizes.fe:117:16
@@ -843,20 +557,7 @@ note:
 120 │ ╭     pub fn get_i256_min() -> i256 {
 121 │ │         return i256(-57896044618658097711785492504343953926634992332820282019728792003956564819968)
 122 │ │     }
-    │ ╰─────^ attributes hash: 8116994679119332188
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i256
 
 note: 
     ┌─ numeric_sizes.fe:121:22
@@ -882,20 +583,7 @@ note:
 124 │ ╭     pub fn get_i256_const_min() -> i256 {
 125 │ │         return I256_MIN
 126 │ │     }
-    │ ╰─────^ attributes hash: 8116994679119332188
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i256
 
 note: 
     ┌─ numeric_sizes.fe:125:16
@@ -909,20 +597,7 @@ note:
 128 │ ╭     pub fn get_u8_max() -> u8 {
 129 │ │         return u8(255)
 130 │ │     }
-    │ ╰─────^ attributes hash: 18193502560299416939
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u8
 
 note: 
     ┌─ numeric_sizes.fe:129:19
@@ -942,20 +617,7 @@ note:
 132 │ ╭     pub fn get_u8_const_max() -> u8 {
 133 │ │         return U8_MAX
 134 │ │     }
-    │ ╰─────^ attributes hash: 18193502560299416939
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u8
 
 note: 
     ┌─ numeric_sizes.fe:133:16
@@ -969,20 +631,7 @@ note:
 136 │ ╭     pub fn get_u16_max() -> u16 {
 137 │ │         return u16(65535)
 138 │ │     }
-    │ ╰─────^ attributes hash: 3086088635989474166
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u16
 
 note: 
     ┌─ numeric_sizes.fe:137:20
@@ -1002,20 +651,7 @@ note:
 140 │ ╭     pub fn get_u16_const_max() -> u16 {
 141 │ │         return U16_MAX
 142 │ │     }
-    │ ╰─────^ attributes hash: 3086088635989474166
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u16
 
 note: 
     ┌─ numeric_sizes.fe:141:16
@@ -1029,20 +665,7 @@ note:
 144 │ ╭     pub fn get_u32_max() -> u32 {
 145 │ │         return u32(4294967295)
 146 │ │     }
-    │ ╰─────^ attributes hash: 1978352585063323439
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u32
 
 note: 
     ┌─ numeric_sizes.fe:145:20
@@ -1062,20 +685,7 @@ note:
 148 │ ╭     pub fn get_u32_const_max() -> u32 {
 149 │ │         return U32_MAX
 150 │ │     }
-    │ ╰─────^ attributes hash: 1978352585063323439
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u32
 
 note: 
     ┌─ numeric_sizes.fe:149:16
@@ -1089,20 +699,7 @@ note:
 152 │ ╭     pub fn get_u64_max() -> u64 {
 153 │ │         return u64(18446744073709551615)
 154 │ │     }
-    │ ╰─────^ attributes hash: 3966212821348382963
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u64
 
 note: 
     ┌─ numeric_sizes.fe:153:20
@@ -1122,20 +719,7 @@ note:
 156 │ ╭     pub fn get_u64_const_max() -> u64 {
 157 │ │         return U64_MAX
 158 │ │     }
-    │ ╰─────^ attributes hash: 3966212821348382963
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u64
 
 note: 
     ┌─ numeric_sizes.fe:157:16
@@ -1149,20 +733,7 @@ note:
 160 │ ╭     pub fn get_u128_max() -> u128 {
 161 │ │         return u128(340282366920938463463374607431768211455)
 162 │ │     }
-    │ ╰─────^ attributes hash: 104322826323649285
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u128
 
 note: 
     ┌─ numeric_sizes.fe:161:21
@@ -1182,20 +753,7 @@ note:
 164 │ ╭     pub fn get_u128_const_max() -> u128 {
 165 │ │         return U128_MAX
 166 │ │     }
-    │ ╰─────^ attributes hash: 104322826323649285
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u128
 
 note: 
     ┌─ numeric_sizes.fe:165:16
@@ -1209,20 +767,7 @@ note:
 168 │ ╭     pub fn get_u256_max() -> u256 {
 169 │ │         return u256(115792089237316195423570985008687907853269984665640564039457584007913129639935)
 170 │ │     }
-    │ ╰─────^ attributes hash: 6115314201970082834
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
     ┌─ numeric_sizes.fe:169:21
@@ -1242,20 +787,7 @@ note:
 172 │ ╭     pub fn get_u256_const_max() -> u256 {
 173 │ │         return U256_MAX
 174 │ │     }
-    │ ╰─────^ attributes hash: 6115314201970082834
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
     ┌─ numeric_sizes.fe:173:16
@@ -1269,20 +801,7 @@ note:
 176 │ ╭     pub fn get_i8_max() -> i8 {
 177 │ │         return i8(127)
 178 │ │     }
-    │ ╰─────^ attributes hash: 15762448841602984320
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i8
 
 note: 
     ┌─ numeric_sizes.fe:177:19
@@ -1302,20 +821,7 @@ note:
 180 │ ╭     pub fn get_i8_const_max() -> i8 {
 181 │ │         return I8_MAX
 182 │ │     }
-    │ ╰─────^ attributes hash: 15762448841602984320
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I8,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i8
 
 note: 
     ┌─ numeric_sizes.fe:181:16
@@ -1329,20 +835,7 @@ note:
 184 │ ╭     pub fn get_i16_max() -> i16 {
 185 │ │         return i16(32767)
 186 │ │     }
-    │ ╰─────^ attributes hash: 1032717434757427850
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i16
 
 note: 
     ┌─ numeric_sizes.fe:185:20
@@ -1362,20 +855,7 @@ note:
 188 │ ╭     pub fn get_i16_const_max() -> i16 {
 189 │ │         return I16_MAX
 190 │ │     }
-    │ ╰─────^ attributes hash: 1032717434757427850
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I16,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i16
 
 note: 
     ┌─ numeric_sizes.fe:189:16
@@ -1389,20 +869,7 @@ note:
 192 │ ╭     pub fn get_i32_max() -> i32 {
 193 │ │         return i32(2147483647)
 194 │ │     }
-    │ ╰─────^ attributes hash: 18058099208132403133
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i32
 
 note: 
     ┌─ numeric_sizes.fe:193:20
@@ -1422,20 +889,7 @@ note:
 196 │ ╭     pub fn get_i32_const_max() -> i32 {
 197 │ │         return I32_MAX
 198 │ │     }
-    │ ╰─────^ attributes hash: 18058099208132403133
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I32,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i32
 
 note: 
     ┌─ numeric_sizes.fe:197:16
@@ -1449,20 +903,7 @@ note:
 200 │ ╭     pub fn get_i64_max() -> i64 {
 201 │ │         return i64(9223372036854775807)
 202 │ │     }
-    │ ╰─────^ attributes hash: 6774734901144681103
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i64
 
 note: 
     ┌─ numeric_sizes.fe:201:20
@@ -1482,20 +923,7 @@ note:
 204 │ ╭     pub fn get_i64_const_max() -> i64 {
 205 │ │         return I64_MAX
 206 │ │     }
-    │ ╰─────^ attributes hash: 6774734901144681103
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I64,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i64
 
 note: 
     ┌─ numeric_sizes.fe:205:16
@@ -1509,20 +937,7 @@ note:
 208 │ ╭     pub fn get_i128_max() -> i128 {
 209 │ │         return i128(170141183460469231731687303715884105727)
 210 │ │     }
-    │ ╰─────^ attributes hash: 155533728466856391
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i128
 
 note: 
     ┌─ numeric_sizes.fe:209:21
@@ -1542,20 +957,7 @@ note:
 212 │ ╭     pub fn get_i128_const_max() -> i128 {
 213 │ │         return I128_MAX
 214 │ │     }
-    │ ╰─────^ attributes hash: 155533728466856391
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I128,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i128
 
 note: 
     ┌─ numeric_sizes.fe:213:16
@@ -1569,20 +971,7 @@ note:
 216 │ ╭     pub fn get_i256_max() -> i256 {
 217 │ │         return i256(57896044618658097711785492504343953926634992332820282019728792003956564819967)
 218 │ │     }
-    │ ╰─────^ attributes hash: 8116994679119332188
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i256
 
 note: 
     ┌─ numeric_sizes.fe:217:21
@@ -1602,20 +991,7 @@ note:
 220 │ ╭     pub fn get_i256_const_max() -> i256 {
 221 │ │         return I256_MAX
 222 │ │     }
-    │ ╰─────^ attributes hash: 8116994679119332188
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      I256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> i256
 
 note: 
     ┌─ numeric_sizes.fe:221:16

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -23,20 +23,7 @@ note:
 15 │ ╭     pub fn owner(self) -> address {
 16 │ │         return self._owner
 17 │ │     }
-   │ ╰─────^ attributes hash: 227275695522088782
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
    ┌─ ownable.fe:16:16
@@ -58,35 +45,7 @@ note:
 21 │ │         self._owner = address(0)
 22 │ │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
 23 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ ownable.fe:20:16
@@ -149,36 +108,6 @@ note:
    │                                                                                   ^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ ownable.fe:22:9
-   │
-22 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
-   │
-   = Event {
-         name: "OwnershipTransferred",
-         fields: [
-             EventField {
-                 name: "previousOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "newOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-         ],
-     }
-
-note: 
    ┌─ ownable.fe:25:5
    │  
 25 │ ╭     pub fn transferOwnership(self, ctx: Context, newOwner: address) {
@@ -187,44 +116,7 @@ note:
 28 │ │         self._owner = newOwner
 29 │ │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
 30 │ │     }
-   │ ╰─────^ attributes hash: 5690910393288515862
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "newOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: newOwner, typ: address }] -> ()
 
 note: 
    ┌─ ownable.fe:26:16
@@ -289,35 +181,5 @@ note:
    │                                                       ^^^^^^^^^^^^^^^^  ^^^^^^^^ address: Value
    │                                                       │                  
    │                                                       address: Value
-
-note: 
-   ┌─ ownable.fe:29:9
-   │
-29 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12166912587337306484
-   │
-   = Event {
-         name: "OwnershipTransferred",
-         fields: [
-             EventField {
-                 name: "previousOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "newOwner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-         ],
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
+++ b/crates/analyzer/tests/snapshots/analysis__pure_fn_standalone.snap
@@ -9,34 +9,7 @@ note:
 1 │ ╭ fn add_bonus(_ x: u256) -> u256 {
 2 │ │     return x + 10
 3 │ │ }
-  │ ╰─^ attributes hash: 4402553917254279762
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }] -> u256
 
 note: 
   ┌─ pure_fn_standalone.fe:2:12
@@ -70,45 +43,7 @@ note:
 13 │ │             self.points[user] += val
 14 │ │         }
 15 │ │     }
-   │ ╰─────^ attributes hash: 11016307003570025576
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "user",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "val",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: user, typ: address }, { label: Some("_"), name: val, typ: u256 }] -> ()
 
 note: 
    ┌─ pure_fn_standalone.fe:10:12
@@ -183,36 +118,7 @@ note:
 21 │ │         self.add_points(a, 100)
 22 │ │         return self.points[a]
 23 │ │     }
-   │ ╰─────^ attributes hash: 15237606768598971644
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: x, typ: u256 }] -> u256
 
 note: 
    ┌─ pure_fn_standalone.fe:18:13

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256 {
 3 │ │         return x + y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6924216180113238234
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> i256
 
 note: 
   ┌─ return_addition_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u128.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u128, y: u128) -> u128 {
 3 │ │         return x + y
 4 │ │     }
-  │ ╰─────^ attributes hash: 233274078014721184
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u128 }, { label: None, name: y, typ: u128 }] -> u128
 
 note: 
   ┌─ return_addition_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_addition_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x + y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_addition_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_array.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_array.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ return_array.fe:2:5
@@ -10,37 +11,7 @@ note:
 4 │ │         my_array[3] = x
 5 │ │         return my_array
 6 │ │     }
-  │ ╰─────^ attributes hash: 4865772778354002151
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Array(
-                Array {
-                    size: 5,
-                    inner: Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }] -> Array<u256, 5>
 
 note: 
   ┌─ return_array.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u128.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u128, y: u128) -> u128 {
 3 │ │         return x & y
 4 │ │     }
-  │ ╰─────^ attributes hash: 233274078014721184
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u128 }, { label: None, name: y, typ: u128 }] -> u128
 
 note: 
   ┌─ return_bitwiseand_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseand_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x & y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_bitwiseand_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseor_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x | y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_bitwiseor_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshl_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x << y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_bitwiseshl_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: u256) -> i256 {
 3 │ │         return x >> y
 4 │ │     }
-  │ ╰─────^ attributes hash: 12518870770702615859
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: u256 }] -> i256
 
 note: 
   ┌─ return_bitwiseshr_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwiseshr_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x >> y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_bitwiseshr_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bitwisexor_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x ^ y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_bitwisexor_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_false.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_false.snap
@@ -9,18 +9,7 @@ note:
 2 │ ╭     pub fn bar() -> bool {
 3 │ │         return false
 4 │ │     }
-  │ ╰─────^ attributes hash: 5583437014632790429
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> bool
 
 note: 
   ┌─ return_bool_false.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_inverted.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_inverted.snap
@@ -9,28 +9,7 @@ note:
 2 │ ╭     pub fn bar(some_condition: bool) -> bool {
 3 │ │         return not some_condition
 4 │ │     }
-  │ ╰─────^ attributes hash: 9793001524182520011
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "some_condition",
-                typ: Ok(
-                    Base(
-                        Bool,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: some_condition, typ: bool }] -> bool
 
 note: 
   ┌─ return_bool_inverted.fe:3:20

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_and.snap
@@ -9,37 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: bool, y: bool) -> bool {
 3 │ │         return x and y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3532809531490166398
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Bool,
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Bool,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: bool }, { label: None, name: y, typ: bool }] -> bool
 
 note: 
   ┌─ return_bool_op_and.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_op_or.snap
@@ -9,37 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: bool, y: bool) -> bool {
 3 │ │         return x or y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3532809531490166398
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Bool,
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Bool,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: bool }, { label: None, name: y, typ: bool }] -> bool
 
 note: 
   ┌─ return_bool_op_or.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_bool_true.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_bool_true.snap
@@ -9,18 +9,7 @@ note:
 2 │ ╭     pub fn bar() -> bool {
 3 │ │         return true
 4 │ │     }
-  │ ╰─────^ attributes hash: 5583437014632790429
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> bool
 
 note: 
   ┌─ return_bool_true.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
@@ -9,35 +9,7 @@ note:
 4 │ ╭     pub fn base_fee(ctx: Context) -> u256 {
 5 │ │         return ctx.base_fee()
 6 │ │     }
-  │ ╰─────^ attributes hash: 10526263819290319263
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: Some(
-            Mutable,
-        ),
-        params: [
-            FunctionParam {
-                label: None,
-                name: "ctx",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "Context",
-                            field_count: 0,
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
   ┌─ return_builtin_attributes.fe:5:16
@@ -57,33 +29,7 @@ note:
  8 │ ╭     pub fn coinbase(ctx: Context) -> address {
  9 │ │         return ctx.block_coinbase()
 10 │ │     }
-   │ ╰─────^ attributes hash: 9364783648076633772
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
   ┌─ return_builtin_attributes.fe:9:16
@@ -103,35 +49,7 @@ note:
 12 │ ╭     pub fn difficulty(ctx: Context) -> u256 {
 13 │ │         return ctx.block_difficulty()
 14 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ return_builtin_attributes.fe:13:16
@@ -151,35 +69,7 @@ note:
 16 │ ╭     pub fn number(ctx: Context) -> u256 {
 17 │ │         return ctx.block_number()
 18 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ return_builtin_attributes.fe:17:16
@@ -199,35 +89,7 @@ note:
 20 │ ╭     pub fn timestamp(ctx: Context) -> u256 {
 21 │ │         return ctx.block_timestamp()
 22 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ return_builtin_attributes.fe:21:16
@@ -247,35 +109,7 @@ note:
 24 │ ╭     pub fn chainid(ctx: Context) -> u256 {
 25 │ │         return ctx.chain_id()
 26 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ return_builtin_attributes.fe:25:16
@@ -295,33 +129,7 @@ note:
 28 │ ╭     pub fn sender(ctx: Context) -> address {
 29 │ │         return ctx.msg_sender()
 30 │ │     }
-   │ ╰─────^ attributes hash: 9364783648076633772
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
    ┌─ return_builtin_attributes.fe:29:16
@@ -341,35 +149,7 @@ note:
 32 │ ╭     pub fn value(ctx: Context) -> u256 {
 33 │ │         return ctx.msg_value()
 34 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ return_builtin_attributes.fe:33:16
@@ -389,33 +169,7 @@ note:
 36 │ ╭     pub fn origin(ctx: Context) -> address {
 37 │ │         return ctx.tx_origin()
 38 │ │     }
-   │ ╰─────^ attributes hash: 9364783648076633772
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
    ┌─ return_builtin_attributes.fe:37:16
@@ -435,35 +189,7 @@ note:
 40 │ ╭     pub fn gas_price(ctx: Context) -> u256 {
 41 │ │         return ctx.tx_gas_price()
 42 │ │     }
-   │ ╰─────^ attributes hash: 10526263819290319263
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ return_builtin_attributes.fe:41:16

--- a/crates/analyzer/tests/snapshots/analysis__return_complex_struct.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_complex_struct.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ return_complex_struct.fe:2:5
@@ -52,23 +53,7 @@ note:
 31 │ │         let complex: StaticComplex = StaticComplex(inner, outer_x: 30)
 32 │ │         return complex
 33 │ │     }
-   │ ╰─────^ attributes hash: 18333022875177944738
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "StaticComplex",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> StaticComplex
 
 note: 
    ┌─ return_complex_struct.fe:30:13
@@ -111,23 +96,7 @@ note:
 37 │ │         let complex: StringComplex = StringComplex(string: "Hello", outer_x: 30)
 38 │ │         return complex
 39 │ │     }
-   │ ╰─────^ attributes hash: 4691780846415744236
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "StringComplex",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> StringComplex
 
 note: 
    ┌─ return_complex_struct.fe:37:13
@@ -158,23 +127,7 @@ note:
 42 │ │         let complex: BytesComplex = BytesComplex(bytes: [1, 2, 3, 4, 5, 6, 7, 8], outer_x: 30)
 43 │ │         return complex
 44 │ │     }
-   │ ╰─────^ attributes hash: 15110112579440786347
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "BytesComplex",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> BytesComplex
 
 note: 
    ┌─ return_complex_struct.fe:42:13
@@ -222,23 +175,7 @@ note:
 50 │ │         let complex: NestedDynamicComplex = NestedDynamicComplex(bytes_complex, static_complex, string_complex)
 51 │ │         return complex
 52 │ │     }
-   │ ╰─────^ attributes hash: 7674472406353226070
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "NestedDynamicComplex",
-                     field_count: 3,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> NestedDynamicComplex
 
 note: 
    ┌─ return_complex_struct.fe:47:13

--- a/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256 {
 3 │ │         return x / y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6924216180113238234
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> i256
 
 note: 
   ┌─ return_division_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_division_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x / y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_division_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_empty_tuple.snap
@@ -9,18 +9,7 @@ note:
 2 │ ╭     pub fn explicit_return_a1() {
 3 │ │         return
 4 │ │     }
-  │ ╰─────^ attributes hash: 8319796915330632390
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> ()
 
 note: 
   ┌─ return_unit.fe:6:5
@@ -28,18 +17,7 @@ note:
 6 │ ╭     pub fn explicit_return_a2() {
 7 │ │         return ()
 8 │ │     }
-  │ ╰─────^ attributes hash: 8319796915330632390
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> ()
 
 note: 
   ┌─ return_unit.fe:7:16
@@ -53,18 +31,7 @@ note:
 10 │ ╭     pub fn explicit_return_b1() -> () {
 11 │ │         return
 12 │ │     }
-   │ ╰─────^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> ()
 
 note: 
    ┌─ return_unit.fe:14:5
@@ -72,18 +39,7 @@ note:
 14 │ ╭     pub fn explicit_return_b2() -> () {
 15 │ │         return ()
 16 │ │     }
-   │ ╰─────^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> ()
 
 note: 
    ┌─ return_unit.fe:15:16
@@ -95,34 +51,12 @@ note:
    ┌─ return_unit.fe:18:5
    │
 18 │     pub fn implicit_a1() {}
-   │     ^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8319796915330632390
-   │
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^ self: None, params: [] -> ()
 
 note: 
    ┌─ return_unit.fe:20:5
    │
 20 │     pub fn implicit_a2() -> () {}
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8319796915330632390
-   │
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ self: None, params: [] -> ()
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_eq_u256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool {
 3 │ │         return x == y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3021624743158907825
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> bool
 
 note: 
   ┌─ return_eq_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_i256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool {
 3 │ │         return x > y
 4 │ │     }
-  │ ╰─────^ attributes hash: 7978284628773169348
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> bool
 
 note: 
   ┌─ return_gt_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gt_u256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool {
 3 │ │         return x > y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3021624743158907825
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> bool
 
 note: 
   ┌─ return_gt_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_i256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool {
 3 │ │         return x >= y
 4 │ │     }
-  │ ╰─────^ attributes hash: 7978284628773169348
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> bool
 
 note: 
   ┌─ return_gte_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_gte_u256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool {
 3 │ │         return x >= y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3021624743158907825
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> bool
 
 note: 
   ┌─ return_gte_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i128_cast.snap
@@ -9,20 +9,7 @@ note:
 2 │ ╭     pub fn bar() -> i128 {
 3 │ │         return i128(-3)
 4 │ │     }
-  │ ╰─────^ attributes hash: 155533728466856391
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> i128
 
 note: 
   ┌─ return_i128_cast.fe:3:22

--- a/crates/analyzer/tests/snapshots/analysis__return_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_i256.snap
@@ -9,20 +9,7 @@ note:
 2 │ ╭     pub fn bar() -> i256 {
 3 │ │         return -3
 4 │ │     }
-  │ ╰─────^ attributes hash: 8116994679119332188
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> i256
 
 note: 
   ┌─ return_i256.fe:3:17

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u128.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u128) -> u128 {
 3 │ │         return x
 4 │ │     }
-  │ ╰─────^ attributes hash: 8882570074302111953
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u128 }] -> u128
 
 note: 
   ┌─ return_identity_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u16.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u16.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u16) -> u16 {
 3 │ │         return x
 4 │ │     }
-  │ ╰─────^ attributes hash: 12880247899747575992
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U16,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U16,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u16 }] -> u16
 
 note: 
   ┌─ return_identity_u16.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u256.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256) -> u256 {
 3 │ │         return x
 4 │ │     }
-  │ ╰─────^ attributes hash: 6622018637299644818
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }] -> u256
 
 note: 
   ┌─ return_identity_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u32.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u32.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u32) -> u32 {
 3 │ │         return x
 4 │ │     }
-  │ ╰─────^ attributes hash: 3053189841811312763
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U32,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U32,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u32 }] -> u32
 
 note: 
   ┌─ return_identity_u32.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u64.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u64.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u64) -> u64 {
 3 │ │         return x
 4 │ │     }
-  │ ╰─────^ attributes hash: 14360693544116809530
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U64,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U64,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u64 }] -> u64
 
 note: 
   ┌─ return_identity_u64.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_identity_u8.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_identity_u8.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u8) -> u8 {
 3 │ │         return x
 4 │ │     }
-  │ ╰─────^ attributes hash: 4472501580732693210
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U8,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U8,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u8 }] -> u8
 
 note: 
   ┌─ return_identity_u8.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_i256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool {
 3 │ │         return x < y
 4 │ │     }
-  │ ╰─────^ attributes hash: 7978284628773169348
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> bool
 
 note: 
   ┌─ return_lt_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u128.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u128, y: u128) -> bool {
 3 │ │         return x < y
 4 │ │     }
-  │ ╰─────^ attributes hash: 4640755342958234471
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u128 }, { label: None, name: y, typ: u128 }] -> bool
 
 note: 
   ┌─ return_lt_u128.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lt_u256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool {
 3 │ │         return x < y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3021624743158907825
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> bool
 
 note: 
   ┌─ return_lt_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_i256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> bool {
 3 │ │         return x <= y
 4 │ │     }
-  │ ╰─────^ attributes hash: 7978284628773169348
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> bool
 
 note: 
   ┌─ return_lte_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_lte_u256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool {
 3 │ │         return x <= y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3021624743158907825
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> bool
 
 note: 
   ┌─ return_lte_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256 {
 3 │ │         return x % y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6924216180113238234
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> i256
 
 note: 
   ┌─ return_mod_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_mod_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x % y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_mod_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
@@ -9,35 +9,7 @@ note:
 4 │ ╭     pub fn bar(ctx: Context) -> u256 {
 5 │ │         return ctx.msg_sig()
 6 │ │     }
-  │ ╰─────^ attributes hash: 10526263819290319263
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: Some(
-            Mutable,
-        ),
-        params: [
-            FunctionParam {
-                label: None,
-                name: "ctx",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "Context",
-                            field_count: 0,
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
   ┌─ return_msg_sig.fe:5:16

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256 {
 3 │ │         return x * y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6924216180113238234
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> i256
 
 note: 
   ┌─ return_multiplication_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_multiplication_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x * y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_multiplication_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_noteq_u256.snap
@@ -9,41 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> bool {
 3 │ │         return x != y
 4 │ │     }
-  │ ╰─────^ attributes hash: 3021624743158907825
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Bool,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> bool
 
 note: 
   ┌─ return_noteq_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i8, y: u8) -> i8 {
 3 │ │         return x ** y
 4 │ │     }
-  │ ╰─────^ attributes hash: 14588309679488297104
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I8,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U8,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I8,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i8 }, { label: None, name: y, typ: u8 }] -> i8
 
 note: 
   ┌─ return_pow_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_pow_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x ** y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_pow_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_i256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: i256, y: i256) -> i256 {
 3 │ │         return x - y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6924216180113238234
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            I256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    I256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i256 }, { label: None, name: y, typ: i256 }] -> i256
 
 note: 
   ┌─ return_subtraction_i256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_subtraction_u256.snap
@@ -9,43 +9,7 @@ note:
 2 │ ╭     pub fn bar(x: u256, y: u256) -> u256 {
 3 │ │         return x - y
 4 │ │     }
-  │ ╰─────^ attributes hash: 6847926207878778580
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u256 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
   ┌─ return_subtraction_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u128_cast.snap
@@ -9,20 +9,7 @@ note:
 2 │ ╭     pub fn bar() -> u128 {
 3 │ │         return u128(42)
 4 │ │     }
-  │ ╰─────^ attributes hash: 104322826323649285
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u128
 
 note: 
   ┌─ return_u128_cast.fe:3:21

--- a/crates/analyzer/tests/snapshots/analysis__return_u256.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256.snap
@@ -9,20 +9,7 @@ note:
 2 │ ╭     pub fn bar() -> u256 {
 3 │ │         return 42
 4 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ return_u256.fe:3:16

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn.snap
@@ -9,22 +9,7 @@ note:
 2 │ ╭     pub fn bar(self) -> u256 {
 3 │ │         return foo()
 4 │ │     }
-  │ ╰─────^ attributes hash: 11773348765973600208
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
   ┌─ return_u256_from_called_fn.fe:3:16
@@ -38,20 +23,7 @@ note:
 6 │ ╭     pub fn foo() -> u256 {
 7 │ │         return 42
 8 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ return_u256_from_called_fn.fe:7:16

--- a/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_u256_from_called_fn_with_args.snap
@@ -15,86 +15,7 @@ note:
 4 │ ╭     pub fn foo(_ v1: u256, _ v2: u256, _ v3: u256, _ v4: u256, _ v5: u256) -> u256 {
 5 │ │         return v1 + v2 + v3 + v4 + v5
 6 │ │     }
-  │ ╰─────^ attributes hash: 1504347162142127509
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "v1",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "v2",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "v3",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "v4",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "v5",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: Some("_"), name: v1, typ: u256 }, { label: Some("_"), name: v2, typ: u256 }, { label: Some("_"), name: v3, typ: u256 }, { label: Some("_"), name: v4, typ: u256 }, { label: Some("_"), name: v5, typ: u256 }] -> u256
 
 note: 
   ┌─ return_u256_from_called_fn_with_args.fe:5:16
@@ -140,20 +61,7 @@ note:
  8 │ ╭     pub fn cem() -> u256 {
  9 │ │         return 100
 10 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ return_u256_from_called_fn_with_args.fe:9:16
@@ -168,22 +76,7 @@ note:
 13 │ │         self.baz[0] = 43
 14 │ │         return foo(5, 2, cem(), 25 + 25, self.baz[0])
 15 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ return_u256_from_called_fn_with_args.fe:13:9

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -23,20 +23,7 @@ note:
 11 │ ╭     pub fn bar() -> u256 {
 12 │ │         revert
 13 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
    ┌─ revert.fe:15:5
@@ -44,33 +31,7 @@ note:
 15 │ ╭     pub fn revert_custom_error(ctx: Context) {
 16 │ │         ctx.send_value(to: address(0), wei: 100)
 17 │ │     }
-   │ ╰─────^ attributes hash: 5519676733853656531
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ revert.fe:16:9
@@ -100,18 +61,7 @@ note:
 19 │ ╭     pub fn revert_other_error() {
 20 │ │         revert OtherError(msg: 1, val: true)
 21 │ │     }
-   │ ╰─────^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> ()
 
 note: 
    ┌─ revert.fe:20:32
@@ -134,20 +84,7 @@ note:
 24 │ │         self.my_other_error = OtherError(msg: 1, val: true)
 25 │ │         revert self.my_other_error.to_mem()
 26 │ │     }
-   │ ╰─────^ attributes hash: 18235041182630809162
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
    ┌─ revert.fe:24:9

--- a/crates/analyzer/tests/snapshots/analysis__self_address.snap
+++ b/crates/analyzer/tests/snapshots/analysis__self_address.snap
@@ -9,33 +9,7 @@ note:
 4 │ ╭     pub fn my_address(ctx: Context) -> address {
 5 │ │         return ctx.self_address()
 6 │ │     }
-  │ ╰─────^ attributes hash: 9364783648076633772
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: Some(
-            Mutable,
-        ),
-        params: [
-            FunctionParam {
-                label: None,
-                name: "ctx",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "Context",
-                            field_count: 0,
-                        },
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Address,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
   ┌─ self_address.fe:5:16

--- a/crates/analyzer/tests/snapshots/analysis__send_value.snap
+++ b/crates/analyzer/tests/snapshots/analysis__send_value.snap
@@ -9,53 +9,7 @@ note:
 4 │ ╭     pub fn send_them_wei(ctx: Context, to: address, wei: u256) {
 5 │ │         ctx.send_value(to, wei)
 6 │ │     }
-  │ ╰─────^ attributes hash: 14069636423119281176
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: Some(
-            Mutable,
-        ),
-        params: [
-            FunctionParam {
-                label: None,
-                name: "ctx",
-                typ: Ok(
-                    Struct(
-                        Struct {
-                            name: "Context",
-                            field_count: 0,
-                        },
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "to",
-                typ: Ok(
-                    Base(
-                        Address,
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "wei",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Unit,
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: wei, typ: u256 }] -> ()
 
 note: 
   ┌─ send_value.fe:5:9

--- a/crates/analyzer/tests/snapshots/analysis__simple_open_auction.snap
+++ b/crates/analyzer/tests/snapshots/analysis__simple_open_auction.snap
@@ -54,35 +54,7 @@ note:
    · │
 55 │ │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
 56 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ simple_open_auction.fe:43:12
@@ -249,38 +221,6 @@ note:
    │                                                                         ^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ simple_open_auction.fe:55:9
-   │
-55 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4299305322532183383
-   │
-   = Event {
-         name: "HighestBidIncreased",
-         fields: [
-             EventField {
-                 name: "bidder",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "amount",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ simple_open_auction.fe:58:5
    │  
 58 │ ╭     pub fn withdraw(self, ctx: Context) -> bool {
@@ -290,35 +230,7 @@ note:
    · │
 65 │ │         return true
 66 │ │     }
-   │ ╰─────^ attributes hash: 2616212654540170552
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> bool
 
 note: 
    ┌─ simple_open_auction.fe:59:13
@@ -418,35 +330,7 @@ note:
    · │
 78 │ │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
 79 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ simple_open_auction.fe:69:12
@@ -540,37 +424,5 @@ note:
    │
 78 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-
-note: 
-   ┌─ simple_open_auction.fe:76:9
-   │
-76 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10704971219741987245
-   │
-   = Event {
-         name: "AuctionEnded",
-         fields: [
-             EventField {
-                 name: "winner",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "amount",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ sized_vals_in_sto.fe:4:5
@@ -28,32 +29,7 @@ note:
 14 │ ╭     pub fn write_num(self, x: u256) {
 15 │ │         self.num = x
 16 │ │     }
-   │ ╰─────^ attributes hash: 4582507849783874218
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: u256 }] -> ()
 
 note: 
    ┌─ sized_vals_in_sto.fe:15:9
@@ -75,22 +51,7 @@ note:
 18 │ ╭     pub fn read_num(self) -> u256 {
 19 │ │         return self.num
 20 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ sized_vals_in_sto.fe:19:16
@@ -110,37 +71,7 @@ note:
 22 │ ╭     pub fn write_nums(self, x: Array<u256, 42>) {
 23 │ │         self.nums = x
 24 │ │     }
-   │ ╰─────^ attributes hash: 3795910266468030735
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 42,
-                             inner: Base(
-                                 Numeric(
-                                     U256,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: Array<u256, 42> }] -> ()
 
 note: 
    ┌─ sized_vals_in_sto.fe:23:9
@@ -162,27 +93,7 @@ note:
 26 │ ╭     pub fn read_nums(self) -> Array<u256, 42> {
 27 │ │         return self.nums.to_mem()
 28 │ │     }
-   │ ╰─────^ attributes hash: 7198573459523579428
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 42,
-                     inner: Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> Array<u256, 42>
 
 note: 
    ┌─ sized_vals_in_sto.fe:27:16
@@ -208,32 +119,7 @@ note:
 30 │ ╭     pub fn write_str(self, x: String<26>) {
 31 │ │         self.str = x
 32 │ │     }
-   │ ╰─────^ attributes hash: 3874088449945578306
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 26,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: String<26> }] -> ()
 
 note: 
    ┌─ sized_vals_in_sto.fe:31:9
@@ -255,22 +141,7 @@ note:
 34 │ ╭     pub fn read_str(self) -> String<26> {
 35 │ │         return self.str.to_mem()
 36 │ │     }
-   │ ╰─────^ attributes hash: 3487383639176435631
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 26,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> String<26>
 
 note: 
    ┌─ sized_vals_in_sto.fe:35:16
@@ -296,35 +167,7 @@ note:
 38 │ ╭     pub fn emit_event(self, ctx: Context) {
 39 │ │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
 40 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ sized_vals_in_sto.fe:39:22
@@ -367,55 +210,5 @@ note:
    │
 39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                                                                         ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
-
-note: 
-   ┌─ sized_vals_in_sto.fe:39:9
-   │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11879127803411427086
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "nums",
-                 typ: Ok(
-                     Array(
-                         Array {
-                             size: 42,
-                             inner: Base(
-                                 Numeric(
-                                     U256,
-                                 ),
-                             ),
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-             EventField {
-                 name: "str",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 26,
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
 
 

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -27,43 +27,7 @@ note:
 18 │ ╭     pub fn bar(s1: String<100>, s2: String<100>) -> String<100> {
 19 │ │         return s2
 20 │ │     }
-   │ ╰─────^ attributes hash: 4992726103398710247
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "s1",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "s2",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 100,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 100,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: s1, typ: String<100> }, { label: None, name: s2, typ: String<100> }] -> String<100>
 
 note: 
    ┌─ strings.fe:19:16
@@ -77,20 +41,7 @@ note:
 22 │ ╭     pub fn return_static_string() -> String<43> {
 23 │ │         return "The quick brown fox jumps over the lazy dog"
 24 │ │     }
-   │ ╰─────^ attributes hash: 16859220121746101219
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 43,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> String<43>
 
 note: 
    ┌─ strings.fe:23:16
@@ -104,20 +55,7 @@ note:
 26 │ ╭     pub fn return_casted_static_string() -> String<100> {
 27 │ │         return String<100>("foo")
 28 │ │     }
-   │ ╰─────^ attributes hash: 11555139189894875514
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 100,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> String<100>
 
 note: 
    ┌─ strings.fe:27:28
@@ -137,18 +75,7 @@ note:
 30 │ ╭     pub fn shorter_string_assign() {
 31 │ │         let s: String<18> = "fe"
 32 │ │     }
-   │ ╰─────^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> ()
 
 note: 
    ┌─ strings.fe:31:13
@@ -169,20 +96,7 @@ note:
 35 │ │         return "\n\"'\r\t
 36 │ │         foo\\"
 37 │ │     }
-   │ ╰─────^ attributes hash: 15142206137302311439
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 18,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> String<18>
 
 note: 
    ┌─ strings.fe:35:16

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -17,44 +17,7 @@ note:
 5 │ ╭     pub fn new(x: u64, y: u64) -> Point {
 6 │ │         return Point(x, y)
 7 │ │     }
-  │ ╰─────^ attributes hash: 16588628800633378656
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "x",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U64,
-                        ),
-                    ),
-                ),
-            },
-            FunctionParam {
-                label: None,
-                name: "y",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U64,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Struct(
-                Struct {
-                    name: "Point",
-                    field_count: 2,
-                },
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> Point
 
 note: 
   ┌─ struct_fns.fe:6:22
@@ -76,21 +39,7 @@ note:
  9 │ ╭     pub fn origin() -> Point {
 10 │ │         return Point(x: 0, y: 0)
 11 │ │     }
-   │ ╰─────^ attributes hash: 6013258294670043138
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Point",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> Point
 
 note: 
    ┌─ struct_fns.fe:10:25
@@ -112,22 +61,7 @@ note:
 13 │ ╭     pub fn x(self) -> u64 {
 14 │ │         return self.x
 15 │ │     }
-   │ ╰─────^ attributes hash: 10117872852848404071
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u64
 
 note: 
    ┌─ struct_fns.fe:14:16
@@ -149,36 +83,7 @@ note:
 19 │ │         self.x = x
 20 │ │         return old
 21 │ │     }
-   │ ╰─────^ attributes hash: 9776752757917359734
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: x, typ: u64 }] -> u64
 
 note: 
    ┌─ struct_fns.fe:18:13
@@ -219,20 +124,7 @@ note:
 26 │ │         self.x = y
 27 │ │         self.y = x
 28 │ │     }
-   │ ╰─────^ attributes hash: 18235041182630809162
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
    ┌─ struct_fns.fe:24:13
@@ -289,43 +181,7 @@ note:
 31 │ │         self.x += x
 32 │ │         self.y += y
 33 │ │     }
-   │ ╰─────^ attributes hash: 7723021135770029200
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "y",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> ()
 
 note: 
    ┌─ struct_fns.fe:31:9
@@ -359,38 +215,7 @@ note:
 37 │ │         let y: u64 = self.y + other.y
 38 │ │         return Point(x, y)
 39 │ │     }
-   │ ╰─────^ attributes hash: 13368777112318344367
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "other",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Point",
-                             field_count: 2,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Point",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: other, typ: Point }] -> Point
 
 note: 
    ┌─ struct_fns.fe:36:13
@@ -468,18 +293,7 @@ note:
 46 │ │     let p3: Point = p1.add(p2)
 47 │ │     assert p3.x == 6 and p3.y == 12
 48 │ │ }
-   │ ╰─^ attributes hash: 8319796915330632390
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─^ self: None, params: [] -> ()
 
 note: 
    ┌─ struct_fns.fe:43:9
@@ -577,43 +391,7 @@ note:
    · │
 58 │ │         return p.y
 59 │ │     }
-   │ ╰─────^ attributes hash: 14881144643149919691
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "y",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> u64
 
 note: 
    ┌─ struct_fns.fe:53:13

--- a/crates/analyzer/tests/snapshots/analysis__structs.snap
+++ b/crates/analyzer/tests/snapshots/analysis__structs.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ structs.fe:2:5
@@ -36,33 +37,7 @@ note:
 17 │ ╭     pub fn new(val: u256) -> Mixed {
 18 │ │         return Mixed(foo: val, bar: false)
 19 │ │     }
-   │ ╰─────^ attributes hash: 2524938698704972422
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "val",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Struct(
-                 Struct {
-                     name: "Mixed",
-                     field_count: 2,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: val, typ: u256 }] -> Mixed
 
 note: 
    ┌─ structs.fe:18:27
@@ -96,27 +71,7 @@ note:
 28 │ ╭     pub fn encode(self) -> Array<u8, 128> {
 29 │ │         return self.abi_encode()
 30 │ │     }
-   │ ╰─────^ attributes hash: 374785682862794405
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 128,
-                     inner: Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> Array<u8, 128>
 
 note: 
    ┌─ structs.fe:29:16
@@ -136,22 +91,7 @@ note:
 32 │ ╭     pub fn hash(self) -> u256 {
 33 │ │         return keccak256(self.encode())
 34 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ structs.fe:33:26
@@ -177,22 +117,7 @@ note:
 36 │ ╭     pub fn price_per_sqft(self) -> u256 {
 37 │ │         return self.price / self.size
 38 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ structs.fe:37:16
@@ -227,20 +152,7 @@ note:
 41 │ │         self.rooms += 1
 42 │ │         self.size += 100
 43 │ │     }
-   │ ╰─────^ attributes hash: 18235041182630809162
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
    ┌─ structs.fe:41:9
@@ -284,22 +196,7 @@ note:
    · │
 79 │ │         return self.my_bar.name.to_mem()
 80 │ │     }
-   │ ╰─────^ attributes hash: 7100809906483982919
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 3,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> String<3>
 
 note: 
    ┌─ structs.fe:51:9
@@ -1080,22 +977,7 @@ note:
     · │
 111 │ │         return val.name
 112 │ │     }
-    │ ╰─────^ attributes hash: 7100809906483982919
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              String(
-                  FeString {
-                      max_size: 3,
-                  },
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> String<3>
 
 note: 
    ┌─ structs.fe:83:13
@@ -1698,22 +1580,7 @@ note:
 115 │ │         let mixed: Mixed = Mixed::new(val: 1)
 116 │ │         return mixed.foo
 117 │ │     }
-    │ ╰─────^ attributes hash: 11773348765973600208
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
     ┌─ structs.fe:115:13
@@ -1747,33 +1614,7 @@ note:
 119 │ ╭     pub fn set_house(self, data: House) {
 120 │ │         self.my_house = data
 121 │ │     }
-    │ ╰─────^ attributes hash: 571714015924720006
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "data",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "House",
-                              field_count: 4,
-                          },
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: data, typ: House }] -> ()
 
 note: 
     ┌─ structs.fe:120:9
@@ -1795,23 +1636,7 @@ note:
 123 │ ╭     pub fn get_house(self) -> House {
 124 │ │         return self.my_house.to_mem()
 125 │ │     }
-    │ ╰─────^ attributes hash: 18226871377775469920
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Struct(
-                  Struct {
-                      name: "House",
-                      field_count: 4,
-                  },
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> House
 
 note: 
     ┌─ structs.fe:124:16
@@ -1841,20 +1666,7 @@ note:
     · │
 152 │ │         assert self.my_house.vacant
 153 │ │     }
-    │ ╰─────^ attributes hash: 18235041182630809162
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
     ┌─ structs.fe:128:9
@@ -2420,20 +2232,7 @@ note:
     · │
 172 │ │         return building.size
 173 │ │     }
-    │ ╰─────^ attributes hash: 6115314201970082834
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
     ┌─ structs.fe:156:13
@@ -2697,25 +2496,7 @@ note:
 176 │ │         let house: House = House(price: 300, size: 500, rooms: u8(20), vacant: true)
 177 │ │         return house.encode()
 178 │ │     }
-    │ ╰─────^ attributes hash: 7483658980613368648
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Array(
-                  Array {
-                      size: 128,
-                      inner: Base(
-                          Numeric(
-                              U8,
-                          ),
-                      ),
-                  },
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> Array<u8, 128>
 
 note: 
     ┌─ structs.fe:176:13
@@ -2761,20 +2542,7 @@ note:
 181 │ │         let house: House = House(price: 300, size: 500, rooms: u8(20), vacant: true)
 182 │ │         return house.hash()
 183 │ │     }
-    │ ╰─────^ attributes hash: 6115314201970082834
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
     ┌─ structs.fe:181:13

--- a/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ternary_expression.snap
@@ -9,32 +9,7 @@ note:
 2 │ ╭     pub fn bar(input: u256) -> u256 {
 3 │ │         return 1 if input > 5 else 0
 4 │ │     }
-  │ ╰─────^ attributes hash: 10660199954095577886
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "input",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: None, name: input, typ: u256 }] -> u256
 
 note: 
   ┌─ ternary_expression.fe:3:21

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/analyzer/tests/analysis.rs
 expression: "build_snapshot(&db, module)"
+
 ---
 note: 
   ┌─ tuple_stress.fe:4:5
@@ -20,62 +21,7 @@ note:
 10 │ ╭     pub fn build_my_tuple(my_num: u256, my_bool: bool, my_address: address) -> (u256, bool, address) {
 11 │ │         return (my_num, my_bool, my_address)
 12 │ │     }
-   │ ╰─────^ attributes hash: 10223738621782129186
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_num",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_bool",
-                 typ: Ok(
-                     Base(
-                         Bool,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_address",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Tuple(
-                 Tuple {
-                     items: [
-                         Base(
-                             Numeric(
-                                 U256,
-                             ),
-                         ),
-                         Base(
-                             Bool,
-                         ),
-                         Base(
-                             Address,
-                         ),
-                     ],
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_num, typ: u256 }, { label: None, name: my_bool, typ: bool }, { label: None, name: my_address, typ: address }] -> (u256, bool, address)
 
 note: 
    ┌─ tuple_stress.fe:11:17
@@ -98,44 +44,7 @@ note:
 14 │ ╭     pub fn read_my_tuple_item0(my_tuple: (u256, bool, address)) -> u256 {
 15 │ │         return my_tuple.item0
 16 │ │     }
-   │ ╰─────^ attributes hash: 1005385906871296536
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> u256
 
 note: 
    ┌─ tuple_stress.fe:15:16
@@ -155,42 +64,7 @@ note:
 18 │ ╭     pub fn read_my_tuple_item1(my_tuple: (u256, bool, address)) -> bool {
 19 │ │         return my_tuple.item1
 20 │ │     }
-   │ ╰─────^ attributes hash: 5615774585289781220
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> bool
 
 note: 
    ┌─ tuple_stress.fe:19:16
@@ -210,42 +84,7 @@ note:
 22 │ ╭     pub fn read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address {
 23 │ │         return my_tuple.item2
 24 │ │     }
-   │ ╰─────^ attributes hash: 13024428391414866682
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> address
 
 note: 
    ┌─ tuple_stress.fe:23:16
@@ -265,84 +104,7 @@ note:
 26 │ ╭     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address {
 27 │ │         return my_tuple.item10
 28 │ │     }
-   │ ╰─────^ attributes hash: 11830390438544540912
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address) }] -> address
 
 note: 
    ┌─ tuple_stress.fe:27:16
@@ -362,56 +124,7 @@ note:
 30 │ ╭     pub fn emit_my_event(ctx: Context, my_tuple: (u256, bool, address)) {
 31 │ │         emit MyEvent(ctx, my_tuple)
 32 │ │     }
-   │ ╰─────^ attributes hash: 10535390144430265813
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: my_tuple, typ: (u256, bool, address) }] -> ()
 
 note: 
    ┌─ tuple_stress.fe:31:22
@@ -422,84 +135,13 @@ note:
    │                      Context: Memory
 
 note: 
-   ┌─ tuple_stress.fe:31:9
-   │
-31 │         emit MyEvent(ctx, my_tuple)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 12913536175581177750
-   │
-   = Event {
-         name: "MyEvent",
-         fields: [
-             EventField {
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
    ┌─ tuple_stress.fe:34:5
    │  
 34 │ ╭     pub fn set_my_sto_tuple(self, my_u256: u256, my_i32: i32) {
 35 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
 36 │ │         self.my_sto_tuple = (my_u256, my_i32)
 37 │ │     }
-   │ ╰─────^ attributes hash: 14404502892103280650
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_u256",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "my_i32",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             I32,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_u256, typ: u256 }, { label: None, name: my_i32, typ: i32 }] -> ()
 
 note: 
    ┌─ tuple_stress.fe:35:16
@@ -590,33 +232,7 @@ note:
 39 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32) {
 40 │ │         return self.my_sto_tuple.to_mem()
 41 │ │     }
-   │ ╰─────^ attributes hash: 6833980121040096883
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Tuple(
-                 Tuple {
-                     items: [
-                         Base(
-                             Numeric(
-                                 U256,
-                             ),
-                         ),
-                         Base(
-                             Numeric(
-                                 I32,
-                             ),
-                         ),
-                     ],
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> (u256, i32)
 
 note: 
    ┌─ tuple_stress.fe:40:16
@@ -644,35 +260,7 @@ note:
 45 │ │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
 46 │ │         emit_my_event(ctx, my_tuple)
 47 │ │     }
-   │ ╰─────^ attributes hash: 1731341862738941170
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
    ┌─ tuple_stress.fe:44:13
@@ -753,49 +341,7 @@ note:
 49 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> Array<u8, 96> {
 50 │ │         return my_tuple.abi_encode()
 51 │ │     }
-   │ ╰─────^ attributes hash: 10651188962262222621
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "my_tuple",
-                 typ: Ok(
-                     Tuple(
-                         Tuple {
-                             items: [
-                                 Base(
-                                     Numeric(
-                                         U256,
-                                     ),
-                                 ),
-                                 Base(
-                                     Bool,
-                                 ),
-                                 Base(
-                                     Address,
-                                 ),
-                             ],
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Array(
-                 Array {
-                     size: 96,
-                     inner: Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> Array<u8, 96>
 
 note: 
    ┌─ tuple_stress.fe:50:16

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -16,37 +16,7 @@ note:
 11 │ │         self.other.set_foo_addr(ctx.self_address())
 12 │ │         return self.other.answer()
 13 │ │     }
-   │ ╰─────^ attributes hash: 3247318976601732237
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
    ┌─ two_contracts.fe:11:9
@@ -94,47 +64,7 @@ note:
 15 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
 16 │ │         return x + y
 17 │ │     }
-   │ ╰─────^ attributes hash: 4448606202021980030
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "x",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "y",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
    ┌─ two_contracts.fe:16:16
@@ -162,32 +92,7 @@ note:
 23 │ ╭     pub fn set_foo_addr(self, _ addr: address) {
 24 │ │         self.other = Foo(addr)
 25 │ │     }
-   │ ╰─────^ attributes hash: 3263176293298741376
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "addr",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: addr, typ: address }] -> ()
 
 note: 
    ┌─ two_contracts.fe:24:9
@@ -215,22 +120,7 @@ note:
 27 │ ╭     pub fn answer(self) -> u256 {
 28 │ │         return self.other.add(20, 22)
 29 │ │     }
-   │ ╰─────^ attributes hash: 11773348765973600208
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
    ┌─ two_contracts.fe:28:16

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -64,46 +64,7 @@ note:
 25 │ │         self.authors[ctx.msg_sender()]
 26 │ │         self.scoreboard[id] = 0
 27 │ │     }
-   │ ╰─────^ attributes hash: 4649056442968527631
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "body",
-                 typ: Ok(
-                     String(
-                         FeString {
-                             max_size: 32,
-                         },
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: body, typ: String<32> }] -> ()
 
 note: 
    ┌─ type_aliases.fe:23:13
@@ -183,34 +144,7 @@ note:
 31 │ │         self.scoreboard[id] = score
 32 │ │         return score
 33 │ │     }
-   │ ╰─────^ attributes hash: 4383698668262923633
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "id",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U64,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: id, typ: u256 }] -> u64
 
 note: 
    ┌─ type_aliases.fe:30:13
@@ -272,34 +206,7 @@ note:
 35 │ ╭     pub fn get_post(self, id: PostId) -> PostBody {
 36 │ │         return self.posts[id].to_mem()
 37 │ │     }
-   │ ╰─────^ attributes hash: 6772945894090223199
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "id",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             String(
-                 FeString {
-                     max_size: 32,
-                 },
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: id, typ: u256 }] -> String<32>
 
 note: 
    ┌─ type_aliases.fe:36:16

--- a/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u128_u128_map.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: u128) -> u128 {
 5 │ │         return self.bar[key]
 6 │ │     }
-  │ ╰─────^ attributes hash: 1939765458140608268
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U128,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U128,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u128 }] -> u128
 
 note: 
   ┌─ u128_u128_map.fe:5:16
@@ -70,43 +43,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: u128, value: u128) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 9126735252114279653
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U128,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U128,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u128 }, { label: None, name: value, typ: u128 }] -> ()
 
 note: 
   ┌─ u128_u128_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u16_u16_map.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: u16) -> u16 {
 5 │ │         return self.bar[key]
 6 │ │     }
-  │ ╰─────^ attributes hash: 18312053447303862075
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U16,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U16,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u16 }] -> u16
 
 note: 
   ┌─ u16_u16_map.fe:5:16
@@ -70,43 +43,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: u16, value: u16) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 8088868709641766820
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U16,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u16 }, { label: None, name: value, typ: u16 }] -> ()
 
 note: 
   ┌─ u16_u16_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u256_u256_map.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: u256) -> u256 {
 5 │ │         return self.bar[key]
 6 │ │     }
-  │ ╰─────^ attributes hash: 14897000516975740248
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U256,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u256 }] -> u256
 
 note: 
   ┌─ u256_u256_map.fe:5:16
@@ -70,43 +43,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: u256, value: u256) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 17030413653610901743
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u256 }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
   ┌─ u256_u256_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u32_u32_map.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: u32) -> u32 {
 5 │ │         return self.bar[key]
 6 │ │     }
-  │ ╰─────^ attributes hash: 17684751964541454304
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U32,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U32,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u32 }] -> u32
 
 note: 
   ┌─ u32_u32_map.fe:5:16
@@ -70,43 +43,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: u32, value: u32) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 9068646997358780798
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U32,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U32,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u32 }, { label: None, name: value, typ: u32 }] -> ()
 
 note: 
   ┌─ u32_u32_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u64_u64_map.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: u64) -> u64 {
 5 │ │         return self.bar[key]
 6 │ │     }
-  │ ╰─────^ attributes hash: 5490397784598880129
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U64,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U64,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u64 }] -> u64
 
 note: 
   ┌─ u64_u64_map.fe:5:16
@@ -70,43 +43,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: u64, value: u64) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 2182326649216136625
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U64,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u64 }, { label: None, name: value, typ: u64 }] -> ()
 
 note: 
   ┌─ u64_u64_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
+++ b/crates/analyzer/tests/snapshots/analysis__u8_u8_map.snap
@@ -15,34 +15,7 @@ note:
 4 │ ╭     pub fn read_bar(self, key: u8) -> u8 {
 5 │ │         return self.bar[key]
 6 │ │     }
-  │ ╰─────^ attributes hash: 3828358868158950430
-  │  
-  = FunctionSignature {
-        self_decl: Some(
-            Mutable,
-        ),
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: None,
-                name: "key",
-                typ: Ok(
-                    Base(
-                        Numeric(
-                            U8,
-                        ),
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U8,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u8 }] -> u8
 
 note: 
   ┌─ u8_u8_map.fe:5:16
@@ -70,43 +43,7 @@ note:
  8 │ ╭     pub fn write_bar(self, key: u8, value: u8) {
  9 │ │         self.bar[key] = value
 10 │ │     }
-   │ ╰─────^ attributes hash: 1989504953336313430
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "key",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U8,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: key, typ: u8 }, { label: None, name: value, typ: u8 }] -> ()
 
 note: 
   ┌─ u8_u8_map.fe:9:9

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -9,32 +9,7 @@ note:
 4 │ ╭     pub fn balanceOf(_ account: address) -> u256 {
 5 │ │         return 0
 6 │ │     }
-  │ ╰─────^ attributes hash: 4709511530683498418
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [
-            FunctionParam {
-                label: Some(
-                    "_",
-                ),
-                name: "account",
-                typ: Ok(
-                    Base(
-                        Address,
-                    ),
-                ),
-            },
-        ],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
   ┌─ uniswap.fe:5:16
@@ -48,41 +23,7 @@ note:
  8 │ ╭     pub fn transfer(to: address, _ amount: u256) -> bool {
  9 │ │         return false
 10 │ │     }
-   │ ╰─────^ attributes hash: 12261720285838819896
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: Some(
-                     "_",
-                 ),
-                 name: "amount",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Bool,
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [{ label: None, name: to, typ: address }, { label: Some("_"), name: amount, typ: u256 }] -> bool
 
 note: 
   ┌─ uniswap.fe:9:16
@@ -196,20 +137,7 @@ note:
 78 │ ╭     pub fn factory(self) -> address {
 79 │ │         return self.factory
 80 │ │     }
-   │ ╰─────^ attributes hash: 227275695522088782
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
    ┌─ uniswap.fe:79:16
@@ -229,20 +157,7 @@ note:
 82 │ ╭     pub fn token0(self) -> address {
 83 │ │         return address(self.token0)
 84 │ │     }
-   │ ╰─────^ attributes hash: 227275695522088782
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
    ┌─ uniswap.fe:83:24
@@ -268,20 +183,7 @@ note:
 86 │ ╭     pub fn token1(self) -> address {
 87 │ │         return address(self.token1)
 88 │ │     }
-   │ ╰─────^ attributes hash: 227275695522088782
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Address,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
    ┌─ uniswap.fe:87:24
@@ -309,55 +211,7 @@ note:
 92 │ │         self.balances[to] = self.balances[to] + value
 93 │ │         emit Transfer(ctx, from: address(0), to, value)
 94 │ │     }
-   │ ╰─────^ attributes hash: 12650409809079895726
-   │  
-   = FunctionSignature {
-         self_decl: Some(
-             Mutable,
-         ),
-         ctx_decl: Some(
-             Mutable,
-         ),
-         params: [
-             FunctionParam {
-                 label: None,
-                 name: "ctx",
-                 typ: Ok(
-                     Struct(
-                         Struct {
-                             name: "Context",
-                             field_count: 0,
-                         },
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-             },
-             FunctionParam {
-                 label: None,
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-             },
-         ],
-         return_type: Ok(
-             Base(
-                 Unit,
-             ),
-         ),
-     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ uniswap.fe:91:9
@@ -441,47 +295,6 @@ note:
    │                                  address: Value
 
 note: 
-   ┌─ uniswap.fe:93:9
-   │
-93 │         emit Transfer(ctx, from: address(0), to, value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
     ┌─ uniswap.fe:96:5
     │  
  96 │ ╭     fn _burn(self, ctx: Context, from: address, value: u256) {
@@ -489,55 +302,7 @@ note:
  98 │ │         self.total_supply = self.total_supply - value
  99 │ │         emit Transfer(ctx, from, to: address(0), value)
 100 │ │     }
-    │ ╰─────^ attributes hash: 16245072311291560743
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "from",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
    ┌─ uniswap.fe:97:9
@@ -621,111 +386,13 @@ note:
    │                                      address: Value
 
 note: 
-   ┌─ uniswap.fe:99:9
-   │
-99 │         emit Transfer(ctx, from, to: address(0), value)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-   │
-   = Event {
-         name: "Transfer",
-         fields: [
-             EventField {
-                 name: "from",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "to",
-                 typ: Ok(
-                     Base(
-                         Address,
-                     ),
-                 ),
-                 is_indexed: true,
-             },
-             EventField {
-                 name: "value",
-                 typ: Ok(
-                     Base(
-                         Numeric(
-                             U256,
-                         ),
-                     ),
-                 ),
-                 is_indexed: false,
-             },
-         ],
-     }
-
-note: 
     ┌─ uniswap.fe:102:5
     │  
 102 │ ╭     fn _approve(self, ctx: Context, owner: address, spender: address, value: u256) {
 103 │ │         self.allowances[owner][spender] = value
 104 │ │         emit Approval(ctx, owner, spender, value)
 105 │ │     }
-    │ ╰─────^ attributes hash: 1630416716014819616
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "owner",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "spender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: owner, typ: address }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
     ┌─ uniswap.fe:103:9
@@ -764,47 +431,6 @@ note:
     │                       Context: Memory
 
 note: 
-    ┌─ uniswap.fe:104:9
-    │
-104 │         emit Approval(ctx, owner, spender, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 8893313742751514912
-    │
-    = Event {
-          name: "Approval",
-          fields: [
-              EventField {
-                  name: "owner",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "spender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:107:5
     │  
 107 │ ╭     fn _transfer(self, ctx: Context, from: address, to: address, value: u256) {
@@ -812,64 +438,7 @@ note:
 109 │ │         self.balances[to] = self.balances[to] + value
 110 │ │         emit Transfer(ctx, from, to, value)
 111 │ │     }
-    │ ╰─────^ attributes hash: 1442617122763943794
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "from",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
     ┌─ uniswap.fe:108:9
@@ -962,102 +531,13 @@ note:
     │                       Context: Memory
 
 note: 
-    ┌─ uniswap.fe:110:9
-    │
-110 │         emit Transfer(ctx, from, to, value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 5533489995250141934
-    │
-    = Event {
-          name: "Transfer",
-          fields: [
-              EventField {
-                  name: "from",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:113:5
     │  
 113 │ ╭     pub fn approve(self, ctx: Context, spender: address, value: u256) -> bool {
 114 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
 115 │ │         return true
 116 │ │     }
-    │ ╰─────^ attributes hash: 8309406699454253603
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "spender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Bool,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
     ┌─ uniswap.fe:114:9
@@ -1092,55 +572,7 @@ note:
 119 │ │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
 120 │ │         return true
 121 │ │     }
-    │ ╰─────^ attributes hash: 14718526948940966913
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Bool,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
     ┌─ uniswap.fe:119:9
@@ -1177,64 +609,7 @@ note:
 126 │ │         self._transfer(ctx, from, to, value)
 127 │ │         return true
 128 │ │     }
-    │ ╰─────^ attributes hash: 3284161617958543499
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "from",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "value",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Bool,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
     ┌─ uniswap.fe:124:16
@@ -1367,34 +742,7 @@ note:
 130 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
 131 │ │         return self.balances[account]
 132 │ │     }
-    │ ╰─────^ attributes hash: 5993653573135321647
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "account",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
     ┌─ uniswap.fe:131:16
@@ -1422,38 +770,7 @@ note:
 134 │ ╭     pub fn get_reserves(self) -> (u256, u256, u256) {
 135 │ │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
 136 │ │     }
-    │ ╰─────^ attributes hash: 3743538709625240197
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Tuple(
-                  Tuple {
-                      items: [
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      ],
-                  },
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> (u256, u256, u256)
 
 note: 
     ┌─ uniswap.fe:135:17
@@ -1497,57 +814,7 @@ note:
 141 │ │         self.token0 = token0
 142 │ │         self.token1 = token1
 143 │ │     }
-    │ ╰─────^ attributes hash: 18170027042989505865
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "token0",
-                  typ: Ok(
-                      Contract(
-                          Contract {
-                              name: "ERC20",
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "token1",
-                  typ: Ok(
-                      Contract(
-                          Contract {
-                              name: "ERC20",
-                          },
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: token0, typ: ERC20 }, { label: None, name: token1, typ: ERC20 }] -> ()
 
 note: 
     ┌─ uniswap.fe:140:16
@@ -1607,79 +874,7 @@ note:
     · │
 158 │ │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
 159 │ │     }
-    │ ╰─────^ attributes hash: 14441581101409065213
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "balance0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "balance1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "reserve0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "reserve1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: balance0, typ: u256 }, { label: None, name: balance1, typ: u256 }, { label: None, name: reserve0, typ: u256 }, { label: None, name: reserve1, typ: u256 }] -> ()
 
 note: 
     ┌─ uniswap.fe:149:13
@@ -1900,40 +1095,6 @@ note:
     │                                                           ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
-    ┌─ uniswap.fe:158:9
-    │
-158 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 11491202868117077488
-    │
-    = Event {
-          name: "Sync",
-          fields: [
-              EventField {
-                  name: "reserve0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "reserve1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:161:5
     │  
 161 │ ╭     fn _mint_fee(self, ctx: Context, reserve0: u256, reserve1: u256) -> bool {
@@ -1943,57 +1104,7 @@ note:
     · │
 181 │ │         return fee_on
 182 │ │     }
-    │ ╰─────^ attributes hash: 12335666382859496931
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "reserve0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "reserve1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Bool,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: reserve0, typ: u256 }, { label: None, name: reserve1, typ: u256 }] -> bool
 
 note: 
     ┌─ uniswap.fe:162:13
@@ -2219,46 +1330,7 @@ note:
     · │
 209 │ │         return liquidity
 210 │ │     }
-    │ ╰─────^ attributes hash: 11513995717553818344
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }] -> u256
 
 note: 
     ┌─ uniswap.fe:186:13
@@ -2576,49 +1648,6 @@ note:
     │                ^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:208:9
-    │
-208 │         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 4243961805717991435
-    │
-    = Event {
-          name: "Mint",
-          fields: [
-              EventField {
-                  name: "sender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "amount0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:213:5
     │  
 213 │ ╭     pub fn burn(self, ctx: Context, to: address) -> (u256, u256) {
@@ -2628,57 +1657,7 @@ note:
     · │
 237 │ │         return (amount0, amount1)
 238 │ │     }
-    │ ╰─────^ attributes hash: 4652297158603848356
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Tuple(
-                  Tuple {
-                      items: [
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                          Base(
-                              Numeric(
-                                  U256,
-                              ),
-                          ),
-                      ],
-                  },
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }] -> (u256, u256)
 
 note: 
     ┌─ uniswap.fe:214:13
@@ -3015,58 +1994,6 @@ note:
     │                ^^^^^^^^^^^^^^^^^^ (u256, u256): Memory
 
 note: 
-    ┌─ uniswap.fe:236:9
-    │
-236 │         emit Burn(ctx, sender: ctx.msg_sender(), amount0, amount1, to)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 10738919684795162003
-    │
-    = Event {
-          name: "Burn",
-          fields: [
-              EventField {
-                  name: "sender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "amount0",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:243:5
     │  
 243 │ ╭     pub fn swap(self, ctx: Context, amount0_out: u256, amount1_out: u256, to: address) {
@@ -3076,66 +2003,7 @@ note:
     · │
 279 │ │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
 280 │ │     }
-    │ ╰─────^ attributes hash: 18411078236281700131
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "amount0_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "amount1_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: amount0_out, typ: u256 }, { label: None, name: amount1_out, typ: u256 }, { label: None, name: to, typ: address }] -> ()
 
 note: 
     ┌─ uniswap.fe:245:13
@@ -3615,80 +2483,6 @@ note:
     │                                address: Value
 
 note: 
-    ┌─ uniswap.fe:279:9
-    │
-279 │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 16055667627771619025
-    │
-    = Event {
-          name: "Swap",
-          fields: [
-              EventField {
-                  name: "sender",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "amount0_in",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1_in",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount0_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "amount1_out",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:283:5
     │  
 283 │ ╭     pub fn skim(self, ctx: Context, to: address) {
@@ -3697,44 +2491,7 @@ note:
 286 │ │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
 287 │ │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
 288 │ │     }
-    │ ╰─────^ attributes hash: 9469713119497359790
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }] -> ()
 
 note: 
     ┌─ uniswap.fe:284:13
@@ -3850,35 +2607,7 @@ note:
     · │
 298 │ │                      reserve1: self.reserve1)
 299 │ │     }
-    │ ╰─────^ attributes hash: 1731341862738941170
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
     ┌─ uniswap.fe:292:13
@@ -4004,20 +2733,7 @@ note:
 322 │ ╭     pub fn fee_to(self) -> address {
 323 │ │         return self.fee_to
 324 │ │     }
-    │ ╰─────^ attributes hash: 227275695522088782
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Address,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
     ┌─ uniswap.fe:323:16
@@ -4037,20 +2753,7 @@ note:
 326 │ ╭     pub fn fee_to_setter(self) -> address {
 327 │ │         return self.fee_to_setter
 328 │ │     }
-    │ ╰─────^ attributes hash: 227275695522088782
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Address,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
     ┌─ uniswap.fe:327:16
@@ -4070,22 +2773,7 @@ note:
 330 │ ╭     pub fn all_pairs_length(self) -> u256 {
 331 │ │         return self.pair_counter
 332 │ │     }
-    │ ╰─────^ attributes hash: 11773348765973600208
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: None,
-          params: [],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
     ┌─ uniswap.fe:331:16
@@ -4109,57 +2797,7 @@ note:
     · │
 352 │ │         return address(pair)
 353 │ │     }
-    │ ╰─────^ attributes hash: 8455575078477255668
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "token_a",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "token_b",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Address,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: Some("_"), name: token_a, typ: address }, { label: Some("_"), name: token_b, typ: address }] -> address
 
 note: 
     ┌─ uniswap.fe:337:13
@@ -4495,100 +3133,13 @@ note:
     │                ^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:351:9
-    │
-351 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attributes hash: 13094055123344570742
-    │
-    = Event {
-          name: "PairCreated",
-          fields: [
-              EventField {
-                  name: "token0",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "token1",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: true,
-              },
-              EventField {
-                  name: "pair",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-              EventField {
-                  name: "index",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-                  is_indexed: false,
-              },
-          ],
-      }
-
-note: 
     ┌─ uniswap.fe:355:5
     │  
 355 │ ╭     pub fn set_fee_to(self, ctx: Context, fee_to: address) {
 356 │ │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
 357 │ │         self.fee_to = fee_to
 358 │ │     }
-    │ ╰─────^ attributes hash: 9061125162615165722
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "fee_to",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: fee_to, typ: address }] -> ()
 
 note: 
     ┌─ uniswap.fe:356:16
@@ -4635,44 +3186,7 @@ note:
 361 │ │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
 362 │ │         self.fee_to_setter = fee_to_setter
 363 │ │     }
-    │ ╰─────^ attributes hash: 16865322734649050051
-    │  
-    = FunctionSignature {
-          self_decl: Some(
-              Mutable,
-          ),
-          ctx_decl: Some(
-              Mutable,
-          ),
-          params: [
-              FunctionParam {
-                  label: None,
-                  name: "ctx",
-                  typ: Ok(
-                      Struct(
-                          Struct {
-                              name: "Context",
-                              field_count: 0,
-                          },
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: None,
-                  name: "fee_to_setter",
-                  typ: Ok(
-                      Base(
-                          Address,
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Unit,
-              ),
-          ),
-      }
+    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: fee_to_setter, typ: address }] -> ()
 
 note: 
     ┌─ uniswap.fe:361:16
@@ -4716,34 +3230,7 @@ note:
     · │
 378 │ │     return z
 379 │ │ }
-    │ ╰─^ attributes hash: 4892692935064256824
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "val",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─^ self: None, params: [{ label: Some("_"), name: val, typ: u256 }] -> u256
 
 note: 
     ┌─ uniswap.fe:367:9
@@ -4855,47 +3342,7 @@ note:
 381 │ ╭ fn min(_ x: u256, _ y: u256) -> u256 {
 382 │ │     return x if x < y else y
 383 │ │ }
-    │ ╰─^ attributes hash: 4448606202021980030
-    │  
-    = FunctionSignature {
-          self_decl: None,
-          ctx_decl: None,
-          params: [
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "x",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-              FunctionParam {
-                  label: Some(
-                      "_",
-                  ),
-                  name: "y",
-                  typ: Ok(
-                      Base(
-                          Numeric(
-                              U256,
-                          ),
-                      ),
-                  ),
-              },
-          ],
-          return_type: Ok(
-              Base(
-                  Numeric(
-                      U256,
-                  ),
-              ),
-          ),
-      }
+    │ ╰─^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
     ┌─ uniswap.fe:382:17

--- a/crates/analyzer/tests/snapshots/analysis__while_loop.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop.snap
@@ -13,20 +13,7 @@ note:
    · │
 10 │ │         return val
 11 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ while_loop.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break.snap
@@ -13,20 +13,7 @@ note:
   · │
 8 │ │         return val
 9 │ │     }
-  │ ╰─────^ attributes hash: 6115314201970082834
-  │  
-  = FunctionSignature {
-        self_decl: None,
-        ctx_decl: None,
-        params: [],
-        return_type: Ok(
-            Base(
-                Numeric(
-                    U256,
-                ),
-            ),
-        ),
-    }
+  │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ while_loop_with_break.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_break_2.snap
@@ -13,20 +13,7 @@ note:
    · │
 10 │ │         return val
 11 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ while_loop_with_break_2.fe:3:13

--- a/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
+++ b/crates/analyzer/tests/snapshots/analysis__while_loop_with_continue.snap
@@ -13,20 +13,7 @@ note:
    · │
 12 │ │         return counter
 13 │ │     }
-   │ ╰─────^ attributes hash: 6115314201970082834
-   │  
-   = FunctionSignature {
-         self_decl: None,
-         ctx_decl: None,
-         params: [],
-         return_type: Ok(
-             Base(
-                 Numeric(
-                     U256,
-                 ),
-             ),
-         ),
-     }
+   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
   ┌─ while_loop_with_continue.fe:3:13

--- a/crates/codegen/src/db/queries/function.rs
+++ b/crates/codegen/src/db/queries/function.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use fe_analyzer::display::Displayable;
 use fe_analyzer::namespace::items::Class;
 use fe_mir::ir::{FunctionBody, FunctionId, FunctionSignature};
 
@@ -33,7 +34,7 @@ pub fn symbol_name(db: &dyn CodegenDb, function: FunctionId) -> Rc<String> {
             let class_name = format!(
                 "{}${}",
                 id.trait_id(db.upcast()).name(db.upcast()),
-                id.receiver(db.upcast()).name()
+                id.receiver(db.upcast()).display(db.upcast())
             );
             format!("{}${}", class_name, func_name)
         }

--- a/crates/codegen/src/db/queries/types.rs
+++ b/crates/codegen/src/db/queries/types.rs
@@ -119,6 +119,6 @@ pub fn legalized_type(db: &dyn CodegenDb, ty: TypeId) -> TypeId {
         _ => return ty,
     };
 
-    let analyzer_ty = ty_data.analyzer_ty.clone();
+    let analyzer_ty = ty_data.analyzer_ty;
     db.mir_intern_type(Type::new(ty_kind, analyzer_ty).into())
 }

--- a/crates/mir/src/db.rs
+++ b/crates/mir/src/db.rs
@@ -39,7 +39,7 @@ pub trait MirDb: AnalyzerDb + Upcast<dyn AnalyzerDb> + UpcastMut<dyn AnalyzerDb>
     ) -> Rc<Vec<ir::FunctionId>>;
 
     #[salsa::invoke(queries::types::mir_lowered_type)]
-    fn mir_lowered_type(&self, analyzer_type: analyzer_types::Type) -> TypeId;
+    fn mir_lowered_type(&self, analyzer_type: analyzer_types::TypeId) -> TypeId;
     #[salsa::invoke(queries::types::mir_lowered_event_type)]
     fn mir_lowered_event_type(&self, analyzer_type: analyzer_items::EventId) -> TypeId;
 
@@ -55,7 +55,7 @@ pub trait MirDb: AnalyzerDb + Upcast<dyn AnalyzerDb> + UpcastMut<dyn AnalyzerDb>
     fn mir_lowered_monomorphized_func_signature(
         &self,
         analyzer_func: analyzer_items::FunctionId,
-        concrete_args: Vec<analyzer_types::Type>,
+        concrete_args: Vec<analyzer_types::TypeId>,
     ) -> ir::FunctionId;
     #[salsa::invoke(queries::function::mir_lowered_func_body)]
     fn mir_lowered_func_body(&self, func: ir::FunctionId) -> Rc<ir::FunctionBody>;

--- a/crates/mir/src/db/queries/function.rs
+++ b/crates/mir/src/db/queries/function.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use fe_analyzer::display::Displayable;
 use fe_analyzer::namespace::items as analyzer_items;
 use fe_analyzer::namespace::items::Class;
 use fe_analyzer::namespace::types as analyzer_types;
@@ -21,7 +22,7 @@ pub fn mir_lowered_func_signature(
 pub fn mir_lowered_monomorphized_func_signature(
     db: &dyn MirDb,
     analyzer_func: analyzer_items::FunctionId,
-    concrete_args: Vec<analyzer_types::Type>,
+    concrete_args: Vec<analyzer_types::TypeId>,
 ) -> ir::FunctionId {
     lower_monomorphized_func_signature(db, analyzer_func, &concrete_args)
 }
@@ -69,7 +70,7 @@ impl ir::FunctionId {
             .resolved_generics
             .values()
             .fold(String::new(), |acc, param| {
-                format!("{}_{}", acc, param.name())
+                format!("{}_{}", acc, param.display(db.upcast()))
             })
             .into()
     }
@@ -92,7 +93,7 @@ impl ir::FunctionId {
             Some(Class::Impl(id)) => {
                 let class_name = format!(
                     "<{} as {}>",
-                    id.receiver(db.upcast()).name(),
+                    id.receiver(db.upcast()).display(db.upcast()),
                     id.trait_id(db.upcast()).name(db.upcast())
                 );
                 format!("{}::{}", class_name, func_name).into()

--- a/crates/mir/src/db/queries/types.rs
+++ b/crates/mir/src/db/queries/types.rs
@@ -14,7 +14,7 @@ use crate::{
     lower::types::{lower_event_type, lower_type},
 };
 
-pub fn mir_lowered_type(db: &dyn MirDb, analyzer_type: analyzer_types::Type) -> TypeId {
+pub fn mir_lowered_type(db: &dyn MirDb, analyzer_type: analyzer_types::TypeId) -> TypeId {
     lower_type(db, &analyzer_type)
 }
 
@@ -27,8 +27,8 @@ impl TypeId {
         db.lookup_mir_intern_type(self)
     }
 
-    pub fn analyzer_ty(self, db: &dyn MirDb) -> Option<analyzer_types::Type> {
-        self.data(db).analyzer_ty.clone()
+    pub fn analyzer_ty(self, db: &dyn MirDb) -> Option<analyzer_types::TypeId> {
+        self.data(db).analyzer_ty
     }
 
     pub fn projection_ty(self, db: &dyn MirDb, access: &Value) -> TypeId {
@@ -168,13 +168,6 @@ impl TypeId {
                 | TypeKind::I64
                 | TypeKind::I128
                 | TypeKind::I256
-        )
-    }
-
-    pub fn is_fe_string(self, db: &dyn MirDb) -> bool {
-        matches!(
-            &self.data(db).analyzer_ty,
-            Some(analyzer_types::Type::String(_))
         )
     }
 

--- a/crates/mir/src/ir/function.rs
+++ b/crates/mir/src/ir/function.rs
@@ -22,7 +22,7 @@ use super::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FunctionSignature {
     pub params: Vec<FunctionParam>,
-    pub resolved_generics: BTreeMap<analyzer_types::Generic, analyzer_types::Type>,
+    pub resolved_generics: BTreeMap<analyzer_types::Generic, analyzer_types::TypeId>,
     pub return_type: Option<TypeId>,
     pub module_id: analyzer_items::ModuleId,
     pub analyzer_func_id: analyzer_items::FunctionId,

--- a/crates/mir/src/ir/types.rs
+++ b/crates/mir/src/ir/types.rs
@@ -6,15 +6,12 @@ use smol_str::SmolStr;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Type {
     pub kind: TypeKind,
-    pub analyzer_ty: Option<analyzer_types::Type>,
+    pub analyzer_ty: Option<analyzer_types::TypeId>,
 }
 
 impl Type {
-    pub fn new(kind: TypeKind, analyzer_type: Option<analyzer_types::Type>) -> Self {
-        Self {
-            kind,
-            analyzer_ty: analyzer_type,
-        }
+    pub fn new(kind: TypeKind, analyzer_ty: Option<analyzer_types::TypeId>) -> Self {
+        Self { kind, analyzer_ty }
     }
 }
 

--- a/crates/mir/src/lower/function.rs
+++ b/crates/mir/src/lower/function.rs
@@ -5,7 +5,7 @@ use fe_analyzer::{
     context::CallType as AnalyzerCallType,
     namespace::{
         items as analyzer_items,
-        types::{self as analyzer_types, Type, TypeDowncast},
+        types::{self as analyzer_types, Type},
     },
 };
 use fe_common::numeric::Literal;
@@ -36,15 +36,14 @@ pub fn lower_func_signature(db: &dyn MirDb, func: analyzer_items::FunctionId) ->
 pub fn lower_monomorphized_func_signature(
     db: &dyn MirDb,
     func: analyzer_items::FunctionId,
-    concrete_args: &[Type],
+    mut concrete_args: &[analyzer_types::TypeId],
 ) -> FunctionId {
     // TODO: Remove this when an analyzer's function signature contains `self` type.
     let mut params = vec![];
-    let mut concrete_args: &[Type] = concrete_args;
     let has_self = func.takes_self(db.upcast());
 
     if has_self {
-        let self_ty = func.self_typ(db.upcast()).unwrap();
+        let self_ty = func.self_type(db.upcast()).unwrap();
         let source = self_arg_source(db, func);
         params.push(make_param(db, "self", self_ty, source));
         // similarly, when in the future analyzer params contain `self` we won't need to adjust the concrete args anymore
@@ -53,7 +52,8 @@ pub fn lower_monomorphized_func_signature(
         }
     }
     let analyzer_signature = func.signature(db.upcast());
-    let mut resolved_generics: BTreeMap<analyzer_types::Generic, Type> = BTreeMap::new();
+    let mut resolved_generics: BTreeMap<analyzer_types::Generic, analyzer_types::TypeId> =
+        BTreeMap::new();
 
     for (index, param) in analyzer_signature.params.iter().enumerate() {
         let source = arg_source(db, func, &param.name);
@@ -62,19 +62,10 @@ pub fn lower_monomorphized_func_signature(
             .cloned()
             .unwrap_or_else(|| param.typ.clone().unwrap());
 
-        params.push(make_param(
-            db,
-            param.clone().name,
-            provided_type.clone(),
-            source,
-        ));
+        params.push(make_param(db, param.clone().name, provided_type, source));
 
-        if let analyzer_types::FunctionParam {
-            typ: Ok(Type::Generic(generic)),
-            ..
-        } = param
-        {
-            resolved_generics.insert(generic.clone(), provided_type);
+        if let Type::Generic(generic) = param.typ.clone().unwrap().typ(db.upcast()) {
+            resolved_generics.insert(generic, provided_type);
         }
     }
 
@@ -147,16 +138,17 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
         }
     }
 
-    fn lower_analyzer_type(&self, analyzer_ty: analyzer_types::Type) -> TypeId {
+    fn lower_analyzer_type(&self, analyzer_ty: analyzer_types::TypeId) -> TypeId {
         // If the analyzer type is generic we first need to resolve it to its concrete type before lowering to a MIR type
-        if let analyzer_types::Type::Generic(generic) = analyzer_ty {
+        if let analyzer_types::Type::Generic(generic) = analyzer_ty.typ(self.db.upcast()) {
             let resolved_type = self
                 .func
                 .signature(self.db)
                 .resolved_generics
                 .get(&generic)
-                .expect("expected generic to be resolved")
-                .clone();
+                .cloned()
+                .expect("expected generic to be resolved");
+
             return self.db.mir_lowered_type(resolved_type);
         }
 
@@ -195,7 +187,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
             }
 
             ast::FuncStmt::ConstantDecl { name, value, .. } => {
-                let ty = self.lower_analyzer_type(self.analyzer_body.var_types[&name.id].clone());
+                let ty = self.lower_analyzer_type(self.analyzer_body.var_types[&name.id]);
 
                 let value = self.analyzer_body.expressions[&value.id]
                     .const_value
@@ -362,7 +354,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
     ) {
         match &var.kind {
             ast::VarDeclTarget::Name(name) => {
-                let ty = self.lower_analyzer_type(self.analyzer_body.var_types[&var.id].clone());
+                let ty = self.lower_analyzer_type(self.analyzer_body.var_types[&var.id]);
                 let local = Local::user_local(name.clone(), ty, var.into());
 
                 let value = self.builder.declare(local);
@@ -403,7 +395,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
     ) {
         match &var.kind {
             ast::VarDeclTarget::Name(name) => {
-                let ty = self.lower_analyzer_type(self.analyzer_body.var_types[&var.id].clone());
+                let ty = self.lower_analyzer_type(self.analyzer_body.var_types[&var.id]);
                 let local = Local::user_local(name.clone(), ty, var.into());
 
                 let lhs = self.builder.declare(local);
@@ -500,7 +492,8 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
         let preheader_bb = self.builder.make_block();
         let entry_bb = self.builder.make_block();
         let exit_bb = self.builder.make_block();
-        let iter_elem_ty = self.analyzer_body.var_types[&loop_variable.id].clone();
+
+        let iter_elem_ty = self.analyzer_body.var_types[&loop_variable.id];
         let iter_elem_ty = self.lower_analyzer_type(iter_elem_ty);
 
         self.builder.jump(preheader_bb, SourceInfo::dummy());
@@ -748,7 +741,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
     }
 
     fn expr_ty(&self, expr: &Node<ast::Expr>) -> TypeId {
-        let analyzer_ty = self.analyzer_body.expressions[&expr.id].typ.clone();
+        let analyzer_ty = self.analyzer_body.expressions[&expr.id].typ;
         self.lower_analyzer_type(analyzer_ty)
     }
 
@@ -929,11 +922,11 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
                     .signature(self.db)
                     .resolved_generics
                     .get(generic_type)
-                    .as_struct()
+                    .expect("unresolved generic type")
+                    .as_struct(self.db.upcast())
                     .expect("unexpected implementer of trait");
 
                 let impl_ = struct_type
-                    .id
                     .get_impl_for(self.db.upcast(), *trait_id)
                     .expect("missing impl");
 
@@ -954,7 +947,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
             }
 
             AnalyzerCallType::TypeConstructor(to_ty) => {
-                if matches!(to_ty, fe_analyzer::namespace::types::Type::String(..)) {
+                if to_ty.is_string(self.db.upcast()) {
                     let arg = *args.last().unwrap();
                     self.builder.mem_copy(arg, source)
                 } else if ty.is_primitive(self.db) {
@@ -1027,7 +1020,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
     }
 
     fn make_unit(&mut self) -> ValueId {
-        let unit_ty = analyzer_types::Type::Base(analyzer_types::Base::Unit);
+        let unit_ty = analyzer_types::TypeId::unit(self.db.upcast());
         let unit_ty = self.db.mir_lowered_type(unit_ty);
         self.builder.make_unit(unit_ty)
     }
@@ -1254,12 +1247,12 @@ fn arg_source(db: &dyn MirDb, func: analyzer_items::FunctionId, arg_name: &str) 
 fn make_param(
     db: &dyn MirDb,
     name: impl Into<SmolStr>,
-    ty: impl Into<analyzer_types::Type>,
+    ty: analyzer_types::TypeId,
     source: SourceInfo,
 ) -> FunctionParam {
     FunctionParam {
         name: name.into(),
-        ty: db.mir_lowered_type(ty.into()),
+        ty: db.mir_lowered_type(ty),
         source,
     }
 }


### PR DESCRIPTION
### What was wrong?

The analyzer `Type` is clone-only, because it contains a vec and a box. It should be copyable. Also `Struct` and `Contract` contain redundant copies of their names.

### How was it fixed?

Type::Struct and ::Contract now just contain ids. All types are interned to get a TypeId. `Type` fields containing things like `Box<Type>` are now contain `TypeId`s instead. Most functions that took `Type` now take `TypeId`. Some of this is messy. I might go through and tidy up a bit, but I'm also quite sick of this so maybe not.

This means that `Type` is no longer `Display`able, except via the new `.display(db)` method. So we traded off `.clone()` for `.display(db)`. Was it worth it? I dunno.

All the analysis test snapshots changed, because Debug printing of `Type` is now useless (ids), so now FunctionSignature printing is terse, and the `emit` event debug print is gone. It'll magically reappear (sort of) when `ctx.emit(my_event)` is implemented.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
