### PR TITLE
Reject zero type when declare event fields

### DIFF
--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -195,6 +195,9 @@ pub trait AnalyzerDb: SourceDb + Upcast<dyn SourceDb> + UpcastMut<dyn SourceDb> 
     #[salsa::invoke(queries::types::type_alias_type)]
     #[salsa::cycle(queries::types::type_alias_type_cycle)]
     fn type_alias_type(&self, id: TypeAliasId) -> Analysis<Result<TypeId, TypeError>>;
+    #[salsa::invoke(queries::types::is_zero_sized)]
+    #[salsa::cycle(queries::types::is_zero_sized_cycle)]
+    fn is_zero_sized(&self, ty: TypeId) -> bool;
 }
 
 #[salsa::database(AnalyzerDbStorage, SourceDbStorage)]

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -42,9 +42,9 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
             let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
                 typ if typ.has_fixed_size(scope.db()) => {
                     if !typ.is_zero_size(scope.db()) {
-                        return Ok(typ)
+                        Ok(typ)
                     } else {
-                        return Err(TypeError::new(scope.error(
+                        Err(TypeError::new(scope.error(
                             "event field type must have a non-zero types",
                             typ_node.span,
                             "this type can't be used as an event field",

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -39,24 +39,34 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
                 typ: typ_node,
             } = &field.kind;
 
-            let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
-                typ if typ.has_fixed_size(scope.db()) => {
-                    if *is_idx && typ.is_zero_sized(db) {
-                        Err(TypeError::new(scope.error(
-                            "event field type must have a non-zero types",
+            let typ =
+                type_desc(&mut scope, typ_node).and_then(|typ| match db.lookup_intern_type(typ) {
+                    types::Type::Generic(_)
+                    | types::Type::Map(_)
+                    | types::Type::SelfContract(_) => Err(TypeError::new(scope.error(
+                        "event field type is invalid",
+                        typ_node.span,
+                        "this type can't be used as an event field",
+                    ))),
+                    _ => match typ {
+                        typ if typ.has_fixed_size(scope.db()) => {
+                            if *is_idx && typ.is_zero_sized(db) {
+                                Err(TypeError::new(scope.error(
+                                    "event field type must have a non-zero types",
+                                    typ_node.span,
+                                    "this type can't be used as an event field",
+                                )))
+                            } else {
+                                Ok(typ)
+                            }
+                        }
+                        _ => Err(TypeError::new(scope.error(
+                            "event field type must have a fixed size",
                             typ_node.span,
-                            "this type can't be used as an event field",
-                        )))
-                    } else {
-                        Ok(typ)
-                    }
-                }
-                _ => Err(TypeError::new(scope.error(
-                    "event field type must have a fixed size",
-                    typ_node.span,
-                    "this can't be used as an event field",
-                ))),
-            });
+                            "this can't be used as an event field",
+                        ))),
+                    },
+                });
 
             // If we've already seen the max number of indexed fields,
             // ignore the `idx` qualifier on this one. We'll emit an error below.

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -39,34 +39,24 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
                 typ: typ_node,
             } = &field.kind;
 
-            let typ =
-                type_desc(&mut scope, typ_node).and_then(|typ| match db.lookup_intern_type(typ) {
-                    types::Type::Generic(_)
-                    | types::Type::Map(_)
-                    | types::Type::SelfContract(_) => Err(TypeError::new(scope.error(
-                        "event field type is invalid",
-                        typ_node.span,
-                        "this type can't be used as an event field",
-                    ))),
-                    _ => match typ {
-                        typ if typ.has_fixed_size(scope.db()) => {
-                            if *is_idx && typ.is_zero_sized(db) {
-                                Err(TypeError::new(scope.error(
-                                    "event field type must have a non-zero types",
-                                    typ_node.span,
-                                    "this type can't be used as an event field",
-                                )))
-                            } else {
-                                Ok(typ)
-                            }
-                        }
-                        _ => Err(TypeError::new(scope.error(
-                            "event field type must have a fixed size",
+            let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
+                typ if typ.has_fixed_size(scope.db()) => {
+                    if *is_idx && typ.is_zero_sized(db) {
+                        Err(TypeError::new(scope.error(
+                            "expected a non zero sized type for an indexed event field",
                             typ_node.span,
-                            "this can't be used as an event field",
-                        ))),
-                    },
-                });
+                            "this must be a non zero sized type",
+                        )))
+                    } else {
+                        Ok(typ)
+                    }
+                }
+                _ => Err(TypeError::new(scope.error(
+                    "event field type must have a fixed size",
+                    typ_node.span,
+                    "this can't be used as an event field",
+                ))),
+            })
 
             // If we've already seen the max number of indexed fields,
             // ignore the `idx` qualifier on this one. We'll emit an error below.

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -41,14 +41,14 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
 
             let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
                 typ if typ.has_fixed_size(scope.db()) => {
-                    if !typ.is_zero_size(scope.db()) {
-                        Ok(typ)
-                    } else {
+                    if *is_idx && typ.is_zero_size(scope.db()) {
                         Err(TypeError::new(scope.error(
                             "event field type must have a non-zero types",
                             typ_node.span,
                             "this type can't be used as an event field",
                         )))
+                    } else {
+                        Ok(typ)
                     }
                 }
                 _ => Err(TypeError::new(scope.error(

--- a/crates/analyzer/src/db/queries/events.rs
+++ b/crates/analyzer/src/db/queries/events.rs
@@ -41,7 +41,7 @@ pub fn event_type(db: &dyn AnalyzerDb, event: EventId) -> Analysis<Rc<types::Eve
 
             let typ = type_desc(&mut scope, typ_node).and_then(|typ| match typ {
                 typ if typ.has_fixed_size(scope.db()) => {
-                    if *is_idx && typ.is_zero_size(scope.db()) {
+                    if *is_idx && typ.is_zero_sized(db) {
                         Err(TypeError::new(scope.error(
                             "event field type must have a non-zero types",
                             typ_node.span,

--- a/crates/analyzer/src/db/queries/types.rs
+++ b/crates/analyzer/src/db/queries/types.rs
@@ -94,16 +94,7 @@ pub fn is_zero_sized(db: &dyn AnalyzerDb, ty: types::TypeId) -> bool {
             }
             true
         }
-        Type::Contract(contract_id) => {
-            for field_type_id in db.contract_all_fields(contract_id).iter() {
-                let field_type = db.contract_field_type(*field_type_id).value.unwrap();
-                if !(field_type).is_zero_sized(db) {
-                    return false;
-                }
-            }
-            true
-        }
-        Type::Generic(_) | Type::Map(_) | Type::SelfContract(_) => false,
+        Type::Generic(_) | Type::Map(_) | Type::SelfContract(_) | Type::Contract(_) => false,
     }
 }
 

--- a/crates/analyzer/src/db/queries/types.rs
+++ b/crates/analyzer/src/db/queries/types.rs
@@ -76,32 +76,32 @@ pub fn is_zero_sized(db: &dyn AnalyzerDb, ty: types::TypeId) -> bool {
         Type::Base(base) => matches!(base, Base::Unit),
         Type::Array(Array { size, inner }) => size == 0 || inner.is_zero_sized(db),
         Type::Tuple(Tuple { items }) => {
-            for item in items.into_iter() {
+            for item in items.iter() {
                 if !db.is_zero_sized(*item) {
                     return false;
                 }
             }
-            return true;
+            true
         }
         Type::String(FeString { max_size }) => max_size == 0,
         Type::Struct(struct_id) => {
-            for field_type_id in db.struct_all_fields(struct_id).into_iter() {
+            for field_type_id in db.struct_all_fields(struct_id).iter() {
                 // assume all type is correct.
                 let field_type = db.struct_field_type(*field_type_id).value.unwrap();
                 if !(field_type).is_zero_sized(db) {
                     return false;
                 }
             }
-            return true;
+            true
         }
         Type::Contract(contract_id) => {
-            for field_type_id in db.contract_all_fields(contract_id).into_iter() {
+            for field_type_id in db.contract_all_fields(contract_id).iter() {
                 let field_type = db.contract_field_type(*field_type_id).value.unwrap();
                 if !(field_type).is_zero_sized(db) {
                     return false;
                 }
             }
-            return true;
+            true
         }
         Type::Generic(_) | Type::Map(_) | Type::SelfContract(_) => false,
     }

--- a/crates/analyzer/src/db/queries/types.rs
+++ b/crates/analyzer/src/db/queries/types.rs
@@ -7,7 +7,7 @@ use crate::db::Analysis;
 use crate::errors::TypeError;
 use crate::namespace::items::{FunctionSigId, ImplId, TraitId, TypeAliasId};
 use crate::namespace::scopes::ItemScope;
-use crate::namespace::types::{self, TypeId, Array, Tuple, Type, FeString, Base};
+use crate::namespace::types::{self, Array, Base, FeString, Tuple, Type, TypeId};
 use crate::traversal::types::type_desc;
 use crate::AnalyzerDb;
 
@@ -107,12 +107,7 @@ pub fn is_zero_sized(db: &dyn AnalyzerDb, ty: types::TypeId) -> bool {
     }
 }
 
-
 // because we already catch this error so this should be empty
-pub fn is_zero_sized_cycle(
-    _db: &dyn AnalyzerDb,
-    _cycle: &[String],
-    _ty: &types::TypeId,
-) -> bool {
+pub fn is_zero_sized_cycle(_db: &dyn AnalyzerDb, _cycle: &[String], _ty: &types::TypeId) -> bool {
     true
 }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -496,7 +496,7 @@ impl Type {
         }
         false
     }
- 
+
     /// Creates an instance of bool.
     pub fn bool() -> Self {
         Type::Base(Base::Bool)

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -502,7 +502,7 @@ impl Type {
             Type::Base(Base::Unit) => true,
             Type::Contract(inner) => inner.fields(db).is_empty(),
             Type::Struct(inner) => inner.fields(db).is_empty(),
-            _ => false
+            _ => false,
         }
     }
     /// Creates an instance of bool.

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -85,7 +85,7 @@ impl TypeId {
         self.typ(db).is_base()
     }
     pub fn is_zero_size(&self, db: &dyn AnalyzerDb) -> bool {
-        self.typ(db).is_zero_size(db)
+        self.typ(db).is_zero_size()
     }
     pub fn is_bool(&self, db: &dyn AnalyzerDb) -> bool {
         matches!(self.typ(db), Type::Base(Base::Bool))
@@ -497,11 +497,9 @@ impl Type {
         false
     }
 
-    pub fn is_zero_size(&self, db: &dyn AnalyzerDb) -> bool {
+    pub fn is_zero_size(&self) -> bool {
         match &self {
             Type::Base(Base::Unit) => true,
-            Type::Contract(inner) => inner.fields(db).is_empty(),
-            Type::Struct(inner) => inner.fields(db).is_empty(),
             _ => false,
         }
     }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -84,8 +84,8 @@ impl TypeId {
     pub fn is_base(&self, db: &dyn AnalyzerDb) -> bool {
         self.typ(db).is_base()
     }
-    pub fn is_zero_size(&self, db: &dyn AnalyzerDb) -> bool {
-        self.typ(db).is_zero_size()
+    pub fn is_zero_sized(&self, db: &dyn AnalyzerDb) -> bool {
+        db.is_zero_sized(*self)
     }
     pub fn is_bool(&self, db: &dyn AnalyzerDb) -> bool {
         matches!(self.typ(db), Type::Base(Base::Bool))
@@ -496,13 +496,7 @@ impl Type {
         }
         false
     }
-
-    pub fn is_zero_size(&self) -> bool {
-        match &self {
-            Type::Base(Base::Unit) => true,
-            _ => false,
-        }
-    }
+ 
     /// Creates an instance of bool.
     pub fn bool() -> Self {
         Type::Base(Base::Bool)

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -84,6 +84,9 @@ impl TypeId {
     pub fn is_base(&self, db: &dyn AnalyzerDb) -> bool {
         self.typ(db).is_base()
     }
+    pub fn is_zero_size(&self, db: &dyn AnalyzerDb) -> bool {
+        self.typ(db).is_zero_size(db)
+    }
     pub fn is_bool(&self, db: &dyn AnalyzerDb) -> bool {
         matches!(self.typ(db), Type::Base(Base::Bool))
     }
@@ -494,6 +497,14 @@ impl Type {
         false
     }
 
+    pub fn is_zero_size(&self, db: &dyn AnalyzerDb) -> bool {
+        match &self {
+            Type::Base(Base::Unit) => true,
+            Type::Contract(inner) => inner.fields(db).is_empty(),
+            Type::Struct(inner) => inner.fields(db).is_empty(),
+            _ => false
+        }
+    }
     /// Creates an instance of bool.
     pub fn bool() -> Self {
         Type::Base(Base::Bool)

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -255,6 +255,7 @@ test_file! { external_call_type_error }
 test_file! { external_call_wrong_number_of_params }
 test_file! { contract_function_with_generic_params }
 test_file! { indexed_event }
+test_file! { invalid_type_in_event_zero_sized }
 test_file! { invalid_compiler_version }
 test_file! { invalid_block_field }
 test_file! { invalid_chain_field }

--- a/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
@@ -68,4 +68,10 @@ error: event field type must have a non-zero types
 47 │     idx f: Foo
    │            ^^^ this type can't be used as an event field
 
+error: event field type is invalid
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:52:8
+   │
+52 │     b: Map<u256,u256>
+   │        ^^^^^^^^^^^^^^ this type can't be used as an event field
+
 

--- a/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
@@ -2,22 +2,82 @@
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 ---
-error: event field type must have a non-zero types
-  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:8:12
-  │
-8 │     idx x: ()
-  │            ^^ this type can't be used as an event field
-
-error: event field type must have a non-zero types
-  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:9:12
-  │
-9 │     idx y: EmptyStruct
-  │            ^^^^^^^^^^^ this type can't be used as an event field
-
-error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:10:12
+error: feature not yet implemented: contract types aren't yet supported as struct fields
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:14:5
    │
-10 │     idx z: EmptyContract
-   │            ^^^^^^^^^^^^^ this type can't be used as an event field
+14 │     y: EmptyContract
+   │     ^^^^^^^^^^^^^^^^ not yet implemented
+
+error: recursive struct `Foo`
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:17:8
+   │
+17 │ struct Foo {
+   │        ^^^ struct `Foo` has infinite size due to recursive definition
+
+error: recursive struct `Baz`
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:21:8
+   │
+21 │ struct Baz {
+   │        ^^^ struct `Baz` has infinite size due to recursive definition
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:27:13
+   │
+27 │     idx a : ()
+   │             ^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:28:13
+   │
+28 │     idx b : EmptyContract 
+   │             ^^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:29:13
+   │
+29 │     idx c : EmptyStruct
+   │             ^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:34:12
+   │
+34 │     idx b: ((), EmptyContract, EmptyStruct) 
+   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:35:12
+   │
+35 │     idx c: Array<EmptyStruct, 0>
+   │            ^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:39:12
+   │
+39 │     idx a: Array<(), 0>
+   │            ^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:40:12
+   │
+40 │     idx b: Array<UnEmptyStruct, 0>
+   │            ^^^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:44:12
+   │
+44 │     idx a: Array<(), 0>
+   │            ^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:45:12
+   │
+45 │     idx b: AnotherEmpty
+   │            ^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:52:12
+   │
+52 │     idx f: Foo
+   │            ^^^ this type can't be used as an event field
 
 

--- a/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
@@ -1,0 +1,23 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+---
+error: event field type must have a non-zero types
+  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:8:8
+  │
+8 │     x: ()
+  │        ^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:9:8
+  │
+9 │     y: EmptyStruct
+  │        ^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:10:8
+   │
+10 │     z: EmptyContract
+   │        ^^^^^^^^^^^^^ this type can't be used as an event field
+
+

--- a/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
@@ -3,21 +3,21 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 ---
 error: event field type must have a non-zero types
-  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:8:8
+  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:8:12
   │
-8 │     x: ()
-  │        ^^ this type can't be used as an event field
+8 │     idx x: ()
+  │            ^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
-  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:9:8
+  ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:9:12
   │
-9 │     y: EmptyStruct
-  │        ^^^^^^^^^^^ this type can't be used as an event field
+9 │     idx y: EmptyStruct
+  │            ^^^^^^^^^^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:10:8
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:10:12
    │
-10 │     z: EmptyContract
-   │        ^^^^^^^^^^^^^ this type can't be used as an event field
+10 │     idx z: EmptyContract
+   │            ^^^^^^^^^^^^^ this type can't be used as an event field
 
 

--- a/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_type_in_event_zero_sized.snap
@@ -2,53 +2,53 @@
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 ---
-error: feature not yet implemented: contract types aren't yet supported as struct fields
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:14:5
-   │
-14 │     y: EmptyContract
-   │     ^^^^^^^^^^^^^^^^ not yet implemented
-
 error: recursive struct `Foo`
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:17:8
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:12:8
    │
-17 │ struct Foo {
+12 │ struct Foo {
    │        ^^^ struct `Foo` has infinite size due to recursive definition
 
 error: recursive struct `Baz`
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:21:8
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:16:8
    │
-21 │ struct Baz {
+16 │ struct Baz {
    │        ^^^ struct `Baz` has infinite size due to recursive definition
 
 error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:27:13
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:22:13
    │
-27 │     idx a : ()
+22 │     idx a : ()
    │             ^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:28:13
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:24:13
    │
-28 │     idx b : EmptyContract 
-   │             ^^^^^^^^^^^^^ this type can't be used as an event field
+24 │     idx c : EmptyStruct
+   │             ^^^^^^^^^^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:29:13
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:29:12
    │
-29 │     idx c : EmptyStruct
-   │             ^^^^^^^^^^^ this type can't be used as an event field
+29 │     idx b: ((), EmptyStruct) 
+   │            ^^^^^^^^^^^^^^^^^ this type can't be used as an event field
+
+error: event field type must have a non-zero types
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:30:12
+   │
+30 │     idx c: Array<EmptyStruct, 0>
+   │            ^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
    ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:34:12
    │
-34 │     idx b: ((), EmptyContract, EmptyStruct) 
-   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
+34 │     idx a: Array<(), 0>
+   │            ^^^^^^^^^^^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
    ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:35:12
    │
-35 │     idx c: Array<EmptyStruct, 0>
-   │            ^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
+35 │     idx b: Array<UnEmptyStruct, 0>
+   │            ^^^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
    ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:39:12
@@ -59,25 +59,13 @@ error: event field type must have a non-zero types
 error: event field type must have a non-zero types
    ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:40:12
    │
-40 │     idx b: Array<UnEmptyStruct, 0>
-   │            ^^^^^^^^^^^^^^^^^^^^^^^ this type can't be used as an event field
-
-error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:44:12
-   │
-44 │     idx a: Array<(), 0>
+40 │     idx b: AnotherEmpty
    │            ^^^^^^^^^^^^ this type can't be used as an event field
 
 error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:45:12
+   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:47:12
    │
-45 │     idx b: AnotherEmpty
-   │            ^^^^^^^^^^^^ this type can't be used as an event field
-
-error: event field type must have a non-zero types
-   ┌─ compile_errors/invalid_type_in_event_zero_sized.fe:52:12
-   │
-52 │     idx f: Foo
+47 │     idx f: Foo
    │            ^^^ this type can't be used as an event field
 
 

--- a/crates/common/src/panic.rs
+++ b/crates/common/src/panic.rs
@@ -1,13 +1,13 @@
 use once_cell::sync::Lazy;
 use std::panic;
 
+type PanicHook = dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static;
 const BUG_REPORT_URL: &str = "https://github.com/ethereum/fe/issues/new";
-static DEFAULT_PANIC_HOOK: Lazy<Box<dyn Fn(&panic::PanicInfo<'_>) + Sync + Send + 'static>> =
-    Lazy::new(|| {
-        let hook = panic::take_hook();
-        panic::set_hook(Box::new(report_ice));
-        hook
-    });
+static DEFAULT_PANIC_HOOK: Lazy<Box<PanicHook>> = Lazy::new(|| {
+    let hook = panic::take_hook();
+    panic::set_hook(Box::new(report_ice));
+    hook
+});
 
 pub fn install_panic_hook() {
     Lazy::force(&DEFAULT_PANIC_HOOK);

--- a/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
@@ -46,3 +46,8 @@ event SixthCase {
     idx e: ((), UnEmptyStruct)
     idx f: Foo
 }
+
+event SeventhCase {
+    idx a: u256
+    b: Map<u256,u256>
+}

--- a/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
@@ -1,17 +1,12 @@
 struct EmptyStruct {}
-contract EmptyContract {}
+contract Contract {}
 
 struct UnEmptyStruct {
     v: u32
 }
 
-contract UnEmptyContract {
-    u: u256
-}
-
 struct AnotherEmpty {
     x: EmptyStruct
-    y: EmptyContract
 }
 
 struct Foo {
@@ -25,13 +20,13 @@ struct Baz {
 
 event FirstCase {
     idx a : ()
-    idx b : EmptyContract 
+    idx b : Contract 
     idx c : EmptyStruct
 }
 
 event SecondCase {
     idx a: u256 
-    idx b: ((), EmptyContract, EmptyStruct) 
+    idx b: ((), EmptyStruct) 
     idx c: Array<EmptyStruct, 0>
 }
 

--- a/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
@@ -5,7 +5,8 @@ struct EmptyStruct {
 }
 
 event Event {
-    x: ()
-    y: EmptyStruct
-    z: EmptyContract
+    idx x: ()
+    idx y: EmptyStruct
+    idx z: EmptyContract
+    v: ()
 }

--- a/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
@@ -1,0 +1,11 @@
+contract EmptyContract {
+}
+
+struct EmptyStruct {
+}
+
+event Event {
+    x: ()
+    y: EmptyStruct
+    z: EmptyContract
+}

--- a/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_type_in_event_zero_sized.fe
@@ -1,12 +1,53 @@
-contract EmptyContract {
+struct EmptyStruct {}
+contract EmptyContract {}
+
+struct UnEmptyStruct {
+    v: u32
 }
 
-struct EmptyStruct {
+contract UnEmptyContract {
+    u: u256
 }
 
-event Event {
-    idx x: ()
-    idx y: EmptyStruct
-    idx z: EmptyContract
-    v: ()
+struct AnotherEmpty {
+    x: EmptyStruct
+    y: EmptyContract
+}
+
+struct Foo {
+    x: Baz
+}
+
+struct Baz {
+    x: Foo
+}
+
+
+event FirstCase {
+    idx a : ()
+    idx b : EmptyContract 
+    idx c : EmptyStruct
+}
+
+event SecondCase {
+    idx a: u256 
+    idx b: ((), EmptyContract, EmptyStruct) 
+    idx c: Array<EmptyStruct, 0>
+}
+
+event ThirdCase {
+    idx a: Array<(), 0>
+    idx b: Array<UnEmptyStruct, 0>
+}
+
+event FifthCase {
+    idx a: Array<(), 0>
+    idx b: AnotherEmpty
+    idx c: Array<UnEmptyStruct, 1>
+}
+
+event SixthCase {
+    idx d: UnEmptyStruct
+    idx e: ((), UnEmptyStruct)
+    idx f: Foo
 }


### PR DESCRIPTION
### What was wrong?
https://github.com/ethereum/fe/issues/712


### How was it fixed?

Add salsa db query `is_zero_type` and check declare field data in event should not zero-sized

Special thank to @Y-Nak! 
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
