### PR TITLE
Ensure traits from other modules can be implemented

### DIFF
--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -1700,10 +1700,9 @@ impl TraitId {
     }
 
     pub fn is_implemented_for(&self, db: &dyn AnalyzerDb, ty: TypeId) -> bool {
-        self.module(db)
-            .all_impls(db)
+        ty.get_all_impls(db)
             .iter()
-            .any(|val| &val.trait_id(db) == self && val.receiver(db) == ty)
+            .any(|val| &val.trait_id(db) == self)
     }
 
     pub fn is_in_std(&self, db: &dyn AnalyzerDb) -> bool {

--- a/crates/test-files/fixtures/features/generic_functions.fe
+++ b/crates/test-files/fixtures/features/generic_functions.fe
@@ -1,8 +1,12 @@
+use std::traits::Dummy
+
 trait Computable {
   fn compute(self, val: u256) -> u256;
 }
 
 struct Mac {}
+
+impl Dummy for Mac {}
 
 impl Computable for Mac {
   fn compute(self, val: u256) -> u256 {
@@ -31,6 +35,10 @@ struct Runner {
   pub fn run<T: Computable>(self, _ val: T) -> u256 {
     return val.compute(val: 1000)
   }
+
+  pub fn dummy<T: Dummy>(self, _ val: T) {
+
+  }
 }
 
 contract Example {
@@ -38,5 +46,8 @@ contract Example {
     let runner: Runner = Runner();
     assert runner.run(Mac()) == 1001
     assert runner.run(Linux(counter: 10)) == 1015
+
+    # We are testing that we can satisfy a trait bound where the trait is defined in another module
+    runner.dummy(Mac())
   }
 }

--- a/newsfragments/773.bugfix.md
+++ b/newsfragments/773.bugfix.md
@@ -1,0 +1,1 @@
+Ensure traits from other modules or even ingots can be implemented


### PR DESCRIPTION
### What was wrong?

It is not possible to implement a trait that is defined in another ingot or even just another module.

### How was it fixed?

Do not just look for implementations in the module of the trait but everywhere.
