### PR TITLE
Treat `trait` exclusively as `Item` not `Type`

### DIFF
--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -330,14 +330,6 @@ pub fn contract_field_type(
 
     let node = &field.data(db).ast;
 
-    if let Ok(Type::Trait(ref val)) = typ {
-        scope.error(
-            "traits can not be used as contract fields",
-            node.span,
-            &format!("trait `{}` can not appear here", val.name),
-        );
-    }
-
     if node.kind.is_pub {
         scope.not_yet_implemented("contract `pub` fields", node.span);
     }

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -89,12 +89,10 @@ pub fn module_all_items(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<[Item]> {
             ast::ModuleStmt::Function(node) => Some(Item::Function(
                 db.intern_function(Rc::new(Function::new(db, node, None, module))),
             )),
-            ast::ModuleStmt::Trait(node) => Some(Item::Type(TypeDef::Trait(db.intern_trait(
-                Rc::new(Trait {
-                    ast: node.clone(),
-                    module,
-                }),
-            )))),
+            ast::ModuleStmt::Trait(node) => Some(Item::Trait(db.intern_trait(Rc::new(Trait {
+                ast: node.clone(),
+                module,
+            })))),
             ast::ModuleStmt::Pragma(_) | ast::ModuleStmt::Use(_) | ast::ModuleStmt::Impl(_) => None,
             ast::ModuleStmt::Event(node) => Some(Item::Event(db.intern_event(Rc::new(Event {
                 ast: node.clone(),
@@ -119,7 +117,7 @@ pub fn module_all_impls(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<[ImplId]> {
                 let mut scope = ItemScope::new(db, module);
                 let receiver_type = type_desc(&mut scope, &impl_node.kind.receiver).unwrap();
 
-                if let Some(Item::Type(TypeDef::Trait(val))) = treit {
+                if let Some(Item::Trait(val)) = treit {
                     Some(db.intern_impl(Rc::new(Impl {
                         trait_id: val,
                         receiver: receiver_type,

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -47,7 +47,6 @@ pub enum Type {
     /// of `self` within a contract function.
     SelfContract(Contract),
     Struct(Struct),
-    Trait(Trait),
     Generic(Generic),
 }
 
@@ -410,7 +409,6 @@ impl Type {
             Type::Tuple(inner) => inner.to_string().into(),
             Type::String(inner) => inner.to_string().into(),
             Type::Struct(inner) => inner.name.clone(),
-            Type::Trait(inner) => inner.name.clone(),
             Type::Generic(inner) => inner.name.clone(),
             Type::Contract(inner) | Type::SelfContract(inner) => inner.name.clone(),
         }
@@ -482,7 +480,7 @@ impl Type {
             | Type::Struct(_)
             | Type::Generic(_)
             | Type::Contract(_) => true,
-            Type::Map(_) | Type::SelfContract(_) | Type::Trait(_) => false,
+            Type::Map(_) | Type::SelfContract(_) => false,
         }
     }
 }
@@ -686,7 +684,6 @@ impl fmt::Display for Type {
             Type::Contract(inner) => inner.fmt(f),
             Type::SelfContract(inner) => inner.fmt(f),
             Type::Struct(inner) => inner.fmt(f),
-            Type::Trait(inner) => inner.fmt(f),
             Type::Generic(inner) => inner.fmt(f),
         }
     }

--- a/crates/analyzer/src/operations.rs
+++ b/crates/analyzer/src/operations.rs
@@ -15,7 +15,6 @@ pub fn index(value: Type, index: Type) -> Result<Type, IndexingError> {
         | Type::String(_)
         | Type::Contract(_)
         | Type::SelfContract(_)
-        | Type::Trait(_)
         | Type::Generic(_)
         | Type::Struct(_) => Err(IndexingError::NotSubscriptable),
     }

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -345,7 +345,7 @@ fn build_snapshot(db: &dyn AnalyzerDb, module: items::ModuleId) -> String {
                     .collect(),
             ]
             .concat(),
-            Item::Type(TypeDef::Trait(val)) => val
+            Item::Trait(val) => val
                 .all_functions(db)
                 .iter()
                 .flat_map(|fun| {

--- a/crates/analyzer/tests/snapshots/errors__traits_as_fields.snap
+++ b/crates/analyzer/tests/snapshots/errors__traits_as_fields.snap
@@ -3,16 +3,22 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: struct field type must have a fixed size
-  ┌─ compile_errors/traits_as_fields.fe:4:5
+error: `Foo` is not a type name
+  ┌─ compile_errors/traits_as_fields.fe:1:7
   │
+1 │ trait Foo {}
+  │       ^^^ `Foo` is defined here as a trait
+  ·
 4 │     val: Foo
-  │     ^^^^^^^^ this can't be used as an struct field
+  │          ^^^ `Foo` is used here as a type
 
-error: traits can not be used as contract fields
-  ┌─ compile_errors/traits_as_fields.fe:8:5
+error: `Foo` is not a type name
+  ┌─ compile_errors/traits_as_fields.fe:1:7
   │
+1 │ trait Foo {}
+  │       ^^^ `Foo` is defined here as a trait
+  ·
 8 │     val: Foo
-  │     ^^^^^^^^ trait `Foo` can not appear here
+  │          ^^^ `Foo` is used here as a type
 
 

--- a/crates/mir/src/lower/types.rs
+++ b/crates/mir/src/lower/types.rs
@@ -18,9 +18,6 @@ pub fn lower_type(db: &dyn MirDb, analyzer_ty: &analyzer_types::Type) -> TypeId 
         analyzer_types::Type::Contract(_) => TypeKind::Address,
         analyzer_types::Type::SelfContract(contract) => lower_contract(db, contract),
         analyzer_types::Type::Struct(struct_) => lower_struct(db, struct_),
-        analyzer_types::Type::Trait(_) => {
-            panic!("traits should only appear in generic bounds for now")
-        }
         analyzer_types::Type::Generic(_) => {
             panic!("should be lowered in `lower_types_in_functions`")
         }

--- a/crates/parser/src/grammar/functions.rs
+++ b/crates/parser/src/grammar/functions.rs
@@ -128,7 +128,7 @@ pub fn parse_generic_param(par: &mut Parser) -> ParseResult<GenericParameter> {
     let name = par.assert(Name);
     match par.optional(Colon) {
         Some(_) => {
-            let bound = par.assert(Name);
+            let bound = par.expect(TokenKind::Name, "failed to parse generic bound")?;
             Ok(GenericParameter::Bounded {
                 name: Node::new(name.text.into(), name.span),
                 bound: Node::new(

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -83,6 +83,8 @@ test_parse_err! { for_no_in, functions::parse_stmt, "for x {}" }
 test_parse_err! { fn_no_args, module::parse_module, "fn f {\n  return 5\n}" }
 test_parse_err! { fn_unsafe_pub, module::parse_module, "unsafe pub fn f() {\n  return 5 }" }
 test_parse_err! { fn_def_kw, module::parse_module, "contract C {\n pub def f(x: u8){\n  return x \n}\n}" }
+
+test_parse_err! { fn_invalid_bound, module::parse_module, "pub fn f<T:(u8, u8)>() {}" }
 test_parse_err! { use_bad_name, module::parse_use, "use x as 123" }
 test_parse_err! { module_bad_stmt, module::parse_module, "if x { y }" }
 test_parse_err! { module_nonsense, module::parse_module, "))" }

--- a/crates/parser/tests/cases/snapshots/cases__errors__fn_invalid_bound.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__fn_invalid_bound.snap
@@ -1,0 +1,12 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(fn_invalid_bound), module::parse_module,\n    \"pub fn f<T:(u8, u8)>() {}\")"
+
+---
+error: failed to parse generic bound
+  ┌─ fn_invalid_bound:1:12
+  │
+1 │ pub fn f<T:(u8, u8)>() {}
+  │            ^ expected a name, found symbol `(`
+
+


### PR DESCRIPTION
### What was wrong?

This is a follow up to #710 which defined `Type::Trait`. Traits are currently only supported as bounds on generics. Since for the foreseeable future we do not plan to support traits in places where types are supported we should remove it from `Type` and instead create an `Item::Trait(TraitId)`

### How was it fixed?

Pretty much what the description already spoiled.
