### PR TITLE
Reject pure functions being called on instances

### DIFF
--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -323,6 +323,7 @@ test_file! { revert_sto_error_no_copy }
 
 test_file! { call_to_mut_fn_without_self }
 test_file! { call_to_pure_fn_on_self }
+test_file! { call_to_pure_struct_fn_on_instance }
 test_file! { missing_self }
 test_file! { self_not_first }
 test_file! { self_in_standalone_fn }

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -251,10 +251,10 @@ note:
 note: 
    ┌─ ingots/basic_ingot/src/bing.fe:12:5
    │  
-12 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
+12 │ ╭     pub fn add(self, _ x: u256, _ y: u256) -> u256 {
 13 │ │         return x + y
 14 │ │     }
-   │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
    ┌─ ingots/basic_ingot/src/bing.fe:13:16

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -16,10 +16,10 @@ note:
 note: 
    ┌─ external_contract.fe:10:5
    │  
-10 │ ╭     pub fn emit_event(ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
+10 │ ╭     pub fn emit_event(self, ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
 11 │ │         emit MyEvent(ctx, my_num, my_addrs, my_string)
 12 │ │     }
-   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
 
 note: 
    ┌─ external_contract.fe:11:22
@@ -34,14 +34,14 @@ note:
 note: 
    ┌─ external_contract.fe:14:5
    │  
-14 │ ╭     pub fn build_array(a: u256, b: u256) -> Array<u256, 3> {
+14 │ ╭     pub fn build_array(self, a: u256, b: u256) -> Array<u256, 3> {
 15 │ │         let my_array: Array<u256, 3> = [0; 3]
 16 │ │         my_array[0] = a
 17 │ │         my_array[1] = a * b
 18 │ │         my_array[2] = b
 19 │ │         return my_array
 20 │ │     }
-   │ ╰─────^ self: None, params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
 
 note: 
    ┌─ external_contract.fe:15:13
@@ -109,32 +109,54 @@ note:
    │                ^^^^^^^^ Array<u256, 3>: Memory
 
 note: 
-   ┌─ external_contract.fe:24:5
+   ┌─ external_contract.fe:22:5
    │  
-24 │ ╭     pub fn call_emit_event(ctx: Context, foo_address: address, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
-25 │ │         let foo: Foo = Foo(foo_address)
-26 │ │         foo.emit_event(ctx, my_num, my_addrs, my_string)
-27 │ │     }
+22 │ ╭     pub fn pure_add(_ x: u256, _ y: u256) -> u256 {
+23 │ │         return x + y
+24 │ │     }
+   │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
+
+note: 
+   ┌─ external_contract.fe:23:16
+   │
+23 │         return x + y
+   │                ^   ^ u256: Value
+   │                │    
+   │                u256: Value
+
+note: 
+   ┌─ external_contract.fe:23:16
+   │
+23 │         return x + y
+   │                ^^^^^ u256: Value
+
+note: 
+   ┌─ external_contract.fe:28:5
+   │  
+28 │ ╭     pub fn call_emit_event(ctx: Context, foo_address: address, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
+29 │ │         let foo: Foo = Foo(foo_address)
+30 │ │         foo.emit_event(ctx, my_num, my_addrs, my_string)
+31 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: foo_address, typ: address }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
 
 note: 
-   ┌─ external_contract.fe:25:13
+   ┌─ external_contract.fe:29:13
    │
-25 │         let foo: Foo = Foo(foo_address)
+29 │         let foo: Foo = Foo(foo_address)
    │             ^^^ Foo
 
 note: 
-   ┌─ external_contract.fe:25:28
+   ┌─ external_contract.fe:29:28
    │
-25 │         let foo: Foo = Foo(foo_address)
+29 │         let foo: Foo = Foo(foo_address)
    │                            ^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ external_contract.fe:25:24
+   ┌─ external_contract.fe:29:24
    │
-25 │         let foo: Foo = Foo(foo_address)
+29 │         let foo: Foo = Foo(foo_address)
    │                        ^^^^^^^^^^^^^^^^ Foo: Value
-26 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
+30 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
    │         ^^^            ^^^  ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory
    │         │              │    │       │          
    │         │              │    │       Array<address, 5>: Memory
@@ -143,47 +165,69 @@ note:
    │         Foo: Value
 
 note: 
-   ┌─ external_contract.fe:26:9
+   ┌─ external_contract.fe:30:9
    │
-26 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
+30 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ external_contract.fe:29:5
+   ┌─ external_contract.fe:33:5
    │  
-29 │ ╭     pub fn call_build_array(foo_address: address, a: u256, b: u256) -> Array<u256, 3> {
-30 │ │         let foo: Foo = Foo(foo_address)
-31 │ │         return foo.build_array(a, b)
-32 │ │     }
+33 │ ╭     pub fn call_build_array(foo_address: address, a: u256, b: u256) -> Array<u256, 3> {
+34 │ │         let foo: Foo = Foo(foo_address)
+35 │ │         return foo.build_array(a, b)
+36 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: foo_address, typ: address }, { label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
 
 note: 
-   ┌─ external_contract.fe:30:13
+   ┌─ external_contract.fe:34:13
    │
-30 │         let foo: Foo = Foo(foo_address)
+34 │         let foo: Foo = Foo(foo_address)
    │             ^^^ Foo
 
 note: 
-   ┌─ external_contract.fe:30:28
+   ┌─ external_contract.fe:34:28
    │
-30 │         let foo: Foo = Foo(foo_address)
+34 │         let foo: Foo = Foo(foo_address)
    │                            ^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ external_contract.fe:30:24
+   ┌─ external_contract.fe:34:24
    │
-30 │         let foo: Foo = Foo(foo_address)
+34 │         let foo: Foo = Foo(foo_address)
    │                        ^^^^^^^^^^^^^^^^ Foo: Value
-31 │         return foo.build_array(a, b)
+35 │         return foo.build_array(a, b)
    │                ^^^             ^  ^ u256: Value
    │                │               │   
    │                │               u256: Value
    │                Foo: Value
 
 note: 
-   ┌─ external_contract.fe:31:16
+   ┌─ external_contract.fe:35:16
    │
-31 │         return foo.build_array(a, b)
+35 │         return foo.build_array(a, b)
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 3>: Memory
+
+note: 
+   ┌─ external_contract.fe:38:5
+   │  
+38 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
+39 │ │         return Foo::pure_add(x, y)
+40 │ │     }
+   │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
+
+note: 
+   ┌─ external_contract.fe:39:30
+   │
+39 │         return Foo::pure_add(x, y)
+   │                              ^  ^ u256: Value
+   │                              │   
+   │                              u256: Value
+
+note: 
+   ┌─ external_contract.fe:39:16
+   │
+39 │         return Foo::pure_add(x, y)
+   │                ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -61,10 +61,10 @@ note:
 note: 
    ┌─ two_contracts.fe:15:5
    │  
-15 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
+15 │ ╭     pub fn add(self, _ x: u256, _ y: u256) -> u256 {
 16 │ │         return x + y
 17 │ │     }
-   │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
+   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
    ┌─ two_contracts.fe:16:16

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -6,10 +6,10 @@ expression: "build_snapshot(&db, module)"
 note: 
   ┌─ uniswap.fe:4:5
   │  
-4 │ ╭     pub fn balanceOf(_ account: address) -> u256 {
+4 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
 5 │ │         return 0
 6 │ │     }
-  │ ╰─────^ self: None, params: [{ label: Some("_"), name: account, typ: address }] -> u256
+  │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
   ┌─ uniswap.fe:5:16
@@ -20,10 +20,10 @@ note:
 note: 
    ┌─ uniswap.fe:8:5
    │  
- 8 │ ╭     pub fn transfer(to: address, _ amount: u256) -> bool {
+ 8 │ ╭     pub fn transfer(self, to: address, _ amount: u256) -> bool {
  9 │ │         return false
 10 │ │     }
-   │ ╰─────^ self: None, params: [{ label: None, name: to, typ: address }, { label: Some("_"), name: amount, typ: u256 }] -> bool
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: to, typ: address }, { label: Some("_"), name: amount, typ: u256 }] -> bool
 
 note: 
   ┌─ uniswap.fe:9:16

--- a/crates/analyzer/tests/snapshots/errors__call_to_pure_fn_on_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_to_pure_fn_on_self.snap
@@ -9,6 +9,6 @@ error: `pure` must be called without `self`
 5 │         self.pure()
   │              ^^^^ function does not take self
   │
-  = Suggestion: try `pure(...)` instead of `self.pure(...)`
+  = Suggestion: try `Foo::pure(...)` instead of `self.pure(...)`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_to_pure_struct_fn_on_instance.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_to_pure_struct_fn_on_instance.snap
@@ -1,0 +1,14 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: `foo` must be called without `self`
+  ┌─ compile_errors/call_to_pure_struct_fn_on_instance.fe:9:15
+  │
+9 │         Bar().foo(1)
+  │               ^^^ function does not take self
+  │
+  = Suggestion: try `Bar::foo(...)` instead of `self.foo(...)`
+
+

--- a/crates/test-files/fixtures/compile_errors/call_to_pure_struct_fn_on_instance.fe
+++ b/crates/test-files/fixtures/compile_errors/call_to_pure_struct_fn_on_instance.fe
@@ -1,0 +1,11 @@
+struct Bar {
+    pub fn foo(_ val: u256){
+    }
+}
+
+contract Foo {
+
+    fn call_bar(self) {
+        Bar().foo(1)
+    }
+}

--- a/crates/test-files/fixtures/compile_errors/external_call_type_error.fe
+++ b/crates/test-files/fixtures/compile_errors/external_call_type_error.fe
@@ -1,7 +1,7 @@
 use std::context::Context
 
 contract Foo {
-    pub fn bar(_ a: u256) {}
+    pub fn bar(self, _ a: u256) {}
 }
 
 contract FooProxy {

--- a/crates/test-files/fixtures/compile_errors/external_call_wrong_number_of_params.fe
+++ b/crates/test-files/fixtures/compile_errors/external_call_wrong_number_of_params.fe
@@ -1,7 +1,7 @@
 use std::context::Context
 
 contract Foo {
-    pub fn bar(a: u256, b: u256) {}
+    pub fn bar(self, a: u256, b: u256) {}
 }
 
 contract FooProxy {

--- a/crates/test-files/fixtures/compile_errors/init_call_on_external_contract.fe
+++ b/crates/test-files/fixtures/compile_errors/init_call_on_external_contract.fe
@@ -3,7 +3,7 @@ use std::context::Context
 contract Foo {
     pub fn __init__() {}
 
-    pub fn f() {}
+    pub fn f(self) {}
 }
 
 contract Bar {

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
@@ -3,7 +3,7 @@ use std::context::Context
 contract Foo {
     val: u8
 
-    pub fn baz(val1: u256, val2: u256) {}
+    pub fn baz(self, val1: u256, val2: u256) {}
 }
 
 contract Bar {

--- a/crates/test-files/fixtures/demos/uniswap.fe
+++ b/crates/test-files/fixtures/demos/uniswap.fe
@@ -1,11 +1,11 @@
 use std::context::Context
 
 contract ERC20 {
-    pub fn balanceOf(_ account: address) -> u256 {
+    pub fn balanceOf(self, _ account: address) -> u256 {
         return 0
     }
 
-    pub fn transfer(to: address, _ amount: u256) -> bool {
+    pub fn transfer(self, to: address, _ amount: u256) -> bool {
         return false
     }
 }

--- a/crates/test-files/fixtures/features/ctx_param_external_func_call.fe
+++ b/crates/test-files/fixtures/features/ctx_param_external_func_call.fe
@@ -3,7 +3,7 @@ use std::context::Context
 contract Foo {
     my_num: u256
 
-    pub fn baz(ctx: Context) -> u256 {
+    pub fn baz(self, ctx: Context) -> u256 {
         return ctx.block_number()
     }
 

--- a/crates/test-files/fixtures/features/external_contract.fe
+++ b/crates/test-files/fixtures/features/external_contract.fe
@@ -7,16 +7,20 @@ contract Foo {
         my_string: String<11>
     }
 
-    pub fn emit_event(ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
+    pub fn emit_event(self, ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
         emit MyEvent(ctx, my_num, my_addrs, my_string)
     }
 
-    pub fn build_array(a: u256, b: u256) -> Array<u256, 3> {
+    pub fn build_array(self, a: u256, b: u256) -> Array<u256, 3> {
         let my_array: Array<u256, 3> = [0; 3]
         my_array[0] = a
         my_array[1] = a * b
         my_array[2] = b
         return my_array
+    }
+
+    pub fn pure_add(_ x: u256, _ y: u256) -> u256 {
+        return x + y
     }
 }
 
@@ -29,5 +33,9 @@ contract FooProxy {
     pub fn call_build_array(foo_address: address, a: u256, b: u256) -> Array<u256, 3> {
         let foo: Foo = Foo(foo_address)
         return foo.build_array(a, b)
+    }
+
+    pub fn add(_ x: u256, _ y: u256) -> u256 {
+        return Foo::pure_add(x, y)
     }
 }

--- a/crates/test-files/fixtures/features/two_contracts.fe
+++ b/crates/test-files/fixtures/features/two_contracts.fe
@@ -12,7 +12,7 @@ contract Foo {
         return self.other.answer()
     }
 
-    pub fn add(_ x: u256, _ y: u256) -> u256 {
+    pub fn add(self, _ x: u256, _ y: u256) -> u256 {
         return x + y
     }
 }

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/bing.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/bing.fe
@@ -9,7 +9,7 @@ pub fn get_42_backend() -> u256 {
 }
 
 pub contract BingContract {
-    pub fn add(_ x: u256, _ y: u256) -> u256 {
+    pub fn add(self, _ x: u256, _ y: u256) -> u256 {
         return x + y
     }
 }

--- a/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
@@ -8,6 +8,6 @@ contract FooBarBing {
 
     pub fn create_foobar_contract(ctx: Context) -> u256 {
         let foo_bar: FooBar = FooBar.create(ctx, 0)
-        return foo_bar.add(40, 50)
+        return FooBar::add(40, 50)
     }
 }

--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -29,31 +29,31 @@ contract Foo {
         self.my_tuple = some_tuple
     }
 
-    pub fn get_string() -> String<10> {
+    pub fn get_string(self) -> String<10> {
         return String<10>("hi")
     }
 
-    pub fn get_array() -> Array<u16, 4> {
+    pub fn get_array(self) -> Array<u16, 4> {
         return [u16(1), u16(2), u16(3), u16(257)]
     }
 
-    pub fn get_tuple() -> (u256, u256, bool) {
+    pub fn get_tuple(self) -> (u256, u256, bool) {
         return (42, 26, false)
     }
 
-    pub fn do_revert() {
+    pub fn do_revert(self) {
         revert
     }
 
-    pub fn do_revert2() -> bool {
+    pub fn do_revert2(self) -> bool {
         revert
     }
 
-    pub fn do_revert_with_data() {
+    pub fn do_revert_with_data(self) {
         revert SomeError(code: 4711)
     }
 
-    pub fn do_revert_with_data2() -> bool {
+    pub fn do_revert_with_data2(self) -> bool {
         revert SomeError(code: 4711)
     }
 }

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -1479,6 +1479,13 @@ fn external_contract() {
             Some(&uint_array_token(&[a, c, b])),
         );
 
+        proxy_harness.test_function(
+            &mut executor,
+            "add",
+            &[uint_token(a), uint_token(b)],
+            Some(&uint_token(68)),
+        );
+
         foo_harness.events_emitted(executor, &[("MyEvent", &[my_num, my_addrs, my_string])]);
 
         assert_harness_gas_report!(proxy_harness);

--- a/crates/tests/src/snapshots/fe_compiler_tests__demo_uniswap__uniswap_contracts.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__demo_uniswap__uniswap_contracts.snap
@@ -12,7 +12,7 @@ balanceOf([Address(0x0000000000000000000000000000000000000000)]) used 621 gas
 get_reserves([]) used 797 gas
 swap([Uint(1993), Uint(0), Address(0x0000000000000000000000000000000000000042)]) used 36362 gas
 get_reserves([]) used 797 gas
-transfer([Address(0x3d221dfb6bdc353ad2e9b148e86f5e7c4a8edfb3), Uint(141421356237309503880)]) used 5795 gas
+transfer([Address(0x57a4f26f3614afce2434dd6bb3931ce32644dd26), Uint(141421356237309503880)]) used 5795 gas
 burn([Address(0x1000000000000000000000000000000000000001)]) used 3634 gas
 get_reserves([]) used 797 gas
 

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__external_contract.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__external_contract.snap
@@ -4,5 +4,6 @@ expression: "format!(\"{}\", proxy_harness.gas_reporter)"
 
 ---
 call_emit_event([Address(0x5dddfce53ee040d9eb21afbc0ae1bb4dbb0ba643), Uint(26), FixedArray([Address(0x0000000000000000000000000000000000000000), Address(0x0000000000000000000000000000000000000001), Address(0x0000000000000000000000000000000000000042), Address(0x0000000000000000000000000000000000000003), Address(0x0000000000000000000000000000000000000004)]), String("hello world")]) used 8249 gas
-call_build_array([Address(0x5dddfce53ee040d9eb21afbc0ae1bb4dbb0ba643), Uint(26), Uint(42)]) used 1956 gas
+call_build_array([Address(0x5dddfce53ee040d9eb21afbc0ae1bb4dbb0ba643), Uint(26), Uint(42)]) used 1963 gas
+add([Uint(26), Uint(42)]) used 313 gas
 

--- a/newsfragments/775.bugfix.md
+++ b/newsfragments/775.bugfix.md
@@ -1,0 +1,2 @@
+Certain cases where the compiler would not reject pure functions
+being called on instances are now properly rejected.


### PR DESCRIPTION
### What was wrong?

There were certain cases were the compiler did not reject code where a pure fn was called on an instance.

### How was it fixed?

Minor tweak
