### PR TITLE
Allow trait methods to be called on non-generic types if trait is in scope

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -1,7 +1,7 @@
 use crate::display::Displayable;
 
 use crate::namespace::items::{
-    Class, ContractId, DiagnosticSink, EventId, FunctionId, FunctionSigId, Item, TraitId,
+    ContractId, DiagnosticSink, EventId, FunctionId, FunctionSigId, Item, TraitId,
 };
 use crate::namespace::types::{Generic, SelfDecl, Type, TypeId};
 use crate::AnalyzerDb;
@@ -451,12 +451,12 @@ pub enum CallType {
 
     // MyStruct.foo() (soon MyStruct::foo())
     AssociatedFunction {
-        class: Class,
+        typ: TypeId,
         function: FunctionId,
     },
     // some_struct_or_contract.foo()
     ValueMethod {
-        class: Class,
+        typ: TypeId,
         method: FunctionId,
     },
     // some_trait.foo()

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -186,6 +186,10 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     // Type
     #[salsa::invoke(queries::types::all_impls)]
     fn all_impls(&self, ty: TypeId) -> Rc<[ImplId]>;
+    #[salsa::invoke(queries::types::impl_for)]
+    fn impl_for(&self, ty: TypeId, treit: TraitId) -> Option<ImplId>;
+    #[salsa::invoke(queries::types::function_sigs)]
+    fn function_sigs(&self, ty: TypeId, name: SmolStr) -> Rc<[FunctionSigId]>;
 
     // Type alias
     #[salsa::invoke(queries::types::type_alias_type)]

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -53,6 +53,10 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     fn ingot_files(&self, ingot: IngotId) -> Rc<[SourceFileId]>;
     #[salsa::input]
     fn ingot_external_ingots(&self, ingot: IngotId) -> Rc<IndexMap<SmolStr, IngotId>>;
+    // Having the root ingot available as a "global" might offend functional programming purists
+    // but it makes for much nicer ergonomics in queries that just need the global entrypoint
+    #[salsa::input]
+    fn root_ingot(&self) -> IngotId;
 
     #[salsa::invoke(queries::ingots::ingot_modules)]
     fn ingot_modules(&self, ingot: IngotId) -> Rc<[ModuleId]>;
@@ -178,6 +182,10 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     // Event
     #[salsa::invoke(queries::events::event_type)]
     fn event_type(&self, event: EventId) -> Analysis<Rc<types::Event>>;
+
+    // Type
+    #[salsa::invoke(queries::types::all_impls)]
+    fn all_impls(&self, ty: TypeId) -> Rc<[ImplId]>;
 
     // Type alias
     #[salsa::invoke(queries::types::type_alias_type)]

--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -381,11 +381,7 @@ pub fn function_dependency_graph(db: &dyn AnalyzerDb, function: FunctionId) -> D
             CallType::Pure(function) | CallType::AssociatedFunction { function, .. } => {
                 directs.push((root, Item::Function(*function), DepLocality::Local));
             }
-            CallType::ValueMethod { class, method, .. } => {
-                // Including the "class" type here is probably redundant; the type will
-                // also be part of the fn sig, or some type decl, or some create/create2 call,
-                // or...
-                directs.push((root, class.as_item(db), DepLocality::Local));
+            CallType::ValueMethod { method, .. } => {
                 directs.push((root, Item::Function(*method), DepLocality::Local));
             }
             CallType::TraitValueMethod { trait_id, .. } => {

--- a/crates/analyzer/src/db/queries/types.rs
+++ b/crates/analyzer/src/db/queries/types.rs
@@ -1,11 +1,27 @@
+use std::rc::Rc;
+
 use crate::context::{AnalyzerContext, TempContext};
 use crate::db::Analysis;
 use crate::errors::TypeError;
-use crate::namespace::items::TypeAliasId;
+use crate::namespace::items::{ImplId, TypeAliasId};
 use crate::namespace::scopes::ItemScope;
-use crate::namespace::types;
+use crate::namespace::types::{self, TypeId};
 use crate::traversal::types::type_desc;
 use crate::AnalyzerDb;
+
+pub fn all_impls(db: &dyn AnalyzerDb, ty: TypeId) -> Rc<[ImplId]> {
+    db.root_ingot()
+        .all_existing_impls(db)
+        .iter()
+        .filter_map(|val| {
+            if val.receiver(db) == ty {
+                Some(*val)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
 
 pub fn type_alias_type(
     db: &dyn AnalyzerDb,

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -393,22 +393,6 @@ impl IngotId {
         self.root_module(db).expect("missing root module").items(db)
     }
 
-    /// Returns all `impl` from the current ingot as well as dependency ingots
-    pub fn all_existing_impls(&self, db: &dyn AnalyzerDb) -> Vec<ImplId> {
-        let ingot_modules = self
-            .all_modules(db)
-            .iter()
-            .flat_map(|module_id| module_id.all_impls(db).to_vec())
-            .collect::<Vec<_>>();
-
-        self.external_ingots(db)
-            .values()
-            .flat_map(|ingot| ingot.all_modules(db).to_vec())
-            .flat_map(|module_id| module_id.all_impls(db).to_vec())
-            .chain(ingot_modules)
-            .collect()
-    }
-
     pub fn diagnostics(&self, db: &dyn AnalyzerDb) -> Vec<Diagnostic> {
         let mut diagnostics = vec![];
         self.sink_diagnostics(db, &mut diagnostics);
@@ -1372,13 +1356,6 @@ impl StructId {
 
     pub fn as_type(&self, db: &dyn AnalyzerDb) -> TypeId {
         db.intern_type(Type::Struct(*self))
-    }
-
-    pub fn get_impl_for(&self, db: &dyn AnalyzerDb, trait_: TraitId) -> Option<ImplId> {
-        self.module(db)
-            .impls(db)
-            .get(&(trait_, db.intern_type(Type::Struct(*self))))
-            .cloned()
     }
 
     pub fn has_private_field(&self, db: &dyn AnalyzerDb) -> bool {

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1437,6 +1437,7 @@ fn expr_call_method(
 
     match target_type
         .function_sigs(context.db(), &field.kind)
+        .to_vec()
         .as_slice()
     {
         [] => Err(FatalError::new(context.fancy_error(

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -211,6 +211,9 @@ test_stmt! { revert_reason_not_struct, "revert 1" }
 test_stmt! { invalid_ascii, "String<2>(\"ä\")" }
 test_stmt! { invert_non_numeric, "~true" }
 
+test_file! { ambiguous_traits }
+test_file! { ambiguous_traits2 }
+test_ingot! { trait_not_in_scope }
 test_file! { bad_string }
 test_file! { bad_tuple_attr1 }
 test_file! { bad_tuple_attr2 }

--- a/crates/analyzer/tests/snapshots/errors__ambiguous_traits.snap
+++ b/crates/analyzer/tests/snapshots/errors__ambiguous_traits.snap
@@ -1,0 +1,17 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: multiple applicable items in scope
+   ┌─ compile_errors/ambiguous_traits.fe:11:6
+   │
+11 │   fn do(self) {
+   │      ^^ candidate #1 is defined here on the `impl`
+   ·
+16 │   fn do(self) {
+   │      ^^ candidate #2 is defined here on the `impl`
+   │
+   = Hint: rename one of the methods to disambiguate
+
+

--- a/crates/analyzer/tests/snapshots/errors__ambiguous_traits2.snap
+++ b/crates/analyzer/tests/snapshots/errors__ambiguous_traits2.snap
@@ -1,0 +1,17 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: multiple applicable items in scope
+   ┌─ compile_errors/ambiguous_traits2.fe:6:6
+   │
+ 6 │   fn do(self) {
+   │      ^^ candidate #2 is defined here on the `struct`
+   ·
+12 │   fn do(self) {
+   │      ^^ candidate #1 is defined here on the `impl`
+   │
+   = Hint: rename one of the methods to disambiguate
+
+

--- a/crates/analyzer/tests/snapshots/errors__bad_ingot.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_ingot.snap
@@ -9,7 +9,7 @@ error: import name conflicts with the ingot named "std"
 1 │ use std
   │     ^^^ `std` is already defined
 
-error: cannot glob import from type
+error: cannot glob import from struct
   ┌─ compile_errors/bad_ingot/src/foo.fe:1:18
   │
 1 │ use ingot::bing::Bong::*
@@ -51,7 +51,7 @@ error: unresolved path item
 4 │ use none::*
   │     ^^^^ not found
 
-error: a type with the same name has already been imported
+error: a struct with the same name has already been imported
   ┌─ compile_errors/bad_ingot/src/main.fe:2:28
   │
 2 │ use biz::bad::{Bur, Bud as Bar, Boo}
@@ -66,11 +66,11 @@ error: function name conflicts with the ingot named "std"
 12 │ fn std() {}
    │    ^^^ `std` is already defined
 
-error: the type `Foo` is private
+error: the struct `Foo` is private
   ┌─ compile_errors/bad_ingot/src/main.fe:7:19
   │
 7 │     pub fn a() -> foo::Foo {
-  │                   ^^^^^^^^ this type is not `pub`
+  │                   ^^^^^^^^ this struct is not `pub`
   │
   ┌─ compile_errors/bad_ingot/src/foo.fe:5:8
   │
@@ -80,11 +80,11 @@ error: the type `Foo` is private
   = `Foo` can only be used within `foo`
   = Hint: use `pub` to make `Foo` visible from outside of `foo`
 
-error: the type `Foo` is private
+error: the struct `Foo` is private
   ┌─ compile_errors/bad_ingot/src/main.fe:8:16
   │
 8 │         return foo::Foo(my_num: true)
-  │                ^^^^^^^^ this type is not `pub`
+  │                ^^^^^^^^ this struct is not `pub`
   │
   ┌─ compile_errors/bad_ingot/src/foo.fe:5:8
   │

--- a/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
@@ -95,11 +95,11 @@ error: cannot find value `ctx` in this scope
 18 │         emit MyEvent(ctx, x: 1)
    │                      ^^^ undefined
 
-error: the type `MyStruct` is private
+error: the struct `MyStruct` is private
    ┌─ compile_errors/bad_visibility/src/main.fe:22:16
    │
 22 │         let s: MyStruct = MyStruct(x: 1)
-   │                ^^^^^^^^ this type is not `pub`
+   │                ^^^^^^^^ this struct is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:11:8
    │
@@ -109,11 +109,11 @@ error: the type `MyStruct` is private
    = `MyStruct` can only be used within `foo`
    = Hint: use `pub` to make `MyStruct` visible from outside of `foo`
 
-error: the type `MyStruct` is private
+error: the struct `MyStruct` is private
    ┌─ compile_errors/bad_visibility/src/main.fe:22:27
    │
 22 │         let s: MyStruct = MyStruct(x: 1)
-   │                           ^^^^^^^^ this type is not `pub`
+   │                           ^^^^^^^^ this struct is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:11:8
    │

--- a/crates/analyzer/tests/snapshots/errors__duplicate_struct_in_module.snap
+++ b/crates/analyzer/tests/snapshots/errors__duplicate_struct_in_module.snap
@@ -3,7 +3,7 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: a type named "MyStruct" has already been defined
+error: a struct named "MyStruct" has already been defined
   ┌─ compile_errors/duplicate_struct_in_module.fe:1:8
   │
 1 │ struct MyStruct {

--- a/crates/analyzer/tests/snapshots/errors__trait_not_in_scope.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_not_in_scope.snap
@@ -1,0 +1,20 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: error_string_ingot(&path)
+
+---
+error: No method named `do` found for type `u256` in the current scope
+  ┌─ compile_errors/trait_not_in_scope/src/main.fe:4:7
+  │
+4 │     1.do()
+  │       ^^ method not found in `u256`
+  │
+  ┌─ compile_errors/trait_not_in_scope/src/foo.fe:7:6
+  │
+7 │   fn do(self) {
+  │      -- the method is available for `u256` here
+  │
+  = Hint: items from traits can only be used if the trait is in scope
+  = Hint: the following trait is implemented but not in scope; perhaps add a `use` for it: `trait DoThing`
+
+

--- a/crates/test-files/fixtures/compile_errors/ambiguous_traits.fe
+++ b/crates/test-files/fixtures/compile_errors/ambiguous_traits.fe
@@ -1,0 +1,24 @@
+trait DoThing {
+  fn do(self);
+}
+
+trait DoOtherThing {
+  fn do(self);
+}
+
+
+impl DoThing for u256 {
+  fn do(self) {
+  }
+}
+
+impl DoOtherThing for u256 {
+  fn do(self) {
+  }
+}
+
+contract Example {
+  pub fn run_test(self) {
+    1.do()
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/ambiguous_traits2.fe
+++ b/crates/test-files/fixtures/compile_errors/ambiguous_traits2.fe
@@ -1,0 +1,20 @@
+trait DoThing {
+  fn do(self);
+}
+
+struct Bar {
+  fn do(self) {
+
+  }
+}
+
+impl DoThing for Bar {
+  fn do(self) {
+  }
+}
+
+contract Example {
+  pub fn run_test(self) {
+    Bar().do()
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src/foo.fe
@@ -1,0 +1,9 @@
+trait DoThing {
+  fn do(self);
+}
+
+
+impl DoThing for u256 {
+  fn do(self) {
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src/main.fe
@@ -1,0 +1,6 @@
+
+contract Example {
+  pub fn run_test(self) {
+    1.do()
+  }
+}

--- a/crates/test-files/fixtures/features/generic_functions.fe
+++ b/crates/test-files/fixtures/features/generic_functions.fe
@@ -34,7 +34,7 @@ struct Runner {
 }
 
 contract Example {
-  pub fn generic_compute(self) {
+  pub fn run_test(self) {
     let runner: Runner = Runner();
     assert runner.run(Mac()) == 1001
     assert runner.run(Linux(counter: 10)) == 1015

--- a/crates/test-files/fixtures/features/generic_functions_primitves.fe
+++ b/crates/test-files/fixtures/features/generic_functions_primitves.fe
@@ -28,7 +28,7 @@ struct Runner {
 
 
 contract Example {
-  pub fn generic_compute(self) {
+  pub fn run_test(self) {
     let runner: Runner = Runner();
     assert runner.run(u8(1)) == 2
     assert runner.run(u16(1000)) == 2000

--- a/crates/test-files/fixtures/features/simple_traits.fe
+++ b/crates/test-files/fixtures/features/simple_traits.fe
@@ -1,0 +1,45 @@
+trait Double {
+  fn double(self) -> u256;
+}
+
+struct Bar {}
+
+impl Double for Bar {
+  fn double(self) -> u256 {
+    return 2
+  }
+}
+
+impl Double for u8 {
+  fn double(self) -> u256 {
+    return u256(self + self)
+  }
+}
+
+impl Double for (u256, u256) {
+  fn double(self) -> u256 {
+    return (self.item0 + self.item1) * 2
+  }
+}
+
+impl Double for Array<u256, 2> {
+  fn double(self) -> u256 {
+    return (self[0] + self[1]) * 2
+  }
+}
+
+contract Example {
+  my_array: Array<u256, 2>
+
+  pub fn __init__(self) {
+    self.my_array = [1, 0]
+  }
+
+  pub fn run_test(self) {
+    assert Bar().double() == 2
+    assert u8(1).double() == 2
+    assert (0, 1).double() == 2
+    assert [1, 0].double() == 2
+    assert self.my_array.to_mem().double() == 2
+  }
+}

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -2065,20 +2065,19 @@ fn ctx_init_in_call() {
     });
 }
 
-#[test]
-fn generics() {
+// These tests are expected to make assertions in Fe only
+#[rstest(
+    fixture_file,
+    case::simple_traits("simple_traits.fe"),
+    case::generic_functions("generic_functions.fe"),
+    case::generic_functions_primitves("generic_functions_primitves.fe")
+)]
+fn execution_tests(fixture_file: &str) {
     with_executor(&|mut executor| {
-        let harness = deploy_contract(&mut executor, "generic_functions.fe", "Example", &[]);
-        harness.test_function(&mut executor, "generic_compute", &[], None);
-
-        let harness = deploy_contract(
-            &mut executor,
-            "generic_functions_primitves.fe",
-            "Example",
-            &[],
-        );
-        harness.test_function(&mut executor, "generic_compute", &[], None);
-    });
+        let harness = deploy_contract(&mut executor, fixture_file, "Example", &[]);
+        harness.test_function(&mut executor, "run_test", &[], None);
+        assert_harness_gas_report!(harness);
+    })
 }
 
 #[test]

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_1_generic_functions.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_1_generic_functions.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 117 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_1_simple_traits.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_1_simple_traits.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 1361 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_2_generic_functions.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_2_generic_functions.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 32 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_2_generic_functions_primitves.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_2_generic_functions_primitves.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 135 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_3_generic_functions_primitves.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_3_generic_functions_primitves.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 32 gas
+

--- a/newsfragments/757.feature.md
+++ b/newsfragments/757.feature.md
@@ -1,0 +1,28 @@
+Allow to call trait methods on types when trait is in scope
+
+So far traits were only useful as bounds for generic functions.
+With this change traits can also be used as illustrated with
+the following example:
+
+```
+trait Double {
+  fn double(self) -> u256;
+}
+
+impl Double for (u256, u256) {
+  fn double(self) -> u256 {
+    return (self.item0 + self.item1) * 2
+  }
+}
+
+contract Example {
+
+  pub fn run_test(self) {
+    assert (0, 1).double() == 2
+  }
+}
+```
+
+If a call turns out to be ambigious the compiler currently asks the
+user to disambiguate via renaming. In the future we will likely
+introduce a syntax to allow to disambiguate at the callsite.


### PR DESCRIPTION
### What was wrong?

Traits can't currently be used without generics but they should be.

### How was it fixed?

Example of what the PR enables:

```rust
trait Double {
  fn double(self) -> u256;
}

impl Double for (u256, u256) {
  fn double(self) -> u256 {
    return (self.item0 + self.item1) * 2
  }
}

contract Example {

  pub fn run_test(self) {
    assert (0, 1).double() == 2
  }
}
```

Some notes:

- If a call turns out to be ambigious the compiler currently asks the user to disambiguate via renaming. In the future we will likely introduce a syntax to allow to disambiguate at the callsite.
- refactored to get rid of `Class` entirely (it's not too useful as a concept since via `impl` and traits any type can have member functions)
- Ensured we fetch all impls even from foreign ingots. E.g. ingot `Foo` may have a struct `Thingy` and a trait `SuperPower` with an `impl` for Thingy. If one imports and uses `Thingy` then we still have to check if `SuperPower` is in scope for `thingy.super_power_move()` to work.
- All the `impl` handling was removed from `Struct` since it is now generalized on `TypeId` directly



