### PR TITLE
Change comments from using `#` to using `//`

### DIFF
--- a/crates/analyzer/tests/snapshots/analysis__const_generics.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_generics.snap
@@ -7,7 +7,7 @@ note:
    ┌─ const_generics.fe:2:5
    │  
  2 │ ╭     pub fn bar() {
- 3 │ │         # const generics with literal.
+ 3 │ │         // const generics with literal.
  4 │ │         let array_lit: Array<i32, 8> = [i32(0); 8]
  5 │ │         let array_lit2: Array<i32, { 8 }> = [i32(0); 8]
    · │

--- a/crates/analyzer/tests/snapshots/analysis__const_local.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_local.snap
@@ -24,21 +24,21 @@ note:
    │               ^^ i64
  5 │         const C3: i64 = 10
    │               ^^ i64
- 6 │         const C4: i64 = (C1 * C2) + C3 # 12
+ 6 │         const C4: i64 = (C1 * C2) + C3 // 12
    │               ^^ i64
  7 │         const EXP: u8 = 2
    │               ^^^ u8
- 8 │         const C5: i64 = (C2 ** EXP) # 4
+ 8 │         const C5: i64 = (C2 ** EXP) // 4
    │               ^^ i64
- 9 │         const C6: i64 = (C5 << 1) # 8
+ 9 │         const C6: i64 = (C5 << 1) // 8
    │               ^^ i64
-10 │         const C7: bool = (C5 < C6) and (C4 > C5) # true
+10 │         const C7: bool = (C5 < C6) and (C4 > C5) // true
    │               ^^ bool
 11 │         const C8: bool = false
    │               ^^ bool
-12 │         const C9: bool = C8 < C7 # true
+12 │         const C9: bool = C8 < C7 // true
    │               ^^ bool
-13 │         const C10: u256 = 42 if C9 else 0 # 42
+13 │         const C10: u256 = 42 if C9 else 0 // 42
    │               ^^^ u256
 14 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
    │             ^^^^ Array<bool, 42>
@@ -52,7 +52,7 @@ note:
   │                         ^ i64: Value
 5 │         const C3: i64 = 10
   │                         ^^ i64: Value
-6 │         const C4: i64 = (C1 * C2) + C3 # 12
+6 │         const C4: i64 = (C1 * C2) + C3 // 12
   │                          ^^   ^^ i64: Value
   │                          │     
   │                          i64: Value
@@ -60,7 +60,7 @@ note:
 note: 
   ┌─ const_local.fe:6:25
   │
-6 │         const C4: i64 = (C1 * C2) + C3 # 12
+6 │         const C4: i64 = (C1 * C2) + C3 // 12
   │                         ^^^^^^^^^   ^^ i64: Value
   │                         │            
   │                         i64: Value
@@ -68,11 +68,11 @@ note:
 note: 
   ┌─ const_local.fe:6:25
   │
-6 │         const C4: i64 = (C1 * C2) + C3 # 12
+6 │         const C4: i64 = (C1 * C2) + C3 // 12
   │                         ^^^^^^^^^^^^^^ i64: Value
 7 │         const EXP: u8 = 2
   │                         ^ u8: Value
-8 │         const C5: i64 = (C2 ** EXP) # 4
+8 │         const C5: i64 = (C2 ** EXP) // 4
   │                          ^^    ^^^ u8: Value
   │                          │      
   │                          i64: Value
@@ -80,9 +80,9 @@ note:
 note: 
   ┌─ const_local.fe:8:25
   │
-8 │         const C5: i64 = (C2 ** EXP) # 4
+8 │         const C5: i64 = (C2 ** EXP) // 4
   │                         ^^^^^^^^^^^ i64: Value
-9 │         const C6: i64 = (C5 << 1) # 8
+9 │         const C6: i64 = (C5 << 1) // 8
   │                          ^^    ^ u256: Value
   │                          │      
   │                          i64: Value
@@ -90,9 +90,9 @@ note:
 note: 
    ┌─ const_local.fe:9:25
    │
- 9 │         const C6: i64 = (C5 << 1) # 8
+ 9 │         const C6: i64 = (C5 << 1) // 8
    │                         ^^^^^^^^^ i64: Value
-10 │         const C7: bool = (C5 < C6) and (C4 > C5) # true
+10 │         const C7: bool = (C5 < C6) and (C4 > C5) // true
    │                           ^^   ^^ i64: Value
    │                           │     
    │                           i64: Value
@@ -100,7 +100,7 @@ note:
 note: 
    ┌─ const_local.fe:10:26
    │
-10 │         const C7: bool = (C5 < C6) and (C4 > C5) # true
+10 │         const C7: bool = (C5 < C6) and (C4 > C5) // true
    │                          ^^^^^^^^^      ^^   ^^ i64: Value
    │                          │              │     
    │                          │              i64: Value
@@ -109,17 +109,17 @@ note:
 note: 
    ┌─ const_local.fe:10:40
    │
-10 │         const C7: bool = (C5 < C6) and (C4 > C5) # true
+10 │         const C7: bool = (C5 < C6) and (C4 > C5) // true
    │                                        ^^^^^^^^^ bool: Value
 
 note: 
    ┌─ const_local.fe:10:26
    │
-10 │         const C7: bool = (C5 < C6) and (C4 > C5) # true
+10 │         const C7: bool = (C5 < C6) and (C4 > C5) // true
    │                          ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 11 │         const C8: bool = false
    │                          ^^^^^ bool: Value
-12 │         const C9: bool = C8 < C7 # true
+12 │         const C9: bool = C8 < C7 // true
    │                          ^^   ^^ bool: Value
    │                          │     
    │                          bool: Value
@@ -127,15 +127,15 @@ note:
 note: 
    ┌─ const_local.fe:12:26
    │
-12 │         const C9: bool = C8 < C7 # true
+12 │         const C9: bool = C8 < C7 // true
    │                          ^^^^^^^ bool: Value
-13 │         const C10: u256 = 42 if C9 else 0 # 42
+13 │         const C10: u256 = 42 if C9 else 0 // 42
    │                                 ^^ bool: Value
 
 note: 
    ┌─ const_local.fe:13:27
    │
-13 │         const C10: u256 = 42 if C9 else 0 # 42
+13 │         const C10: u256 = 42 if C9 else 0 // 42
    │                           ^^            ^ u256: Value
    │                           │              
    │                           u256: Value
@@ -143,7 +143,7 @@ note:
 note: 
    ┌─ const_local.fe:13:27
    │
-13 │         const C10: u256 = 42 if C9 else 0 # 42
+13 │         const C10: u256 = 42 if C9 else 0 // 42
    │                           ^^^^^^^^^^^^^^^ u256: Value
 14 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
    │                                 ^^^       ^^^^    ^^^ u256: Value

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -19,7 +19,7 @@ note:
    ┌─ guest_book.fe:16:5
    │  
 16 │ ╭     pub fn sign(self, ctx: Context, book_msg: String<100>) {
-17 │ │         # All storage access is explicit using `self.<some-key>`
+17 │ │         // All storage access is explicit using `self.<some-key>`
 18 │ │         self.messages[ctx.msg_sender()] = book_msg
 19 │ │ 
    · │
@@ -64,8 +64,8 @@ note:
    ┌─ guest_book.fe:25:5
    │  
 25 │ ╭     pub fn get_msg(self, addr: address) -> String<100> {
-26 │ │         # Copying data from storage to memory
-27 │ │         # has to be done explicitly via `to_mem()`
+26 │ │         // Copying data from storage to memory
+27 │ │         // has to be done explicitly via `to_mem()`
 28 │ │         return self.messages[addr].to_mem()
 29 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: addr, typ: address }] -> String<100>

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -868,8 +868,8 @@ note:
     ┌─ uniswap.fe:146:5
     │  
 146 │ ╭     fn _update(self, ctx: Context, balance0: u256, balance1: u256, reserve0: u256, reserve1: u256) {
-147 │ │         # changed from u32s
-148 │ │         # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
+147 │ │         // changed from u32s
+148 │ │         // TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
 149 │ │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     · │
 158 │ │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
@@ -1351,7 +1351,7 @@ note:
     │             ^^^^^^^ u256
 193 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │             ^^^^^^ bool
-194 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+194 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
     │             ^^^^^^^^^^^^ u256
 195 │         let liquidity: u256 = 0
     │             ^^^^^^^^^ u256
@@ -1465,13 +1465,13 @@ note:
     │
 193 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-194 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+194 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
     │                                  ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:194:34
     │
-194 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+194 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
     │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 195 │         let liquidity: u256 = 0
     │                               ^ u256: Value
@@ -1510,7 +1510,7 @@ note:
     │
 197 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
     │             ^^^^       ^^^              ^ u256: Value
     │             │          │                 
     │             │          Context: Memory
@@ -1519,7 +1519,7 @@ note:
 note: 
     ┌─ uniswap.fe:198:33
     │
-198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
     │                                 ^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ u256: Value
     │                                 │                   
     │                                 address: Value
@@ -1527,7 +1527,7 @@ note:
 note: 
     ┌─ uniswap.fe:198:13
     │
-198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 199 │         } else {
 200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
@@ -1613,13 +1613,13 @@ note:
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 205 │         if fee_on {
     │            ^^^^^^ bool: Value
-206 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+206 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
     │             ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:206:13
     │
-206 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+206 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
     │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │             │             │           
     │             │             u256: Value
@@ -1628,7 +1628,7 @@ note:
 note: 
     ┌─ uniswap.fe:206:27
     │
-206 │             self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+206 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
     │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
 207 │         }
 208 │         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
@@ -1679,11 +1679,11 @@ note:
 221 │ 
 222 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │             ^^^^^^ bool
-223 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+223 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
     │             ^^^^^^^^^^^^ u256
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │             ^^^^^^^ u256
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │             ^^^^^^^ u256
 
 note: 
@@ -1788,15 +1788,15 @@ note:
     │
 222 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-223 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+223 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
     │                                  ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:223:34
     │
-223 │         let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
+223 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
     │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │                              ^^^^^^^^^   ^^^^^^^^ u256: Value
     │                              │            
     │                              u256: Value
@@ -1804,7 +1804,7 @@ note:
 note: 
     ┌─ uniswap.fe:224:29
     │
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                         
     │                             u256: Value
@@ -1812,9 +1812,9 @@ note:
 note: 
     ┌─ uniswap.fe:224:29
     │
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
+224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │                              ^^^^^^^^^   ^^^^^^^^ u256: Value
     │                              │            
     │                              u256: Value
@@ -1822,7 +1822,7 @@ note:
 note: 
     ┌─ uniswap.fe:225:29
     │
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                         
     │                             u256: Value
@@ -1830,7 +1830,7 @@ note:
 note: 
     ┌─ uniswap.fe:225:29
     │
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 226 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
     │                ^^^^^^^   ^ u256: Value
@@ -2174,7 +2174,7 @@ note:
     │
 255 │         if amount0_out > 0 {
     │            ^^^^^^^^^^^^^^^ bool: Value
-256 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
+256 │             token0.transfer(to, amount0_out) // optimistically transfer tokens
     │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value
     │             │               │    
     │             │               address: Value
@@ -2183,7 +2183,7 @@ note:
 note: 
     ┌─ uniswap.fe:256:13
     │
-256 │             token0.transfer(to, amount0_out) # optimistically transfer tokens
+256 │             token0.transfer(to, amount0_out) // optimistically transfer tokens
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 257 │         }
 258 │         if amount1_out > 0 {
@@ -2196,7 +2196,7 @@ note:
     │
 258 │         if amount1_out > 0 {
     │            ^^^^^^^^^^^^^^^ bool: Value
-259 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
+259 │             token1.transfer(to, amount1_out) // optimistically transfer tokens
     │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value
     │             │               │    
     │             │               address: Value
@@ -2205,7 +2205,7 @@ note:
 note: 
     ┌─ uniswap.fe:259:13
     │
-259 │             token1.transfer(to, amount1_out) # optimistically transfer tokens
+259 │             token1.transfer(to, amount1_out) // optimistically transfer tokens
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     ·
 265 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
@@ -2486,8 +2486,8 @@ note:
     ┌─ uniswap.fe:283:5
     │  
 283 │ ╭     pub fn skim(self, ctx: Context, to: address) {
-284 │ │         let token0: ERC20 = self.token0 # gas savings
-285 │ │         let token1: ERC20 = self.token1 # gas savings
+284 │ │         let token0: ERC20 = self.token0 // gas savings
+285 │ │         let token1: ERC20 = self.token1 // gas savings
 286 │ │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
 287 │ │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
 288 │ │     }
@@ -2496,29 +2496,29 @@ note:
 note: 
     ┌─ uniswap.fe:284:13
     │
-284 │         let token0: ERC20 = self.token0 # gas savings
+284 │         let token0: ERC20 = self.token0 // gas savings
     │             ^^^^^^ ERC20
-285 │         let token1: ERC20 = self.token1 # gas savings
+285 │         let token1: ERC20 = self.token1 // gas savings
     │             ^^^^^^ ERC20
 
 note: 
     ┌─ uniswap.fe:284:29
     │
-284 │         let token0: ERC20 = self.token0 # gas savings
+284 │         let token0: ERC20 = self.token0 // gas savings
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:284:29
     │
-284 │         let token0: ERC20 = self.token0 # gas savings
+284 │         let token0: ERC20 = self.token0 // gas savings
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(5) } => Value
-285 │         let token1: ERC20 = self.token1 # gas savings
+285 │         let token1: ERC20 = self.token1 // gas savings
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:285:29
     │
-285 │         let token1: ERC20 = self.token1 # gas savings
+285 │         let token1: ERC20 = self.token1 // gas savings
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
 286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
     │         ^^^^^^          ^^  ^^^^^^           ^^^ Context: Memory

--- a/crates/analyzer/tests/snapshots/errors__call_create2_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_create2_with_wrong_type.snap
@@ -12,7 +12,7 @@ error: incorrect type for argument to `Bar.create2`
 error: `create2` expects 3 arguments, but 2 were provided
   ┌─ compile_errors/call_create2_with_wrong_type.fe:8:13
   │
-8 │         Bar.create2(ctx, 1)  # agroce #447
+8 │         Bar.create2(ctx, 1)  // agroce //447
   │             ^^^^^^^ ---  - supplied 2 arguments
   │             │             
   │             expects 3 arguments

--- a/crates/analyzer/tests/snapshots/errors__call_create_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_create_with_wrong_type.snap
@@ -12,7 +12,7 @@ error: incorrect type for argument to `Bar.create`
 error: `create` expects 2 arguments, but 1 was provided
   ┌─ compile_errors/call_create_with_wrong_type.fe:8:13
   │
-8 │         Bar.create(ctx)     # agroce #447
+8 │         Bar.create(ctx)     // agroce //447
   │             ^^^^^^ --- supplied 1 argument
   │             │       
   │             expects 2 arguments

--- a/crates/library/std/src/evm.fe
+++ b/crates/library/std/src/evm.fe
@@ -1,4 +1,4 @@
-# Basic context accessor functions.
+// Basic context accessor functions.
 pub unsafe fn chain_id() -> u256 {
   return __chainid()
 }
@@ -64,8 +64,8 @@ pub unsafe fn call_value() -> u256 {
 }
 
 
-# Overflowing math ops. Should these be unsafe or named
-# `overflowing_add`, etc?
+// Overflowing math ops. Should these be unsafe or named
+// `overflowing_add`, etc?
 pub fn add(_ x: u256, _ y: u256) -> u256 {
   unsafe { return __add(x, y) }
 }
@@ -111,8 +111,8 @@ pub fn sign_extend(_ i: u256, _ x: u256) -> u256 {
 }
 
 
-# Comparison ops
-# TODO: return bool (see issue #653)
+// Comparison ops
+// TODO: return bool (see issue //653)
 pub fn lt(_ x: u256, _ y: u256) -> u256 {
   unsafe { return __lt(x, y) }
 }
@@ -138,7 +138,7 @@ pub fn is_zero(_ x: u256) -> u256 {
 }
 
 
-# Bitwise ops
+// Bitwise ops
 pub fn bitwise_and(_ x: u256, _ y: u256) -> u256 {
   unsafe { return __and(x, y) }
 }
@@ -172,7 +172,7 @@ pub fn sar(_ x: u256, _ y: u256) -> u256 {
 }
 
 
-# Evm state access and control
+// Evm state access and control
 pub unsafe fn return_mem(offset: u256, len: u256) {
     __return(offset, len)
 }
@@ -185,9 +185,9 @@ pub unsafe fn selfdestruct(_ addr: address) {
     __selfdestruct(u256(addr))
 }
 
-# Invalid opcode. Equivalent to revert(0, 0),
-# except that all remaining gas in the current context
-# is consumed.
+// Invalid opcode. Equivalent to revert(0, 0),
+// except that all remaining gas in the current context
+// is consumed.
 pub unsafe fn invalid() {
     __invalid()
 }
@@ -200,10 +200,10 @@ pub unsafe fn pc() -> u256 {
     return __pc()
 }
 
-# TODO: dunno if we should enable this
-# pub unsafe fn pop(_ x: u256) {
-#     return __pop(x)
-# }
+// TODO: dunno if we should enable this
+// pub unsafe fn pop(_ x: u256) {
+//     return __pop(x)
+// }
 
 pub unsafe fn mload(offset p: u256) -> u256 {
     return __mload(p)
@@ -274,7 +274,7 @@ pub unsafe fn keccak256_mem(offset: u256, len: u256) -> u256 {
 }
 
 
-# Contract creation and calling
+// Contract creation and calling
 
 pub unsafe fn create(value v: u256, offset p: u256, len n: u256) -> address {
     return address(__create(v, p, n))
@@ -284,7 +284,7 @@ pub unsafe fn create2(value v: u256, offset p: u256, len n: u256, salt s: u256) 
     return address(__create2(v, p, n, s))
 }
 
-# TODO: return bool (success)
+// TODO: return bool (success)
 pub unsafe fn call(gas: u256, addr: address, value: u256, input_offset: u256, input_len: u256, output_offset: u256, output_len: u256) -> u256 {
     return __call(gas, u256(addr), value, input_offset, input_len, output_offset, output_len)
 }
@@ -301,7 +301,7 @@ pub unsafe fn static_call(gas: u256, addr: address, input_offset: u256, input_le
     return __staticcall(gas, u256(addr), input_offset, input_len, output_offset, output_len)
 }
 
-# Logging functions
+// Logging functions
 
 pub unsafe fn log0(offset p: u256, len s: u256) {
     return __log0(p, s)

--- a/crates/library/std/src/traits.fe
+++ b/crates/library/std/src/traits.fe
@@ -1,3 +1,3 @@
-# Dummy trait used in testing. We can remove this once we have more useful traits
+// Dummy trait used in testing. We can remove this once we have more useful traits
 
 pub trait Dummy {}

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn tabs_and_comment() {
         check(
-            "\n\t \tcontract\n\tFoo # hi mom!\n ",
+            "\n\t \tcontract\n\tFoo // hi mom!\n ",
             &[Newline, Contract, Newline, Name, Newline],
         );
     }

--- a/crates/parser/src/lexer/token.rs
+++ b/crates/parser/src/lexer/token.rs
@@ -29,7 +29,7 @@ impl<'a> Add<&Token<'a>> for Span {
 pub enum TokenKind {
     // Ignoring comments and spaces/tabs for now.
     // If we implement an auto-formatting tool, we'll probably want to change this.
-    #[regex(r"#[^\n]*", logos::skip)]
+    #[regex(r"//[^\n]*", logos::skip)]
     #[regex("[ \t]+", logos::skip)]
     #[error]
     Error,

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr1.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr1.fe
@@ -1,4 +1,4 @@
-# See ethereum/fe issue #396
+// See ethereum/fe issue //396
 contract foo {
     my_sto_tuple: (u256, i32)
 

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr2.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr2.fe
@@ -1,4 +1,4 @@
-# See ethereum/fe issue #399
+// See ethereum/fe issue //399
 contract foo {
     my_sto_tuple: (u256, i32)
 

--- a/crates/test-files/fixtures/compile_errors/bad_tuple_attr3.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_tuple_attr3.fe
@@ -1,4 +1,4 @@
-# See ethereum/fe issue #470
+// See ethereum/fe issue //470
 contract foo {
     my_sto_tuple: (u256, i32)
 

--- a/crates/test-files/fixtures/compile_errors/call_create2_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_create2_with_wrong_type.fe
@@ -5,7 +5,7 @@ contract Bar {}
 contract Foo {
     pub fn foo(ctx: Context) {
         Bar.create2(ctx, true, 1)
-        Bar.create2(ctx, 1)  # agroce #447
+        Bar.create2(ctx, 1)  // agroce //447
         Bar.create2(ctx)
     }
 }

--- a/crates/test-files/fixtures/compile_errors/call_create_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_create_with_wrong_type.fe
@@ -5,6 +5,6 @@ contract Bar {}
 contract Foo {
     pub fn foo(ctx: Context) {
         Bar.create(ctx, true)
-        Bar.create(ctx)     # agroce #447
+        Bar.create(ctx)     // agroce //447
     }
 }

--- a/crates/test-files/fixtures/compile_errors/struct_recursive_cycles.fe
+++ b/crates/test-files/fixtures/compile_errors/struct_recursive_cycles.fe
@@ -1,20 +1,20 @@
-# structs `Foo` and `Bar` contains indirect recursion
-# struct Foo depends on `Bar`
+// structs `Foo` and `Bar` contains indirect recursion
+// struct Foo depends on `Bar`
 struct Foo {
     x: Bar
 }
 
-# struct Bar depends on `Foo`
+// struct Bar depends on `Foo`
 struct Bar {
     x: Foo
 }
 
-# struct `Foo2` depends on itself - contains direct recursion
+// struct `Foo2` depends on itself - contains direct recursion
 struct Foo2 {
     x: Foo2
 }
 
-# struct `Bar2` has no recursion
+// struct `Bar2` has no recursion
 struct Bar2 {
     x: Foo
     y: Bar

--- a/crates/test-files/fixtures/compile_errors/undefined_type_param.fe
+++ b/crates/test-files/fixtures/compile_errors/undefined_type_param.fe
@@ -1,4 +1,4 @@
-# https://github.com/ethereum/fe/issues/530
+// https://github.com/ethereum/fe/issues/530
 
 struct BadField {
     pub x: MysteryType

--- a/crates/test-files/fixtures/demos/guest_book.fe
+++ b/crates/test-files/fixtures/demos/guest_book.fe
@@ -1,30 +1,30 @@
-# Context is a struct provided by the standard library
-# that gives access to various features of the EVM
+// Context is a struct provided by the standard library
+// that gives access to various features of the EVM
 use std::context::Context
 
-# The `contract` keyword defines a new contract type
+// The `contract` keyword defines a new contract type
 contract GuestBook {
-    # Strings are generic over a constant number
-    # that restricts its maximum size
+    // Strings are generic over a constant number
+    // that restricts its maximum size
     messages: Map<address, String<100>>
 
-    # Events can be defined on contract or module level
+    // Events can be defined on contract or module level
     event Signed {
         book_msg: String<100>
     }
 
     pub fn sign(self, ctx: Context, book_msg: String<100>) {
-        # All storage access is explicit using `self.<some-key>`
+        // All storage access is explicit using `self.<some-key>`
         self.messages[ctx.msg_sender()] = book_msg
 
-        # Emit the `Signed` event. In the future, this will change to:
-        # `ctx.emit(Signed(ctx, book_msg))`
+        // Emit the `Signed` event. In the future, this will change to:
+        // `ctx.emit(Signed(ctx, book_msg))`
         emit Signed(ctx, book_msg)
     }
 
     pub fn get_msg(self, addr: address) -> String<100> {
-        # Copying data from storage to memory
-        # has to be done explicitly via `to_mem()`
+        // Copying data from storage to memory
+        // has to be done explicitly via `to_mem()`
         return self.messages[addr].to_mem()
     }
 }

--- a/crates/test-files/fixtures/demos/simple_open_auction.fe
+++ b/crates/test-files/fixtures/demos/simple_open_auction.fe
@@ -1,6 +1,6 @@
 use std::context::Context
 
-# errors
+// errors
 struct AuctionAlreadyEnded {}
 struct AuctionNotYetEnded {}
 struct AuctionEndAlreadyCalled {}
@@ -10,7 +10,7 @@ struct BidNotHighEnough {
 }
 
 contract SimpleOpenAuction {
-    # states
+    // states
     auction_end_time: u256
     beneficiary: address
 
@@ -21,7 +21,7 @@ contract SimpleOpenAuction {
 
     ended: bool
 
-    # events
+    // events
     event HighestBidIncreased {
         idx bidder: address
         amount: u256
@@ -32,13 +32,13 @@ contract SimpleOpenAuction {
         amount: u256
     }
 
-    # constructor
+    // constructor
     pub fn __init__(self, ctx: Context, bidding_time: u256, beneficiary_addr: address) {
         self.beneficiary = beneficiary_addr
         self.auction_end_time = ctx.block_timestamp() + bidding_time
     }
 
-    #method
+    //method
     pub fn bid(self, ctx: Context) {
         if ctx.block_timestamp() > self.auction_end_time {
             revert AuctionAlreadyEnded()

--- a/crates/test-files/fixtures/demos/uniswap.fe
+++ b/crates/test-files/fixtures/demos/uniswap.fe
@@ -11,8 +11,8 @@ contract ERC20 {
 }
 
 contract UniswapV2Pair {
-    # TODO: const support (https://github.com/ethereum/fe/issues/192)
-    # const MINIMUM_LIQUIDITY: u256 = 1000
+    // TODO: const support (https://github.com/ethereum/fe/issues/192)
+    // const MINIMUM_LIQUIDITY: u256 = 1000
 
     balances: Map<address, u256>
     allowances: Map<address, Map<address, u256>>
@@ -135,17 +135,17 @@ contract UniswapV2Pair {
         return (self.reserve0, self.reserve1, self.block_timestamp_last)
     }
 
-    # called once by the factory at time of deployment
+    // called once by the factory at time of deployment
     pub fn initialize(self, ctx: Context, token0: ERC20, token1: ERC20) {
         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
         self.token0 = token0
         self.token1 = token1
     }
 
-    # update reserves and, on the first call per block, price accumulators
+    // update reserves and, on the first call per block, price accumulators
     fn _update(self, ctx: Context, balance0: u256, balance1: u256, reserve0: u256, reserve1: u256) {
-        # changed from u32s
-        # TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
+        // changed from u32s
+        // TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
@@ -181,7 +181,7 @@ contract UniswapV2Pair {
         return fee_on
     }
 
-    # this low-level function should be called from a contract which performs important safety checks
+    // this low-level function should be called from a contract which performs important safety checks
     pub fn mint(self, ctx: Context, to: address) -> u256 {
         let MINIMUM_LIQUIDITY: u256 = 1000
         let reserve0: u256 = self.reserve0
@@ -191,11 +191,11 @@ contract UniswapV2Pair {
         let amount0: u256 = balance0 - self.reserve0
         let amount1: u256 = balance1 - self.reserve1
         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
-        let total_supply: u256 = self.total_supply # gas savings, must be defined here since totalSupply can update in _mintFee
+        let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
         let liquidity: u256 = 0
         if total_supply == 0 {
             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
-            self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) # permanently lock the first MINIMUM_LIQUIDITY tokens
+            self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
         } else {
             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
         }
@@ -203,13 +203,13 @@ contract UniswapV2Pair {
         self._mint(ctx, to, value: liquidity)
         self._update(ctx, balance0, balance1, reserve0, reserve1)
         if fee_on {
-            self.k_last = reserve0 * reserve1 # reserve0 and reserve1 are up-to-date
+            self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
         }
         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
         return liquidity
     }
 
-    # this low-level function should be called from a contract which performs important safety checks
+    // this low-level function should be called from a contract which performs important safety checks
     pub fn burn(self, ctx: Context, to: address) -> (u256, u256) {
         let reserve0: u256 = self.reserve0
         let reserve1: u256 = self.reserve1
@@ -220,9 +220,9 @@ contract UniswapV2Pair {
         let liquidity: u256 = self.balances[ctx.self_address()]
 
         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
-        let total_supply: u256 = self.total_supply # gas savings, must be defined here since total_supply can update in _mintFee
-        let amount0: u256 = (liquidity * balance0) / total_supply # using balances ensures pro-rata distribution
-        let amount1: u256 = (liquidity * balance1) / total_supply # using balances ensures pro-rata distribution
+        let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
+        let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
+        let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
         self._burn(ctx, from: ctx.self_address(), value: liquidity)
         token0.transfer(to, amount0)
@@ -237,9 +237,9 @@ contract UniswapV2Pair {
         return (amount0, amount1)
     }
 
-    # this low-level function should be called from a contract which performs important safety checks
-    # TODO: add support for the bytes type (https://github.com/ethereum/fe/issues/280)
-    # pub fn swap(amount0_out: u256, amount1_out: u256, to: address, data: bytes):
+    // this low-level function should be called from a contract which performs important safety checks
+    // TODO: add support for the bytes type (https://github.com/ethereum/fe/issues/280)
+    // pub fn swap(amount0_out: u256, amount1_out: u256, to: address, data: bytes):
     pub fn swap(self, ctx: Context, amount0_out: u256, amount1_out: u256, to: address) {
         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
         let reserve0: u256 = self.reserve0
@@ -249,18 +249,18 @@ contract UniswapV2Pair {
         let token0: ERC20 = self.token0
         let token1: ERC20 = self.token1
 
-        # TODO: we should be using `token0.address` (https://github.com/ethereum/fe/issues/287)
+        // TODO: we should be using `token0.address` (https://github.com/ethereum/fe/issues/287)
         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
 
         if amount0_out > 0 {
-            token0.transfer(to, amount0_out) # optimistically transfer tokens
+            token0.transfer(to, amount0_out) // optimistically transfer tokens
         }
         if amount1_out > 0 {
-            token1.transfer(to, amount1_out) # optimistically transfer tokens
+            token1.transfer(to, amount1_out) // optimistically transfer tokens
         }
-        # TODO: bytes support
-        # if data.length > 0:
-        #     IUniswapV2Callee(to).uniswapV2Call(msg.sender, amount0_out, amount1_out, data)
+        // TODO: bytes support
+        // if data.length > 0:
+        //     IUniswapV2Callee(to).uniswapV2Call(msg.sender, amount0_out, amount1_out, data)
 
         let balance0: u256 = token0.balanceOf(ctx.self_address())
         let balance1: u256 = token1.balanceOf(ctx.self_address())
@@ -279,15 +279,15 @@ contract UniswapV2Pair {
         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
     }
 
-    # force balances to match reserves
+    // force balances to match reserves
     pub fn skim(self, ctx: Context, to: address) {
-        let token0: ERC20 = self.token0 # gas savings
-        let token1: ERC20 = self.token1 # gas savings
+        let token0: ERC20 = self.token0 // gas savings
+        let token1: ERC20 = self.token1 // gas savings
         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
     }
 
-    # force reserves to match balances
+    // force reserves to match balances
     pub fn sync(self, ctx: Context) {
         let token0: ERC20 = self.token0
         let token1: ERC20 = self.token1

--- a/crates/test-files/fixtures/features/const_generics.fe
+++ b/crates/test-files/fixtures/features/const_generics.fe
@@ -1,17 +1,17 @@
 contract Foo {
     pub fn bar() {
-        # const generics with literal.
+        // const generics with literal.
         let array_lit: Array<i32, 8> = [i32(0); 8]
         let array_lit2: Array<i32, { 8 }> = [i32(0); 8]
 
-        # const generics with ternary expression.
+        // const generics with ternary expression.
         let array_ternary: Array<i32, { 3 if false else 8 }> = [i32(0); { 3 if false else 8 }]
 
-        # const generics with logical expression.
+        // const generics with logical expression.
         let array_logical_or: Array<i32, { 8 if (true or false) else 0 }> = [i32(0); { 8 if (true or false) else 0 }]
         let array_logical_and: Array<i32, { 0 if (true and false) else 8 }> = [i32(0); { 0 if (true and false) else 8 }]
 
-        # const generics with binary expression.
+        // const generics with binary expression.
         let array_add: Array<i32, { 5 + 3 }> = [i32(42); 8]
         let array_sub: Array<i32, { 10 -  2 }> = [i32(26); 8]
         let array_mul: Array<i32, { 2 * 4 }> = [i32(0); 8]
@@ -24,7 +24,7 @@ contract Foo {
         let array_xor: Array<i32, { 0b1111 ^ 0b0111 }> = [i32(0); 8]
         let array_bitand: Array<i32, { 0b1010 & 0b1101 }> = [i32(0); 8]
 
-        # const generics with comparison expression.
+        // const generics with comparison expression.
         let array_eq: Array<i32, { 8 if 10 == 10 else 0 }> = [i32(0); 8]
         let array_ne: Array<i32, { 8 if 10 != 0 else 0 }> = [i32(0); 8]
         let array_lt1: Array<i32, { 8 if 0 < 10 else 0 }> = [i32(0); 8]
@@ -36,10 +36,10 @@ contract Foo {
         let array_gte: Array<i32, { 1 if 0 >= 10 else 8 }> = [i32(0); 8]
         let array_gte2: Array<i32, { 8 if 10 >= 10 else 0 }> = [i32(0); 8]
 
-        # const generics with unary expression.
+        // const generics with unary expression.
         let array_not: Array<i32, { 8 if not false else 0 }> = [i32(0); 8]
 
-        # const generics with const variable.
+        // const generics with const variable.
         const DOUBLE_ARRAY_LENGTH: u64 = 16
         const TWO: u64 = 2
 

--- a/crates/test-files/fixtures/features/const_local.fe
+++ b/crates/test-files/fixtures/features/const_local.fe
@@ -3,14 +3,14 @@ contract Foo {
         const C1: i64 = 1
         const C2: i64 = 2
         const C3: i64 = 10
-        const C4: i64 = (C1 * C2) + C3 # 12
+        const C4: i64 = (C1 * C2) + C3 // 12
         const EXP: u8 = 2
-        const C5: i64 = (C2 ** EXP) # 4
-        const C6: i64 = (C5 << 1) # 8
-        const C7: bool = (C5 < C6) and (C4 > C5) # true
+        const C5: i64 = (C2 ** EXP) // 4
+        const C6: i64 = (C5 << 1) // 8
+        const C7: bool = (C5 < C6) and (C4 > C5) // true
         const C8: bool = false
-        const C9: bool = C8 < C7 # true
-        const C10: u256 = 42 if C9 else 0 # 42
+        const C9: bool = C8 < C7 // true
+        const C10: u256 = 42 if C9 else 0 // 42
         let _arr: Array<bool, { C10 }> = [true; { C10 }]
         return C10
     }

--- a/docs/src/spec/comments.md
+++ b/docs/src/spec/comments.md
@@ -2,4 +2,4 @@
 
 > **<sup>Lexer</sup>**\
 > LINE_COMMENT :\
-> &nbsp;&nbsp; &nbsp;&nbsp; `#` <sup>*</sup>
+> &nbsp;&nbsp; &nbsp;&nbsp; `//` <sup>*</sup>

--- a/docs/theme/custom-highlight.js
+++ b/docs/theme/custom-highlight.js
@@ -78,7 +78,7 @@ function highlight_fe(hljs) {
         end: '"',
         contains: [{ begin: "\\\\." }],
       },
-      hljs.COMMENT("#", "\n"),
+      hljs.COMMENT("//", "\n"),
     ],
   }
 }

--- a/newsfragments/776.feature.md
+++ b/newsfragments/776.feature.md
@@ -1,0 +1,1 @@
+Changed comments to use `//` instead of `#`

--- a/website/index.html
+++ b/website/index.html
@@ -195,34 +195,34 @@
   23
 
                       </div>
-                      <code class="language-python flex-auto relative block text-white pt-4 pb-4 px-4 overflow-auto">
-# Context is a struct provided by the standard library
-# that gives access to various features of the EVM
+                      <code class="language-fe flex-auto relative block text-white pt-4 pb-4 px-4 overflow-auto">
+// Context is a struct provided by the standard library
+// that gives access to various features of the EVM
 use std::context::Context
 
-# The `contract` keyword defines a new contract type
+// The `contract` keyword defines a new contract type
 contract GuestBook {
-    # Strings are generic over a constant number
-    # that restricts its maximum size
+    // Strings are generic over a constant number
+    // that restricts its maximum size
     messages: Map&lt;address, String&lt;100&gt;&gt;
 
-    # Events can be defined on contract or module level
+    // Events can be defined on contract or module level
     event Signed {
         book_msg: String&lt;100&gt;
     }
 
     pub fn sign(self, ctx: Context, book_msg: String&lt;100&gt;) {
-        # All storage access is explicit using `self.&lt;some-key&gt;`
+        // All storage access is explicit using `self.&lt;some-key&gt;`
         self.messages[ctx.msg_sender()] = book_msg
 
-        # Emit the `Signed` event. In the future, this will change to:
-        # `ctx.emit(Signed(ctx, book_msg))`
+        // Emit the `Signed` event. In the future, this will change to:
+        // `ctx.emit(Signed(ctx, book_msg))`
         emit Signed(ctx, book_msg)
     }
 
     pub fn get_msg(self, addr: address) -> String&lt;100&gt; {
-        # Copying data from storage to memory
-        # has to be done explicitly via `to_mem()`
+        // Copying data from storage to memory
+        // has to be done explicitly via `to_mem()`
         return self.messages[addr].to_mem()
     }
 }
@@ -348,7 +348,7 @@ contract GuestBook {
 
   </script>
   <script src="https://unpkg.com/@highlightjs/cdn-assets@10.7.2/highlight.min.js"></script>
-  <script src="https://unpkg.com/@highlightjs/cdn-assets@10.7.2/languages/python.min.js"></script>
+  <script src="docs/theme/custom-highlight.js"></script>
   <script>hljs.highlightAll();</script>
 </body>
 </html>


### PR DESCRIPTION
### What was wrong?

It seems like we have consensus that we don't want to continue to use `#` for comments but rather use `//` instead. This PR changes that.

### How was it fixed?

- Tiny change in the parser
- Updated code files
- Updated examples + docs
- Updated highlight.js on the website to use the custom `fe` highlighting that the docs already use