### PR TITLE
Documentation Build Command

### DIFF
--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -50,7 +50,7 @@ contract GuestBook {
 }
 ```
 
-If you haven't already, run `./fe guest_book.fe --overwrite` to obtain the bytecode that we want to deploy.
+If you haven't already, run `./fe build guest_book.fe --overwrite` to obtain the bytecode that we want to deploy.
 
 To make the deployment, we will need to send a transaction to a node that participates in the Görli network. We can run our own node, sign up at [Infura](https://infura.io/) or [Alchemy](https://www.alchemy.com/) to use one of their nodes or find an open public node such as `https://goerli-light.eth.linkpool.io` which we will use to keep this tutorial as accessible as possible.
 

--- a/docs/src/quickstart/first_contract.md
+++ b/docs/src/quickstart/first_contract.md
@@ -25,7 +25,7 @@ Here we're using a [`map`](../spec/type_system/types/map.md) to associate messag
 The messages will simply be a [`string`](../spec/type_system/types/string.md) of a maximum length of `100` written as `String<100>`.
 The addresses are represented by the builtin [`address`](../spec/type_system/types/address.md) type.
 
-Execute `./fe guest_book.fe` to compile the file. The compiler tells us that it compiled our contract and that it has put the artifacts into a subdirectory called `output`.
+Execute `./fe build guest_book.fe` to compile the file. The compiler tells us that it compiled our contract and that it has put the artifacts into a subdirectory called `output`.
 
 ```
 Compiled guest_book.fe. Outputs in `output`
@@ -74,7 +74,7 @@ Failed to write output to directory: `output`. Error: Directory 'output' is not 
 
 Oops, the compiler is telling us that the `output` directory is a non-empty directory and plays it safe by asking us if we are sure that we want to overwrite it. We have to use the `--overwrite` flag to allow the compiler to overwrite what is stored in the `output` directory.
 
-Let's try it again with `./fe guest_book.fe --overwrite`.
+Let's try it again with `./fe build guest_book.fe --overwrite`.
 
 This time it worked and we can also see that the `GuestBook_abi.json` has become slightly more interesting.
 


### PR DESCRIPTION
### What was wrong?

- As far as I understand, the docs referenced an outdated build command for the guest book contract demo


### How was it fixed?

- Replaced build command instances of `./fe <TARGET>` with `./fe build <TARGET>`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
