### PR TITLE
Fix enforcement of visibility rules of function calls

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1459,7 +1459,8 @@ fn expr_call_method(
     // and the global objects are replaced by `Context`, we can remove this.
     // All other `NamedThing`s will be handled correctly by `expr()`.
     if let fe::Expr::Name(name) = &target.kind {
-        if let Ok(Some(NamedThing::Item(Item::Type(def)))) = context.resolve_name(name, target.span) {
+        if let Ok(Some(NamedThing::Item(Item::Type(def)))) = context.resolve_name(name, target.span)
+        {
             let typ = def.typ(context.db())?;
             return expr_call_type_attribute(context, typ, target.span, field, generic_args, args);
         }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -228,6 +228,8 @@ test_file! { call_undefined_function_on_external_contract }
 test_file! { call_undefined_function_on_memory_struct }
 test_file! { call_undefined_function_on_storage_struct }
 test_file! { call_non_pub_fn_on_external_contract }
+test_file! { call_non_pub_fn_on_struct }
+test_file! { call_non_pub_fn_on_struct2 }
 test_file! { cannot_move }
 test_file! { cannot_move2 }
 test_file! { circular_dependency_create }

--- a/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
+++ b/crates/analyzer/tests/snapshots/analysis__struct_fns.snap
@@ -14,7 +14,7 @@ note:
 note: 
   ┌─ struct_fns.fe:5:5
   │  
-5 │ ╭     pub fn new(x: u64, y: u64) -> Point {
+5 │ ╭     fn internal_new(x: u64, y: u64) -> Point {
 6 │ │         return Point(x, y)
 7 │ │     }
   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> Point
@@ -36,485 +36,507 @@ note:
 note: 
    ┌─ struct_fns.fe:9:5
    │  
- 9 │ ╭     pub fn origin() -> Point {
-10 │ │         return Point(x: 0, y: 0)
+ 9 │ ╭     pub fn new(x: u64, y: u64) -> Point {
+10 │ │         return Point::internal_new(x, y)
 11 │ │     }
+   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> Point
+
+note: 
+   ┌─ struct_fns.fe:10:36
+   │
+10 │         return Point::internal_new(x, y)
+   │                                    ^  ^ u64: Value
+   │                                    │   
+   │                                    u64: Value
+
+note: 
+   ┌─ struct_fns.fe:10:16
+   │
+10 │         return Point::internal_new(x, y)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ Point: Memory
+
+note: 
+   ┌─ struct_fns.fe:13:5
+   │  
+13 │ ╭     pub fn origin() -> Point {
+14 │ │         return Point(x: 0, y: 0)
+15 │ │     }
    │ ╰─────^ self: None, params: [] -> Point
 
 note: 
-   ┌─ struct_fns.fe:10:25
+   ┌─ struct_fns.fe:14:25
    │
-10 │         return Point(x: 0, y: 0)
+14 │         return Point(x: 0, y: 0)
    │                         ^     ^ u64: Value
    │                         │      
    │                         u64: Value
 
 note: 
-   ┌─ struct_fns.fe:10:16
+   ┌─ struct_fns.fe:14:16
    │
-10 │         return Point(x: 0, y: 0)
+14 │         return Point(x: 0, y: 0)
    │                ^^^^^^^^^^^^^^^^^ Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:13:5
-   │  
-13 │ ╭     pub fn x(self) -> u64 {
-14 │ │         return self.x
-15 │ │     }
-   │ ╰─────^ self: Some(Mutable), params: [] -> u64
-
-note: 
-   ┌─ struct_fns.fe:14:16
-   │
-14 │         return self.x
-   │                ^^^^ Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:14:16
-   │
-14 │         return self.x
-   │                ^^^^^^ u64: Memory => Value
 
 note: 
    ┌─ struct_fns.fe:17:5
    │  
-17 │ ╭     pub fn set_x(self, _ x: u64) -> u64 {
-18 │ │         let old: u64 = self.x
-19 │ │         self.x = x
-20 │ │         return old
-21 │ │     }
+17 │ ╭     pub fn x(self) -> u64 {
+18 │ │         return self.x
+19 │ │     }
+   │ ╰─────^ self: Some(Mutable), params: [] -> u64
+
+note: 
+   ┌─ struct_fns.fe:18:16
+   │
+18 │         return self.x
+   │                ^^^^ Point: Memory
+
+note: 
+   ┌─ struct_fns.fe:18:16
+   │
+18 │         return self.x
+   │                ^^^^^^ u64: Memory => Value
+
+note: 
+   ┌─ struct_fns.fe:21:5
+   │  
+21 │ ╭     pub fn set_x(self, _ x: u64) -> u64 {
+22 │ │         let old: u64 = self.x
+23 │ │         self.x = x
+24 │ │         return old
+25 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: x, typ: u64 }] -> u64
 
 note: 
-   ┌─ struct_fns.fe:18:13
+   ┌─ struct_fns.fe:22:13
    │
-18 │         let old: u64 = self.x
+22 │         let old: u64 = self.x
    │             ^^^ u64
 
 note: 
-   ┌─ struct_fns.fe:18:24
+   ┌─ struct_fns.fe:22:24
    │
-18 │         let old: u64 = self.x
+22 │         let old: u64 = self.x
    │                        ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:18:24
+   ┌─ struct_fns.fe:22:24
    │
-18 │         let old: u64 = self.x
+22 │         let old: u64 = self.x
    │                        ^^^^^^ u64: Memory => Value
-19 │         self.x = x
+23 │         self.x = x
    │         ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:19:9
+   ┌─ struct_fns.fe:23:9
    │
-19 │         self.x = x
+23 │         self.x = x
    │         ^^^^^^   ^ u64: Value
    │         │         
    │         u64: Memory
-20 │         return old
+24 │         return old
    │                ^^^ u64: Value
 
 note: 
-   ┌─ struct_fns.fe:23:5
+   ┌─ struct_fns.fe:27:5
    │  
-23 │ ╭     pub fn reflect(self) {
-24 │ │         let x: u64 = self.x
-25 │ │         let y: u64 = self.y
-26 │ │         self.x = y
-27 │ │         self.y = x
-28 │ │     }
+27 │ ╭     pub fn reflect(self) {
+28 │ │         let x: u64 = self.x
+29 │ │         let y: u64 = self.y
+30 │ │         self.x = y
+31 │ │         self.y = x
+32 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
-   ┌─ struct_fns.fe:24:13
+   ┌─ struct_fns.fe:28:13
    │
-24 │         let x: u64 = self.x
+28 │         let x: u64 = self.x
    │             ^ u64
-25 │         let y: u64 = self.y
+29 │         let y: u64 = self.y
    │             ^ u64
 
 note: 
-   ┌─ struct_fns.fe:24:22
+   ┌─ struct_fns.fe:28:22
    │
-24 │         let x: u64 = self.x
+28 │         let x: u64 = self.x
    │                      ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:24:22
+   ┌─ struct_fns.fe:28:22
    │
-24 │         let x: u64 = self.x
+28 │         let x: u64 = self.x
    │                      ^^^^^^ u64: Memory => Value
-25 │         let y: u64 = self.y
+29 │         let y: u64 = self.y
    │                      ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:25:22
+   ┌─ struct_fns.fe:29:22
    │
-25 │         let y: u64 = self.y
+29 │         let y: u64 = self.y
    │                      ^^^^^^ u64: Memory => Value
-26 │         self.x = y
+30 │         self.x = y
    │         ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:26:9
+   ┌─ struct_fns.fe:30:9
    │
-26 │         self.x = y
+30 │         self.x = y
    │         ^^^^^^   ^ u64: Value
    │         │         
    │         u64: Memory
-27 │         self.y = x
+31 │         self.y = x
    │         ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:27:9
+   ┌─ struct_fns.fe:31:9
    │
-27 │         self.y = x
+31 │         self.y = x
    │         ^^^^^^   ^ u64: Value
    │         │         
    │         u64: Memory
 
 note: 
-   ┌─ struct_fns.fe:30:5
+   ┌─ struct_fns.fe:34:5
    │  
-30 │ ╭     pub fn translate(self, x: u64, y: u64) {
-31 │ │         self.x += x
-32 │ │         self.y += y
-33 │ │     }
+34 │ ╭     pub fn translate(self, x: u64, y: u64) {
+35 │ │         self.x += x
+36 │ │         self.y += y
+37 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> ()
 
 note: 
-   ┌─ struct_fns.fe:31:9
+   ┌─ struct_fns.fe:35:9
    │
-31 │         self.x += x
+35 │         self.x += x
    │         ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:31:9
+   ┌─ struct_fns.fe:35:9
    │
-31 │         self.x += x
+35 │         self.x += x
    │         ^^^^^^    ^ u64: Value
    │         │          
    │         u64: Memory
-32 │         self.y += y
+36 │         self.y += y
    │         ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:32:9
+   ┌─ struct_fns.fe:36:9
    │
-32 │         self.y += y
+36 │         self.y += y
    │         ^^^^^^    ^ u64: Value
    │         │          
    │         u64: Memory
 
 note: 
-   ┌─ struct_fns.fe:35:5
+   ┌─ struct_fns.fe:39:5
    │  
-35 │ ╭     pub fn add(self, _ other: Point) -> Point {
-36 │ │         let x: u64 = self.x + other.x
-37 │ │         let y: u64 = self.y + other.y
-38 │ │         return Point(x, y)
-39 │ │     }
+39 │ ╭     pub fn add(self, _ other: Point) -> Point {
+40 │ │         let x: u64 = self.x + other.x
+41 │ │         let y: u64 = self.y + other.y
+42 │ │         return Point(x, y)
+43 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: other, typ: Point }] -> Point
 
 note: 
-   ┌─ struct_fns.fe:36:13
+   ┌─ struct_fns.fe:40:13
    │
-36 │         let x: u64 = self.x + other.x
+40 │         let x: u64 = self.x + other.x
    │             ^ u64
-37 │         let y: u64 = self.y + other.y
+41 │         let y: u64 = self.y + other.y
    │             ^ u64
 
 note: 
-   ┌─ struct_fns.fe:36:22
+   ┌─ struct_fns.fe:40:22
    │
-36 │         let x: u64 = self.x + other.x
+40 │         let x: u64 = self.x + other.x
    │                      ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:36:22
+   ┌─ struct_fns.fe:40:22
    │
-36 │         let x: u64 = self.x + other.x
+40 │         let x: u64 = self.x + other.x
    │                      ^^^^^^   ^^^^^ Point: Memory
    │                      │         
    │                      u64: Memory => Value
 
 note: 
-   ┌─ struct_fns.fe:36:31
+   ┌─ struct_fns.fe:40:31
    │
-36 │         let x: u64 = self.x + other.x
+40 │         let x: u64 = self.x + other.x
    │                               ^^^^^^^ u64: Memory => Value
 
 note: 
-   ┌─ struct_fns.fe:36:22
+   ┌─ struct_fns.fe:40:22
    │
-36 │         let x: u64 = self.x + other.x
+40 │         let x: u64 = self.x + other.x
    │                      ^^^^^^^^^^^^^^^^ u64: Value
-37 │         let y: u64 = self.y + other.y
+41 │         let y: u64 = self.y + other.y
    │                      ^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:37:22
+   ┌─ struct_fns.fe:41:22
    │
-37 │         let y: u64 = self.y + other.y
+41 │         let y: u64 = self.y + other.y
    │                      ^^^^^^   ^^^^^ Point: Memory
    │                      │         
    │                      u64: Memory => Value
 
 note: 
-   ┌─ struct_fns.fe:37:31
+   ┌─ struct_fns.fe:41:31
    │
-37 │         let y: u64 = self.y + other.y
+41 │         let y: u64 = self.y + other.y
    │                               ^^^^^^^ u64: Memory => Value
 
 note: 
-   ┌─ struct_fns.fe:37:22
+   ┌─ struct_fns.fe:41:22
    │
-37 │         let y: u64 = self.y + other.y
+41 │         let y: u64 = self.y + other.y
    │                      ^^^^^^^^^^^^^^^^ u64: Value
-38 │         return Point(x, y)
+42 │         return Point(x, y)
    │                      ^  ^ u64: Value
    │                      │   
    │                      u64: Value
 
 note: 
-   ┌─ struct_fns.fe:38:16
+   ┌─ struct_fns.fe:42:16
    │
-38 │         return Point(x, y)
+42 │         return Point(x, y)
    │                ^^^^^^^^^^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:42:1
+   ┌─ struct_fns.fe:46:1
    │  
-42 │ ╭ pub fn do_pointy_things() {
-43 │ │     let p1: Point = Point::origin()
-44 │ │     p1.translate(x: 5, y: 10)
-45 │ │     let p2: Point = Point(x: 1, y: 2)
-46 │ │     let p3: Point = p1.add(p2)
-47 │ │     assert p3.x == 6 and p3.y == 12
-48 │ │ }
+46 │ ╭ pub fn do_pointy_things() {
+47 │ │     let p1: Point = Point::origin()
+48 │ │     p1.translate(x: 5, y: 10)
+49 │ │     let p2: Point = Point(x: 1, y: 2)
+50 │ │     let p3: Point = p1.add(p2)
+51 │ │     assert p3.x == 6 and p3.y == 12
+52 │ │ }
    │ ╰─^ self: None, params: [] -> ()
 
 note: 
-   ┌─ struct_fns.fe:43:9
+   ┌─ struct_fns.fe:47:9
    │
-43 │     let p1: Point = Point::origin()
+47 │     let p1: Point = Point::origin()
    │         ^^ Point
-44 │     p1.translate(x: 5, y: 10)
-45 │     let p2: Point = Point(x: 1, y: 2)
+48 │     p1.translate(x: 5, y: 10)
+49 │     let p2: Point = Point(x: 1, y: 2)
    │         ^^ Point
-46 │     let p3: Point = p1.add(p2)
+50 │     let p3: Point = p1.add(p2)
    │         ^^ Point
 
 note: 
-   ┌─ struct_fns.fe:43:21
+   ┌─ struct_fns.fe:47:21
    │
-43 │     let p1: Point = Point::origin()
+47 │     let p1: Point = Point::origin()
    │                     ^^^^^^^^^^^^^^^ Point: Memory
-44 │     p1.translate(x: 5, y: 10)
+48 │     p1.translate(x: 5, y: 10)
    │     ^^              ^     ^^ u64: Value
    │     │               │      
    │     │               u64: Value
    │     Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:44:5
+   ┌─ struct_fns.fe:48:5
    │
-44 │     p1.translate(x: 5, y: 10)
+48 │     p1.translate(x: 5, y: 10)
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-45 │     let p2: Point = Point(x: 1, y: 2)
+49 │     let p2: Point = Point(x: 1, y: 2)
    │                              ^     ^ u64: Value
    │                              │      
    │                              u64: Value
 
 note: 
-   ┌─ struct_fns.fe:45:21
+   ┌─ struct_fns.fe:49:21
    │
-45 │     let p2: Point = Point(x: 1, y: 2)
+49 │     let p2: Point = Point(x: 1, y: 2)
    │                     ^^^^^^^^^^^^^^^^^ Point: Memory
-46 │     let p3: Point = p1.add(p2)
+50 │     let p3: Point = p1.add(p2)
    │                     ^^     ^^ Point: Memory
    │                     │       
    │                     Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:46:21
+   ┌─ struct_fns.fe:50:21
    │
-46 │     let p3: Point = p1.add(p2)
+50 │     let p3: Point = p1.add(p2)
    │                     ^^^^^^^^^^ Point: Memory
-47 │     assert p3.x == 6 and p3.y == 12
+51 │     assert p3.x == 6 and p3.y == 12
    │            ^^ Point: Memory
 
 note: 
-   ┌─ struct_fns.fe:47:12
+   ┌─ struct_fns.fe:51:12
    │
-47 │     assert p3.x == 6 and p3.y == 12
+51 │     assert p3.x == 6 and p3.y == 12
    │            ^^^^    ^ u64: Value
    │            │        
    │            u64: Memory => Value
 
 note: 
-   ┌─ struct_fns.fe:47:12
+   ┌─ struct_fns.fe:51:12
    │
-47 │     assert p3.x == 6 and p3.y == 12
+51 │     assert p3.x == 6 and p3.y == 12
    │            ^^^^^^^^^     ^^ Point: Memory
    │            │              
    │            bool: Value
 
 note: 
-   ┌─ struct_fns.fe:47:26
+   ┌─ struct_fns.fe:51:26
    │
-47 │     assert p3.x == 6 and p3.y == 12
+51 │     assert p3.x == 6 and p3.y == 12
    │                          ^^^^    ^^ u64: Value
    │                          │        
    │                          u64: Memory => Value
 
 note: 
-   ┌─ struct_fns.fe:47:26
+   ┌─ struct_fns.fe:51:26
    │
-47 │     assert p3.x == 6 and p3.y == 12
+51 │     assert p3.x == 6 and p3.y == 12
    │                          ^^^^^^^^^^ bool: Value
 
 note: 
-   ┌─ struct_fns.fe:47:12
+   ┌─ struct_fns.fe:51:12
    │
-47 │     assert p3.x == 6 and p3.y == 12
+51 │     assert p3.x == 6 and p3.y == 12
    │            ^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-   ┌─ struct_fns.fe:51:5
+   ┌─ struct_fns.fe:55:5
    │  
-51 │ ╭     pub fn bar(x: u64, y: u64) -> u64 {
-52 │ │         do_pointy_things()
-53 │ │         let p: Point = Point::new(x, y)
-54 │ │         assert p.x == x and p.y == y
+55 │ ╭     pub fn bar(x: u64, y: u64) -> u64 {
+56 │ │         do_pointy_things()
+57 │ │         let p: Point = Point::new(x, y)
+58 │ │         assert p.x == x and p.y == y
    · │
-58 │ │         return p.y
-59 │ │     }
+62 │ │         return p.y
+63 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u64 }, { label: None, name: y, typ: u64 }] -> u64
 
 note: 
-   ┌─ struct_fns.fe:53:13
+   ┌─ struct_fns.fe:57:13
    │
-53 │         let p: Point = Point::new(x, y)
+57 │         let p: Point = Point::new(x, y)
    │             ^ Point
 
 note: 
-   ┌─ struct_fns.fe:52:9
+   ┌─ struct_fns.fe:56:9
    │
-52 │         do_pointy_things()
+56 │         do_pointy_things()
    │         ^^^^^^^^^^^^^^^^^^ (): Value
-53 │         let p: Point = Point::new(x, y)
+57 │         let p: Point = Point::new(x, y)
    │                                   ^  ^ u64: Value
    │                                   │   
    │                                   u64: Value
 
 note: 
-   ┌─ struct_fns.fe:53:24
+   ┌─ struct_fns.fe:57:24
    │
-53 │         let p: Point = Point::new(x, y)
+57 │         let p: Point = Point::new(x, y)
    │                        ^^^^^^^^^^^^^^^^ Point: Memory
-54 │         assert p.x == x and p.y == y
-   │                ^ Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:54:16
-   │
-54 │         assert p.x == x and p.y == y
-   │                ^^^    ^ u64: Value
-   │                │       
-   │                u64: Memory => Value
-
-note: 
-   ┌─ struct_fns.fe:54:16
-   │
-54 │         assert p.x == x and p.y == y
-   │                ^^^^^^^^     ^ Point: Memory
-   │                │             
-   │                bool: Value
-
-note: 
-   ┌─ struct_fns.fe:54:29
-   │
-54 │         assert p.x == x and p.y == y
-   │                             ^^^    ^ u64: Value
-   │                             │       
-   │                             u64: Memory => Value
-
-note: 
-   ┌─ struct_fns.fe:54:29
-   │
-54 │         assert p.x == x and p.y == y
-   │                             ^^^^^^^^ bool: Value
-
-note: 
-   ┌─ struct_fns.fe:54:16
-   │
-54 │         assert p.x == x and p.y == y
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-55 │         p.set_x(100)
-   │         ^       ^^^ u64: Value
-   │         │        
-   │         Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:55:9
-   │
-55 │         p.set_x(100)
-   │         ^^^^^^^^^^^^ u64: Value
-56 │         p.reflect()
-   │         ^ Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:56:9
-   │
-56 │         p.reflect()
-   │         ^^^^^^^^^^^ (): Value
-57 │         assert p.x() == y and p.y == 100
-   │                ^ Point: Memory
-
-note: 
-   ┌─ struct_fns.fe:57:16
-   │
-57 │         assert p.x() == y and p.y == 100
-   │                ^^^^^    ^ u64: Value
-   │                │         
-   │                u64: Value
-
-note: 
-   ┌─ struct_fns.fe:57:16
-   │
-57 │         assert p.x() == y and p.y == 100
-   │                ^^^^^^^^^^     ^ Point: Memory
-   │                │               
-   │                bool: Value
-
-note: 
-   ┌─ struct_fns.fe:57:31
-   │
-57 │         assert p.x() == y and p.y == 100
-   │                               ^^^    ^^^ u64: Value
-   │                               │       
-   │                               u64: Memory => Value
-
-note: 
-   ┌─ struct_fns.fe:57:31
-   │
-57 │         assert p.x() == y and p.y == 100
-   │                               ^^^^^^^^^^ bool: Value
-
-note: 
-   ┌─ struct_fns.fe:57:16
-   │
-57 │         assert p.x() == y and p.y == 100
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-58 │         return p.y
+58 │         assert p.x == x and p.y == y
    │                ^ Point: Memory
 
 note: 
    ┌─ struct_fns.fe:58:16
    │
-58 │         return p.y
+58 │         assert p.x == x and p.y == y
+   │                ^^^    ^ u64: Value
+   │                │       
+   │                u64: Memory => Value
+
+note: 
+   ┌─ struct_fns.fe:58:16
+   │
+58 │         assert p.x == x and p.y == y
+   │                ^^^^^^^^     ^ Point: Memory
+   │                │             
+   │                bool: Value
+
+note: 
+   ┌─ struct_fns.fe:58:29
+   │
+58 │         assert p.x == x and p.y == y
+   │                             ^^^    ^ u64: Value
+   │                             │       
+   │                             u64: Memory => Value
+
+note: 
+   ┌─ struct_fns.fe:58:29
+   │
+58 │         assert p.x == x and p.y == y
+   │                             ^^^^^^^^ bool: Value
+
+note: 
+   ┌─ struct_fns.fe:58:16
+   │
+58 │         assert p.x == x and p.y == y
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
+59 │         p.set_x(100)
+   │         ^       ^^^ u64: Value
+   │         │        
+   │         Point: Memory
+
+note: 
+   ┌─ struct_fns.fe:59:9
+   │
+59 │         p.set_x(100)
+   │         ^^^^^^^^^^^^ u64: Value
+60 │         p.reflect()
+   │         ^ Point: Memory
+
+note: 
+   ┌─ struct_fns.fe:60:9
+   │
+60 │         p.reflect()
+   │         ^^^^^^^^^^^ (): Value
+61 │         assert p.x() == y and p.y == 100
+   │                ^ Point: Memory
+
+note: 
+   ┌─ struct_fns.fe:61:16
+   │
+61 │         assert p.x() == y and p.y == 100
+   │                ^^^^^    ^ u64: Value
+   │                │         
+   │                u64: Value
+
+note: 
+   ┌─ struct_fns.fe:61:16
+   │
+61 │         assert p.x() == y and p.y == 100
+   │                ^^^^^^^^^^     ^ Point: Memory
+   │                │               
+   │                bool: Value
+
+note: 
+   ┌─ struct_fns.fe:61:31
+   │
+61 │         assert p.x() == y and p.y == 100
+   │                               ^^^    ^^^ u64: Value
+   │                               │       
+   │                               u64: Memory => Value
+
+note: 
+   ┌─ struct_fns.fe:61:31
+   │
+61 │         assert p.x() == y and p.y == 100
+   │                               ^^^^^^^^^^ bool: Value
+
+note: 
+   ┌─ struct_fns.fe:61:16
+   │
+61 │         assert p.x() == y and p.y == 100
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+62 │         return p.y
+   │                ^ Point: Memory
+
+note: 
+   ┌─ struct_fns.fe:62:16
+   │
+62 │         return p.y
    │                ^^^ u64: Memory => Value
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
@@ -3,13 +3,16 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: the function `do_private_thingz` on `contract Foo` is private
+error: the function `do_private_thingz` on `type Foo` is private
    ┌─ compile_errors/call_non_pub_fn_on_external_contract.fe:13:25
    │
  6 │     fn do_private_thingz(self) {
-   │     -------------------------- `do_private_thingz` is defined here
+   │        ----------------- `do_private_thingz` is defined here
    ·
 13 │         Foo(address(0)).do_private_thingz()
    │                         ^^^^^^^^^^^^^^^^^ this function is not `pub`
+   │
+   = `do_private_thingz` can only be called from other functions within `Foo`
+   = Hint: use `pub fn do_private_thingz(..)` to make `do_private_thingz` callable from outside of `Foo`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_struct.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_struct.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: the function `do_private_thingz` on `struct Foo` is private
+  ┌─ compile_errors/call_non_pub_fn_on_struct.fe:8:9
+  │
+2 │     fn do_private_thingz() {
+  │        ----------------- `do_private_thingz` is defined here
+  ·
+8 │         Foo::do_private_thingz()
+  │         ^^^^^^^^^^^^^^^^^^^^^^ this function is not `pub`
+  │
+  = `do_private_thingz` can only be called from other functions within `Foo`
+  = Hint: use `pub fn do_private_thingz(..)` to make `do_private_thingz` callable from outside of `Foo`
+
+

--- a/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_struct2.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_struct2.snap
@@ -1,0 +1,18 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: the function `do_private_thingz` on `struct Foo` is private
+  ┌─ compile_errors/call_non_pub_fn_on_struct2.fe:8:15
+  │
+2 │     fn do_private_thingz(self) {
+  │        ----------------- `do_private_thingz` is defined here
+  ·
+8 │         Foo().do_private_thingz()
+  │               ^^^^^^^^^^^^^^^^^ this function is not `pub`
+  │
+  = `do_private_thingz` can only be called from other functions within `Foo`
+  = Hint: use `pub fn do_private_thingz(..)` to make `do_private_thingz` callable from outside of `Foo`
+
+

--- a/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_struct.fe
+++ b/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_struct.fe
@@ -1,0 +1,10 @@
+struct Foo {
+    fn do_private_thingz() {
+    }
+}
+
+contract Bar {
+    fn test() {
+        Foo::do_private_thingz()
+    }
+}

--- a/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_struct2.fe
+++ b/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_struct2.fe
@@ -1,0 +1,10 @@
+struct Foo {
+    fn do_private_thingz(self) {
+    }
+}
+
+contract Bar {
+    fn test() {
+        Foo().do_private_thingz()
+    }
+}

--- a/crates/test-files/fixtures/features/contract_pure_fns.fe
+++ b/crates/test-files/fixtures/features/contract_pure_fns.fe
@@ -1,0 +1,19 @@
+contract Example {
+
+    pub fn run_test(self) {
+        assert self.bar(42, 26) == 68
+        assert self.bar2(42, 26) == 68
+    }
+
+    pub fn bar(self, _ x: u256, _ y: u256) -> u256 {
+        return pure_bar(x, y)
+    }
+
+    pub fn bar2(self, _ x: u256, _ y: u256) -> u256 {
+        return Example::pure_bar(x, y)
+    }
+
+    fn pure_bar(x: u256, y: u256) -> u256 {
+        return x + y
+    }
+}

--- a/crates/test-files/fixtures/features/pure_fn_internal_call.fe
+++ b/crates/test-files/fixtures/features/pure_fn_internal_call.fe
@@ -3,7 +3,7 @@ contract Foo {
         return pure_bar(x, y)
     }
 
-    pub fn pure_bar(x: u256, y: u256) -> u256 {
+    fn pure_bar(x: u256, y: u256) -> u256 {
         return x + y
     }
 }

--- a/crates/test-files/fixtures/features/simple_traits.fe
+++ b/crates/test-files/fixtures/features/simple_traits.fe
@@ -36,6 +36,8 @@ contract Example {
   }
 
   pub fn run_test(self) {
+    let x: Bar = Bar()
+    assert x.double() == 2
     assert Bar().double() == 2
     assert u8(1).double() == 2
     assert (0, 1).double() == 2

--- a/crates/test-files/fixtures/features/struct_fns.fe
+++ b/crates/test-files/fixtures/features/struct_fns.fe
@@ -2,8 +2,12 @@ struct Point {
     pub x: u64
     pub y: u64
 
-    pub fn new(x: u64, y: u64) -> Point {
+    fn internal_new(x: u64, y: u64) -> Point {
         return Point(x, y)
+    }
+
+    pub fn new(x: u64, y: u64) -> Point {
+        return Point::internal_new(x, y)
     }
 
     pub fn origin() -> Point {

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -2070,7 +2070,8 @@ fn ctx_init_in_call() {
     fixture_file,
     case::simple_traits("simple_traits.fe"),
     case::generic_functions("generic_functions.fe"),
-    case::generic_functions_primitves("generic_functions_primitves.fe")
+    case::generic_functions_primitves("generic_functions_primitves.fe"),
+    case::contract_pure_fns("contract_pure_fns.fe")
 )]
 fn execution_tests(fixture_file: &str) {
     with_executor(&|mut executor| {

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_056.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_056.snap
@@ -3,5 +3,5 @@ source: crates/tests/src/features.rs
 expression: "format!(\"{}\", harness.gas_reporter)"
 
 ---
-bar([Uint(42), Uint(26)]) used 250 gas
+bar([Uint(42), Uint(26)]) used 202 gas
 

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_161_struct_fns.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_161_struct_fns.snap
@@ -3,5 +3,5 @@ source: crates/tests/src/features.rs
 expression: "format!(\"{}\", harness.gas_reporter)"
 
 ---
-bar([Uint(10), Uint(20)]) used 2056 gas
+bar([Uint(10), Uint(20)]) used 2082 gas
 

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_4_contract_pure_fns.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_4_contract_pure_fns.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 35 gas
+

--- a/newsfragments/767.bugfix.md
+++ b/newsfragments/767.bugfix.md
@@ -1,0 +1,18 @@
+Fix issue where calls to assiciated functions did not enforce visibility rules.
+
+E.g the following code should be rejected but previously wasn't:
+
+```
+struct Foo {
+    fn do_private_things() {
+    }
+}
+
+contract Bar {
+    fn test() {
+        Foo::do_private_things()
+    }
+}
+```
+
+With this change, the above code is now rejected because `do_private_things` is not `pub`.

--- a/newsfragments/767.feature.md
+++ b/newsfragments/767.feature.md
@@ -1,0 +1,1 @@
+Allow contract associated functions to be called via `ContractName::function_name()` syntax.


### PR DESCRIPTION
### What was wrong?

The code that validates the visibility rules of function calls is duplicated, faulty and incomple.

### How was it fixed?

1. Created a single function `validate_visibility_of_called_fn` that can be called from any place that needs to enforce the rules
2. Ensured the rules are enforced for calls to associated functions
3. Added a bunch more tests
4. Bonus: Made it possible to use `MyContract::static_func()` syntax which wasn't yet possible for contracts (but worked for structs)
5. More test coverage
