### PR TITLE
Allow traits to be implemented for almost all types

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -350,6 +350,8 @@ pub enum Location {
     },
     Memory,
     Value,
+    // An unresolved location is used for generic types prior to monomorphization.
+    Unresolved,
 }
 
 impl Location {
@@ -358,12 +360,8 @@ impl Location {
     pub fn assign_location(typ: &Type) -> Self {
         match typ {
             Type::Base(_) | Type::Contract(_) => Location::Value,
-            // For now assume that generics can only ever refer to structs
-            Type::Array(_)
-            | Type::Tuple(_)
-            | Type::String(_)
-            | Type::Struct(_)
-            | Type::Generic(_) => Location::Memory,
+            Type::Generic(_) => Location::Unresolved,
+            Type::Array(_) | Type::Tuple(_) | Type::String(_) | Type::Struct(_) => Location::Memory,
             _ => panic!("Type can not be assigned, returned or passed"),
         }
     }

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -219,7 +219,7 @@ pub enum NamedThing {
 
         /// The function's parent, if any. If `None`, `self` has been
         /// used in a module-level function.
-        class: Option<Class>,
+        parent: Option<Item>,
         span: Option<Span>,
     },
     // SelfType // when/if we add a `Self` type keyword

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -22,9 +22,14 @@ pub fn contract_all_functions(db: &dyn AnalyzerDb, contract: ContractId) -> Rc<[
     body.iter()
         .filter_map(|stmt| match stmt {
             ast::ContractStmt::Event(_) => None,
-            ast::ContractStmt::Function(node) => Some(db.intern_function(Rc::new(
-                items::Function::new(db, node, Some(items::Class::Contract(contract)), module),
-            ))),
+            ast::ContractStmt::Function(node) => {
+                Some(db.intern_function(Rc::new(items::Function::new(
+                    db,
+                    node,
+                    Some(Item::Type(TypeDef::Contract(contract))),
+                    module,
+                ))))
+            }
         })
         .collect()
 }

--- a/crates/analyzer/src/db/queries/impls.rs
+++ b/crates/analyzer/src/db/queries/impls.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use smol_str::SmolStr;
 
 use crate::context::{Analysis, AnalyzerContext};
-use crate::namespace::items::{Class, Function, FunctionId, ImplId};
+use crate::namespace::items::{Function, FunctionId, ImplId, Item};
 use crate::namespace::scopes::ItemScope;
 use crate::AnalyzerDb;
 use std::rc::Rc;
@@ -19,7 +19,7 @@ pub fn impl_all_functions(db: &dyn AnalyzerDb, impl_: ImplId) -> Rc<[FunctionId]
             db.intern_function(Rc::new(Function::new(
                 db,
                 node,
-                Some(Class::Impl(impl_)),
+                Some(Item::Impl(impl_)),
                 impl_data.module,
             )))
         })

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -116,7 +116,7 @@ pub fn struct_all_functions(db: &dyn AnalyzerDb, struct_: StructId) -> Rc<[Funct
             db.intern_function(Rc::new(items::Function::new(
                 db,
                 node,
-                Some(items::Class::Struct(struct_)),
+                Some(Item::Type(TypeDef::Struct(struct_))),
                 struct_data.module,
             )))
         })

--- a/crates/analyzer/src/db/queries/traits.rs
+++ b/crates/analyzer/src/db/queries/traits.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use smol_str::SmolStr;
 
 use crate::context::{Analysis, AnalyzerContext};
-use crate::namespace::items::{FunctionSig, FunctionSigId, TraitId};
+use crate::namespace::items::{FunctionSig, FunctionSigId, Item, TraitId};
 use crate::namespace::scopes::ItemScope;
 use crate::namespace::types::TypeId;
 use crate::AnalyzerDb;
@@ -20,7 +20,7 @@ pub fn trait_all_functions(db: &dyn AnalyzerDb, trait_: TraitId) -> Rc<[Function
             db.intern_function_sig(Rc::new(FunctionSig {
                 ast: node.clone(),
                 module: trait_.module(db),
-                parent: Some(trait_.as_class()),
+                parent: Some(Item::Trait(trait_)),
             }))
         })
         .collect()

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -4,7 +4,7 @@ use crate::context::{
     AnalyzerContext, CallType, Constant, ExpressionAttributes, FunctionBody, NamedThing,
 };
 use crate::errors::{AlreadyDefined, IncompleteItem, TypeError};
-use crate::namespace::items::{Class, EventId, FunctionId, ModuleId};
+use crate::namespace::items::{EventId, FunctionId, ModuleId};
 use crate::namespace::items::{Item, TypeDef};
 use crate::namespace::types::{Type, TypeId};
 use crate::AnalyzerDb;
@@ -292,7 +292,7 @@ impl<'a> AnalyzerContext for FunctionScope<'a> {
         if name == "self" {
             return Ok(Some(NamedThing::SelfValue {
                 decl: sig.self_decl,
-                class: self.function.class(self.db),
+                parent: self.function.sig(self.db).self_item(self.db),
                 span: self.function.self_span(self.db),
             }));
         }
@@ -324,11 +324,12 @@ impl<'a> AnalyzerContext for FunctionScope<'a> {
         if let Some(param) = param {
             Ok(Some(param))
         } else {
-            let item = if let Some(Class::Contract(contract)) = self.function.class(self.db) {
-                contract.resolve_name(self.db, name)
-            } else {
-                self.function.module(self.db).resolve_name(self.db, name)
-            }?;
+            let item =
+                if let Item::Type(TypeDef::Contract(contract)) = self.function.parent(self.db) {
+                    contract.resolve_name(self.db, name)
+                } else {
+                    self.function.module(self.db).resolve_name(self.db, name)
+                }?;
 
             if let Some(item) = item {
                 check_item_visibility(self, item, span);

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -15,6 +15,8 @@ use std::rc::Rc;
 use std::str::FromStr;
 use strum::{AsRefStr, EnumIter, EnumString};
 
+use super::items::ImplId;
+
 pub fn u256_min() -> BigInt {
     BigInt::from(0)
 }
@@ -95,6 +97,12 @@ impl TypeId {
     }
     pub fn as_class(&self, db: &dyn AnalyzerDb) -> Option<Class> {
         self.typ(db).as_class()
+    }
+    pub fn get_impl_for(&self, db: &dyn AnalyzerDb, trait_: TraitId) -> Option<ImplId> {
+        match self.typ(db) {
+            Type::Struct(id) => id.get_impl_for(db, trait_),
+            _ => trait_.module(db).impls(db).get(&(trait_, *self)).cloned(),
+        }
     }
 }
 
@@ -409,6 +417,7 @@ impl Type {
     pub fn id(&self, db: &dyn AnalyzerDb) -> TypeId {
         db.intern_type(self.clone())
     }
+
     pub fn name(&self, db: &dyn AnalyzerDb) -> SmolStr {
         match self {
             Type::Base(inner) => inner.name(),

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -541,7 +541,7 @@ impl TypeDowncast for Type {
             Type::Struct(id) => Some(Class::Struct(*id)),
             Type::Contract(id) | Type::SelfContract(id) => Some(Class::Contract(*id)),
             Type::Generic(inner) if !inner.bounds.is_empty() => {
-                // FIXME: This won't hold when we support multiple bounds or traits can be implemented for non-struct types
+                // FIXME: This won't hold when we support multiple bounds
                 inner.bounds.first().map(TraitId::as_class)
             }
             _ => None,

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -352,6 +352,13 @@ fn build_snapshot(db: &dyn AnalyzerDb, module: items::ModuleId) -> String {
                     build_display_diagnostic(fun.data(db).ast.span, &fun.signature(db).display(db))
                 })
                 .collect::<Vec<_>>(),
+            Item::Impl(val) => val
+                .all_functions(db)
+                .iter()
+                .map(|fun| {
+                    build_display_diagnostic(fun.data(db).ast.span, &fun.signature(db).display(db))
+                })
+                .collect::<Vec<_>>(),
             Item::Function(id) => function_diagnostics(*id, db),
             Item::Constant(id) => vec![build_display_diagnostic(
                 id.span(db),

--- a/crates/analyzer/tests/snapshots/errors__self_in_standalone_fn.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_in_standalone_fn.snap
@@ -3,17 +3,17 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: `self` can only be used in contract or struct functions
+error: `self` can only be used in contract, struct, trait or impl functions
   ┌─ compile_errors/self_in_standalone_fn.fe:1:12
   │
 1 │ fn pure_fn(self) {
-  │            ^^^^ not allowed in functions defined outside of a contract or struct
+  │            ^^^^ not allowed in functions defined directly in a module
 
-error: `self` can only be used in contract or struct functions
+error: `self` can only be used in contract, struct, trait or impl functions
   ┌─ compile_errors/self_in_standalone_fn.fe:2:5
   │
 2 │     self.mut_fn()
-  │     ^^^^ not allowed in functions defined outside of a contract or struct
+  │     ^^^^ not allowed in functions defined directly in a module
 
 error: `pure_fn` expects 0 arguments, but 1 was provided
   ┌─ compile_errors/self_in_standalone_fn.fe:1:4

--- a/crates/analyzer/tests/snapshots/errors__self_misuse.snap
+++ b/crates/analyzer/tests/snapshots/errors__self_misuse.snap
@@ -9,11 +9,11 @@ error: `self` can't be used as a variable name
 2 │     let self: u8 = 10
   │         ^^^^ expected a name, found keyword `self`
 
-error: `self` can only be used in contract or struct functions
+error: `self` can only be used in contract, struct, trait or impl functions
   ┌─ compile_errors/self_misuse.fe:3:5
   │
 3 │     self = 5
-  │     ^^^^ not allowed in functions defined outside of a contract or struct
+  │     ^^^^ not allowed in functions defined directly in a module
 
 error: `self` is not callable
    ┌─ compile_errors/self_misuse.fe:16:9

--- a/crates/codegen/src/db/queries/function.rs
+++ b/crates/codegen/src/db/queries/function.rs
@@ -1,7 +1,6 @@
 use std::rc::Rc;
 
-use fe_analyzer::display::Displayable;
-use fe_analyzer::namespace::items::Class;
+use fe_analyzer::{display::Displayable, namespace::items::Item};
 use fe_mir::ir::{FunctionBody, FunctionId, FunctionSignature};
 
 use crate::{db::CodegenDb, yul::legalize};
@@ -29,8 +28,8 @@ pub fn symbol_name(db: &dyn CodegenDb, function: FunctionId) -> Rc<String> {
         function.type_suffix(db.upcast())
     );
 
-    let func_name = match analyzer_func.class(db.upcast()) {
-        Some(Class::Impl(id)) => {
+    let func_name = match analyzer_func.sig(db.upcast()).self_item(db.upcast()) {
+        Some(Item::Impl(id)) => {
             let class_name = format!(
                 "{}${}",
                 id.trait_id(db.upcast()).name(db.upcast()),

--- a/crates/codegen/src/db/queries/function.rs
+++ b/crates/codegen/src/db/queries/function.rs
@@ -1,7 +1,15 @@
 use std::rc::Rc;
 
-use fe_analyzer::{display::Displayable, namespace::items::Item};
+use fe_analyzer::{
+    display::Displayable,
+    namespace::{
+        items::Item,
+        types::{Type, TypeId},
+    },
+};
 use fe_mir::ir::{FunctionBody, FunctionId, FunctionSignature};
+use salsa::InternKey;
+use smol_str::SmolStr;
 
 use crate::{db::CodegenDb, yul::legalize};
 
@@ -25,7 +33,7 @@ pub fn symbol_name(db: &dyn CodegenDb, function: FunctionId) -> Rc<String> {
     let func_name = format!(
         "{}{}",
         analyzer_func.name(db.upcast()),
-        function.type_suffix(db.upcast())
+        type_suffix(function, db)
     );
 
     let func_name = match analyzer_func.sig(db.upcast()).self_item(db.upcast()) {
@@ -33,7 +41,7 @@ pub fn symbol_name(db: &dyn CodegenDb, function: FunctionId) -> Rc<String> {
             let class_name = format!(
                 "{}${}",
                 id.trait_id(db.upcast()).name(db.upcast()),
-                id.receiver(db.upcast()).display(db.upcast())
+                safe_name(db, id.receiver(db.upcast()))
             );
             format!("{}${}", class_name, func_name)
         }
@@ -45,4 +53,24 @@ pub fn symbol_name(db: &dyn CodegenDb, function: FunctionId) -> Rc<String> {
     };
 
     format!("{}${}", module_name, func_name).into()
+}
+
+fn type_suffix(function: FunctionId, db: &dyn CodegenDb) -> SmolStr {
+    function
+        .signature(db.upcast())
+        .resolved_generics
+        .values()
+        .fold(String::new(), |acc, param| {
+            format!("{}_{}", acc, safe_name(db, *param))
+        })
+        .into()
+}
+
+fn safe_name(db: &dyn CodegenDb, ty: TypeId) -> SmolStr {
+    match ty.typ(db.upcast()) {
+        // TODO: Would be nice to get more human friendly names here
+        Type::Array(_) => format!("array_{:?}", ty.as_intern_id()).into(),
+        Type::Tuple(_) => format!("tuple_{:?}", ty.as_intern_id()).into(),
+        _ => format!("{}", ty.display(db.upcast())).into(),
+    }
 }

--- a/crates/mir/src/db/queries/function.rs
+++ b/crates/mir/src/db/queries/function.rs
@@ -2,8 +2,9 @@ use std::rc::Rc;
 
 use fe_analyzer::display::Displayable;
 use fe_analyzer::namespace::items as analyzer_items;
-use fe_analyzer::namespace::items::Class;
 use fe_analyzer::namespace::types as analyzer_types;
+use fe_analyzer::namespace::items::Item;
+
 use smol_str::SmolStr;
 
 use crate::{
@@ -89,8 +90,8 @@ impl ir::FunctionId {
             self.type_suffix(db)
         );
 
-        match analyzer_func.class(db.upcast()) {
-            Some(Class::Impl(id)) => {
+        match analyzer_func.sig(db.upcast()).self_item(db.upcast()) {
+            Some(Item::Impl(id)) => {
                 let class_name = format!(
                     "<{} as {}>",
                     id.receiver(db.upcast()).display(db.upcast()),

--- a/crates/mir/src/db/queries/function.rs
+++ b/crates/mir/src/db/queries/function.rs
@@ -2,8 +2,8 @@ use std::rc::Rc;
 
 use fe_analyzer::display::Displayable;
 use fe_analyzer::namespace::items as analyzer_items;
-use fe_analyzer::namespace::types as analyzer_types;
 use fe_analyzer::namespace::items::Item;
+use fe_analyzer::namespace::types as analyzer_types;
 
 use smol_str::SmolStr;
 

--- a/crates/mir/src/lower/function.rs
+++ b/crates/mir/src/lower/function.rs
@@ -917,16 +917,15 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
                 let mut method_args = vec![self.lower_method_receiver(func)];
                 method_args.append(&mut args);
 
-                let struct_type = self
+                let concrete_type = self
                     .func
                     .signature(self.db)
                     .resolved_generics
                     .get(generic_type)
-                    .expect("unresolved generic type")
-                    .as_struct(self.db.upcast())
-                    .expect("unexpected implementer of trait");
+                    .cloned()
+                    .expect("unresolved generic type");
 
-                let impl_ = struct_type
+                let impl_ = concrete_type
                     .get_impl_for(self.db.upcast(), *trait_id)
                     .expect("missing impl");
 

--- a/crates/test-files/fixtures/features/generic_functions_primitves.fe
+++ b/crates/test-files/fixtures/features/generic_functions_primitves.fe
@@ -1,0 +1,37 @@
+trait Double {
+  fn double(self) -> u256;
+}
+
+impl Double for u8 {
+  fn double(self) -> u256 {
+    return u256(self + self)
+  }
+}
+
+impl Double for u16 {
+  fn double(self) -> u256 {
+    return u256(self + self)
+  }
+}
+
+impl Double for (u256, u256) {
+  fn double(self) -> u256 {
+    return u256(self.item0 + self.item0 + self.item1 + self.item1)
+  }
+}
+
+struct Runner {
+  pub fn run<T: Double>(self, _ val: T) -> u256 {
+    return val.double()
+  }
+}
+
+
+contract Example {
+  pub fn generic_compute(self) {
+    let runner: Runner = Runner();
+    assert runner.run(u8(1)) == 2
+    assert runner.run(u16(1000)) == 2000
+    assert runner.run((1, 1)) == 4
+  }
+}

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -2070,5 +2070,13 @@ fn generics() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "generic_functions.fe", "Example", &[]);
         harness.test_function(&mut executor, "generic_compute", &[], None);
+
+        let harness = deploy_contract(
+            &mut executor,
+            "generic_functions_primitves.fe",
+            "Example",
+            &[],
+        );
+        harness.test_function(&mut executor, "generic_compute", &[], None);
     });
 }

--- a/newsfragments/710.feature.md
+++ b/newsfragments/710.feature.md
@@ -8,7 +8,6 @@ trait Computable {
 }
 ```
 
-For now, traits can only be implemented for structs.
 The mechanism to implement a trait is via an `impl` block e.g:
 
 ```


### PR DESCRIPTION
### What was wrong?

Currently traits can only be implemented for structs. The reason for that is that prior to monomorphization we do not know the `Location` of a type generic type (e.g. `T`) and for that reason hard coded it to `Location::Memory` which would exclude primitive types such as `u8`.

### How was it fixed?

I made attempts to get rid of `Location` in the analyzer entirely but I kept failing. Then I realized that we actually don't yet allow to assign generic arguments anyway. Since the location is only relevant for when variables are assigned we could have used `Location::Value` and it would have worked exactly the same, it's superfluous information for now.
Hence, I thought we could introduce a `Location::Unresolved` for now and in return lift the restriction to allow traits to be implemented for all base types, arrays and tuples. 

In addition this fixes two ICEs related to calling `to_mem()` or `clone()` on a generic type.

E.g.

```
trait Double {
  fn double(self) -> u256;
}

impl Double for u8 {
  fn double(self) -> u256 {
    return u256(self + self)
  }
}

impl Double for u16 {
  fn double(self) -> u256 {
    return u256(self + self)
  }
}

impl Double for (u256, u256) {
  fn double(self) -> u256 {
    return u256(self.item0 + self.item0 + self.item1 + self.item1)
  }
}

struct Runner {
  pub fn run<T: Double>(self, _ val: T) -> u256 {
    return val.double()
  }
}


contract Example {
  pub fn generic_compute(self) {
    let runner: Runner = Runner();
    assert runner.run(u8(1)) == 2
    assert runner.run(u16(1000)) == 2000
    assert runner.run((1, 1)) == 4
  }
}
```