### PR TITLE
Automatically `use std::prelude::*` in every user module

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Run `fe --help` to explore further options.
 The following is a simple contract implemented in Fe.
 
 ```rust
-use std::context::Context
-
 contract GuestBook {
     messages: Map<address, String<100>>
 

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -258,8 +258,7 @@ impl Item {
     }
 }
 
-// Placeholder; someday std::prelude will be a proper module.
-pub fn std_prelude_items() -> IndexMap<SmolStr, Item> {
+pub fn builtin_items() -> IndexMap<SmolStr, Item> {
     let mut items = indexmap! {
         SmolStr::new("bool") => Item::Type(TypeDef::Primitive(types::Base::Bool)),
         SmolStr::new("address") => Item::Type(TypeDef::Primitive(types::Base::Address)),
@@ -689,7 +688,7 @@ impl ModuleId {
             .external_ingots(db)
             .iter()
             .map(|(name, ingot)| (name.clone(), Item::Ingot(*ingot)))
-            .chain(std_prelude_items())
+            .chain(builtin_items())
             .collect::<IndexMap<_, _>>();
 
         if ingot.data(db).mode != IngotMode::StandaloneModule {

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1895,7 +1895,7 @@ fn expr_call_type_attribute(
                                 vec![
                                     Label::primary(
                                         args.span,
-                                        "`ctx` must be defined and passed into the function",
+                                        "`ctx` must be passed into the function",
                                     ),
                                     Label::secondary(
                                         context.parent_function().name_span(context.db()),
@@ -1906,10 +1906,7 @@ fn expr_call_type_attribute(
                                         "Example: `pub fn foo(ctx: Context, ...)`",
                                     ),
                                 ],
-                                vec![
-                                    "Note: import context with `use std::context::Context`".into(),
-                                    "Example: `MyContract.create(ctx, 0)`".into(),
-                                ],
+                                vec!["Example: `MyContract.create(ctx, 0)`".into()],
                             );
                         }
                     } else if !attrs.typ.is_integer(context.db()) {

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -219,10 +219,7 @@ fn emit(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) -> Result<(), FatalEr
                                 "Example: `pub fn foo(ctx: Context, ...)`",
                             ),
                         ],
-                        vec![
-                            "Note: import context with `use std::context::Context`".into(),
-                            "Example: emit MyEvent(ctx, ...)".into(),
-                        ],
+                        vec!["Example: emit MyEvent(ctx, ...)".into()],
                     );
                 }
             }

--- a/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__abi_encoding_stress.snap
@@ -4,516 +4,516 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ abi_encoding_stress.fe:4:5
+  ┌─ abi_encoding_stress.fe:2:5
   │
-4 │     pub my_num: u256
+2 │     pub my_num: u256
   │     ^^^^^^^^^^^^^^^^ u256
-5 │     pub my_num2: u8
+3 │     pub my_num2: u8
   │     ^^^^^^^^^^^^^^^ u8
-6 │     pub my_bool: bool
+4 │     pub my_bool: bool
   │     ^^^^^^^^^^^^^^^^^ bool
-7 │     pub my_addr: address
+5 │     pub my_addr: address
   │     ^^^^^^^^^^^^^^^^^^^^ address
 
 note: 
-   ┌─ abi_encoding_stress.fe:11:5
+   ┌─ abi_encoding_stress.fe:9:5
    │
-11 │     my_addrs: Array<address, 5>
+ 9 │     my_addrs: Array<address, 5>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
-12 │     my_u128: u128
+10 │     my_u128: u128
    │     ^^^^^^^^^^^^^ u128
-13 │     my_string: String<10>
+11 │     my_string: String<10>
    │     ^^^^^^^^^^^^^^^^^^^^^ String<10>
-14 │     my_u16s: Array<u16, 255>
+12 │     my_u16s: Array<u16, 255>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>
-15 │     my_bool: bool
+13 │     my_bool: bool
    │     ^^^^^^^^^^^^^ bool
-16 │     my_bytes: Array<u8, 100>
+14 │     my_bytes: Array<u8, 100>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>
 
 note: 
-   ┌─ abi_encoding_stress.fe:19:9
+   ┌─ abi_encoding_stress.fe:17:9
    │
-19 │         my_addrs: Array<address, 5>
+17 │         my_addrs: Array<address, 5>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
-20 │         my_u128: u128
+18 │         my_u128: u128
    │         ^^^^^^^^^^^^^ u128
-21 │         my_string: String<10>
+19 │         my_string: String<10>
    │         ^^^^^^^^^^^^^^^^^^^^^ String<10>
-22 │         my_u16s: Array<u16, 255>
+20 │         my_u16s: Array<u16, 255>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>
-23 │         my_bool: bool
+21 │         my_bool: bool
    │         ^^^^^^^^^^^^^ bool
-24 │         my_bytes: Array<u8, 100>
+22 │         my_bytes: Array<u8, 100>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>
 
 note: 
-   ┌─ abi_encoding_stress.fe:27:5
+   ┌─ abi_encoding_stress.fe:25:5
    │  
-27 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 5>) {
-28 │ │         self.my_addrs = my_addrs
-29 │ │     }
+25 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 5>) {
+26 │ │         self.my_addrs = my_addrs
+27 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_addrs, typ: Array<address, 5> }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:28:9
+   ┌─ abi_encoding_stress.fe:26:9
    │
-28 │         self.my_addrs = my_addrs
+26 │         self.my_addrs = my_addrs
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:28:9
+   ┌─ abi_encoding_stress.fe:26:9
    │
-28 │         self.my_addrs = my_addrs
+26 │         self.my_addrs = my_addrs
    │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 5>: Memory
    │         │                
    │         Array<address, 5>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:31:5
+   ┌─ abi_encoding_stress.fe:29:5
    │  
-31 │ ╭     pub fn get_my_addrs(self) -> Array<address, 5> {
-32 │ │         return self.my_addrs.to_mem()
-33 │ │     }
+29 │ ╭     pub fn get_my_addrs(self) -> Array<address, 5> {
+30 │ │         return self.my_addrs.to_mem()
+31 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> Array<address, 5>
 
 note: 
-   ┌─ abi_encoding_stress.fe:32:16
+   ┌─ abi_encoding_stress.fe:30:16
    │
-32 │         return self.my_addrs.to_mem()
+30 │         return self.my_addrs.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:32:16
+   ┌─ abi_encoding_stress.fe:30:16
    │
-32 │         return self.my_addrs.to_mem()
+30 │         return self.my_addrs.to_mem()
    │                ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:32:16
+   ┌─ abi_encoding_stress.fe:30:16
    │
-32 │         return self.my_addrs.to_mem()
+30 │         return self.my_addrs.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:35:5
+   ┌─ abi_encoding_stress.fe:33:5
    │  
-35 │ ╭     pub fn set_my_u128(self, my_u128: u128) {
-36 │ │         self.my_u128 = my_u128
-37 │ │     }
+33 │ ╭     pub fn set_my_u128(self, my_u128: u128) {
+34 │ │         self.my_u128 = my_u128
+35 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_u128, typ: u128 }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:36:9
+   ┌─ abi_encoding_stress.fe:34:9
    │
-36 │         self.my_u128 = my_u128
+34 │         self.my_u128 = my_u128
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:36:9
+   ┌─ abi_encoding_stress.fe:34:9
    │
-36 │         self.my_u128 = my_u128
+34 │         self.my_u128 = my_u128
    │         ^^^^^^^^^^^^   ^^^^^^^ u128: Value
    │         │               
    │         u128: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:39:5
+   ┌─ abi_encoding_stress.fe:37:5
    │  
-39 │ ╭     pub fn get_my_u128(self) -> u128 {
-40 │ │         return self.my_u128
-41 │ │     }
+37 │ ╭     pub fn get_my_u128(self) -> u128 {
+38 │ │         return self.my_u128
+39 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> u128
 
 note: 
-   ┌─ abi_encoding_stress.fe:40:16
+   ┌─ abi_encoding_stress.fe:38:16
    │
-40 │         return self.my_u128
+38 │         return self.my_u128
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:40:16
+   ┌─ abi_encoding_stress.fe:38:16
    │
-40 │         return self.my_u128
+38 │         return self.my_u128
    │                ^^^^^^^^^^^^ u128: Storage { nonce: Some(1) } => Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:43:5
+   ┌─ abi_encoding_stress.fe:41:5
    │  
-43 │ ╭     pub fn set_my_string(self, my_string: String<10>) {
-44 │ │         self.my_string = my_string
-45 │ │     }
+41 │ ╭     pub fn set_my_string(self, my_string: String<10>) {
+42 │ │         self.my_string = my_string
+43 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_string, typ: String<10> }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:44:9
+   ┌─ abi_encoding_stress.fe:42:9
    │
-44 │         self.my_string = my_string
+42 │         self.my_string = my_string
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:44:9
+   ┌─ abi_encoding_stress.fe:42:9
    │
-44 │         self.my_string = my_string
+42 │         self.my_string = my_string
    │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<10>: Memory
    │         │                 
    │         String<10>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:47:5
+   ┌─ abi_encoding_stress.fe:45:5
    │  
-47 │ ╭     pub fn get_my_string(self) -> String<10> {
-48 │ │         return self.my_string.to_mem()
-49 │ │     }
+45 │ ╭     pub fn get_my_string(self) -> String<10> {
+46 │ │         return self.my_string.to_mem()
+47 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> String<10>
 
 note: 
-   ┌─ abi_encoding_stress.fe:48:16
+   ┌─ abi_encoding_stress.fe:46:16
    │
-48 │         return self.my_string.to_mem()
+46 │         return self.my_string.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:48:16
+   ┌─ abi_encoding_stress.fe:46:16
    │
-48 │         return self.my_string.to_mem()
+46 │         return self.my_string.to_mem()
    │                ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:48:16
+   ┌─ abi_encoding_stress.fe:46:16
    │
-48 │         return self.my_string.to_mem()
+46 │         return self.my_string.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:51:5
+   ┌─ abi_encoding_stress.fe:49:5
    │  
-51 │ ╭     pub fn set_my_u16s(self, my_u16s: Array<u16, 255>) {
-52 │ │         self.my_u16s = my_u16s
-53 │ │     }
+49 │ ╭     pub fn set_my_u16s(self, my_u16s: Array<u16, 255>) {
+50 │ │         self.my_u16s = my_u16s
+51 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_u16s, typ: Array<u16, 255> }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:52:9
+   ┌─ abi_encoding_stress.fe:50:9
    │
-52 │         self.my_u16s = my_u16s
+50 │         self.my_u16s = my_u16s
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:52:9
+   ┌─ abi_encoding_stress.fe:50:9
    │
-52 │         self.my_u16s = my_u16s
+50 │         self.my_u16s = my_u16s
    │         ^^^^^^^^^^^^   ^^^^^^^ Array<u16, 255>: Memory
    │         │               
    │         Array<u16, 255>: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:55:5
+   ┌─ abi_encoding_stress.fe:53:5
    │  
-55 │ ╭     pub fn get_my_u16s(self) -> Array<u16, 255> {
-56 │ │         return self.my_u16s.to_mem()
-57 │ │     }
+53 │ ╭     pub fn get_my_u16s(self) -> Array<u16, 255> {
+54 │ │         return self.my_u16s.to_mem()
+55 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> Array<u16, 255>
 
 note: 
-   ┌─ abi_encoding_stress.fe:56:16
+   ┌─ abi_encoding_stress.fe:54:16
    │
-56 │         return self.my_u16s.to_mem()
+54 │         return self.my_u16s.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:56:16
+   ┌─ abi_encoding_stress.fe:54:16
    │
-56 │         return self.my_u16s.to_mem()
+54 │         return self.my_u16s.to_mem()
    │                ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:56:16
+   ┌─ abi_encoding_stress.fe:54:16
    │
-56 │         return self.my_u16s.to_mem()
+54 │         return self.my_u16s.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:59:5
+   ┌─ abi_encoding_stress.fe:57:5
    │  
-59 │ ╭     pub fn set_my_bool(self, my_bool: bool) {
-60 │ │         self.my_bool = my_bool
-61 │ │     }
+57 │ ╭     pub fn set_my_bool(self, my_bool: bool) {
+58 │ │         self.my_bool = my_bool
+59 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_bool, typ: bool }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:60:9
+   ┌─ abi_encoding_stress.fe:58:9
    │
-60 │         self.my_bool = my_bool
+58 │         self.my_bool = my_bool
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:60:9
+   ┌─ abi_encoding_stress.fe:58:9
    │
-60 │         self.my_bool = my_bool
+58 │         self.my_bool = my_bool
    │         ^^^^^^^^^^^^   ^^^^^^^ bool: Value
    │         │               
    │         bool: Storage { nonce: Some(4) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:63:5
+   ┌─ abi_encoding_stress.fe:61:5
    │  
-63 │ ╭     pub fn get_my_bool(self) -> bool {
-64 │ │         return self.my_bool
-65 │ │     }
+61 │ ╭     pub fn get_my_bool(self) -> bool {
+62 │ │         return self.my_bool
+63 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> bool
 
 note: 
-   ┌─ abi_encoding_stress.fe:64:16
+   ┌─ abi_encoding_stress.fe:62:16
    │
-64 │         return self.my_bool
+62 │         return self.my_bool
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:64:16
+   ┌─ abi_encoding_stress.fe:62:16
    │
-64 │         return self.my_bool
+62 │         return self.my_bool
    │                ^^^^^^^^^^^^ bool: Storage { nonce: Some(4) } => Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:67:5
+   ┌─ abi_encoding_stress.fe:65:5
    │  
-67 │ ╭     pub fn set_my_bytes(self, my_bytes: Array<u8, 100>) {
-68 │ │         self.my_bytes = my_bytes
-69 │ │     }
+65 │ ╭     pub fn set_my_bytes(self, my_bytes: Array<u8, 100>) {
+66 │ │         self.my_bytes = my_bytes
+67 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_bytes, typ: Array<u8, 100> }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:68:9
+   ┌─ abi_encoding_stress.fe:66:9
    │
-68 │         self.my_bytes = my_bytes
+66 │         self.my_bytes = my_bytes
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:68:9
+   ┌─ abi_encoding_stress.fe:66:9
    │
-68 │         self.my_bytes = my_bytes
+66 │         self.my_bytes = my_bytes
    │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<u8, 100>: Memory
    │         │                
    │         Array<u8, 100>: Storage { nonce: Some(5) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:71:5
+   ┌─ abi_encoding_stress.fe:69:5
    │  
-71 │ ╭     pub fn get_my_bytes(self) -> Array<u8, 100> {
-72 │ │         return self.my_bytes.to_mem()
-73 │ │     }
+69 │ ╭     pub fn get_my_bytes(self) -> Array<u8, 100> {
+70 │ │         return self.my_bytes.to_mem()
+71 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> Array<u8, 100>
 
 note: 
-   ┌─ abi_encoding_stress.fe:72:16
+   ┌─ abi_encoding_stress.fe:70:16
    │
-72 │         return self.my_bytes.to_mem()
+70 │         return self.my_bytes.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:72:16
+   ┌─ abi_encoding_stress.fe:70:16
    │
-72 │         return self.my_bytes.to_mem()
+70 │         return self.my_bytes.to_mem()
    │                ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:72:16
+   ┌─ abi_encoding_stress.fe:70:16
    │
-72 │         return self.my_bytes.to_mem()
+70 │         return self.my_bytes.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:75:5
+   ┌─ abi_encoding_stress.fe:73:5
    │  
-75 │ ╭     pub fn get_my_struct() -> MyStruct {
-76 │ │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
-77 │ │     }
+73 │ ╭     pub fn get_my_struct() -> MyStruct {
+74 │ │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
+75 │ │     }
    │ ╰─────^ self: None, params: [] -> MyStruct
 
 note: 
-   ┌─ abi_encoding_stress.fe:76:33
+   ┌─ abi_encoding_stress.fe:74:33
    │
-76 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
+74 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
    │                                 ^^              ^^ u8: Value
    │                                 │                
    │                                 u256: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:76:46
+   ┌─ abi_encoding_stress.fe:74:46
    │
-76 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
+74 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
    │                                              ^^^^^^           ^^^^                   ^^^^^^ u256: Value
    │                                              │                │                       
    │                                              │                bool: Value
    │                                              u8: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:76:78
+   ┌─ abi_encoding_stress.fe:74:78
    │
-76 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
+74 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
    │                                                                              ^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:76:16
+   ┌─ abi_encoding_stress.fe:74:16
    │
-76 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
+74 │         return MyStruct(my_num: 42, my_num2: u8(26), my_bool: true, my_addr: address(123456))
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:79:5
+   ┌─ abi_encoding_stress.fe:77:5
    │  
-79 │ ╭     pub fn mod_my_struct(my_struct: MyStruct) -> MyStruct {
-80 │ │         my_struct.my_num = 12341234
-81 │ │         my_struct.my_num2 = u8(42)
-82 │ │         my_struct.my_bool = false
-83 │ │         my_struct.my_addr = address(9999)
-84 │ │         return my_struct
-85 │ │     }
+77 │ ╭     pub fn mod_my_struct(my_struct: MyStruct) -> MyStruct {
+78 │ │         my_struct.my_num = 12341234
+79 │ │         my_struct.my_num2 = u8(42)
+80 │ │         my_struct.my_bool = false
+81 │ │         my_struct.my_addr = address(9999)
+82 │ │         return my_struct
+83 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_struct, typ: MyStruct }] -> MyStruct
 
 note: 
-   ┌─ abi_encoding_stress.fe:80:9
+   ┌─ abi_encoding_stress.fe:78:9
    │
-80 │         my_struct.my_num = 12341234
+78 │         my_struct.my_num = 12341234
    │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:80:9
+   ┌─ abi_encoding_stress.fe:78:9
    │
-80 │         my_struct.my_num = 12341234
+78 │         my_struct.my_num = 12341234
    │         ^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
    │         │                   
    │         u256: Memory
-81 │         my_struct.my_num2 = u8(42)
+79 │         my_struct.my_num2 = u8(42)
    │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:81:9
+   ┌─ abi_encoding_stress.fe:79:9
    │
-81 │         my_struct.my_num2 = u8(42)
+79 │         my_struct.my_num2 = u8(42)
    │         ^^^^^^^^^^^^^^^^^      ^^ u8: Value
    │         │                       
    │         u8: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:81:29
+   ┌─ abi_encoding_stress.fe:79:29
    │
-81 │         my_struct.my_num2 = u8(42)
+79 │         my_struct.my_num2 = u8(42)
    │                             ^^^^^^ u8: Value
-82 │         my_struct.my_bool = false
+80 │         my_struct.my_bool = false
    │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:82:9
+   ┌─ abi_encoding_stress.fe:80:9
    │
-82 │         my_struct.my_bool = false
+80 │         my_struct.my_bool = false
    │         ^^^^^^^^^^^^^^^^^   ^^^^^ bool: Value
    │         │                    
    │         bool: Memory
-83 │         my_struct.my_addr = address(9999)
+81 │         my_struct.my_addr = address(9999)
    │         ^^^^^^^^^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:83:9
+   ┌─ abi_encoding_stress.fe:81:9
    │
-83 │         my_struct.my_addr = address(9999)
+81 │         my_struct.my_addr = address(9999)
    │         ^^^^^^^^^^^^^^^^^           ^^^^ u256: Value
    │         │                            
    │         address: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:83:29
+   ┌─ abi_encoding_stress.fe:81:29
    │
-83 │         my_struct.my_addr = address(9999)
+81 │         my_struct.my_addr = address(9999)
    │                             ^^^^^^^^^^^^^ address: Value
-84 │         return my_struct
+82 │         return my_struct
    │                ^^^^^^^^^ MyStruct: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:87:5
+   ┌─ abi_encoding_stress.fe:85:5
    │  
-87 │ ╭     pub fn emit_my_event(self, ctx: Context) {
-88 │ │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
-89 │ │     }
+85 │ ╭     pub fn emit_my_event(self, ctx: Context) {
+86 │ │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+87 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:22
+   ┌─ abi_encoding_stress.fe:86:22
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                      ^^^            ^^^^ Foo: Value
    │                      │               
    │                      Context: Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:37
+   ┌─ abi_encoding_stress.fe:86:37
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                     ^^^^^^^^^^^^^ Array<address, 5>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:37
+   ┌─ abi_encoding_stress.fe:86:37
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                     ^^^^^^^^^^^^^^^^^^^^^^           ^^^^ Foo: Value
    │                                     │                                 
    │                                     Array<address, 5>: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:70
+   ┌─ abi_encoding_stress.fe:86:70
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                      ^^^^^^^^^^^^             ^^^^ Foo: Value
    │                                                                      │                         
    │                                                                      u128: Storage { nonce: Some(1) } => Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:95
+   ┌─ abi_encoding_stress.fe:86:95
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                               ^^^^^^^^^^^^^^ String<10>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:95
+   ┌─ abi_encoding_stress.fe:86:95
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                               ^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ Foo: Value
    │                                                                                               │                                  
    │                                                                                               String<10>: Storage { nonce: Some(2) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:129
+   ┌─ abi_encoding_stress.fe:86:129
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                                                                 ^^^^^^^^^^^^ Array<u16, 255>: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:129
+   ┌─ abi_encoding_stress.fe:86:129
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                                                                 ^^^^^^^^^^^^^^^^^^^^^           ^^^^ Foo: Value
    │                                                                                                                                 │                                
    │                                                                                                                                 Array<u16, 255>: Storage { nonce: Some(3) } => Memory
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:161
+   ┌─ abi_encoding_stress.fe:86:161
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                                                                                                 ^^^^^^^^^^^^            ^^^^ Foo: Value
    │                                                                                                                                                                 │                        
    │                                                                                                                                                                 bool: Storage { nonce: Some(4) } => Value
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:185
+   ┌─ abi_encoding_stress.fe:86:185
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                                                                                                                         ^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) }
 
 note: 
-   ┌─ abi_encoding_stress.fe:88:185
+   ┌─ abi_encoding_stress.fe:86:185
    │
-88 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
+86 │         emit MyEvent(ctx, my_addrs: self.my_addrs.to_mem(), my_u128: self.my_u128, my_string: self.my_string.to_mem(), my_u16s: self.my_u16s.to_mem(), my_bool: self.my_bool, my_bytes: self.my_bytes.to_mem())
    │                                                                                                                                                                                         ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>: Storage { nonce: Some(5) } => Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__balances.snap
+++ b/crates/analyzer/tests/snapshots/analysis__balances.snap
@@ -4,45 +4,45 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ balances.fe:5:5
+  ┌─ balances.fe:4:5
   │  
-5 │ ╭     pub fn my_balance(self, ctx: Context) -> u256 {
-6 │ │         return ctx.self_balance()
-7 │ │     }
+4 │ ╭     pub fn my_balance(self, ctx: Context) -> u256 {
+5 │ │         return ctx.self_balance()
+6 │ │     }
   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-  ┌─ balances.fe:6:16
+  ┌─ balances.fe:5:16
   │
-6 │         return ctx.self_balance()
+5 │         return ctx.self_balance()
   │                ^^^ Context: Memory
 
 note: 
-  ┌─ balances.fe:6:16
+  ┌─ balances.fe:5:16
   │
-6 │         return ctx.self_balance()
+5 │         return ctx.self_balance()
   │                ^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ balances.fe:9:5
+   ┌─ balances.fe:8:5
    │  
- 9 │ ╭     pub fn other_balance(self, ctx: Context, someone: address) -> u256 {
-10 │ │         return ctx.balance_of(someone)
-11 │ │     }
+ 8 │ ╭     pub fn other_balance(self, ctx: Context, someone: address) -> u256 {
+ 9 │ │         return ctx.balance_of(someone)
+10 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: someone, typ: address }] -> u256
 
 note: 
-   ┌─ balances.fe:10:16
-   │
-10 │         return ctx.balance_of(someone)
-   │                ^^^            ^^^^^^^ address: Value
-   │                │               
-   │                Context: Memory
+  ┌─ balances.fe:9:16
+  │
+9 │         return ctx.balance_of(someone)
+  │                ^^^            ^^^^^^^ address: Value
+  │                │               
+  │                Context: Memory
 
 note: 
-   ┌─ balances.fe:10:16
-   │
-10 │         return ctx.balance_of(someone)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+  ┌─ balances.fe:9:16
+  │
+9 │         return ctx.balance_of(someone)
+  │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -4,204 +4,204 @@ expression: snapshot
 
 ---
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:10:5
+   ┌─ ingots/basic_ingot/src/main.fe:9:5
    │  
-10 │ ╭     pub fn get_my_baz() -> Baz {
-11 │ │         assert file_items_work()
-12 │ │         return Baz(my_bool: true, my_u256: 26)
-13 │ │     }
+ 9 │ ╭     pub fn get_my_baz() -> Baz {
+10 │ │         assert file_items_work()
+11 │ │         return Baz(my_bool: true, my_u256: 26)
+12 │ │     }
    │ ╰─────^ self: None, params: [] -> Baz
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:11:16
+   ┌─ ingots/basic_ingot/src/main.fe:10:16
    │
-11 │         assert file_items_work()
+10 │         assert file_items_work()
    │                ^^^^^^^^^^^^^^^^^ bool: Value
-12 │         return Baz(my_bool: true, my_u256: 26)
+11 │         return Baz(my_bool: true, my_u256: 26)
    │                             ^^^^           ^^ u256: Value
    │                             │               
    │                             bool: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:12:16
+   ┌─ ingots/basic_ingot/src/main.fe:11:16
    │
-12 │         return Baz(my_bool: true, my_u256: 26)
+11 │         return Baz(my_bool: true, my_u256: 26)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Baz: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:15:5
+   ┌─ ingots/basic_ingot/src/main.fe:14:5
    │  
-15 │ ╭     pub fn get_my_bing() -> Bong {
-16 │ │         return Bong(my_address: address(42))
-17 │ │     }
+14 │ ╭     pub fn get_my_bing() -> Bong {
+15 │ │         return Bong(my_address: address(42))
+16 │ │     }
    │ ╰─────^ self: None, params: [] -> Bing
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:16:41
+   ┌─ ingots/basic_ingot/src/main.fe:15:41
    │
-16 │         return Bong(my_address: address(42))
+15 │         return Bong(my_address: address(42))
    │                                         ^^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:16:33
+   ┌─ ingots/basic_ingot/src/main.fe:15:33
    │
-16 │         return Bong(my_address: address(42))
+15 │         return Bong(my_address: address(42))
    │                                 ^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:16:16
+   ┌─ ingots/basic_ingot/src/main.fe:15:16
    │
-16 │         return Bong(my_address: address(42))
+15 │         return Bong(my_address: address(42))
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Bing: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:19:5
+   ┌─ ingots/basic_ingot/src/main.fe:18:5
    │  
-19 │ ╭     pub fn get_42() -> u256 {
-20 │ │         return get_42_backend()
-21 │ │     }
+18 │ ╭     pub fn get_42() -> u256 {
+19 │ │         return get_42_backend()
+20 │ │     }
    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:20:16
+   ┌─ ingots/basic_ingot/src/main.fe:19:16
    │
-20 │         return get_42_backend()
+19 │         return get_42_backend()
    │                ^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:23:5
+   ┌─ ingots/basic_ingot/src/main.fe:22:5
    │  
-23 │ ╭     pub fn get_26() -> u256 {
-24 │ │         return std::evm::add(13, 13)
-25 │ │     }
+22 │ ╭     pub fn get_26() -> u256 {
+23 │ │         return std::evm::add(13, 13)
+24 │ │     }
    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:24:30
+   ┌─ ingots/basic_ingot/src/main.fe:23:30
    │
-24 │         return std::evm::add(13, 13)
+23 │         return std::evm::add(13, 13)
    │                              ^^  ^^ u256: Value
    │                              │    
    │                              u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:24:16
+   ┌─ ingots/basic_ingot/src/main.fe:23:16
    │
-24 │         return std::evm::add(13, 13)
+23 │         return std::evm::add(13, 13)
    │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:27:5
+   ┌─ ingots/basic_ingot/src/main.fe:26:5
    │  
-27 │ ╭     pub fn call_on_path() {
-28 │ │         assert bar::mee::Mee::kawum() == 1
-29 │ │         assert bar::mee::Mee().rums() == 1
-30 │ │     }
+26 │ ╭     pub fn call_on_path() {
+27 │ │         assert bar::mee::Mee::kawum() == 1
+28 │ │         assert bar::mee::Mee().rums() == 1
+29 │ │     }
    │ ╰─────^ self: None, params: [] -> ()
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:28:16
+   ┌─ ingots/basic_ingot/src/main.fe:27:16
    │
-28 │         assert bar::mee::Mee::kawum() == 1
+27 │         assert bar::mee::Mee::kawum() == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                          
    │                u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:28:16
+   ┌─ ingots/basic_ingot/src/main.fe:27:16
    │
-28 │         assert bar::mee::Mee::kawum() == 1
+27 │         assert bar::mee::Mee::kawum() == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-29 │         assert bar::mee::Mee().rums() == 1
+28 │         assert bar::mee::Mee().rums() == 1
    │                ^^^^^^^^^^^^^^^ Mee: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:29:16
+   ┌─ ingots/basic_ingot/src/main.fe:28:16
    │
-29 │         assert bar::mee::Mee().rums() == 1
+28 │         assert bar::mee::Mee().rums() == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                          
    │                u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:29:16
+   ┌─ ingots/basic_ingot/src/main.fe:28:16
    │
-29 │         assert bar::mee::Mee().rums() == 1
+28 │         assert bar::mee::Mee().rums() == 1
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:32:5
+   ┌─ ingots/basic_ingot/src/main.fe:31:5
    │  
-32 │ ╭     pub fn get_my_dyng() -> dong::Dyng {
-33 │ │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
-34 │ │     }
+31 │ ╭     pub fn get_my_dyng() -> dong::Dyng {
+32 │ │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
+33 │ │     }
    │ ╰─────^ self: None, params: [] -> Dyng
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:33:47
+   ┌─ ingots/basic_ingot/src/main.fe:32:47
    │
-33 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
+32 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
    │                                               ^ u256: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:33:39
+   ┌─ ingots/basic_ingot/src/main.fe:32:39
    │
-33 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
+32 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
    │                                       ^^^^^^^^^^           ^^          ^ u256: Value
    │                                       │                    │            
    │                                       │                    u256: Value
    │                                       address: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:33:71
+   ┌─ ingots/basic_ingot/src/main.fe:32:71
    │
-33 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
+32 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
    │                                                                       ^^ i8: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:33:16
+   ┌─ ingots/basic_ingot/src/main.fe:32:16
    │
-33 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
+32 │         return dong::Dyng(my_address: address(8), my_u256: 42, my_i8: -1)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Dyng: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:36:5
+   ┌─ ingots/basic_ingot/src/main.fe:35:5
    │  
-36 │ ╭     pub fn create_bing_contract(ctx: Context) -> u256 {
-37 │ │         let bing_contract: BingContract = BingContract.create(ctx, 0)
-38 │ │         return bing_contract.add(40, 50)
-39 │ │     }
+35 │ ╭     pub fn create_bing_contract(ctx: Context) -> u256 {
+36 │ │         let bing_contract: BingContract = BingContract.create(ctx, 0)
+37 │ │         return bing_contract.add(40, 50)
+38 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:37:13
+   ┌─ ingots/basic_ingot/src/main.fe:36:13
    │
-37 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
+36 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
    │             ^^^^^^^^^^^^^ BingContract
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:37:63
+   ┌─ ingots/basic_ingot/src/main.fe:36:63
    │
-37 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
+36 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
    │                                                               ^^^  ^ u256: Value
    │                                                               │     
    │                                                               Context: Memory
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:37:43
+   ┌─ ingots/basic_ingot/src/main.fe:36:43
    │
-37 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
+36 │         let bing_contract: BingContract = BingContract.create(ctx, 0)
    │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ BingContract: Value
-38 │         return bing_contract.add(40, 50)
+37 │         return bing_contract.add(40, 50)
    │                ^^^^^^^^^^^^^     ^^  ^^ u256: Value
    │                │                 │    
    │                │                 u256: Value
    │                BingContract: Value
 
 note: 
-   ┌─ ingots/basic_ingot/src/main.fe:38:16
+   ┌─ ingots/basic_ingot/src/main.fe:37:16
    │
-38 │         return bing_contract.add(40, 50)
+37 │         return bing_contract.add(40, 50)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create2_contract.snap
@@ -4,55 +4,55 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ create2_contract.fe:4:5
+  ┌─ create2_contract.fe:2:5
   │  
-4 │ ╭     pub fn get_my_num() -> u256 {
-5 │ │         return 42
-6 │ │     }
+2 │ ╭     pub fn get_my_num() -> u256 {
+3 │ │         return 42
+4 │ │     }
   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-  ┌─ create2_contract.fe:5:16
+  ┌─ create2_contract.fe:3:16
   │
-5 │         return 42
+3 │         return 42
   │                ^^ u256: Value
 
 note: 
-   ┌─ create2_contract.fe:10:5
+   ┌─ create2_contract.fe:8:5
    │  
-10 │ ╭     pub fn create2_foo(ctx: Context) -> address {
-11 │ │         let foo: Foo = Foo.create2(ctx, 0, 52)
-12 │ │         return address(foo)
-13 │ │     }
+ 8 │ ╭     pub fn create2_foo(ctx: Context) -> address {
+ 9 │ │         let foo: Foo = Foo.create2(ctx, 0, 52)
+10 │ │         return address(foo)
+11 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
-   ┌─ create2_contract.fe:11:13
-   │
-11 │         let foo: Foo = Foo.create2(ctx, 0, 52)
-   │             ^^^ Foo
+  ┌─ create2_contract.fe:9:13
+  │
+9 │         let foo: Foo = Foo.create2(ctx, 0, 52)
+  │             ^^^ Foo
 
 note: 
-   ┌─ create2_contract.fe:11:36
-   │
-11 │         let foo: Foo = Foo.create2(ctx, 0, 52)
-   │                                    ^^^  ^  ^^ u256: Value
-   │                                    │    │   
-   │                                    │    u256: Value
-   │                                    Context: Memory
+  ┌─ create2_contract.fe:9:36
+  │
+9 │         let foo: Foo = Foo.create2(ctx, 0, 52)
+  │                                    ^^^  ^  ^^ u256: Value
+  │                                    │    │   
+  │                                    │    u256: Value
+  │                                    Context: Memory
 
 note: 
-   ┌─ create2_contract.fe:11:24
+   ┌─ create2_contract.fe:9:24
    │
-11 │         let foo: Foo = Foo.create2(ctx, 0, 52)
+ 9 │         let foo: Foo = Foo.create2(ctx, 0, 52)
    │                        ^^^^^^^^^^^^^^^^^^^^^^^ Foo: Value
-12 │         return address(foo)
+10 │         return address(foo)
    │                        ^^^ Foo: Value
 
 note: 
-   ┌─ create2_contract.fe:12:16
+   ┌─ create2_contract.fe:10:16
    │
-12 │         return address(foo)
+10 │         return address(foo)
    │                ^^^^^^^^^^^^ address: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__create_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract.snap
@@ -4,54 +4,54 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ create_contract.fe:4:5
+  ┌─ create_contract.fe:2:5
   │  
-4 │ ╭     pub fn get_my_num() -> u256 {
-5 │ │         return 42
-6 │ │     }
+2 │ ╭     pub fn get_my_num() -> u256 {
+3 │ │         return 42
+4 │ │     }
   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-  ┌─ create_contract.fe:5:16
+  ┌─ create_contract.fe:3:16
   │
-5 │         return 42
+3 │         return 42
   │                ^^ u256: Value
 
 note: 
-   ┌─ create_contract.fe:10:5
+   ┌─ create_contract.fe:8:5
    │  
-10 │ ╭     pub fn create_foo(ctx: Context) -> address {
-11 │ │         let foo: Foo = Foo.create(ctx, 0)
-12 │ │         return address(foo)
-13 │ │     }
+ 8 │ ╭     pub fn create_foo(ctx: Context) -> address {
+ 9 │ │         let foo: Foo = Foo.create(ctx, 0)
+10 │ │         return address(foo)
+11 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
-   ┌─ create_contract.fe:11:13
-   │
-11 │         let foo: Foo = Foo.create(ctx, 0)
-   │             ^^^ Foo
+  ┌─ create_contract.fe:9:13
+  │
+9 │         let foo: Foo = Foo.create(ctx, 0)
+  │             ^^^ Foo
 
 note: 
-   ┌─ create_contract.fe:11:35
-   │
-11 │         let foo: Foo = Foo.create(ctx, 0)
-   │                                   ^^^  ^ u256: Value
-   │                                   │     
-   │                                   Context: Memory
+  ┌─ create_contract.fe:9:35
+  │
+9 │         let foo: Foo = Foo.create(ctx, 0)
+  │                                   ^^^  ^ u256: Value
+  │                                   │     
+  │                                   Context: Memory
 
 note: 
-   ┌─ create_contract.fe:11:24
+   ┌─ create_contract.fe:9:24
    │
-11 │         let foo: Foo = Foo.create(ctx, 0)
+ 9 │         let foo: Foo = Foo.create(ctx, 0)
    │                        ^^^^^^^^^^^^^^^^^^ Foo: Value
-12 │         return address(foo)
+10 │         return address(foo)
    │                        ^^^ Foo: Value
 
 note: 
-   ┌─ create_contract.fe:12:16
+   ┌─ create_contract.fe:10:16
    │
-12 │         return address(foo)
+10 │         return address(foo)
    │                ^^^^^^^^^^^^ address: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
+++ b/crates/analyzer/tests/snapshots/analysis__create_contract_from_init.snap
@@ -4,43 +4,43 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ create_contract_from_init.fe:4:5
+  ┌─ create_contract_from_init.fe:2:5
   │  
-4 │ ╭     pub fn get_my_num() -> u256 {
-5 │ │         return 42
-6 │ │     }
+2 │ ╭     pub fn get_my_num() -> u256 {
+3 │ │         return 42
+4 │ │     }
   │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-  ┌─ create_contract_from_init.fe:5:16
+  ┌─ create_contract_from_init.fe:3:16
   │
-5 │         return 42
+3 │         return 42
   │                ^^ u256: Value
 
 note: 
-   ┌─ create_contract_from_init.fe:10:5
-   │
-10 │     foo_addr: address
-   │     ^^^^^^^^^^^^^^^^^ address
+  ┌─ create_contract_from_init.fe:8:5
+  │
+8 │     foo_addr: address
+  │     ^^^^^^^^^^^^^^^^^ address
 
 note: 
-   ┌─ create_contract_from_init.fe:16:5
+   ┌─ create_contract_from_init.fe:14:5
    │  
-16 │ ╭     pub fn get_foo_addr(self) -> address {
-17 │ │         return self.foo_addr
-18 │ │     }
+14 │ ╭     pub fn get_foo_addr(self) -> address {
+15 │ │         return self.foo_addr
+16 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-   ┌─ create_contract_from_init.fe:17:16
+   ┌─ create_contract_from_init.fe:15:16
    │
-17 │         return self.foo_addr
+15 │         return self.foo_addr
    │                ^^^^ FooFactory: Value
 
 note: 
-   ┌─ create_contract_from_init.fe:17:16
+   ┌─ create_contract_from_init.fe:15:16
    │
-17 │         return self.foo_addr
+15 │         return self.foo_addr
    │                ^^^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__data_copying_stress.snap
@@ -4,425 +4,461 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ data_copying_stress.fe:4:5
+  ┌─ data_copying_stress.fe:2:5
   │
-4 │     my_string: String<42>
+2 │     my_string: String<42>
   │     ^^^^^^^^^^^^^^^^^^^^^ String<42>
-5 │     my_other_string: String<42>
+3 │     my_other_string: String<42>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<42>
-6 │     my_u256: u256
+4 │     my_u256: u256
   │     ^^^^^^^^^^^^^ u256
-7 │     my_other_u256: u256
+5 │     my_other_u256: u256
   │     ^^^^^^^^^^^^^^^^^^^ u256
-8 │     my_nums: Array<u256, 5>
+6 │     my_nums: Array<u256, 5>
   │     ^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>
-9 │     my_addrs: Array<address, 3>
+7 │     my_addrs: Array<address, 3>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 3>
 
 note: 
-   ┌─ data_copying_stress.fe:12:9
+   ┌─ data_copying_stress.fe:10:9
    │
-12 │         my_string: String<42>
+10 │         my_string: String<42>
    │         ^^^^^^^^^^^^^^^^^^^^^ String<42>
-13 │         my_u256: u256
+11 │         my_u256: u256
    │         ^^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ data_copying_stress.fe:16:5
+   ┌─ data_copying_stress.fe:14:5
    │  
-16 │ ╭     pub fn set_my_vals(self, my_string: String<42>, my_other_string: String<42>, my_u256: u256, my_other_u256: u256) {
-17 │ │         self.my_string = my_string
-18 │ │         self.my_other_string = my_other_string
-19 │ │         self.my_u256 = my_u256
-20 │ │         self.my_other_u256 = my_other_u256
-21 │ │     }
+14 │ ╭     pub fn set_my_vals(self, my_string: String<42>, my_other_string: String<42>, my_u256: u256, my_other_u256: u256) {
+15 │ │         self.my_string = my_string
+16 │ │         self.my_other_string = my_other_string
+17 │ │         self.my_u256 = my_u256
+18 │ │         self.my_other_u256 = my_other_u256
+19 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_string, typ: String<42> }, { label: None, name: my_other_string, typ: String<42> }, { label: None, name: my_u256, typ: u256 }, { label: None, name: my_other_u256, typ: u256 }] -> ()
 
 note: 
-   ┌─ data_copying_stress.fe:17:9
+   ┌─ data_copying_stress.fe:15:9
    │
-17 │         self.my_string = my_string
+15 │         self.my_string = my_string
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ data_copying_stress.fe:15:9
+   │
+15 │         self.my_string = my_string
+   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<42>: Memory
+   │         │                 
+   │         String<42>: Storage { nonce: Some(0) }
+16 │         self.my_other_string = my_other_string
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ data_copying_stress.fe:16:9
+   │
+16 │         self.my_other_string = my_other_string
+   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ String<42>: Memory
+   │         │                       
+   │         String<42>: Storage { nonce: Some(1) }
+17 │         self.my_u256 = my_u256
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ data_copying_stress.fe:17:9
    │
-17 │         self.my_string = my_string
-   │         ^^^^^^^^^^^^^^   ^^^^^^^^^ String<42>: Memory
-   │         │                 
-   │         String<42>: Storage { nonce: Some(0) }
-18 │         self.my_other_string = my_other_string
+17 │         self.my_u256 = my_u256
+   │         ^^^^^^^^^^^^   ^^^^^^^ u256: Value
+   │         │               
+   │         u256: Storage { nonce: Some(2) }
+18 │         self.my_other_u256 = my_other_u256
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ data_copying_stress.fe:18:9
    │
-18 │         self.my_other_string = my_other_string
-   │         ^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ String<42>: Memory
-   │         │                       
-   │         String<42>: Storage { nonce: Some(1) }
-19 │         self.my_u256 = my_u256
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ data_copying_stress.fe:19:9
-   │
-19 │         self.my_u256 = my_u256
-   │         ^^^^^^^^^^^^   ^^^^^^^ u256: Value
-   │         │               
-   │         u256: Storage { nonce: Some(2) }
-20 │         self.my_other_u256 = my_other_u256
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ data_copying_stress.fe:20:9
-   │
-20 │         self.my_other_u256 = my_other_u256
+18 │         self.my_other_u256 = my_other_u256
    │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ u256: Value
    │         │                     
    │         u256: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ data_copying_stress.fe:23:5
+   ┌─ data_copying_stress.fe:21:5
    │  
-23 │ ╭     pub fn set_to_my_other_vals(self) {
-24 │ │         self.my_string = self.my_other_string
-25 │ │         self.my_u256 = self.my_other_u256
-26 │ │     }
+21 │ ╭     pub fn set_to_my_other_vals(self) {
+22 │ │         self.my_string = self.my_other_string
+23 │ │         self.my_u256 = self.my_other_u256
+24 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
-   ┌─ data_copying_stress.fe:24:9
+   ┌─ data_copying_stress.fe:22:9
    │
-24 │         self.my_string = self.my_other_string
+22 │         self.my_string = self.my_other_string
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ data_copying_stress.fe:24:9
+   ┌─ data_copying_stress.fe:22:9
    │
-24 │         self.my_string = self.my_other_string
+22 │         self.my_string = self.my_other_string
    │         ^^^^^^^^^^^^^^   ^^^^ Foo: Value
    │         │                 
    │         String<42>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ data_copying_stress.fe:24:26
+   ┌─ data_copying_stress.fe:22:26
    │
-24 │         self.my_string = self.my_other_string
+22 │         self.my_string = self.my_other_string
    │                          ^^^^^^^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(1) }
-25 │         self.my_u256 = self.my_other_u256
+23 │         self.my_u256 = self.my_other_u256
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ data_copying_stress.fe:25:9
+   ┌─ data_copying_stress.fe:23:9
    │
-25 │         self.my_u256 = self.my_other_u256
+23 │         self.my_u256 = self.my_other_u256
    │         ^^^^^^^^^^^^   ^^^^ Foo: Value
    │         │               
    │         u256: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ data_copying_stress.fe:25:24
+   ┌─ data_copying_stress.fe:23:24
    │
-25 │         self.my_u256 = self.my_other_u256
+23 │         self.my_u256 = self.my_other_u256
    │                        ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ data_copying_stress.fe:28:5
+   ┌─ data_copying_stress.fe:26:5
    │  
-28 │ ╭     pub fn multiple_references_shared_memory(my_array: Array<u256, 10>) {
-29 │ │         let my_2nd_array: Array<u256, 10> = my_array
-30 │ │         let my_3rd_array: Array<u256, 10> = my_2nd_array
-31 │ │         assert my_array[3] != 5
+26 │ ╭     pub fn multiple_references_shared_memory(my_array: Array<u256, 10>) {
+27 │ │         let my_2nd_array: Array<u256, 10> = my_array
+28 │ │         let my_3rd_array: Array<u256, 10> = my_2nd_array
+29 │ │         assert my_array[3] != 5
    · │
-39 │ │         assert my_3rd_array[3] == 50
-40 │ │     }
+37 │ │         assert my_3rd_array[3] == 50
+38 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> ()
 
 note: 
-   ┌─ data_copying_stress.fe:29:13
+   ┌─ data_copying_stress.fe:27:13
    │
-29 │         let my_2nd_array: Array<u256, 10> = my_array
+27 │         let my_2nd_array: Array<u256, 10> = my_array
    │             ^^^^^^^^^^^^ Array<u256, 10>
-30 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
+28 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
    │             ^^^^^^^^^^^^ Array<u256, 10>
 
 note: 
-   ┌─ data_copying_stress.fe:29:45
+   ┌─ data_copying_stress.fe:27:45
    │
-29 │         let my_2nd_array: Array<u256, 10> = my_array
+27 │         let my_2nd_array: Array<u256, 10> = my_array
    │                                             ^^^^^^^^ Array<u256, 10>: Memory
-30 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
+28 │         let my_3rd_array: Array<u256, 10> = my_2nd_array
    │                                             ^^^^^^^^^^^^ Array<u256, 10>: Memory
-31 │         assert my_array[3] != 5
+29 │         assert my_array[3] != 5
    │                ^^^^^^^^ ^ u256: Value
    │                │         
    │                Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:31:16
+   ┌─ data_copying_stress.fe:29:16
    │
-31 │         assert my_array[3] != 5
+29 │         assert my_array[3] != 5
    │                ^^^^^^^^^^^    ^ u256: Value
    │                │               
    │                u256: Memory => Value
 
 note: 
-   ┌─ data_copying_stress.fe:31:16
+   ┌─ data_copying_stress.fe:29:16
    │
-31 │         assert my_array[3] != 5
+29 │         assert my_array[3] != 5
    │                ^^^^^^^^^^^^^^^^ bool: Value
-32 │         my_array[3] = 5
+30 │         my_array[3] = 5
    │         ^^^^^^^^ ^ u256: Value
    │         │         
    │         Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:32:9
+   ┌─ data_copying_stress.fe:30:9
    │
-32 │         my_array[3] = 5
+30 │         my_array[3] = 5
    │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
    │         u256: Memory
-33 │         assert my_array[3] == 5
+31 │         assert my_array[3] == 5
    │                ^^^^^^^^ ^ u256: Value
    │                │         
    │                Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:33:16
+   ┌─ data_copying_stress.fe:31:16
    │
-33 │         assert my_array[3] == 5
+31 │         assert my_array[3] == 5
    │                ^^^^^^^^^^^    ^ u256: Value
    │                │               
    │                u256: Memory => Value
 
 note: 
+   ┌─ data_copying_stress.fe:31:16
+   │
+31 │         assert my_array[3] == 5
+   │                ^^^^^^^^^^^^^^^^ bool: Value
+32 │         assert my_2nd_array[3] == 5
+   │                ^^^^^^^^^^^^ ^ u256: Value
+   │                │             
+   │                Array<u256, 10>: Memory
+
+note: 
+   ┌─ data_copying_stress.fe:32:16
+   │
+32 │         assert my_2nd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^    ^ u256: Value
+   │                │                   
+   │                u256: Memory => Value
+
+note: 
+   ┌─ data_copying_stress.fe:32:16
+   │
+32 │         assert my_2nd_array[3] == 5
+   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
+33 │         assert my_3rd_array[3] == 5
+   │                ^^^^^^^^^^^^ ^ u256: Value
+   │                │             
+   │                Array<u256, 10>: Memory
+
+note: 
    ┌─ data_copying_stress.fe:33:16
    │
-33 │         assert my_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^ bool: Value
-34 │         assert my_2nd_array[3] == 5
-   │                ^^^^^^^^^^^^ ^ u256: Value
-   │                │             
-   │                Array<u256, 10>: Memory
-
-note: 
-   ┌─ data_copying_stress.fe:34:16
-   │
-34 │         assert my_2nd_array[3] == 5
+33 │         assert my_3rd_array[3] == 5
    │                ^^^^^^^^^^^^^^^    ^ u256: Value
    │                │                   
    │                u256: Memory => Value
 
 note: 
-   ┌─ data_copying_stress.fe:34:16
+   ┌─ data_copying_stress.fe:33:16
    │
-34 │         assert my_2nd_array[3] == 5
+33 │         assert my_3rd_array[3] == 5
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-35 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^ ^ u256: Value
-   │                │             
-   │                Array<u256, 10>: Memory
-
-note: 
-   ┌─ data_copying_stress.fe:35:16
-   │
-35 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^    ^ u256: Value
-   │                │                   
-   │                u256: Memory => Value
-
-note: 
-   ┌─ data_copying_stress.fe:35:16
-   │
-35 │         assert my_3rd_array[3] == 5
-   │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-36 │         my_3rd_array[3] = 50
+34 │         my_3rd_array[3] = 50
    │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
    │         Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:36:9
+   ┌─ data_copying_stress.fe:34:9
    │
-36 │         my_3rd_array[3] = 50
+34 │         my_3rd_array[3] = 50
    │         ^^^^^^^^^^^^^^^   ^^ u256: Value
    │         │                  
    │         u256: Memory
-37 │         assert my_array[3] == 50
+35 │         assert my_array[3] == 50
    │                ^^^^^^^^ ^ u256: Value
    │                │         
    │                Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:37:16
+   ┌─ data_copying_stress.fe:35:16
    │
-37 │         assert my_array[3] == 50
+35 │         assert my_array[3] == 50
    │                ^^^^^^^^^^^    ^^ u256: Value
    │                │               
    │                u256: Memory => Value
 
 note: 
+   ┌─ data_copying_stress.fe:35:16
+   │
+35 │         assert my_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^ bool: Value
+36 │         assert my_2nd_array[3] == 50
+   │                ^^^^^^^^^^^^ ^ u256: Value
+   │                │             
+   │                Array<u256, 10>: Memory
+
+note: 
+   ┌─ data_copying_stress.fe:36:16
+   │
+36 │         assert my_2nd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^    ^^ u256: Value
+   │                │                   
+   │                u256: Memory => Value
+
+note: 
+   ┌─ data_copying_stress.fe:36:16
+   │
+36 │         assert my_2nd_array[3] == 50
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
+37 │         assert my_3rd_array[3] == 50
+   │                ^^^^^^^^^^^^ ^ u256: Value
+   │                │             
+   │                Array<u256, 10>: Memory
+
+note: 
    ┌─ data_copying_stress.fe:37:16
    │
-37 │         assert my_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^ bool: Value
-38 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^ ^ u256: Value
-   │                │             
-   │                Array<u256, 10>: Memory
-
-note: 
-   ┌─ data_copying_stress.fe:38:16
-   │
-38 │         assert my_2nd_array[3] == 50
+37 │         assert my_3rd_array[3] == 50
    │                ^^^^^^^^^^^^^^^    ^^ u256: Value
    │                │                   
    │                u256: Memory => Value
 
 note: 
-   ┌─ data_copying_stress.fe:38:16
+   ┌─ data_copying_stress.fe:37:16
    │
-38 │         assert my_2nd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-39 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^ ^ u256: Value
-   │                │             
-   │                Array<u256, 10>: Memory
-
-note: 
-   ┌─ data_copying_stress.fe:39:16
-   │
-39 │         assert my_3rd_array[3] == 50
-   │                ^^^^^^^^^^^^^^^    ^^ u256: Value
-   │                │                   
-   │                u256: Memory => Value
-
-note: 
-   ┌─ data_copying_stress.fe:39:16
-   │
-39 │         assert my_3rd_array[3] == 50
+37 │         assert my_3rd_array[3] == 50
    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-   ┌─ data_copying_stress.fe:42:5
+   ┌─ data_copying_stress.fe:40:5
    │  
-42 │ ╭     pub fn mutate_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
-43 │ │         my_array[3] = 5
-44 │ │         return my_array
-45 │ │     }
+40 │ ╭     pub fn mutate_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
+41 │ │         my_array[3] = 5
+42 │ │         return my_array
+43 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> Array<u256, 10>
 
 note: 
-   ┌─ data_copying_stress.fe:43:9
+   ┌─ data_copying_stress.fe:41:9
    │
-43 │         my_array[3] = 5
+41 │         my_array[3] = 5
    │         ^^^^^^^^ ^ u256: Value
    │         │         
    │         Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:43:9
+   ┌─ data_copying_stress.fe:41:9
    │
-43 │         my_array[3] = 5
+41 │         my_array[3] = 5
    │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
    │         u256: Memory
-44 │         return my_array
+42 │         return my_array
    │                ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:47:5
+   ┌─ data_copying_stress.fe:45:5
    │  
-47 │ ╭     pub fn clone_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
-48 │ │         return my_array.clone()
-49 │ │     }
+45 │ ╭     pub fn clone_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
+46 │ │         return my_array.clone()
+47 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> Array<u256, 10>
 
 note: 
-   ┌─ data_copying_stress.fe:48:16
+   ┌─ data_copying_stress.fe:46:16
    │
-48 │         return my_array.clone()
+46 │         return my_array.clone()
    │                ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:48:16
+   ┌─ data_copying_stress.fe:46:16
    │
-48 │         return my_array.clone()
+46 │         return my_array.clone()
    │                ^^^^^^^^^^^^^^^^ Array<u256, 10>: Memory => Memory
 
 note: 
-   ┌─ data_copying_stress.fe:51:5
+   ┌─ data_copying_stress.fe:49:5
    │  
-51 │ ╭     pub fn clone_mutate_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
-52 │ │         my_array.clone()[3] = 5
-53 │ │         return my_array
-54 │ │     }
+49 │ ╭     pub fn clone_mutate_and_return(my_array: Array<u256, 10>) -> Array<u256, 10> {
+50 │ │         my_array.clone()[3] = 5
+51 │ │         return my_array
+52 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_array, typ: Array<u256, 10> }] -> Array<u256, 10>
 
 note: 
-   ┌─ data_copying_stress.fe:52:9
+   ┌─ data_copying_stress.fe:50:9
    │
-52 │         my_array.clone()[3] = 5
+50 │         my_array.clone()[3] = 5
    │         ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:52:9
+   ┌─ data_copying_stress.fe:50:9
    │
-52 │         my_array.clone()[3] = 5
+50 │         my_array.clone()[3] = 5
    │         ^^^^^^^^^^^^^^^^ ^ u256: Value
    │         │                 
    │         Array<u256, 10>: Memory => Memory
 
 note: 
-   ┌─ data_copying_stress.fe:52:9
+   ┌─ data_copying_stress.fe:50:9
    │
-52 │         my_array.clone()[3] = 5
+50 │         my_array.clone()[3] = 5
    │         ^^^^^^^^^^^^^^^^^^^   ^ u256: Value
    │         │                      
    │         u256: Memory
-53 │         return my_array
+51 │         return my_array
    │                ^^^^^^^^ Array<u256, 10>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:56:5
+   ┌─ data_copying_stress.fe:54:5
    │  
-56 │ ╭     pub fn assign_my_nums_and_return(self) -> Array<u256, 5> {
-57 │ │         let my_nums_mem: Array<u256, 5> = [0; 5]
-58 │ │         self.my_nums[0] = 42
-59 │ │         self.my_nums[1] = 26
+54 │ ╭     pub fn assign_my_nums_and_return(self) -> Array<u256, 5> {
+55 │ │         let my_nums_mem: Array<u256, 5> = [0; 5]
+56 │ │         self.my_nums[0] = 42
+57 │ │         self.my_nums[1] = 26
    · │
-64 │ │         return my_nums_mem
-65 │ │     }
+62 │ │         return my_nums_mem
+63 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> Array<u256, 5>
 
 note: 
-   ┌─ data_copying_stress.fe:57:13
+   ┌─ data_copying_stress.fe:55:13
    │
-57 │         let my_nums_mem: Array<u256, 5> = [0; 5]
+55 │         let my_nums_mem: Array<u256, 5> = [0; 5]
    │             ^^^^^^^^^^^ Array<u256, 5>
 
 note: 
-   ┌─ data_copying_stress.fe:57:44
+   ┌─ data_copying_stress.fe:55:44
    │
-57 │         let my_nums_mem: Array<u256, 5> = [0; 5]
+55 │         let my_nums_mem: Array<u256, 5> = [0; 5]
    │                                            ^  ^ u256: Value
    │                                            │   
    │                                            u256: Value
 
 note: 
-   ┌─ data_copying_stress.fe:57:43
+   ┌─ data_copying_stress.fe:55:43
    │
-57 │         let my_nums_mem: Array<u256, 5> = [0; 5]
+55 │         let my_nums_mem: Array<u256, 5> = [0; 5]
    │                                           ^^^^^^ Array<u256, 5>: Memory
-58 │         self.my_nums[0] = 42
+56 │         self.my_nums[0] = 42
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ data_copying_stress.fe:56:9
+   │
+56 │         self.my_nums[0] = 42
+   │         ^^^^^^^^^^^^ ^ u256: Value
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ data_copying_stress.fe:56:9
+   │
+56 │         self.my_nums[0] = 42
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                  
+   │         u256: Storage { nonce: None }
+57 │         self.my_nums[1] = 26
+   │         ^^^^ Foo: Value
+
+note: 
+   ┌─ data_copying_stress.fe:57:9
+   │
+57 │         self.my_nums[1] = 26
+   │         ^^^^^^^^^^^^ ^ u256: Value
+   │         │             
+   │         Array<u256, 5>: Storage { nonce: Some(4) }
+
+note: 
+   ┌─ data_copying_stress.fe:57:9
+   │
+57 │         self.my_nums[1] = 26
+   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
+   │         │                  
+   │         u256: Storage { nonce: None }
+58 │         self.my_nums[2] = 0
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ data_copying_stress.fe:58:9
    │
-58 │         self.my_nums[0] = 42
+58 │         self.my_nums[2] = 0
    │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
    │         Array<u256, 5>: Storage { nonce: Some(4) }
@@ -430,17 +466,17 @@ note:
 note: 
    ┌─ data_copying_stress.fe:58:9
    │
-58 │         self.my_nums[0] = 42
-   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
+58 │         self.my_nums[2] = 0
+   │         ^^^^^^^^^^^^^^^   ^ u256: Value
    │         │                  
    │         u256: Storage { nonce: None }
-59 │         self.my_nums[1] = 26
+59 │         self.my_nums[3] = 1
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ data_copying_stress.fe:59:9
    │
-59 │         self.my_nums[1] = 26
+59 │         self.my_nums[3] = 1
    │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
    │         Array<u256, 5>: Storage { nonce: Some(4) }
@@ -448,17 +484,17 @@ note:
 note: 
    ┌─ data_copying_stress.fe:59:9
    │
-59 │         self.my_nums[1] = 26
-   │         ^^^^^^^^^^^^^^^   ^^ u256: Value
+59 │         self.my_nums[3] = 1
+   │         ^^^^^^^^^^^^^^^   ^ u256: Value
    │         │                  
    │         u256: Storage { nonce: None }
-60 │         self.my_nums[2] = 0
+60 │         self.my_nums[4] = 255
    │         ^^^^ Foo: Value
 
 note: 
    ┌─ data_copying_stress.fe:60:9
    │
-60 │         self.my_nums[2] = 0
+60 │         self.my_nums[4] = 255
    │         ^^^^^^^^^^^^ ^ u256: Value
    │         │             
    │         Array<u256, 5>: Storage { nonce: Some(4) }
@@ -466,172 +502,136 @@ note:
 note: 
    ┌─ data_copying_stress.fe:60:9
    │
-60 │         self.my_nums[2] = 0
-   │         ^^^^^^^^^^^^^^^   ^ u256: Value
-   │         │                  
-   │         u256: Storage { nonce: None }
-61 │         self.my_nums[3] = 1
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ data_copying_stress.fe:61:9
-   │
-61 │         self.my_nums[3] = 1
-   │         ^^^^^^^^^^^^ ^ u256: Value
-   │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) }
-
-note: 
-   ┌─ data_copying_stress.fe:61:9
-   │
-61 │         self.my_nums[3] = 1
-   │         ^^^^^^^^^^^^^^^   ^ u256: Value
-   │         │                  
-   │         u256: Storage { nonce: None }
-62 │         self.my_nums[4] = 255
-   │         ^^^^ Foo: Value
-
-note: 
-   ┌─ data_copying_stress.fe:62:9
-   │
-62 │         self.my_nums[4] = 255
-   │         ^^^^^^^^^^^^ ^ u256: Value
-   │         │             
-   │         Array<u256, 5>: Storage { nonce: Some(4) }
-
-note: 
-   ┌─ data_copying_stress.fe:62:9
-   │
-62 │         self.my_nums[4] = 255
+60 │         self.my_nums[4] = 255
    │         ^^^^^^^^^^^^^^^   ^^^ u256: Value
    │         │                  
    │         u256: Storage { nonce: None }
-63 │         my_nums_mem = self.my_nums.to_mem()
+61 │         my_nums_mem = self.my_nums.to_mem()
    │         ^^^^^^^^^^^   ^^^^ Foo: Value
    │         │              
    │         Array<u256, 5>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:63:23
+   ┌─ data_copying_stress.fe:61:23
    │
-63 │         my_nums_mem = self.my_nums.to_mem()
+61 │         my_nums_mem = self.my_nums.to_mem()
    │                       ^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) }
 
 note: 
-   ┌─ data_copying_stress.fe:63:23
+   ┌─ data_copying_stress.fe:61:23
    │
-63 │         my_nums_mem = self.my_nums.to_mem()
+61 │         my_nums_mem = self.my_nums.to_mem()
    │                       ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 5>: Storage { nonce: Some(4) } => Memory
-64 │         return my_nums_mem
+62 │         return my_nums_mem
    │                ^^^^^^^^^^^ Array<u256, 5>: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:67:5
+   ┌─ data_copying_stress.fe:65:5
    │  
-67 │ ╭     pub fn emit_my_event(self, ctx: Context) {
-68 │ │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
-69 │ │     }
+65 │ ╭     pub fn emit_my_event(self, ctx: Context) {
+66 │ │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
+67 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ data_copying_stress.fe:68:32
+   ┌─ data_copying_stress.fe:66:32
    │
-68 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
+66 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
    │                                ^^^  ^^^^ Foo: Value
    │                                │     
    │                                Context: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:68:37
+   ┌─ data_copying_stress.fe:66:37
    │
-68 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
+66 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
    │                                     ^^^^^^^^^^^^^^ String<42>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ data_copying_stress.fe:68:37
+   ┌─ data_copying_stress.fe:66:37
    │
-68 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
+66 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
    │                                     ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^ Foo: Value
    │                                     │                         
    │                                     String<42>: Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ data_copying_stress.fe:68:62
+   ┌─ data_copying_stress.fe:66:62
    │
-68 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
+66 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
    │                                                              ^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ data_copying_stress.fe:68:9
+   ┌─ data_copying_stress.fe:66:9
    │
-68 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
+66 │         emit_my_event_internal(ctx, self.my_string.to_mem(), self.my_u256)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ data_copying_stress.fe:71:5
+   ┌─ data_copying_stress.fe:69:5
    │  
-71 │ ╭     fn emit_my_event_internal(ctx: Context, _ my_string: String<42>, _ my_u256: u256) {
-72 │ │         emit MyEvent(ctx, my_string, my_u256)
-73 │ │     }
+69 │ ╭     fn emit_my_event_internal(ctx: Context, _ my_string: String<42>, _ my_u256: u256) {
+70 │ │         emit MyEvent(ctx, my_string, my_u256)
+71 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: Some("_"), name: my_string, typ: String<42> }, { label: Some("_"), name: my_u256, typ: u256 }] -> ()
 
 note: 
-   ┌─ data_copying_stress.fe:72:22
+   ┌─ data_copying_stress.fe:70:22
    │
-72 │         emit MyEvent(ctx, my_string, my_u256)
+70 │         emit MyEvent(ctx, my_string, my_u256)
    │                      ^^^  ^^^^^^^^^  ^^^^^^^ u256: Value
    │                      │    │           
    │                      │    String<42>: Memory
    │                      Context: Memory
 
 note: 
-   ┌─ data_copying_stress.fe:75:5
+   ┌─ data_copying_stress.fe:73:5
    │  
-75 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>) {
-76 │ │         self.my_addrs = my_addrs
-77 │ │     }
+73 │ ╭     pub fn set_my_addrs(self, my_addrs: Array<address, 3>) {
+74 │ │         self.my_addrs = my_addrs
+75 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_addrs, typ: Array<address, 3> }] -> ()
 
 note: 
-   ┌─ data_copying_stress.fe:76:9
+   ┌─ data_copying_stress.fe:74:9
    │
-76 │         self.my_addrs = my_addrs
+74 │         self.my_addrs = my_addrs
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ data_copying_stress.fe:76:9
+   ┌─ data_copying_stress.fe:74:9
    │
-76 │         self.my_addrs = my_addrs
+74 │         self.my_addrs = my_addrs
    │         ^^^^^^^^^^^^^   ^^^^^^^^ Array<address, 3>: Memory
    │         │                
    │         Array<address, 3>: Storage { nonce: Some(5) }
 
 note: 
-   ┌─ data_copying_stress.fe:79:5
+   ┌─ data_copying_stress.fe:77:5
    │  
-79 │ ╭     pub fn get_my_second_addr(self) -> address {
-80 │ │         return self.my_addrs[1]
-81 │ │     }
+77 │ ╭     pub fn get_my_second_addr(self) -> address {
+78 │ │         return self.my_addrs[1]
+79 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-   ┌─ data_copying_stress.fe:80:16
+   ┌─ data_copying_stress.fe:78:16
    │
-80 │         return self.my_addrs[1]
+78 │         return self.my_addrs[1]
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ data_copying_stress.fe:80:16
+   ┌─ data_copying_stress.fe:78:16
    │
-80 │         return self.my_addrs[1]
+78 │         return self.my_addrs[1]
    │                ^^^^^^^^^^^^^ ^ u256: Value
    │                │              
    │                Array<address, 3>: Storage { nonce: Some(5) }
 
 note: 
-   ┌─ data_copying_stress.fe:80:16
+   ┌─ data_copying_stress.fe:78:16
    │
-80 │         return self.my_addrs[1]
+78 │         return self.my_addrs[1]
    │                ^^^^^^^^^^^^^^^^ address: Storage { nonce: None } => Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -4,320 +4,320 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ erc20_token.fe:4:5
+  ┌─ erc20_token.fe:2:5
   │
-4 │     _balances: Map<address, u256>
+2 │     _balances: Map<address, u256>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-5 │     _allowances: Map<address, Map<address, u256>>
+3 │     _allowances: Map<address, Map<address, u256>>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>
-6 │     _total_supply: u256
+4 │     _total_supply: u256
   │     ^^^^^^^^^^^^^^^^^^^ u256
-7 │     _name: String<100>
+5 │     _name: String<100>
   │     ^^^^^^^^^^^^^^^^^^ String<100>
-8 │     _symbol: String<100>
+6 │     _symbol: String<100>
   │     ^^^^^^^^^^^^^^^^^^^^ String<100>
-9 │     _decimals: u8
+7 │     _decimals: u8
   │     ^^^^^^^^^^^^^ u8
 
 note: 
-   ┌─ erc20_token.fe:12:9
+   ┌─ erc20_token.fe:10:9
    │
-12 │         idx owner: address
+10 │         idx owner: address
    │         ^^^^^^^^^^^^^^^^^^ address
-13 │         idx spender: address
+11 │         idx spender: address
    │         ^^^^^^^^^^^^^^^^^^^^ address
-14 │         value: u256
+12 │         value: u256
    │         ^^^^^^^^^^^ u256
 
 note: 
-   ┌─ erc20_token.fe:18:9
+   ┌─ erc20_token.fe:16:9
    │
-18 │         idx from: address
+16 │         idx from: address
    │         ^^^^^^^^^^^^^^^^^ address
-19 │         idx to: address
+17 │         idx to: address
    │         ^^^^^^^^^^^^^^^ address
-20 │         value: u256
+18 │         value: u256
    │         ^^^^^^^^^^^ u256
 
 note: 
-   ┌─ erc20_token.fe:30:5
+   ┌─ erc20_token.fe:28:5
    │  
-30 │ ╭     pub fn name(self) -> String<100> {
-31 │ │         return self._name.to_mem()
-32 │ │     }
+28 │ ╭     pub fn name(self) -> String<100> {
+29 │ │         return self._name.to_mem()
+30 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> String<100>
 
 note: 
-   ┌─ erc20_token.fe:31:16
+   ┌─ erc20_token.fe:29:16
    │
-31 │         return self._name.to_mem()
+29 │         return self._name.to_mem()
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:31:16
+   ┌─ erc20_token.fe:29:16
    │
-31 │         return self._name.to_mem()
+29 │         return self._name.to_mem()
    │                ^^^^^^^^^^ String<100>: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ erc20_token.fe:31:16
+   ┌─ erc20_token.fe:29:16
    │
-31 │         return self._name.to_mem()
+29 │         return self._name.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(3) } => Memory
 
 note: 
-   ┌─ erc20_token.fe:34:5
+   ┌─ erc20_token.fe:32:5
    │  
-34 │ ╭     pub fn symbol(self) -> String<100> {
-35 │ │         return self._symbol.to_mem()
-36 │ │     }
+32 │ ╭     pub fn symbol(self) -> String<100> {
+33 │ │         return self._symbol.to_mem()
+34 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> String<100>
 
 note: 
-   ┌─ erc20_token.fe:35:16
+   ┌─ erc20_token.fe:33:16
    │
-35 │         return self._symbol.to_mem()
+33 │         return self._symbol.to_mem()
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:35:16
+   ┌─ erc20_token.fe:33:16
    │
-35 │         return self._symbol.to_mem()
+33 │         return self._symbol.to_mem()
    │                ^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) }
 
 note: 
-   ┌─ erc20_token.fe:35:16
+   ┌─ erc20_token.fe:33:16
    │
-35 │         return self._symbol.to_mem()
+33 │         return self._symbol.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: Some(4) } => Memory
 
 note: 
-   ┌─ erc20_token.fe:38:5
+   ┌─ erc20_token.fe:36:5
    │  
-38 │ ╭     pub fn decimals(self) -> u8 {
-39 │ │         return self._decimals
-40 │ │     }
+36 │ ╭     pub fn decimals(self) -> u8 {
+37 │ │         return self._decimals
+38 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> u8
 
 note: 
-   ┌─ erc20_token.fe:39:16
+   ┌─ erc20_token.fe:37:16
    │
-39 │         return self._decimals
+37 │         return self._decimals
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:39:16
+   ┌─ erc20_token.fe:37:16
    │
-39 │         return self._decimals
+37 │         return self._decimals
    │                ^^^^^^^^^^^^^^ u8: Storage { nonce: Some(5) } => Value
 
 note: 
-   ┌─ erc20_token.fe:42:5
+   ┌─ erc20_token.fe:40:5
    │  
-42 │ ╭     pub fn totalSupply(self) -> u256 {
-43 │ │         return self._total_supply
-44 │ │     }
+40 │ ╭     pub fn totalSupply(self) -> u256 {
+41 │ │         return self._total_supply
+42 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
-   ┌─ erc20_token.fe:43:16
+   ┌─ erc20_token.fe:41:16
    │
-43 │         return self._total_supply
+41 │         return self._total_supply
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:43:16
+   ┌─ erc20_token.fe:41:16
    │
-43 │         return self._total_supply
+41 │         return self._total_supply
    │                ^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ erc20_token.fe:46:5
+   ┌─ erc20_token.fe:44:5
    │  
-46 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
-47 │ │         return self._balances[account]
-48 │ │     }
+44 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
+45 │ │         return self._balances[account]
+46 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
-   ┌─ erc20_token.fe:47:16
+   ┌─ erc20_token.fe:45:16
    │
-47 │         return self._balances[account]
+45 │         return self._balances[account]
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:47:16
+   ┌─ erc20_token.fe:45:16
    │
-47 │         return self._balances[account]
+45 │         return self._balances[account]
    │                ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                │               
    │                Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:47:16
+   ┌─ erc20_token.fe:45:16
    │
-47 │         return self._balances[account]
+45 │         return self._balances[account]
    │                ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:50:5
+   ┌─ erc20_token.fe:48:5
    │  
-50 │ ╭     pub fn transfer(self, ctx: Context, recipient: address, value: u256) -> bool {
-51 │ │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
-52 │ │         return true
-53 │ │     }
+48 │ ╭     pub fn transfer(self, ctx: Context, recipient: address, value: u256) -> bool {
+49 │ │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
+50 │ │         return true
+51 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: recipient, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
-   ┌─ erc20_token.fe:51:9
+   ┌─ erc20_token.fe:49:9
    │
-51 │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
+49 │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
    │         ^^^^           ^^^          ^^^ Context: Memory
    │         │              │             
    │         │              Context: Memory
    │         ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:51:37
+   ┌─ erc20_token.fe:49:37
    │
-51 │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
+49 │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
    │                                     ^^^^^^^^^^^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value
    │                                     │                 │           
    │                                     │                 address: Value
    │                                     address: Value
 
 note: 
-   ┌─ erc20_token.fe:51:9
+   ┌─ erc20_token.fe:49:9
    │
-51 │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
+49 │         self._transfer(ctx, sender: ctx.msg_sender(), recipient, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-52 │         return true
+50 │         return true
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:55:5
+   ┌─ erc20_token.fe:53:5
    │  
-55 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256 {
-56 │ │         return self._allowances[owner][spender]
-57 │ │     }
+53 │ ╭     pub fn allowance(self, owner: address, spender: address) -> u256 {
+54 │ │         return self._allowances[owner][spender]
+55 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: owner, typ: address }, { label: None, name: spender, typ: address }] -> u256
 
 note: 
-   ┌─ erc20_token.fe:56:16
+   ┌─ erc20_token.fe:54:16
    │
-56 │         return self._allowances[owner][spender]
+54 │         return self._allowances[owner][spender]
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:56:16
+   ┌─ erc20_token.fe:54:16
    │
-56 │         return self._allowances[owner][spender]
+54 │         return self._allowances[owner][spender]
    │                ^^^^^^^^^^^^^^^^ ^^^^^ address: Value
    │                │                 
    │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ erc20_token.fe:56:16
+   ┌─ erc20_token.fe:54:16
    │
-56 │         return self._allowances[owner][spender]
+54 │         return self._allowances[owner][spender]
    │                ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                │                        
    │                Map<address, u256>: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:56:16
+   ┌─ erc20_token.fe:54:16
    │
-56 │         return self._allowances[owner][spender]
+54 │         return self._allowances[owner][spender]
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:59:5
+   ┌─ erc20_token.fe:57:5
    │  
-59 │ ╭     pub fn approve(self, ctx: Context, spender: address, value: u256) -> bool {
-60 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
-61 │ │         return true
-62 │ │     }
+57 │ ╭     pub fn approve(self, ctx: Context, spender: address, value: u256) -> bool {
+58 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+59 │ │         return true
+60 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
-   ┌─ erc20_token.fe:60:9
+   ┌─ erc20_token.fe:58:9
    │
-60 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+58 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
    │         ^^^^          ^^^         ^^^ Context: Memory
    │         │             │            
    │         │             Context: Memory
    │         ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:60:35
+   ┌─ erc20_token.fe:58:35
    │
-60 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+58 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
    │                                   ^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value
    │                                   │                 │         
    │                                   │                 address: Value
    │                                   address: Value
 
 note: 
-   ┌─ erc20_token.fe:60:9
+   ┌─ erc20_token.fe:58:9
    │
-60 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+58 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-61 │         return true
+59 │         return true
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:64:5
+   ┌─ erc20_token.fe:62:5
    │  
-64 │ ╭     pub fn transferFrom(self, ctx: Context, sender: address, recipient: address, value: u256) -> bool {
-65 │ │         assert self._allowances[sender][ctx.msg_sender()] >= value
-66 │ │         self._transfer(ctx, sender, recipient, value)
-67 │ │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
-68 │ │         return true
-69 │ │     }
+62 │ ╭     pub fn transferFrom(self, ctx: Context, sender: address, recipient: address, value: u256) -> bool {
+63 │ │         assert self._allowances[sender][ctx.msg_sender()] >= value
+64 │ │         self._transfer(ctx, sender, recipient, value)
+65 │ │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+66 │ │         return true
+67 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: sender, typ: address }, { label: None, name: recipient, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
-   ┌─ erc20_token.fe:65:16
+   ┌─ erc20_token.fe:63:16
    │
-65 │         assert self._allowances[sender][ctx.msg_sender()] >= value
+63 │         assert self._allowances[sender][ctx.msg_sender()] >= value
    │                ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:65:16
+   ┌─ erc20_token.fe:63:16
    │
-65 │         assert self._allowances[sender][ctx.msg_sender()] >= value
+63 │         assert self._allowances[sender][ctx.msg_sender()] >= value
    │                ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
    │                │                 
    │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ erc20_token.fe:65:16
+   ┌─ erc20_token.fe:63:16
    │
-65 │         assert self._allowances[sender][ctx.msg_sender()] >= value
+63 │         assert self._allowances[sender][ctx.msg_sender()] >= value
    │                ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
    │                │                         
    │                Map<address, u256>: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:65:41
+   ┌─ erc20_token.fe:63:41
    │
-65 │         assert self._allowances[sender][ctx.msg_sender()] >= value
+63 │         assert self._allowances[sender][ctx.msg_sender()] >= value
    │                                         ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:65:16
+   ┌─ erc20_token.fe:63:16
    │
-65 │         assert self._allowances[sender][ctx.msg_sender()] >= value
+63 │         assert self._allowances[sender][ctx.msg_sender()] >= value
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value
    │                │                                              
    │                u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:65:16
+   ┌─ erc20_token.fe:63:16
    │
-65 │         assert self._allowances[sender][ctx.msg_sender()] >= value
+63 │         assert self._allowances[sender][ctx.msg_sender()] >= value
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-66 │         self._transfer(ctx, sender, recipient, value)
+64 │         self._transfer(ctx, sender, recipient, value)
    │         ^^^^           ^^^  ^^^^^^  ^^^^^^^^^  ^^^^^ u256: Value
    │         │              │    │       │           
    │         │              │    │       address: Value
@@ -326,11 +326,11 @@ note:
    │         ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:66:9
+   ┌─ erc20_token.fe:64:9
    │
-66 │         self._transfer(ctx, sender, recipient, value)
+64 │         self._transfer(ctx, sender, recipient, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │         ^^^^          ^^^         ^^^^^^           ^^^ Context: Memory
    │         │             │           │                 
    │         │             │           address: Value
@@ -338,338 +338,338 @@ note:
    │         ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:67:52
+   ┌─ erc20_token.fe:65:52
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │                                                    ^^^^^^^^^^^^^^^^         ^^^^ ERC20: Value
    │                                                    │                         
    │                                                    address: Value
 
 note: 
-   ┌─ erc20_token.fe:67:77
+   ┌─ erc20_token.fe:65:77
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │                                                                             ^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
    │                                                                             │                 
    │                                                                             Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ erc20_token.fe:67:77
+   ┌─ erc20_token.fe:65:77
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
    │                                                                             │                         
    │                                                                             Map<address, u256>: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:67:102
+   ┌─ erc20_token.fe:65:102
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │                                                                                                      ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:67:77
+   ┌─ erc20_token.fe:65:77
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                                                             │                                             
    │                                                                             u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:67:77
+   ┌─ erc20_token.fe:65:77
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ erc20_token.fe:67:9
+   ┌─ erc20_token.fe:65:9
    │
-67 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
+65 │         self._approve(ctx, owner: sender, spender: ctx.msg_sender(), value: self._allowances[sender][ctx.msg_sender()] - value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-68 │         return true
+66 │         return true
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:71:5
+   ┌─ erc20_token.fe:69:5
    │  
-71 │ ╭     pub fn increaseAllowance(self, ctx: Context, spender: address, addedValue: u256) -> bool {
-72 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
-73 │ │         return true
-74 │ │     }
+69 │ ╭     pub fn increaseAllowance(self, ctx: Context, spender: address, addedValue: u256) -> bool {
+70 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+71 │ │         return true
+72 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: addedValue, typ: u256 }] -> bool
 
 note: 
-   ┌─ erc20_token.fe:72:9
+   ┌─ erc20_token.fe:70:9
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │         ^^^^          ^^^         ^^^ Context: Memory
    │         │             │            
    │         │             Context: Memory
    │         ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:72:35
+   ┌─ erc20_token.fe:70:35
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │                                   ^^^^^^^^^^^^^^^^  ^^^^^^^         ^^^^ ERC20: Value
    │                                   │                 │                
    │                                   │                 address: Value
    │                                   address: Value
 
 note: 
-   ┌─ erc20_token.fe:72:69
+   ┌─ erc20_token.fe:70:69
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │                                                                     ^^^^^^^^^^^^^^^^ ^^^ Context: Memory
    │                                                                     │                 
    │                                                                     Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ erc20_token.fe:72:86
+   ┌─ erc20_token.fe:70:86
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │                                                                                      ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:72:69
+   ┌─ erc20_token.fe:70:69
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                                                                     │                                   
    │                                                                     Map<address, u256>: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:72:69
+   ┌─ erc20_token.fe:70:69
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^ u256: Value
    │                                                                     │                                              
    │                                                                     u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:72:69
+   ┌─ erc20_token.fe:70:69
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ erc20_token.fe:72:9
+   ┌─ erc20_token.fe:70:9
    │
-72 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
+70 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] + addedValue)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-73 │         return true
+71 │         return true
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:76:5
+   ┌─ erc20_token.fe:74:5
    │  
-76 │ ╭     pub fn decreaseAllowance(self, ctx: Context, spender: address, subtractedValue: u256) -> bool {
-77 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
-78 │ │         return true
-79 │ │     }
+74 │ ╭     pub fn decreaseAllowance(self, ctx: Context, spender: address, subtractedValue: u256) -> bool {
+75 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+76 │ │         return true
+77 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: subtractedValue, typ: u256 }] -> bool
 
 note: 
-   ┌─ erc20_token.fe:77:9
+   ┌─ erc20_token.fe:75:9
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │         ^^^^          ^^^         ^^^ Context: Memory
    │         │             │            
    │         │             Context: Memory
    │         ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:77:35
+   ┌─ erc20_token.fe:75:35
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │                                   ^^^^^^^^^^^^^^^^  ^^^^^^^         ^^^^ ERC20: Value
    │                                   │                 │                
    │                                   │                 address: Value
    │                                   address: Value
 
 note: 
-   ┌─ erc20_token.fe:77:69
+   ┌─ erc20_token.fe:75:69
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │                                                                     ^^^^^^^^^^^^^^^^ ^^^ Context: Memory
    │                                                                     │                 
    │                                                                     Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ erc20_token.fe:77:86
+   ┌─ erc20_token.fe:75:86
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │                                                                                      ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:77:69
+   ┌─ erc20_token.fe:75:69
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                                                                     │                                   
    │                                                                     Map<address, u256>: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:77:69
+   ┌─ erc20_token.fe:75:69
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value
    │                                                                     │                                              
    │                                                                     u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:77:69
+   ┌─ erc20_token.fe:75:69
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ erc20_token.fe:77:9
+   ┌─ erc20_token.fe:75:9
    │
-77 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
+75 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value: self._allowances[ctx.msg_sender()][spender] - subtractedValue)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-78 │         return true
+76 │         return true
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ erc20_token.fe:81:5
+   ┌─ erc20_token.fe:79:5
    │  
-81 │ ╭     fn _transfer(self, ctx: Context, sender: address, recipient: address, value: u256) {
-82 │ │         assert sender != address(0)
-83 │ │         assert recipient != address(0)
-84 │ │         _before_token_transfer(from: sender, to: recipient, value)
+79 │ ╭     fn _transfer(self, ctx: Context, sender: address, recipient: address, value: u256) {
+80 │ │         assert sender != address(0)
+81 │ │         assert recipient != address(0)
+82 │ │         _before_token_transfer(from: sender, to: recipient, value)
    · │
-87 │ │         emit Transfer(ctx, from: sender, to: recipient, value)
-88 │ │     }
+85 │ │         emit Transfer(ctx, from: sender, to: recipient, value)
+86 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: sender, typ: address }, { label: None, name: recipient, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-   ┌─ erc20_token.fe:82:16
+   ┌─ erc20_token.fe:80:16
    │
-82 │         assert sender != address(0)
+80 │         assert sender != address(0)
    │                ^^^^^^            ^ u256: Value
    │                │                  
    │                address: Value
 
 note: 
-   ┌─ erc20_token.fe:82:26
+   ┌─ erc20_token.fe:80:26
    │
-82 │         assert sender != address(0)
+80 │         assert sender != address(0)
    │                          ^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:82:16
+   ┌─ erc20_token.fe:80:16
    │
-82 │         assert sender != address(0)
+80 │         assert sender != address(0)
    │                ^^^^^^^^^^^^^^^^^^^^ bool: Value
-83 │         assert recipient != address(0)
+81 │         assert recipient != address(0)
    │                ^^^^^^^^^            ^ u256: Value
    │                │                     
    │                address: Value
 
 note: 
-   ┌─ erc20_token.fe:83:29
+   ┌─ erc20_token.fe:81:29
    │
-83 │         assert recipient != address(0)
+81 │         assert recipient != address(0)
    │                             ^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:83:16
+   ┌─ erc20_token.fe:81:16
    │
-83 │         assert recipient != address(0)
+81 │         assert recipient != address(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-84 │         _before_token_transfer(from: sender, to: recipient, value)
+82 │         _before_token_transfer(from: sender, to: recipient, value)
    │                                      ^^^^^^      ^^^^^^^^^  ^^^^^ u256: Value
    │                                      │           │           
    │                                      │           address: Value
    │                                      address: Value
 
 note: 
-   ┌─ erc20_token.fe:84:9
+   ┌─ erc20_token.fe:82:9
    │
-84 │         _before_token_transfer(from: sender, to: recipient, value)
+82 │         _before_token_transfer(from: sender, to: recipient, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-85 │         self._balances[sender] = self._balances[sender] - value
+83 │         self._balances[sender] = self._balances[sender] - value
    │         ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:85:9
+   ┌─ erc20_token.fe:83:9
    │
-85 │         self._balances[sender] = self._balances[sender] - value
+83 │         self._balances[sender] = self._balances[sender] - value
    │         ^^^^^^^^^^^^^^ ^^^^^^ address: Value
    │         │               
    │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:85:9
+   ┌─ erc20_token.fe:83:9
    │
-85 │         self._balances[sender] = self._balances[sender] - value
+83 │         self._balances[sender] = self._balances[sender] - value
    │         ^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
    │         │                         
    │         u256: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:85:34
+   ┌─ erc20_token.fe:83:34
    │
-85 │         self._balances[sender] = self._balances[sender] - value
+83 │         self._balances[sender] = self._balances[sender] - value
    │                                  ^^^^^^^^^^^^^^ ^^^^^^ address: Value
    │                                  │               
    │                                  Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:85:34
+   ┌─ erc20_token.fe:83:34
    │
-85 │         self._balances[sender] = self._balances[sender] - value
+83 │         self._balances[sender] = self._balances[sender] - value
    │                                  ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                  │                         
    │                                  u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:85:34
+   ┌─ erc20_token.fe:83:34
    │
-85 │         self._balances[sender] = self._balances[sender] - value
+83 │         self._balances[sender] = self._balances[sender] - value
    │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-86 │         self._balances[recipient] = self._balances[recipient] + value
+84 │         self._balances[recipient] = self._balances[recipient] + value
    │         ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:86:9
+   ┌─ erc20_token.fe:84:9
    │
-86 │         self._balances[recipient] = self._balances[recipient] + value
+84 │         self._balances[recipient] = self._balances[recipient] + value
    │         ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value
    │         │               
    │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:86:9
+   ┌─ erc20_token.fe:84:9
    │
-86 │         self._balances[recipient] = self._balances[recipient] + value
+84 │         self._balances[recipient] = self._balances[recipient] + value
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
    │         │                            
    │         u256: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:86:37
+   ┌─ erc20_token.fe:84:37
    │
-86 │         self._balances[recipient] = self._balances[recipient] + value
+84 │         self._balances[recipient] = self._balances[recipient] + value
    │                                     ^^^^^^^^^^^^^^ ^^^^^^^^^ address: Value
    │                                     │               
    │                                     Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:86:37
+   ┌─ erc20_token.fe:84:37
    │
-86 │         self._balances[recipient] = self._balances[recipient] + value
+84 │         self._balances[recipient] = self._balances[recipient] + value
    │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                     │                            
    │                                     u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:86:37
+   ┌─ erc20_token.fe:84:37
    │
-86 │         self._balances[recipient] = self._balances[recipient] + value
+84 │         self._balances[recipient] = self._balances[recipient] + value
    │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-87 │         emit Transfer(ctx, from: sender, to: recipient, value)
+85 │         emit Transfer(ctx, from: sender, to: recipient, value)
    │                       ^^^        ^^^^^^      ^^^^^^^^^  ^^^^^ u256: Value
    │                       │          │           │           
    │                       │          │           address: Value
@@ -677,331 +677,331 @@ note:
    │                       Context: Memory
 
 note: 
-   ┌─ erc20_token.fe:90:5
+   ┌─ erc20_token.fe:88:5
    │  
-90 │ ╭     fn _mint(self, ctx: Context, account: address, value: u256) {
-91 │ │         assert account != address(0)
-92 │ │         _before_token_transfer(from: address(0), to: account, value)
-93 │ │         self._total_supply = self._total_supply + value
-94 │ │         self._balances[account] = self._balances[account] + value
-95 │ │         emit Transfer(ctx, from: address(0), to: account, value)
-96 │ │     }
+88 │ ╭     fn _mint(self, ctx: Context, account: address, value: u256) {
+89 │ │         assert account != address(0)
+90 │ │         _before_token_transfer(from: address(0), to: account, value)
+91 │ │         self._total_supply = self._total_supply + value
+92 │ │         self._balances[account] = self._balances[account] + value
+93 │ │         emit Transfer(ctx, from: address(0), to: account, value)
+94 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: account, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-   ┌─ erc20_token.fe:91:16
+   ┌─ erc20_token.fe:89:16
    │
-91 │         assert account != address(0)
+89 │         assert account != address(0)
    │                ^^^^^^^            ^ u256: Value
    │                │                   
    │                address: Value
 
 note: 
-   ┌─ erc20_token.fe:91:27
+   ┌─ erc20_token.fe:89:27
    │
-91 │         assert account != address(0)
+89 │         assert account != address(0)
    │                           ^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ erc20_token.fe:91:16
+   ┌─ erc20_token.fe:89:16
    │
-91 │         assert account != address(0)
+89 │         assert account != address(0)
    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-92 │         _before_token_transfer(from: address(0), to: account, value)
+90 │         _before_token_transfer(from: address(0), to: account, value)
    │                                              ^ u256: Value
 
 note: 
-   ┌─ erc20_token.fe:92:38
+   ┌─ erc20_token.fe:90:38
    │
-92 │         _before_token_transfer(from: address(0), to: account, value)
+90 │         _before_token_transfer(from: address(0), to: account, value)
    │                                      ^^^^^^^^^^      ^^^^^^^  ^^^^^ u256: Value
    │                                      │               │         
    │                                      │               address: Value
    │                                      address: Value
 
 note: 
-   ┌─ erc20_token.fe:92:9
+   ┌─ erc20_token.fe:90:9
    │
-92 │         _before_token_transfer(from: address(0), to: account, value)
+90 │         _before_token_transfer(from: address(0), to: account, value)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-93 │         self._total_supply = self._total_supply + value
+91 │         self._total_supply = self._total_supply + value
    │         ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:93:9
+   ┌─ erc20_token.fe:91:9
    │
-93 │         self._total_supply = self._total_supply + value
+91 │         self._total_supply = self._total_supply + value
    │         ^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
    │         │                     
    │         u256: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ erc20_token.fe:93:30
+   ┌─ erc20_token.fe:91:30
    │
-93 │         self._total_supply = self._total_supply + value
+91 │         self._total_supply = self._total_supply + value
    │                              ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                              │                     
    │                              u256: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ erc20_token.fe:93:30
+   ┌─ erc20_token.fe:91:30
    │
-93 │         self._total_supply = self._total_supply + value
+91 │         self._total_supply = self._total_supply + value
    │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-94 │         self._balances[account] = self._balances[account] + value
+92 │         self._balances[account] = self._balances[account] + value
    │         ^^^^ ERC20: Value
 
 note: 
-   ┌─ erc20_token.fe:94:9
+   ┌─ erc20_token.fe:92:9
    │
-94 │         self._balances[account] = self._balances[account] + value
+92 │         self._balances[account] = self._balances[account] + value
    │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │         │               
    │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:94:9
+   ┌─ erc20_token.fe:92:9
    │
-94 │         self._balances[account] = self._balances[account] + value
+92 │         self._balances[account] = self._balances[account] + value
    │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
    │         │                          
    │         u256: Storage { nonce: None }
 
 note: 
-   ┌─ erc20_token.fe:94:35
+   ┌─ erc20_token.fe:92:35
    │
-94 │         self._balances[account] = self._balances[account] + value
+92 │         self._balances[account] = self._balances[account] + value
    │                                   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
    │                                   │               
    │                                   Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ erc20_token.fe:94:35
+   ┌─ erc20_token.fe:92:35
    │
-94 │         self._balances[account] = self._balances[account] + value
+92 │         self._balances[account] = self._balances[account] + value
    │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                                   │                          
    │                                   u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ erc20_token.fe:94:35
+   ┌─ erc20_token.fe:92:35
    │
-94 │         self._balances[account] = self._balances[account] + value
+92 │         self._balances[account] = self._balances[account] + value
    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-95 │         emit Transfer(ctx, from: address(0), to: account, value)
+93 │         emit Transfer(ctx, from: address(0), to: account, value)
    │                       ^^^                ^ u256: Value
    │                       │                   
    │                       Context: Memory
 
 note: 
-   ┌─ erc20_token.fe:95:34
+   ┌─ erc20_token.fe:93:34
    │
-95 │         emit Transfer(ctx, from: address(0), to: account, value)
+93 │         emit Transfer(ctx, from: address(0), to: account, value)
    │                                  ^^^^^^^^^^      ^^^^^^^  ^^^^^ u256: Value
    │                                  │               │         
    │                                  │               address: Value
    │                                  address: Value
 
 note: 
-    ┌─ erc20_token.fe:98:5
+    ┌─ erc20_token.fe:96:5
     │  
- 98 │ ╭     fn _burn(self, ctx: Context, account: address, value: u256) {
- 99 │ │         assert account != address(0)
-100 │ │         _before_token_transfer(from: account, to: address(0), value)
-101 │ │         self._balances[account] = self._balances[account] - value
-102 │ │         self._total_supply = self._total_supply - value
-103 │ │         emit Transfer(ctx, from: account, to: address(0), value)
-104 │ │     }
+ 96 │ ╭     fn _burn(self, ctx: Context, account: address, value: u256) {
+ 97 │ │         assert account != address(0)
+ 98 │ │         _before_token_transfer(from: account, to: address(0), value)
+ 99 │ │         self._balances[account] = self._balances[account] - value
+100 │ │         self._total_supply = self._total_supply - value
+101 │ │         emit Transfer(ctx, from: account, to: address(0), value)
+102 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: account, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-   ┌─ erc20_token.fe:99:16
+   ┌─ erc20_token.fe:97:16
    │
-99 │         assert account != address(0)
+97 │         assert account != address(0)
    │                ^^^^^^^            ^ u256: Value
    │                │                   
    │                address: Value
 
 note: 
-   ┌─ erc20_token.fe:99:27
+   ┌─ erc20_token.fe:97:27
    │
-99 │         assert account != address(0)
+97 │         assert account != address(0)
    │                           ^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ erc20_token.fe:99:16
-    │
- 99 │         assert account != address(0)
-    │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-100 │         _before_token_transfer(from: account, to: address(0), value)
-    │                                      ^^^^^^^              ^ u256: Value
-    │                                      │                     
-    │                                      address: Value
+   ┌─ erc20_token.fe:97:16
+   │
+97 │         assert account != address(0)
+   │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
+98 │         _before_token_transfer(from: account, to: address(0), value)
+   │                                      ^^^^^^^              ^ u256: Value
+   │                                      │                     
+   │                                      address: Value
 
 note: 
-    ┌─ erc20_token.fe:100:51
+   ┌─ erc20_token.fe:98:51
+   │
+98 │         _before_token_transfer(from: account, to: address(0), value)
+   │                                                   ^^^^^^^^^^  ^^^^^ u256: Value
+   │                                                   │            
+   │                                                   address: Value
+
+note: 
+   ┌─ erc20_token.fe:98:9
+   │
+98 │         _before_token_transfer(from: account, to: address(0), value)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
+99 │         self._balances[account] = self._balances[account] - value
+   │         ^^^^ ERC20: Value
+
+note: 
+   ┌─ erc20_token.fe:99:9
+   │
+99 │         self._balances[account] = self._balances[account] - value
+   │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │         │               
+   │         Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ erc20_token.fe:99:9
+   │
+99 │         self._balances[account] = self._balances[account] - value
+   │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
+   │         │                          
+   │         u256: Storage { nonce: None }
+
+note: 
+   ┌─ erc20_token.fe:99:35
+   │
+99 │         self._balances[account] = self._balances[account] - value
+   │                                   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
+   │                                   │               
+   │                                   Map<address, u256>: Storage { nonce: Some(0) }
+
+note: 
+   ┌─ erc20_token.fe:99:35
+   │
+99 │         self._balances[account] = self._balances[account] - value
+   │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
+   │                                   │                          
+   │                                   u256: Storage { nonce: None } => Value
+
+note: 
+    ┌─ erc20_token.fe:99:35
     │
-100 │         _before_token_transfer(from: account, to: address(0), value)
-    │                                                   ^^^^^^^^^^  ^^^^^ u256: Value
-    │                                                   │            
-    │                                                   address: Value
+ 99 │         self._balances[account] = self._balances[account] - value
+    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+100 │         self._total_supply = self._total_supply - value
+    │         ^^^^ ERC20: Value
 
 note: 
     ┌─ erc20_token.fe:100:9
     │
-100 │         _before_token_transfer(from: account, to: address(0), value)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-101 │         self._balances[account] = self._balances[account] - value
-    │         ^^^^ ERC20: Value
-
-note: 
-    ┌─ erc20_token.fe:101:9
-    │
-101 │         self._balances[account] = self._balances[account] - value
-    │         ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
-    │         │               
-    │         Map<address, u256>: Storage { nonce: Some(0) }
-
-note: 
-    ┌─ erc20_token.fe:101:9
-    │
-101 │         self._balances[account] = self._balances[account] - value
-    │         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
-    │         │                          
-    │         u256: Storage { nonce: None }
-
-note: 
-    ┌─ erc20_token.fe:101:35
-    │
-101 │         self._balances[account] = self._balances[account] - value
-    │                                   ^^^^^^^^^^^^^^ ^^^^^^^ address: Value
-    │                                   │               
-    │                                   Map<address, u256>: Storage { nonce: Some(0) }
-
-note: 
-    ┌─ erc20_token.fe:101:35
-    │
-101 │         self._balances[account] = self._balances[account] - value
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
-    │                                   │                          
-    │                                   u256: Storage { nonce: None } => Value
-
-note: 
-    ┌─ erc20_token.fe:101:35
-    │
-101 │         self._balances[account] = self._balances[account] - value
-    │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-102 │         self._total_supply = self._total_supply - value
-    │         ^^^^ ERC20: Value
-
-note: 
-    ┌─ erc20_token.fe:102:9
-    │
-102 │         self._total_supply = self._total_supply - value
+100 │         self._total_supply = self._total_supply - value
     │         ^^^^^^^^^^^^^^^^^^   ^^^^ ERC20: Value
     │         │                     
     │         u256: Storage { nonce: Some(2) }
 
 note: 
-    ┌─ erc20_token.fe:102:30
+    ┌─ erc20_token.fe:100:30
     │
-102 │         self._total_supply = self._total_supply - value
+100 │         self._total_supply = self._total_supply - value
     │                              ^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │                              │                     
     │                              u256: Storage { nonce: Some(2) } => Value
 
 note: 
-    ┌─ erc20_token.fe:102:30
+    ┌─ erc20_token.fe:100:30
     │
-102 │         self._total_supply = self._total_supply - value
+100 │         self._total_supply = self._total_supply - value
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-103 │         emit Transfer(ctx, from: account, to: address(0), value)
+101 │         emit Transfer(ctx, from: account, to: address(0), value)
     │                       ^^^        ^^^^^^^              ^ u256: Value
     │                       │          │                     
     │                       │          address: Value
     │                       Context: Memory
 
 note: 
-    ┌─ erc20_token.fe:103:47
+    ┌─ erc20_token.fe:101:47
     │
-103 │         emit Transfer(ctx, from: account, to: address(0), value)
+101 │         emit Transfer(ctx, from: account, to: address(0), value)
     │                                               ^^^^^^^^^^  ^^^^^ u256: Value
     │                                               │            
     │                                               address: Value
 
 note: 
-    ┌─ erc20_token.fe:106:5
+    ┌─ erc20_token.fe:104:5
     │  
-106 │ ╭     fn _approve(self, ctx: Context, owner: address, spender: address, value: u256) {
-107 │ │         assert owner != address(0)
-108 │ │         assert spender != address(0)
-109 │ │         self._allowances[owner][spender] = value
-110 │ │         emit Approval(ctx, owner, spender, value)
-111 │ │     }
+104 │ ╭     fn _approve(self, ctx: Context, owner: address, spender: address, value: u256) {
+105 │ │         assert owner != address(0)
+106 │ │         assert spender != address(0)
+107 │ │         self._allowances[owner][spender] = value
+108 │ │         emit Approval(ctx, owner, spender, value)
+109 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: owner, typ: address }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-    ┌─ erc20_token.fe:107:16
+    ┌─ erc20_token.fe:105:16
     │
-107 │         assert owner != address(0)
+105 │         assert owner != address(0)
     │                ^^^^^            ^ u256: Value
     │                │                 
     │                address: Value
 
 note: 
-    ┌─ erc20_token.fe:107:25
+    ┌─ erc20_token.fe:105:25
     │
-107 │         assert owner != address(0)
+105 │         assert owner != address(0)
     │                         ^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ erc20_token.fe:107:16
+    ┌─ erc20_token.fe:105:16
     │
-107 │         assert owner != address(0)
+105 │         assert owner != address(0)
     │                ^^^^^^^^^^^^^^^^^^^ bool: Value
-108 │         assert spender != address(0)
+106 │         assert spender != address(0)
     │                ^^^^^^^            ^ u256: Value
     │                │                   
     │                address: Value
 
 note: 
-    ┌─ erc20_token.fe:108:27
+    ┌─ erc20_token.fe:106:27
     │
-108 │         assert spender != address(0)
+106 │         assert spender != address(0)
     │                           ^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ erc20_token.fe:108:16
+    ┌─ erc20_token.fe:106:16
     │
-108 │         assert spender != address(0)
+106 │         assert spender != address(0)
     │                ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-109 │         self._allowances[owner][spender] = value
+107 │         self._allowances[owner][spender] = value
     │         ^^^^ ERC20: Value
 
 note: 
-    ┌─ erc20_token.fe:109:9
+    ┌─ erc20_token.fe:107:9
     │
-109 │         self._allowances[owner][spender] = value
+107 │         self._allowances[owner][spender] = value
     │         ^^^^^^^^^^^^^^^^ ^^^^^ address: Value
     │         │                 
     │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-    ┌─ erc20_token.fe:109:9
+    ┌─ erc20_token.fe:107:9
     │
-109 │         self._allowances[owner][spender] = value
+107 │         self._allowances[owner][spender] = value
     │         ^^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
     │         │                        
     │         Map<address, u256>: Storage { nonce: None }
 
 note: 
-    ┌─ erc20_token.fe:109:9
+    ┌─ erc20_token.fe:107:9
     │
-109 │         self._allowances[owner][spender] = value
+107 │         self._allowances[owner][spender] = value
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │         │                                   
     │         u256: Storage { nonce: None }
-110 │         emit Approval(ctx, owner, spender, value)
+108 │         emit Approval(ctx, owner, spender, value)
     │                       ^^^  ^^^^^  ^^^^^^^  ^^^^^ u256: Value
     │                       │    │      │         
     │                       │    │      address: Value
@@ -1009,31 +1009,31 @@ note:
     │                       Context: Memory
 
 note: 
-    ┌─ erc20_token.fe:113:5
+    ┌─ erc20_token.fe:111:5
     │  
-113 │ ╭     fn _setup_decimals(self, _ decimals_: u8) {
-114 │ │         self._decimals = decimals_
-115 │ │     }
+111 │ ╭     fn _setup_decimals(self, _ decimals_: u8) {
+112 │ │         self._decimals = decimals_
+113 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: decimals_, typ: u8 }] -> ()
 
 note: 
-    ┌─ erc20_token.fe:114:9
+    ┌─ erc20_token.fe:112:9
     │
-114 │         self._decimals = decimals_
+112 │         self._decimals = decimals_
     │         ^^^^ ERC20: Value
 
 note: 
-    ┌─ erc20_token.fe:114:9
+    ┌─ erc20_token.fe:112:9
     │
-114 │         self._decimals = decimals_
+112 │         self._decimals = decimals_
     │         ^^^^^^^^^^^^^^   ^^^^^^^^^ u8: Value
     │         │                 
     │         u8: Storage { nonce: Some(5) }
 
 note: 
-    ┌─ erc20_token.fe:117:5
+    ┌─ erc20_token.fe:115:5
     │
-117 │     fn _before_token_transfer(from: address, to: address, _ value: u256) {}
+115 │     fn _before_token_transfer(from: address, to: address, _ value: u256) {}
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ self: None, params: [{ label: None, name: from, typ: address }, { label: None, name: to, typ: address }, { label: Some("_"), name: value, typ: u256 }] -> ()
 
 

--- a/crates/analyzer/tests/snapshots/analysis__events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__events.snap
@@ -4,85 +4,85 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ events.fe:5:9
+  ┌─ events.fe:3:9
   │
-5 │         idx num1: u256
+3 │         idx num1: u256
   │         ^^^^^^^^^^^^^^ u256
-6 │         num2: u256
+4 │         num2: u256
   │         ^^^^^^^^^^ u256
 
 note: 
-   ┌─ events.fe:10:9
-   │
-10 │         num: u256
-   │         ^^^^^^^^^ u256
-11 │         addr: address
-   │         ^^^^^^^^^^^^^ address
+  ┌─ events.fe:8:9
+  │
+8 │         num: u256
+  │         ^^^^^^^^^ u256
+9 │         addr: address
+  │         ^^^^^^^^^^^^^ address
 
 note: 
-   ┌─ events.fe:15:9
+   ┌─ events.fe:13:9
    │
-15 │         num1: u256
+13 │         num1: u256
    │         ^^^^^^^^^^ u256
-16 │         idx addr: address
+14 │         idx addr: address
    │         ^^^^^^^^^^^^^^^^^ address
-17 │         num2: u256
+15 │         num2: u256
    │         ^^^^^^^^^^ u256
-18 │         my_bytes: Array<u8, 100>
+16 │         my_bytes: Array<u8, 100>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 100>
 
 note: 
-   ┌─ events.fe:22:9
+   ┌─ events.fe:20:9
    │
-22 │         addrs: Array<address, 2>
+20 │         addrs: Array<address, 2>
    │         ^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 2>
 
 note: 
-   ┌─ events.fe:25:5
+   ┌─ events.fe:23:5
    │  
-25 │ ╭     pub fn emit_nums(ctx: Context) {
-26 │ │         emit Nums(ctx, num1: 26, num2: 42)
-27 │ │     }
+23 │ ╭     pub fn emit_nums(ctx: Context) {
+24 │ │         emit Nums(ctx, num1: 26, num2: 42)
+25 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ events.fe:26:19
+   ┌─ events.fe:24:19
    │
-26 │         emit Nums(ctx, num1: 26, num2: 42)
+24 │         emit Nums(ctx, num1: 26, num2: 42)
    │                   ^^^        ^^        ^^ u256: Value
    │                   │          │          
    │                   │          u256: Value
    │                   Context: Memory
 
 note: 
-   ┌─ events.fe:29:5
+   ┌─ events.fe:27:5
    │  
-29 │ ╭     pub fn emit_bases(ctx: Context, addr: address) {
-30 │ │         emit Bases(ctx, num: 26, addr)
-31 │ │     }
+27 │ ╭     pub fn emit_bases(ctx: Context, addr: address) {
+28 │ │         emit Bases(ctx, num: 26, addr)
+29 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: addr, typ: address }] -> ()
 
 note: 
-   ┌─ events.fe:30:20
+   ┌─ events.fe:28:20
    │
-30 │         emit Bases(ctx, num: 26, addr)
+28 │         emit Bases(ctx, num: 26, addr)
    │                    ^^^       ^^  ^^^^ address: Value
    │                    │         │    
    │                    │         u256: Value
    │                    Context: Memory
 
 note: 
-   ┌─ events.fe:33:5
+   ┌─ events.fe:31:5
    │  
-33 │ ╭     pub fn emit_mix(ctx: Context, addr: address, my_bytes: Array<u8, 100>) {
-34 │ │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
-35 │ │     }
+31 │ ╭     pub fn emit_mix(ctx: Context, addr: address, my_bytes: Array<u8, 100>) {
+32 │ │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
+33 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: addr, typ: address }, { label: None, name: my_bytes, typ: Array<u8, 100> }] -> ()
 
 note: 
-   ┌─ events.fe:34:18
+   ┌─ events.fe:32:18
    │
-34 │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
+32 │         emit Mix(ctx, num1: 26, addr, num2: 42, my_bytes)
    │                  ^^^        ^^  ^^^^        ^^  ^^^^^^^^ Array<u8, 100>: Memory
    │                  │          │   │           │    
    │                  │          │   │           u256: Value
@@ -91,66 +91,66 @@ note:
    │                  Context: Memory
 
 note: 
-   ┌─ events.fe:37:5
+   ┌─ events.fe:35:5
    │  
-37 │ ╭     pub fn emit_addresses(ctx: Context, addr1: address, addr2: address) {
-38 │ │         let addrs: Array<address, 2> = [address(0); 2]
-39 │ │         addrs[0] = addr1
-40 │ │         addrs[1] = addr2
-41 │ │         emit Addresses(ctx, addrs)
-42 │ │     }
+35 │ ╭     pub fn emit_addresses(ctx: Context, addr1: address, addr2: address) {
+36 │ │         let addrs: Array<address, 2> = [address(0); 2]
+37 │ │         addrs[0] = addr1
+38 │ │         addrs[1] = addr2
+39 │ │         emit Addresses(ctx, addrs)
+40 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: addr1, typ: address }, { label: None, name: addr2, typ: address }] -> ()
 
 note: 
-   ┌─ events.fe:38:13
+   ┌─ events.fe:36:13
    │
-38 │         let addrs: Array<address, 2> = [address(0); 2]
+36 │         let addrs: Array<address, 2> = [address(0); 2]
    │             ^^^^^ Array<address, 2>
 
 note: 
-   ┌─ events.fe:38:49
+   ┌─ events.fe:36:49
    │
-38 │         let addrs: Array<address, 2> = [address(0); 2]
+36 │         let addrs: Array<address, 2> = [address(0); 2]
    │                                                 ^ u256: Value
 
 note: 
-   ┌─ events.fe:38:41
+   ┌─ events.fe:36:41
    │
-38 │         let addrs: Array<address, 2> = [address(0); 2]
+36 │         let addrs: Array<address, 2> = [address(0); 2]
    │                                         ^^^^^^^^^^  ^ u256: Value
    │                                         │            
    │                                         address: Value
 
 note: 
-   ┌─ events.fe:38:40
+   ┌─ events.fe:36:40
    │
-38 │         let addrs: Array<address, 2> = [address(0); 2]
+36 │         let addrs: Array<address, 2> = [address(0); 2]
    │                                        ^^^^^^^^^^^^^^^ Array<address, 2>: Memory
-39 │         addrs[0] = addr1
+37 │         addrs[0] = addr1
    │         ^^^^^ ^ u256: Value
    │         │      
    │         Array<address, 2>: Memory
 
 note: 
-   ┌─ events.fe:39:9
+   ┌─ events.fe:37:9
    │
-39 │         addrs[0] = addr1
+37 │         addrs[0] = addr1
    │         ^^^^^^^^   ^^^^^ address: Value
    │         │           
    │         address: Memory
-40 │         addrs[1] = addr2
+38 │         addrs[1] = addr2
    │         ^^^^^ ^ u256: Value
    │         │      
    │         Array<address, 2>: Memory
 
 note: 
-   ┌─ events.fe:40:9
+   ┌─ events.fe:38:9
    │
-40 │         addrs[1] = addr2
+38 │         addrs[1] = addr2
    │         ^^^^^^^^   ^^^^^ address: Value
    │         │           
    │         address: Memory
-41 │         emit Addresses(ctx, addrs)
+39 │         emit Addresses(ctx, addrs)
    │                        ^^^  ^^^^^ Array<address, 2>: Memory
    │                        │     
    │                        Context: Memory

--- a/crates/analyzer/tests/snapshots/analysis__external_contract.snap
+++ b/crates/analyzer/tests/snapshots/analysis__external_contract.snap
@@ -4,65 +4,96 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ external_contract.fe:5:9
+  ┌─ external_contract.fe:3:9
   │
-5 │         my_num: u256
+3 │         my_num: u256
   │         ^^^^^^^^^^^^ u256
-6 │         my_addrs: Array<address, 5>
+4 │         my_addrs: Array<address, 5>
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 5>
-7 │         my_string: String<11>
+5 │         my_string: String<11>
   │         ^^^^^^^^^^^^^^^^^^^^^ String<11>
 
 note: 
-   ┌─ external_contract.fe:10:5
+   ┌─ external_contract.fe:8:5
    │  
-10 │ ╭     pub fn emit_event(self, ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
-11 │ │         emit MyEvent(ctx, my_num, my_addrs, my_string)
-12 │ │     }
+ 8 │ ╭     pub fn emit_event(self, ctx: Context, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
+ 9 │ │         emit MyEvent(ctx, my_num, my_addrs, my_string)
+10 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
 
 note: 
-   ┌─ external_contract.fe:11:22
-   │
-11 │         emit MyEvent(ctx, my_num, my_addrs, my_string)
-   │                      ^^^  ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory
-   │                      │    │       │          
-   │                      │    │       Array<address, 5>: Memory
-   │                      │    u256: Value
-   │                      Context: Memory
+  ┌─ external_contract.fe:9:22
+  │
+9 │         emit MyEvent(ctx, my_num, my_addrs, my_string)
+  │                      ^^^  ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory
+  │                      │    │       │          
+  │                      │    │       Array<address, 5>: Memory
+  │                      │    u256: Value
+  │                      Context: Memory
 
 note: 
-   ┌─ external_contract.fe:14:5
+   ┌─ external_contract.fe:12:5
    │  
-14 │ ╭     pub fn build_array(self, a: u256, b: u256) -> Array<u256, 3> {
-15 │ │         let my_array: Array<u256, 3> = [0; 3]
-16 │ │         my_array[0] = a
-17 │ │         my_array[1] = a * b
-18 │ │         my_array[2] = b
-19 │ │         return my_array
-20 │ │     }
+12 │ ╭     pub fn build_array(self, a: u256, b: u256) -> Array<u256, 3> {
+13 │ │         let my_array: Array<u256, 3> = [0; 3]
+14 │ │         my_array[0] = a
+15 │ │         my_array[1] = a * b
+16 │ │         my_array[2] = b
+17 │ │         return my_array
+18 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
 
 note: 
-   ┌─ external_contract.fe:15:13
+   ┌─ external_contract.fe:13:13
    │
-15 │         let my_array: Array<u256, 3> = [0; 3]
+13 │         let my_array: Array<u256, 3> = [0; 3]
    │             ^^^^^^^^ Array<u256, 3>
 
 note: 
-   ┌─ external_contract.fe:15:41
+   ┌─ external_contract.fe:13:41
    │
-15 │         let my_array: Array<u256, 3> = [0; 3]
+13 │         let my_array: Array<u256, 3> = [0; 3]
    │                                         ^  ^ u256: Value
    │                                         │   
    │                                         u256: Value
 
 note: 
-   ┌─ external_contract.fe:15:40
+   ┌─ external_contract.fe:13:40
    │
-15 │         let my_array: Array<u256, 3> = [0; 3]
+13 │         let my_array: Array<u256, 3> = [0; 3]
    │                                        ^^^^^^ Array<u256, 3>: Memory
-16 │         my_array[0] = a
+14 │         my_array[0] = a
+   │         ^^^^^^^^ ^ u256: Value
+   │         │         
+   │         Array<u256, 3>: Memory
+
+note: 
+   ┌─ external_contract.fe:14:9
+   │
+14 │         my_array[0] = a
+   │         ^^^^^^^^^^^   ^ u256: Value
+   │         │              
+   │         u256: Memory
+15 │         my_array[1] = a * b
+   │         ^^^^^^^^ ^ u256: Value
+   │         │         
+   │         Array<u256, 3>: Memory
+
+note: 
+   ┌─ external_contract.fe:15:9
+   │
+15 │         my_array[1] = a * b
+   │         ^^^^^^^^^^^   ^   ^ u256: Value
+   │         │             │    
+   │         │             u256: Value
+   │         u256: Memory
+
+note: 
+   ┌─ external_contract.fe:15:23
+   │
+15 │         my_array[1] = a * b
+   │                       ^^^^^ u256: Value
+16 │         my_array[2] = b
    │         ^^^^^^^^ ^ u256: Value
    │         │         
    │         Array<u256, 3>: Memory
@@ -70,93 +101,62 @@ note:
 note: 
    ┌─ external_contract.fe:16:9
    │
-16 │         my_array[0] = a
+16 │         my_array[2] = b
    │         ^^^^^^^^^^^   ^ u256: Value
    │         │              
    │         u256: Memory
-17 │         my_array[1] = a * b
-   │         ^^^^^^^^ ^ u256: Value
-   │         │         
-   │         Array<u256, 3>: Memory
-
-note: 
-   ┌─ external_contract.fe:17:9
-   │
-17 │         my_array[1] = a * b
-   │         ^^^^^^^^^^^   ^   ^ u256: Value
-   │         │             │    
-   │         │             u256: Value
-   │         u256: Memory
-
-note: 
-   ┌─ external_contract.fe:17:23
-   │
-17 │         my_array[1] = a * b
-   │                       ^^^^^ u256: Value
-18 │         my_array[2] = b
-   │         ^^^^^^^^ ^ u256: Value
-   │         │         
-   │         Array<u256, 3>: Memory
-
-note: 
-   ┌─ external_contract.fe:18:9
-   │
-18 │         my_array[2] = b
-   │         ^^^^^^^^^^^   ^ u256: Value
-   │         │              
-   │         u256: Memory
-19 │         return my_array
+17 │         return my_array
    │                ^^^^^^^^ Array<u256, 3>: Memory
 
 note: 
-   ┌─ external_contract.fe:22:5
+   ┌─ external_contract.fe:20:5
    │  
-22 │ ╭     pub fn pure_add(_ x: u256, _ y: u256) -> u256 {
-23 │ │         return x + y
-24 │ │     }
+20 │ ╭     pub fn pure_add(_ x: u256, _ y: u256) -> u256 {
+21 │ │         return x + y
+22 │ │     }
    │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
-   ┌─ external_contract.fe:23:16
+   ┌─ external_contract.fe:21:16
    │
-23 │         return x + y
+21 │         return x + y
    │                ^   ^ u256: Value
    │                │    
    │                u256: Value
 
 note: 
-   ┌─ external_contract.fe:23:16
+   ┌─ external_contract.fe:21:16
    │
-23 │         return x + y
+21 │         return x + y
    │                ^^^^^ u256: Value
 
 note: 
-   ┌─ external_contract.fe:28:5
+   ┌─ external_contract.fe:26:5
    │  
-28 │ ╭     pub fn call_emit_event(ctx: Context, foo_address: address, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
-29 │ │         let foo: Foo = Foo(foo_address)
-30 │ │         foo.emit_event(ctx, my_num, my_addrs, my_string)
-31 │ │     }
+26 │ ╭     pub fn call_emit_event(ctx: Context, foo_address: address, my_num: u256, my_addrs: Array<address, 5>, my_string: String<11>) {
+27 │ │         let foo: Foo = Foo(foo_address)
+28 │ │         foo.emit_event(ctx, my_num, my_addrs, my_string)
+29 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: foo_address, typ: address }, { label: None, name: my_num, typ: u256 }, { label: None, name: my_addrs, typ: Array<address, 5> }, { label: None, name: my_string, typ: String<11> }] -> ()
 
 note: 
-   ┌─ external_contract.fe:29:13
+   ┌─ external_contract.fe:27:13
    │
-29 │         let foo: Foo = Foo(foo_address)
+27 │         let foo: Foo = Foo(foo_address)
    │             ^^^ Foo
 
 note: 
-   ┌─ external_contract.fe:29:28
+   ┌─ external_contract.fe:27:28
    │
-29 │         let foo: Foo = Foo(foo_address)
+27 │         let foo: Foo = Foo(foo_address)
    │                            ^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ external_contract.fe:29:24
+   ┌─ external_contract.fe:27:24
    │
-29 │         let foo: Foo = Foo(foo_address)
+27 │         let foo: Foo = Foo(foo_address)
    │                        ^^^^^^^^^^^^^^^^ Foo: Value
-30 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
+28 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
    │         ^^^            ^^^  ^^^^^^  ^^^^^^^^  ^^^^^^^^^ String<11>: Memory
    │         │              │    │       │          
    │         │              │    │       Array<address, 5>: Memory
@@ -165,69 +165,69 @@ note:
    │         Foo: Value
 
 note: 
-   ┌─ external_contract.fe:30:9
+   ┌─ external_contract.fe:28:9
    │
-30 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
+28 │         foo.emit_event(ctx, my_num, my_addrs, my_string)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ external_contract.fe:33:5
+   ┌─ external_contract.fe:31:5
    │  
-33 │ ╭     pub fn call_build_array(foo_address: address, a: u256, b: u256) -> Array<u256, 3> {
-34 │ │         let foo: Foo = Foo(foo_address)
-35 │ │         return foo.build_array(a, b)
-36 │ │     }
+31 │ ╭     pub fn call_build_array(foo_address: address, a: u256, b: u256) -> Array<u256, 3> {
+32 │ │         let foo: Foo = Foo(foo_address)
+33 │ │         return foo.build_array(a, b)
+34 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: foo_address, typ: address }, { label: None, name: a, typ: u256 }, { label: None, name: b, typ: u256 }] -> Array<u256, 3>
 
 note: 
-   ┌─ external_contract.fe:34:13
+   ┌─ external_contract.fe:32:13
    │
-34 │         let foo: Foo = Foo(foo_address)
+32 │         let foo: Foo = Foo(foo_address)
    │             ^^^ Foo
 
 note: 
-   ┌─ external_contract.fe:34:28
+   ┌─ external_contract.fe:32:28
    │
-34 │         let foo: Foo = Foo(foo_address)
+32 │         let foo: Foo = Foo(foo_address)
    │                            ^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ external_contract.fe:34:24
+   ┌─ external_contract.fe:32:24
    │
-34 │         let foo: Foo = Foo(foo_address)
+32 │         let foo: Foo = Foo(foo_address)
    │                        ^^^^^^^^^^^^^^^^ Foo: Value
-35 │         return foo.build_array(a, b)
+33 │         return foo.build_array(a, b)
    │                ^^^             ^  ^ u256: Value
    │                │               │   
    │                │               u256: Value
    │                Foo: Value
 
 note: 
-   ┌─ external_contract.fe:35:16
+   ┌─ external_contract.fe:33:16
    │
-35 │         return foo.build_array(a, b)
+33 │         return foo.build_array(a, b)
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 3>: Memory
 
 note: 
-   ┌─ external_contract.fe:38:5
+   ┌─ external_contract.fe:36:5
    │  
-38 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
-39 │ │         return Foo::pure_add(x, y)
-40 │ │     }
+36 │ ╭     pub fn add(_ x: u256, _ y: u256) -> u256 {
+37 │ │         return Foo::pure_add(x, y)
+38 │ │     }
    │ ╰─────^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
-   ┌─ external_contract.fe:39:30
+   ┌─ external_contract.fe:37:30
    │
-39 │         return Foo::pure_add(x, y)
+37 │         return Foo::pure_add(x, y)
    │                              ^  ^ u256: Value
    │                              │   
    │                              u256: Value
 
 note: 
-   ┌─ external_contract.fe:39:16
+   ┌─ external_contract.fe:37:16
    │
-39 │         return Foo::pure_add(x, y)
+37 │         return Foo::pure_add(x, y)
    │                ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__guest_book.snap
+++ b/crates/analyzer/tests/snapshots/analysis__guest_book.snap
@@ -4,96 +4,96 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ guest_book.fe:9:5
+  ┌─ guest_book.fe:5:5
   │
-9 │     messages: Map<address, String<100>>
+5 │     messages: Map<address, String<100>>
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, String<100>>
 
 note: 
-   ┌─ guest_book.fe:13:9
-   │
-13 │         book_msg: String<100>
-   │         ^^^^^^^^^^^^^^^^^^^^^ String<100>
+  ┌─ guest_book.fe:9:9
+  │
+9 │         book_msg: String<100>
+  │         ^^^^^^^^^^^^^^^^^^^^^ String<100>
 
 note: 
-   ┌─ guest_book.fe:16:5
+   ┌─ guest_book.fe:14:5
    │  
-16 │ ╭     pub fn sign(self, ctx: Context, book_msg: String<100>) {
-17 │ │         // All storage access is explicit using `self.<some-key>`
-18 │ │         self.messages[ctx.msg_sender()] = book_msg
-19 │ │ 
+14 │ ╭     pub fn sign(self, ctx: Context, book_msg: String<100>) {
+15 │ │         // All storage access is explicit using `self.<some-key>`
+16 │ │         self.messages[ctx.msg_sender()] = book_msg
+17 │ │ 
    · │
-22 │ │         emit Signed(ctx, book_msg)
-23 │ │     }
+20 │ │         emit Signed(ctx, book_msg)
+21 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: book_msg, typ: String<100> }] -> ()
 
 note: 
-   ┌─ guest_book.fe:18:9
+   ┌─ guest_book.fe:16:9
    │
-18 │         self.messages[ctx.msg_sender()] = book_msg
+16 │         self.messages[ctx.msg_sender()] = book_msg
    │         ^^^^ GuestBook: Value
 
 note: 
-   ┌─ guest_book.fe:18:9
+   ┌─ guest_book.fe:16:9
    │
-18 │         self.messages[ctx.msg_sender()] = book_msg
+16 │         self.messages[ctx.msg_sender()] = book_msg
    │         ^^^^^^^^^^^^^ ^^^ Context: Memory
    │         │              
    │         Map<address, String<100>>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ guest_book.fe:18:23
+   ┌─ guest_book.fe:16:23
    │
-18 │         self.messages[ctx.msg_sender()] = book_msg
+16 │         self.messages[ctx.msg_sender()] = book_msg
    │                       ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ guest_book.fe:18:9
+   ┌─ guest_book.fe:16:9
    │
-18 │         self.messages[ctx.msg_sender()] = book_msg
+16 │         self.messages[ctx.msg_sender()] = book_msg
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ String<100>: Memory
    │         │                                  
    │         String<100>: Storage { nonce: None }
    ·
-22 │         emit Signed(ctx, book_msg)
+20 │         emit Signed(ctx, book_msg)
    │                     ^^^  ^^^^^^^^ String<100>: Memory
    │                     │     
    │                     Context: Memory
 
 note: 
-   ┌─ guest_book.fe:25:5
+   ┌─ guest_book.fe:23:5
    │  
-25 │ ╭     pub fn get_msg(self, addr: address) -> String<100> {
-26 │ │         // Copying data from storage to memory
-27 │ │         // has to be done explicitly via `to_mem()`
-28 │ │         return self.messages[addr].to_mem()
-29 │ │     }
+23 │ ╭     pub fn get_msg(self, addr: address) -> String<100> {
+24 │ │         // Copying data from storage to memory
+25 │ │         // has to be done explicitly via `to_mem()`
+26 │ │         return self.messages[addr].to_mem()
+27 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: addr, typ: address }] -> String<100>
 
 note: 
-   ┌─ guest_book.fe:28:16
+   ┌─ guest_book.fe:26:16
    │
-28 │         return self.messages[addr].to_mem()
+26 │         return self.messages[addr].to_mem()
    │                ^^^^ GuestBook: Value
 
 note: 
-   ┌─ guest_book.fe:28:16
+   ┌─ guest_book.fe:26:16
    │
-28 │         return self.messages[addr].to_mem()
+26 │         return self.messages[addr].to_mem()
    │                ^^^^^^^^^^^^^ ^^^^ address: Value
    │                │              
    │                Map<address, String<100>>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ guest_book.fe:28:16
+   ┌─ guest_book.fe:26:16
    │
-28 │         return self.messages[addr].to_mem()
+26 │         return self.messages[addr].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None }
 
 note: 
-   ┌─ guest_book.fe:28:16
+   ┌─ guest_book.fe:26:16
    │
-28 │         return self.messages[addr].to_mem()
+26 │         return self.messages[addr].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<100>: Storage { nonce: None } => Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__module_level_events.snap
+++ b/crates/analyzer/tests/snapshots/analysis__module_level_events.snap
@@ -4,38 +4,38 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ module_level_events.fe:4:5
+  ┌─ module_level_events.fe:2:5
   │
-4 │     idx sender: address
+2 │     idx sender: address
   │     ^^^^^^^^^^^^^^^^^^^ address
-5 │     idx receiver: address
+3 │     idx receiver: address
   │     ^^^^^^^^^^^^^^^^^^^^^ address
-6 │     value: u256
+4 │     value: u256
   │     ^^^^^^^^^^^ u256
 
 note: 
-   ┌─ module_level_events.fe:10:5
+   ┌─ module_level_events.fe:8:5
    │  
-10 │ ╭     fn transfer(ctx: Context, to: address, value: u256) {
-11 │ │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
-12 │ │     }
+ 8 │ ╭     fn transfer(ctx: Context, to: address, value: u256) {
+ 9 │ │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
+10 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-   ┌─ module_level_events.fe:11:23
-   │
-11 │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
-   │                       ^^^          ^^^ Context: Memory
-   │                       │             
-   │                       Context: Memory
+  ┌─ module_level_events.fe:9:23
+  │
+9 │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
+  │                       ^^^          ^^^ Context: Memory
+  │                       │             
+  │                       Context: Memory
 
 note: 
-   ┌─ module_level_events.fe:11:36
-   │
-11 │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
-   │                                    ^^^^^^^^^^^^^^^^            ^^  ^^^^^ u256: Value
-   │                                    │                           │    
-   │                                    │                           address: Value
-   │                                    address: Value
+  ┌─ module_level_events.fe:9:36
+  │
+9 │         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
+  │                                    ^^^^^^^^^^^^^^^^            ^^  ^^^^^ u256: Value
+  │                                    │                           │    
+  │                                    │                           address: Value
+  │                                    address: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__ownable.snap
+++ b/crates/analyzer/tests/snapshots/analysis__ownable.snap
@@ -4,180 +4,180 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ ownable.fe:4:5
+  ┌─ ownable.fe:2:5
   │
-4 │     _owner: address
+2 │     _owner: address
   │     ^^^^^^^^^^^^^^^ address
 
 note: 
-  ┌─ ownable.fe:7:9
+  ┌─ ownable.fe:5:9
   │
-7 │         idx previousOwner: address
+5 │         idx previousOwner: address
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^ address
-8 │         idx newOwner: address
+6 │         idx newOwner: address
   │         ^^^^^^^^^^^^^^^^^^^^^ address
 
 note: 
-   ┌─ ownable.fe:15:5
+   ┌─ ownable.fe:13:5
    │  
-15 │ ╭     pub fn owner(self) -> address {
-16 │ │         return self._owner
-17 │ │     }
+13 │ ╭     pub fn owner(self) -> address {
+14 │ │         return self._owner
+15 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-   ┌─ ownable.fe:16:16
+   ┌─ ownable.fe:14:16
    │
-16 │         return self._owner
+14 │         return self._owner
    │                ^^^^ Ownable: Value
 
 note: 
-   ┌─ ownable.fe:16:16
+   ┌─ ownable.fe:14:16
    │
-16 │         return self._owner
+14 │         return self._owner
    │                ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ ownable.fe:19:5
+   ┌─ ownable.fe:17:5
    │  
-19 │ ╭     pub fn renounceOwnership(self, ctx: Context) {
-20 │ │         assert ctx.msg_sender() == self._owner
-21 │ │         self._owner = address(0)
-22 │ │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
-23 │ │     }
+17 │ ╭     pub fn renounceOwnership(self, ctx: Context) {
+18 │ │         assert ctx.msg_sender() == self._owner
+19 │ │         self._owner = address(0)
+20 │ │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
+21 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ ownable.fe:20:16
+   ┌─ ownable.fe:18:16
    │
-20 │         assert ctx.msg_sender() == self._owner
+18 │         assert ctx.msg_sender() == self._owner
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ ownable.fe:20:16
+   ┌─ ownable.fe:18:16
    │
-20 │         assert ctx.msg_sender() == self._owner
+18 │         assert ctx.msg_sender() == self._owner
    │                ^^^^^^^^^^^^^^^^    ^^^^ Ownable: Value
    │                │                    
    │                address: Value
 
 note: 
-   ┌─ ownable.fe:20:36
+   ┌─ ownable.fe:18:36
    │
-20 │         assert ctx.msg_sender() == self._owner
+18 │         assert ctx.msg_sender() == self._owner
    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ ownable.fe:20:16
+   ┌─ ownable.fe:18:16
    │
-20 │         assert ctx.msg_sender() == self._owner
+18 │         assert ctx.msg_sender() == self._owner
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-21 │         self._owner = address(0)
+19 │         self._owner = address(0)
    │         ^^^^ Ownable: Value
 
 note: 
-   ┌─ ownable.fe:21:9
+   ┌─ ownable.fe:19:9
    │
-21 │         self._owner = address(0)
+19 │         self._owner = address(0)
    │         ^^^^^^^^^^^           ^ u256: Value
    │         │                      
    │         address: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ ownable.fe:21:23
+   ┌─ ownable.fe:19:23
    │
-21 │         self._owner = address(0)
+19 │         self._owner = address(0)
    │                       ^^^^^^^^^^ address: Value
-22 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
+20 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
    │                                   ^^^                 ^^^ Context: Memory
    │                                   │                    
    │                                   Context: Memory
 
 note: 
-   ┌─ ownable.fe:22:55
+   ┌─ ownable.fe:20:55
    │
-22 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
+20 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
    │                                                       ^^^^^^^^^^^^^^^^                    ^ u256: Value
    │                                                       │                                    
    │                                                       address: Value
 
 note: 
-   ┌─ ownable.fe:22:83
+   ┌─ ownable.fe:20:83
    │
-22 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
+20 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner: address(0))
    │                                                                                   ^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ ownable.fe:25:5
+   ┌─ ownable.fe:23:5
    │  
-25 │ ╭     pub fn transferOwnership(self, ctx: Context, newOwner: address) {
-26 │ │         assert ctx.msg_sender() == self._owner
-27 │ │         assert newOwner != address(0)
-28 │ │         self._owner = newOwner
-29 │ │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
-30 │ │     }
+23 │ ╭     pub fn transferOwnership(self, ctx: Context, newOwner: address) {
+24 │ │         assert ctx.msg_sender() == self._owner
+25 │ │         assert newOwner != address(0)
+26 │ │         self._owner = newOwner
+27 │ │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
+28 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: newOwner, typ: address }] -> ()
 
 note: 
-   ┌─ ownable.fe:26:16
+   ┌─ ownable.fe:24:16
    │
-26 │         assert ctx.msg_sender() == self._owner
+24 │         assert ctx.msg_sender() == self._owner
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ ownable.fe:26:16
+   ┌─ ownable.fe:24:16
    │
-26 │         assert ctx.msg_sender() == self._owner
+24 │         assert ctx.msg_sender() == self._owner
    │                ^^^^^^^^^^^^^^^^    ^^^^ Ownable: Value
    │                │                    
    │                address: Value
 
 note: 
-   ┌─ ownable.fe:26:36
+   ┌─ ownable.fe:24:36
    │
-26 │         assert ctx.msg_sender() == self._owner
+24 │         assert ctx.msg_sender() == self._owner
    │                                    ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ ownable.fe:26:16
+   ┌─ ownable.fe:24:16
    │
-26 │         assert ctx.msg_sender() == self._owner
+24 │         assert ctx.msg_sender() == self._owner
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-27 │         assert newOwner != address(0)
+25 │         assert newOwner != address(0)
    │                ^^^^^^^^            ^ u256: Value
    │                │                    
    │                address: Value
 
 note: 
-   ┌─ ownable.fe:27:28
+   ┌─ ownable.fe:25:28
    │
-27 │         assert newOwner != address(0)
+25 │         assert newOwner != address(0)
    │                            ^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ ownable.fe:27:16
+   ┌─ ownable.fe:25:16
    │
-27 │         assert newOwner != address(0)
+25 │         assert newOwner != address(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-28 │         self._owner = newOwner
+26 │         self._owner = newOwner
    │         ^^^^ Ownable: Value
 
 note: 
-   ┌─ ownable.fe:28:9
+   ┌─ ownable.fe:26:9
    │
-28 │         self._owner = newOwner
+26 │         self._owner = newOwner
    │         ^^^^^^^^^^^   ^^^^^^^^ address: Value
    │         │              
    │         address: Storage { nonce: Some(0) }
-29 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
+27 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
    │                                   ^^^                 ^^^ Context: Memory
    │                                   │                    
    │                                   Context: Memory
 
 note: 
-   ┌─ ownable.fe:29:55
+   ┌─ ownable.fe:27:55
    │
-29 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
+27 │         emit OwnershipTransferred(ctx, previousOwner: ctx.msg_sender(), newOwner)
    │                                                       ^^^^^^^^^^^^^^^^  ^^^^^^^^ address: Value
    │                                                       │                  
    │                                                       address: Value

--- a/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_builtin_attributes.snap
@@ -4,203 +4,203 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ return_builtin_attributes.fe:4:5
+  ┌─ return_builtin_attributes.fe:2:5
   │  
-4 │ ╭     pub fn base_fee(ctx: Context) -> u256 {
-5 │ │         return ctx.base_fee()
-6 │ │     }
+2 │ ╭     pub fn base_fee(ctx: Context) -> u256 {
+3 │ │         return ctx.base_fee()
+4 │ │     }
   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-  ┌─ return_builtin_attributes.fe:5:16
+  ┌─ return_builtin_attributes.fe:3:16
   │
-5 │         return ctx.base_fee()
+3 │         return ctx.base_fee()
   │                ^^^ Context: Memory
 
 note: 
-  ┌─ return_builtin_attributes.fe:5:16
+  ┌─ return_builtin_attributes.fe:3:16
   │
-5 │         return ctx.base_fee()
+3 │         return ctx.base_fee()
   │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:8:5
-   │  
- 8 │ ╭     pub fn coinbase(ctx: Context) -> address {
- 9 │ │         return ctx.block_coinbase()
-10 │ │     }
-   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
+  ┌─ return_builtin_attributes.fe:6:5
+  │  
+6 │ ╭     pub fn coinbase(ctx: Context) -> address {
+7 │ │         return ctx.block_coinbase()
+8 │ │     }
+  │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
-  ┌─ return_builtin_attributes.fe:9:16
+  ┌─ return_builtin_attributes.fe:7:16
   │
-9 │         return ctx.block_coinbase()
+7 │         return ctx.block_coinbase()
   │                ^^^ Context: Memory
 
 note: 
-  ┌─ return_builtin_attributes.fe:9:16
+  ┌─ return_builtin_attributes.fe:7:16
   │
-9 │         return ctx.block_coinbase()
+7 │         return ctx.block_coinbase()
   │                ^^^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:12:5
+   ┌─ return_builtin_attributes.fe:10:5
    │  
-12 │ ╭     pub fn difficulty(ctx: Context) -> u256 {
-13 │ │         return ctx.block_difficulty()
-14 │ │     }
+10 │ ╭     pub fn difficulty(ctx: Context) -> u256 {
+11 │ │         return ctx.block_difficulty()
+12 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ return_builtin_attributes.fe:13:16
+   ┌─ return_builtin_attributes.fe:11:16
    │
-13 │         return ctx.block_difficulty()
+11 │         return ctx.block_difficulty()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:13:16
+   ┌─ return_builtin_attributes.fe:11:16
    │
-13 │         return ctx.block_difficulty()
+11 │         return ctx.block_difficulty()
    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:16:5
+   ┌─ return_builtin_attributes.fe:14:5
    │  
-16 │ ╭     pub fn number(ctx: Context) -> u256 {
-17 │ │         return ctx.block_number()
-18 │ │     }
+14 │ ╭     pub fn number(ctx: Context) -> u256 {
+15 │ │         return ctx.block_number()
+16 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ return_builtin_attributes.fe:17:16
+   ┌─ return_builtin_attributes.fe:15:16
    │
-17 │         return ctx.block_number()
+15 │         return ctx.block_number()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:17:16
+   ┌─ return_builtin_attributes.fe:15:16
    │
-17 │         return ctx.block_number()
+15 │         return ctx.block_number()
    │                ^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:20:5
+   ┌─ return_builtin_attributes.fe:18:5
    │  
-20 │ ╭     pub fn timestamp(ctx: Context) -> u256 {
-21 │ │         return ctx.block_timestamp()
-22 │ │     }
+18 │ ╭     pub fn timestamp(ctx: Context) -> u256 {
+19 │ │         return ctx.block_timestamp()
+20 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ return_builtin_attributes.fe:21:16
+   ┌─ return_builtin_attributes.fe:19:16
    │
-21 │         return ctx.block_timestamp()
+19 │         return ctx.block_timestamp()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:21:16
+   ┌─ return_builtin_attributes.fe:19:16
    │
-21 │         return ctx.block_timestamp()
+19 │         return ctx.block_timestamp()
    │                ^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:24:5
+   ┌─ return_builtin_attributes.fe:22:5
    │  
-24 │ ╭     pub fn chainid(ctx: Context) -> u256 {
-25 │ │         return ctx.chain_id()
-26 │ │     }
+22 │ ╭     pub fn chainid(ctx: Context) -> u256 {
+23 │ │         return ctx.chain_id()
+24 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ return_builtin_attributes.fe:25:16
+   ┌─ return_builtin_attributes.fe:23:16
    │
-25 │         return ctx.chain_id()
+23 │         return ctx.chain_id()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:25:16
+   ┌─ return_builtin_attributes.fe:23:16
    │
-25 │         return ctx.chain_id()
+23 │         return ctx.chain_id()
    │                ^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:28:5
+   ┌─ return_builtin_attributes.fe:26:5
    │  
-28 │ ╭     pub fn sender(ctx: Context) -> address {
-29 │ │         return ctx.msg_sender()
-30 │ │     }
+26 │ ╭     pub fn sender(ctx: Context) -> address {
+27 │ │         return ctx.msg_sender()
+28 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
-   ┌─ return_builtin_attributes.fe:29:16
+   ┌─ return_builtin_attributes.fe:27:16
    │
-29 │         return ctx.msg_sender()
+27 │         return ctx.msg_sender()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:29:16
+   ┌─ return_builtin_attributes.fe:27:16
    │
-29 │         return ctx.msg_sender()
+27 │         return ctx.msg_sender()
    │                ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:32:5
+   ┌─ return_builtin_attributes.fe:30:5
    │  
-32 │ ╭     pub fn value(ctx: Context) -> u256 {
-33 │ │         return ctx.msg_value()
-34 │ │     }
+30 │ ╭     pub fn value(ctx: Context) -> u256 {
+31 │ │         return ctx.msg_value()
+32 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ return_builtin_attributes.fe:33:16
+   ┌─ return_builtin_attributes.fe:31:16
    │
-33 │         return ctx.msg_value()
+31 │         return ctx.msg_value()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:33:16
+   ┌─ return_builtin_attributes.fe:31:16
    │
-33 │         return ctx.msg_value()
+31 │         return ctx.msg_value()
    │                ^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:36:5
+   ┌─ return_builtin_attributes.fe:34:5
    │  
-36 │ ╭     pub fn origin(ctx: Context) -> address {
-37 │ │         return ctx.tx_origin()
-38 │ │     }
+34 │ ╭     pub fn origin(ctx: Context) -> address {
+35 │ │         return ctx.tx_origin()
+36 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
-   ┌─ return_builtin_attributes.fe:37:16
+   ┌─ return_builtin_attributes.fe:35:16
    │
-37 │         return ctx.tx_origin()
+35 │         return ctx.tx_origin()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:37:16
+   ┌─ return_builtin_attributes.fe:35:16
    │
-37 │         return ctx.tx_origin()
+35 │         return ctx.tx_origin()
    │                ^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ return_builtin_attributes.fe:40:5
+   ┌─ return_builtin_attributes.fe:38:5
    │  
-40 │ ╭     pub fn gas_price(ctx: Context) -> u256 {
-41 │ │         return ctx.tx_gas_price()
-42 │ │     }
+38 │ ╭     pub fn gas_price(ctx: Context) -> u256 {
+39 │ │         return ctx.tx_gas_price()
+40 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ return_builtin_attributes.fe:41:16
+   ┌─ return_builtin_attributes.fe:39:16
    │
-41 │         return ctx.tx_gas_price()
+39 │         return ctx.tx_gas_price()
    │                ^^^ Context: Memory
 
 note: 
-   ┌─ return_builtin_attributes.fe:41:16
+   ┌─ return_builtin_attributes.fe:39:16
    │
-41 │         return ctx.tx_gas_price()
+39 │         return ctx.tx_gas_price()
    │                ^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
+++ b/crates/analyzer/tests/snapshots/analysis__return_msg_sig.snap
@@ -4,23 +4,23 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ return_msg_sig.fe:4:5
+  ┌─ return_msg_sig.fe:2:5
   │  
-4 │ ╭     pub fn bar(ctx: Context) -> u256 {
-5 │ │         return ctx.msg_sig()
-6 │ │     }
+2 │ ╭     pub fn bar(ctx: Context) -> u256 {
+3 │ │         return ctx.msg_sig()
+4 │ │     }
   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-  ┌─ return_msg_sig.fe:5:16
+  ┌─ return_msg_sig.fe:3:16
   │
-5 │         return ctx.msg_sig()
+3 │         return ctx.msg_sig()
   │                ^^^ Context: Memory
 
 note: 
-  ┌─ return_msg_sig.fe:5:16
+  ┌─ return_msg_sig.fe:3:16
   │
-5 │         return ctx.msg_sig()
+3 │         return ctx.msg_sig()
   │                ^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__revert.snap
+++ b/crates/analyzer/tests/snapshots/analysis__revert.snap
@@ -4,121 +4,121 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ revert.fe:4:5
+  ┌─ revert.fe:2:5
   │
-4 │     pub msg: u256
+2 │     pub msg: u256
   │     ^^^^^^^^^^^^^ u256
-5 │     pub val: bool
+3 │     pub val: bool
   │     ^^^^^^^^^^^^^ bool
 
 note: 
-  ┌─ revert.fe:9:5
+  ┌─ revert.fe:7:5
   │
-9 │     my_other_error: OtherError
+7 │     my_other_error: OtherError
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError
 
 note: 
-   ┌─ revert.fe:11:5
+   ┌─ revert.fe:9:5
    │  
-11 │ ╭     pub fn bar() -> u256 {
-12 │ │         revert
-13 │ │     }
+ 9 │ ╭     pub fn bar() -> u256 {
+10 │ │         revert
+11 │ │     }
    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-   ┌─ revert.fe:15:5
+   ┌─ revert.fe:13:5
    │  
-15 │ ╭     pub fn revert_custom_error(ctx: Context) {
-16 │ │         ctx.send_value(to: address(0), wei: 100)
-17 │ │     }
+13 │ ╭     pub fn revert_custom_error(ctx: Context) {
+14 │ │         ctx.send_value(to: address(0), wei: 100)
+15 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ revert.fe:16:9
+   ┌─ revert.fe:14:9
    │
-16 │         ctx.send_value(to: address(0), wei: 100)
+14 │         ctx.send_value(to: address(0), wei: 100)
    │         ^^^                        ^ u256: Value
    │         │                           
    │         Context: Memory
 
 note: 
-   ┌─ revert.fe:16:28
+   ┌─ revert.fe:14:28
    │
-16 │         ctx.send_value(to: address(0), wei: 100)
+14 │         ctx.send_value(to: address(0), wei: 100)
    │                            ^^^^^^^^^^       ^^^ u256: Value
    │                            │                 
    │                            address: Value
 
 note: 
-   ┌─ revert.fe:16:9
+   ┌─ revert.fe:14:9
    │
-16 │         ctx.send_value(to: address(0), wei: 100)
+14 │         ctx.send_value(to: address(0), wei: 100)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ revert.fe:19:5
+   ┌─ revert.fe:17:5
    │  
-19 │ ╭     pub fn revert_other_error() {
-20 │ │         revert OtherError(msg: 1, val: true)
-21 │ │     }
+17 │ ╭     pub fn revert_other_error() {
+18 │ │         revert OtherError(msg: 1, val: true)
+19 │ │     }
    │ ╰─────^ self: None, params: [] -> ()
 
 note: 
-   ┌─ revert.fe:20:32
+   ┌─ revert.fe:18:32
    │
-20 │         revert OtherError(msg: 1, val: true)
+18 │         revert OtherError(msg: 1, val: true)
    │                                ^       ^^^^ bool: Value
    │                                │        
    │                                u256: Value
 
 note: 
-   ┌─ revert.fe:20:16
+   ┌─ revert.fe:18:16
    │
-20 │         revert OtherError(msg: 1, val: true)
+18 │         revert OtherError(msg: 1, val: true)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
 
 note: 
-   ┌─ revert.fe:23:5
+   ┌─ revert.fe:21:5
    │  
-23 │ ╭     pub fn revert_other_error_from_sto(self) {
-24 │ │         self.my_other_error = OtherError(msg: 1, val: true)
-25 │ │         revert self.my_other_error.to_mem()
-26 │ │     }
+21 │ ╭     pub fn revert_other_error_from_sto(self) {
+22 │ │         self.my_other_error = OtherError(msg: 1, val: true)
+23 │ │         revert self.my_other_error.to_mem()
+24 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> ()
 
 note: 
-   ┌─ revert.fe:24:9
+   ┌─ revert.fe:22:9
    │
-24 │         self.my_other_error = OtherError(msg: 1, val: true)
+22 │         self.my_other_error = OtherError(msg: 1, val: true)
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ revert.fe:24:9
+   ┌─ revert.fe:22:9
    │
-24 │         self.my_other_error = OtherError(msg: 1, val: true)
+22 │         self.my_other_error = OtherError(msg: 1, val: true)
    │         ^^^^^^^^^^^^^^^^^^^                   ^       ^^^^ bool: Value
    │         │                                     │        
    │         │                                     u256: Value
    │         OtherError: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ revert.fe:24:31
+   ┌─ revert.fe:22:31
    │
-24 │         self.my_other_error = OtherError(msg: 1, val: true)
+22 │         self.my_other_error = OtherError(msg: 1, val: true)
    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Memory
-25 │         revert self.my_other_error.to_mem()
+23 │         revert self.my_other_error.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ revert.fe:25:16
+   ┌─ revert.fe:23:16
    │
-25 │         revert self.my_other_error.to_mem()
+23 │         revert self.my_other_error.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ revert.fe:25:16
+   ┌─ revert.fe:23:16
    │
-25 │         revert self.my_other_error.to_mem()
+23 │         revert self.my_other_error.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ OtherError: Storage { nonce: Some(0) } => Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__self_address.snap
+++ b/crates/analyzer/tests/snapshots/analysis__self_address.snap
@@ -4,23 +4,23 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ self_address.fe:4:5
+  ┌─ self_address.fe:2:5
   │  
-4 │ ╭     pub fn my_address(ctx: Context) -> address {
-5 │ │         return ctx.self_address()
-6 │ │     }
+2 │ ╭     pub fn my_address(ctx: Context) -> address {
+3 │ │         return ctx.self_address()
+4 │ │     }
   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }] -> address
 
 note: 
-  ┌─ self_address.fe:5:16
+  ┌─ self_address.fe:3:16
   │
-5 │         return ctx.self_address()
+3 │         return ctx.self_address()
   │                ^^^ Context: Memory
 
 note: 
-  ┌─ self_address.fe:5:16
+  ┌─ self_address.fe:3:16
   │
-5 │         return ctx.self_address()
+3 │         return ctx.self_address()
   │                ^^^^^^^^^^^^^^^^^^ address: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__send_value.snap
+++ b/crates/analyzer/tests/snapshots/analysis__send_value.snap
@@ -4,26 +4,26 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ send_value.fe:4:5
+  ┌─ send_value.fe:2:5
   │  
-4 │ ╭     pub fn send_them_wei(ctx: Context, to: address, wei: u256) {
-5 │ │         ctx.send_value(to, wei)
-6 │ │     }
+2 │ ╭     pub fn send_them_wei(ctx: Context, to: address, wei: u256) {
+3 │ │         ctx.send_value(to, wei)
+4 │ │     }
   │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: wei, typ: u256 }] -> ()
 
 note: 
-  ┌─ send_value.fe:5:9
+  ┌─ send_value.fe:3:9
   │
-5 │         ctx.send_value(to, wei)
+3 │         ctx.send_value(to, wei)
   │         ^^^            ^^  ^^^ u256: Value
   │         │              │    
   │         │              address: Value
   │         Context: Memory
 
 note: 
-  ┌─ send_value.fe:5:9
+  ┌─ send_value.fe:3:9
   │
-5 │         ctx.send_value(to, wei)
+3 │         ctx.send_value(to, wei)
   │         ^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__simple_open_auction.snap
+++ b/crates/analyzer/tests/snapshots/analysis__simple_open_auction.snap
@@ -4,425 +4,425 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ simple_open_auction.fe:9:5
+  ┌─ simple_open_auction.fe:7:5
   │
-9 │     pub highest_bid: u256
+7 │     pub highest_bid: u256
   │     ^^^^^^^^^^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ simple_open_auction.fe:14:5
+   ┌─ simple_open_auction.fe:12:5
    │
-14 │     auction_end_time: u256
+12 │     auction_end_time: u256
    │     ^^^^^^^^^^^^^^^^^^^^^^ u256
-15 │     beneficiary: address
+13 │     beneficiary: address
    │     ^^^^^^^^^^^^^^^^^^^^ address
-16 │ 
-17 │     highest_bidder: address
+14 │ 
+15 │     highest_bidder: address
    │     ^^^^^^^^^^^^^^^^^^^^^^^ address
-18 │     highest_bid: u256
+16 │     highest_bid: u256
    │     ^^^^^^^^^^^^^^^^^ u256
-19 │ 
-20 │     pending_returns: Map<address, u256>
+17 │ 
+18 │     pending_returns: Map<address, u256>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-21 │ 
-22 │     ended: bool
+19 │ 
+20 │     ended: bool
    │     ^^^^^^^^^^^ bool
 
 note: 
-   ┌─ simple_open_auction.fe:26:9
+   ┌─ simple_open_auction.fe:24:9
    │
-26 │         idx bidder: address
+24 │         idx bidder: address
    │         ^^^^^^^^^^^^^^^^^^^ address
-27 │         amount: u256
+25 │         amount: u256
    │         ^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ simple_open_auction.fe:31:9
+   ┌─ simple_open_auction.fe:29:9
    │
-31 │         idx winner: address
+29 │         idx winner: address
    │         ^^^^^^^^^^^^^^^^^^^ address
-32 │         amount: u256
+30 │         amount: u256
    │         ^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ simple_open_auction.fe:42:5
+   ┌─ simple_open_auction.fe:40:5
    │  
-42 │ ╭     pub fn bid(self, ctx: Context) {
-43 │ │         if ctx.block_timestamp() > self.auction_end_time {
-44 │ │             revert AuctionAlreadyEnded()
-45 │ │         }
+40 │ ╭     pub fn bid(self, ctx: Context) {
+41 │ │         if ctx.block_timestamp() > self.auction_end_time {
+42 │ │             revert AuctionAlreadyEnded()
+43 │ │         }
    · │
-55 │ │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
-56 │ │     }
+53 │ │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
+54 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ simple_open_auction.fe:43:12
+   ┌─ simple_open_auction.fe:41:12
    │
-43 │         if ctx.block_timestamp() > self.auction_end_time {
+41 │         if ctx.block_timestamp() > self.auction_end_time {
    │            ^^^ Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:43:12
+   ┌─ simple_open_auction.fe:41:12
    │
-43 │         if ctx.block_timestamp() > self.auction_end_time {
+41 │         if ctx.block_timestamp() > self.auction_end_time {
    │            ^^^^^^^^^^^^^^^^^^^^^   ^^^^ SimpleOpenAuction: Value
    │            │                        
    │            u256: Value
 
 note: 
-   ┌─ simple_open_auction.fe:43:36
+   ┌─ simple_open_auction.fe:41:36
    │
-43 │         if ctx.block_timestamp() > self.auction_end_time {
+41 │         if ctx.block_timestamp() > self.auction_end_time {
    │                                    ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:43:12
+   ┌─ simple_open_auction.fe:41:12
    │
-43 │         if ctx.block_timestamp() > self.auction_end_time {
+41 │         if ctx.block_timestamp() > self.auction_end_time {
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-44 │             revert AuctionAlreadyEnded()
+42 │             revert AuctionAlreadyEnded()
    │                    ^^^^^^^^^^^^^^^^^^^^^ AuctionAlreadyEnded: Memory
-45 │         }
-46 │         if ctx.msg_value() <= self.highest_bid {
+43 │         }
+44 │         if ctx.msg_value() <= self.highest_bid {
    │            ^^^ Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:46:12
+   ┌─ simple_open_auction.fe:44:12
    │
-46 │         if ctx.msg_value() <= self.highest_bid {
+44 │         if ctx.msg_value() <= self.highest_bid {
    │            ^^^^^^^^^^^^^^^    ^^^^ SimpleOpenAuction: Value
    │            │                   
    │            u256: Value
 
 note: 
-   ┌─ simple_open_auction.fe:46:31
+   ┌─ simple_open_auction.fe:44:31
    │
-46 │         if ctx.msg_value() <= self.highest_bid {
+44 │         if ctx.msg_value() <= self.highest_bid {
    │                               ^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:46:12
+   ┌─ simple_open_auction.fe:44:12
    │
-46 │         if ctx.msg_value() <= self.highest_bid {
+44 │         if ctx.msg_value() <= self.highest_bid {
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-47 │             revert BidNotHighEnough(highest_bid: self.highest_bid)
+45 │             revert BidNotHighEnough(highest_bid: self.highest_bid)
    │                                                  ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:47:50
+   ┌─ simple_open_auction.fe:45:50
    │
-47 │             revert BidNotHighEnough(highest_bid: self.highest_bid)
+45 │             revert BidNotHighEnough(highest_bid: self.highest_bid)
    │                                                  ^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:47:20
+   ┌─ simple_open_auction.fe:45:20
    │
-47 │             revert BidNotHighEnough(highest_bid: self.highest_bid)
+45 │             revert BidNotHighEnough(highest_bid: self.highest_bid)
    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ BidNotHighEnough: Memory
-48 │         }
-49 │         if self.highest_bid != 0 {
+46 │         }
+47 │         if self.highest_bid != 0 {
    │            ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:49:12
+   ┌─ simple_open_auction.fe:47:12
    │
-49 │         if self.highest_bid != 0 {
+47 │         if self.highest_bid != 0 {
    │            ^^^^^^^^^^^^^^^^    ^ u256: Value
    │            │                    
    │            u256: Storage { nonce: Some(3) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:49:12
+   ┌─ simple_open_auction.fe:47:12
    │
-49 │         if self.highest_bid != 0 {
+47 │         if self.highest_bid != 0 {
    │            ^^^^^^^^^^^^^^^^^^^^^ bool: Value
-50 │             self.pending_returns[self.highest_bidder] += self.highest_bid
+48 │             self.pending_returns[self.highest_bidder] += self.highest_bid
    │             ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:50:13
+   ┌─ simple_open_auction.fe:48:13
    │
-50 │             self.pending_returns[self.highest_bidder] += self.highest_bid
+48 │             self.pending_returns[self.highest_bidder] += self.highest_bid
    │             ^^^^^^^^^^^^^^^^^^^^ ^^^^ SimpleOpenAuction: Value
    │             │                     
    │             Map<address, u256>: Storage { nonce: Some(4) }
 
 note: 
-   ┌─ simple_open_auction.fe:50:34
+   ┌─ simple_open_auction.fe:48:34
    │
-50 │             self.pending_returns[self.highest_bidder] += self.highest_bid
+48 │             self.pending_returns[self.highest_bidder] += self.highest_bid
    │                                  ^^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:50:13
+   ┌─ simple_open_auction.fe:48:13
    │
-50 │             self.pending_returns[self.highest_bidder] += self.highest_bid
+48 │             self.pending_returns[self.highest_bidder] += self.highest_bid
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^ SimpleOpenAuction: Value
    │             │                                             
    │             u256: Storage { nonce: None }
 
 note: 
-   ┌─ simple_open_auction.fe:50:58
+   ┌─ simple_open_auction.fe:48:58
    │
-50 │             self.pending_returns[self.highest_bidder] += self.highest_bid
+48 │             self.pending_returns[self.highest_bidder] += self.highest_bid
    │                                                          ^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) }
-51 │         }
-52 │         self.highest_bidder = ctx.msg_sender()
+49 │         }
+50 │         self.highest_bidder = ctx.msg_sender()
    │         ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:52:9
+   ┌─ simple_open_auction.fe:50:9
    │
-52 │         self.highest_bidder = ctx.msg_sender()
+50 │         self.highest_bidder = ctx.msg_sender()
    │         ^^^^^^^^^^^^^^^^^^^   ^^^ Context: Memory
    │         │                      
    │         address: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ simple_open_auction.fe:52:31
+   ┌─ simple_open_auction.fe:50:31
    │
-52 │         self.highest_bidder = ctx.msg_sender()
+50 │         self.highest_bidder = ctx.msg_sender()
    │                               ^^^^^^^^^^^^^^^^ address: Value
-53 │         self.highest_bid = ctx.msg_value()
+51 │         self.highest_bid = ctx.msg_value()
    │         ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:53:9
+   ┌─ simple_open_auction.fe:51:9
    │
-53 │         self.highest_bid = ctx.msg_value()
+51 │         self.highest_bid = ctx.msg_value()
    │         ^^^^^^^^^^^^^^^^   ^^^ Context: Memory
    │         │                   
    │         u256: Storage { nonce: Some(3) }
 
 note: 
-   ┌─ simple_open_auction.fe:53:28
+   ┌─ simple_open_auction.fe:51:28
    │
-53 │         self.highest_bid = ctx.msg_value()
+51 │         self.highest_bid = ctx.msg_value()
    │                            ^^^^^^^^^^^^^^^ u256: Value
-54 │ 
-55 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
+52 │ 
+53 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
    │                                  ^^^          ^^^ Context: Memory
    │                                  │             
    │                                  Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:55:47
+   ┌─ simple_open_auction.fe:53:47
    │
-55 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
+53 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
    │                                               ^^^^^^^^^^^^^^^^          ^^^ Context: Memory
    │                                               │                          
    │                                               address: Value
 
 note: 
-   ┌─ simple_open_auction.fe:55:73
+   ┌─ simple_open_auction.fe:53:73
    │
-55 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
+53 │         emit HighestBidIncreased(ctx, bidder: ctx.msg_sender(), amount: ctx.msg_value())
    │                                                                         ^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ simple_open_auction.fe:58:5
+   ┌─ simple_open_auction.fe:56:5
    │  
-58 │ ╭     pub fn withdraw(self, ctx: Context) -> bool {
-59 │ │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
-60 │ │ 
-61 │ │         if amount > 0 {
+56 │ ╭     pub fn withdraw(self, ctx: Context) -> bool {
+57 │ │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
+58 │ │ 
+59 │ │         if amount > 0 {
    · │
-65 │ │         return true
-66 │ │     }
+63 │ │         return true
+64 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> bool
 
 note: 
-   ┌─ simple_open_auction.fe:59:13
+   ┌─ simple_open_auction.fe:57:13
    │
-59 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
+57 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
    │             ^^^^^^ u256
 
 note: 
-   ┌─ simple_open_auction.fe:59:28
+   ┌─ simple_open_auction.fe:57:28
    │
-59 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
+57 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
    │                            ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:59:28
+   ┌─ simple_open_auction.fe:57:28
    │
-59 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
+57 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
    │                            ^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
    │                            │                     
    │                            Map<address, u256>: Storage { nonce: Some(4) }
 
 note: 
-   ┌─ simple_open_auction.fe:59:49
+   ┌─ simple_open_auction.fe:57:49
    │
-59 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
+57 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
    │                                                 ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ simple_open_auction.fe:59:28
+   ┌─ simple_open_auction.fe:57:28
    │
-59 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
+57 │         let amount: u256 = self.pending_returns[ctx.msg_sender()]
    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
-60 │ 
-61 │         if amount > 0 {
+58 │ 
+59 │         if amount > 0 {
    │            ^^^^^^   ^ u256: Value
    │            │         
    │            u256: Value
 
 note: 
-   ┌─ simple_open_auction.fe:61:12
+   ┌─ simple_open_auction.fe:59:12
    │
-61 │         if amount > 0 {
+59 │         if amount > 0 {
    │            ^^^^^^^^^^ bool: Value
-62 │             self.pending_returns[ctx.msg_sender()] = 0
+60 │             self.pending_returns[ctx.msg_sender()] = 0
    │             ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:62:13
+   ┌─ simple_open_auction.fe:60:13
    │
-62 │             self.pending_returns[ctx.msg_sender()] = 0
+60 │             self.pending_returns[ctx.msg_sender()] = 0
    │             ^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
    │             │                     
    │             Map<address, u256>: Storage { nonce: Some(4) }
 
 note: 
-   ┌─ simple_open_auction.fe:62:34
+   ┌─ simple_open_auction.fe:60:34
    │
-62 │             self.pending_returns[ctx.msg_sender()] = 0
+60 │             self.pending_returns[ctx.msg_sender()] = 0
    │                                  ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ simple_open_auction.fe:62:13
+   ┌─ simple_open_auction.fe:60:13
    │
-62 │             self.pending_returns[ctx.msg_sender()] = 0
+60 │             self.pending_returns[ctx.msg_sender()] = 0
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^ u256: Value
    │             │                                         
    │             u256: Storage { nonce: None }
-63 │             ctx.send_value(to: ctx.msg_sender(), wei: amount)
+61 │             ctx.send_value(to: ctx.msg_sender(), wei: amount)
    │             ^^^                ^^^ Context: Memory
    │             │                   
    │             Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:63:32
+   ┌─ simple_open_auction.fe:61:32
    │
-63 │             ctx.send_value(to: ctx.msg_sender(), wei: amount)
+61 │             ctx.send_value(to: ctx.msg_sender(), wei: amount)
    │                                ^^^^^^^^^^^^^^^^       ^^^^^^ u256: Value
    │                                │                       
    │                                address: Value
 
 note: 
-   ┌─ simple_open_auction.fe:63:13
+   ┌─ simple_open_auction.fe:61:13
    │
-63 │             ctx.send_value(to: ctx.msg_sender(), wei: amount)
+61 │             ctx.send_value(to: ctx.msg_sender(), wei: amount)
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-64 │         }
-65 │         return true
+62 │         }
+63 │         return true
    │                ^^^^ bool: Value
 
 note: 
-   ┌─ simple_open_auction.fe:68:5
+   ┌─ simple_open_auction.fe:66:5
    │  
-68 │ ╭     pub fn action_end(self, ctx: Context) {
-69 │ │         if ctx.block_timestamp() <= self.auction_end_time {
-70 │ │             revert AuctionNotYetEnded()
-71 │ │         }
+66 │ ╭     pub fn action_end(self, ctx: Context) {
+67 │ │         if ctx.block_timestamp() <= self.auction_end_time {
+68 │ │             revert AuctionNotYetEnded()
+69 │ │         }
    · │
-78 │ │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
-79 │ │     }
+76 │ │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
+77 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ simple_open_auction.fe:69:12
+   ┌─ simple_open_auction.fe:67:12
    │
-69 │         if ctx.block_timestamp() <= self.auction_end_time {
+67 │         if ctx.block_timestamp() <= self.auction_end_time {
    │            ^^^ Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:69:12
+   ┌─ simple_open_auction.fe:67:12
    │
-69 │         if ctx.block_timestamp() <= self.auction_end_time {
+67 │         if ctx.block_timestamp() <= self.auction_end_time {
    │            ^^^^^^^^^^^^^^^^^^^^^    ^^^^ SimpleOpenAuction: Value
    │            │                         
    │            u256: Value
 
 note: 
-   ┌─ simple_open_auction.fe:69:37
+   ┌─ simple_open_auction.fe:67:37
    │
-69 │         if ctx.block_timestamp() <= self.auction_end_time {
+67 │         if ctx.block_timestamp() <= self.auction_end_time {
    │                                     ^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:69:12
+   ┌─ simple_open_auction.fe:67:12
    │
-69 │         if ctx.block_timestamp() <= self.auction_end_time {
+67 │         if ctx.block_timestamp() <= self.auction_end_time {
    │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-70 │             revert AuctionNotYetEnded()
+68 │             revert AuctionNotYetEnded()
    │                    ^^^^^^^^^^^^^^^^^^^^ AuctionNotYetEnded: Memory
-71 │         }
-72 │         if self.ended {
+69 │         }
+70 │         if self.ended {
    │            ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:72:12
+   ┌─ simple_open_auction.fe:70:12
    │
-72 │         if self.ended {
+70 │         if self.ended {
    │            ^^^^^^^^^^ bool: Storage { nonce: Some(5) } => Value
-73 │             revert AuctionEndAlreadyCalled()
+71 │             revert AuctionEndAlreadyCalled()
    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^ AuctionEndAlreadyCalled: Memory
-74 │         }
-75 │         self.ended = true
+72 │         }
+73 │         self.ended = true
    │         ^^^^ SimpleOpenAuction: Value
 
 note: 
-   ┌─ simple_open_auction.fe:75:9
+   ┌─ simple_open_auction.fe:73:9
    │
-75 │         self.ended = true
+73 │         self.ended = true
    │         ^^^^^^^^^^   ^^^^ bool: Value
    │         │             
    │         bool: Storage { nonce: Some(5) }
-76 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
+74 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
    │                           ^^^          ^^^^ SimpleOpenAuction: Value
    │                           │             
    │                           Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:76:40
+   ┌─ simple_open_auction.fe:74:40
    │
-76 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
+74 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
    │                                        ^^^^^^^^^^^^^^^^^^^          ^^^^ SimpleOpenAuction: Value
    │                                        │                             
    │                                        address: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:76:69
+   ┌─ simple_open_auction.fe:74:69
    │
-76 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
+74 │         emit AuctionEnded(ctx, winner: self.highest_bidder, amount: self.highest_bid)
    │                                                                     ^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => Value
-77 │ 
-78 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
+75 │ 
+76 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
    │         ^^^                ^^^^ SimpleOpenAuction: Value
    │         │                   
    │         Context: Memory
 
 note: 
-   ┌─ simple_open_auction.fe:78:28
+   ┌─ simple_open_auction.fe:76:28
    │
-78 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
+76 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
    │                            ^^^^^^^^^^^^^^^^       ^^^^ SimpleOpenAuction: Value
    │                            │                       
    │                            address: Storage { nonce: Some(1) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:78:51
+   ┌─ simple_open_auction.fe:76:51
    │
-78 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
+76 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
    │                                                   ^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(3) } => Value
 
 note: 
-   ┌─ simple_open_auction.fe:78:9
+   ┌─ simple_open_auction.fe:76:9
    │
-78 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
+76 │         ctx.send_value(to: self.beneficiary, wei: self.highest_bid)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
+++ b/crates/analyzer/tests/snapshots/analysis__sized_vals_in_sto.snap
@@ -4,211 +4,211 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ sized_vals_in_sto.fe:4:5
+  ┌─ sized_vals_in_sto.fe:2:5
   │
-4 │     num: u256
+2 │     num: u256
   │     ^^^^^^^^^ u256
-5 │     nums: Array<u256, 42>
+3 │     nums: Array<u256, 42>
   │     ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
-6 │     str: String<26>
+4 │     str: String<26>
   │     ^^^^^^^^^^^^^^^ String<26>
 
 note: 
-   ┌─ sized_vals_in_sto.fe:9:9
-   │
- 9 │         num: u256
-   │         ^^^^^^^^^ u256
-10 │         nums: Array<u256, 42>
-   │         ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
-11 │         str: String<26>
-   │         ^^^^^^^^^^^^^^^ String<26>
+  ┌─ sized_vals_in_sto.fe:7:9
+  │
+7 │         num: u256
+  │         ^^^^^^^^^ u256
+8 │         nums: Array<u256, 42>
+  │         ^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
+9 │         str: String<26>
+  │         ^^^^^^^^^^^^^^^ String<26>
 
 note: 
-   ┌─ sized_vals_in_sto.fe:14:5
+   ┌─ sized_vals_in_sto.fe:12:5
    │  
-14 │ ╭     pub fn write_num(self, x: u256) {
-15 │ │         self.num = x
-16 │ │     }
+12 │ ╭     pub fn write_num(self, x: u256) {
+13 │ │         self.num = x
+14 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: u256 }] -> ()
 
 note: 
-   ┌─ sized_vals_in_sto.fe:15:9
+   ┌─ sized_vals_in_sto.fe:13:9
    │
-15 │         self.num = x
+13 │         self.num = x
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:15:9
+   ┌─ sized_vals_in_sto.fe:13:9
    │
-15 │         self.num = x
+13 │         self.num = x
    │         ^^^^^^^^   ^ u256: Value
    │         │           
    │         u256: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:18:5
+   ┌─ sized_vals_in_sto.fe:16:5
    │  
-18 │ ╭     pub fn read_num(self) -> u256 {
-19 │ │         return self.num
-20 │ │     }
+16 │ ╭     pub fn read_num(self) -> u256 {
+17 │ │         return self.num
+18 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
-   ┌─ sized_vals_in_sto.fe:19:16
+   ┌─ sized_vals_in_sto.fe:17:16
    │
-19 │         return self.num
+17 │         return self.num
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:19:16
+   ┌─ sized_vals_in_sto.fe:17:16
    │
-19 │         return self.num
+17 │         return self.num
    │                ^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:22:5
+   ┌─ sized_vals_in_sto.fe:20:5
    │  
-22 │ ╭     pub fn write_nums(self, x: Array<u256, 42>) {
-23 │ │         self.nums = x
-24 │ │     }
+20 │ ╭     pub fn write_nums(self, x: Array<u256, 42>) {
+21 │ │         self.nums = x
+22 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: Array<u256, 42> }] -> ()
 
 note: 
-   ┌─ sized_vals_in_sto.fe:23:9
+   ┌─ sized_vals_in_sto.fe:21:9
    │
-23 │         self.nums = x
+21 │         self.nums = x
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:23:9
+   ┌─ sized_vals_in_sto.fe:21:9
    │
-23 │         self.nums = x
+21 │         self.nums = x
    │         ^^^^^^^^^   ^ Array<u256, 42>: Memory
    │         │            
    │         Array<u256, 42>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:26:5
+   ┌─ sized_vals_in_sto.fe:24:5
    │  
-26 │ ╭     pub fn read_nums(self) -> Array<u256, 42> {
-27 │ │         return self.nums.to_mem()
-28 │ │     }
+24 │ ╭     pub fn read_nums(self) -> Array<u256, 42> {
+25 │ │         return self.nums.to_mem()
+26 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> Array<u256, 42>
 
 note: 
-   ┌─ sized_vals_in_sto.fe:27:16
+   ┌─ sized_vals_in_sto.fe:25:16
    │
-27 │         return self.nums.to_mem()
+25 │         return self.nums.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:27:16
+   ┌─ sized_vals_in_sto.fe:25:16
    │
-27 │         return self.nums.to_mem()
+25 │         return self.nums.to_mem()
    │                ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:27:16
+   ┌─ sized_vals_in_sto.fe:25:16
    │
-27 │         return self.nums.to_mem()
+25 │         return self.nums.to_mem()
    │                ^^^^^^^^^^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) } => Memory
 
 note: 
-   ┌─ sized_vals_in_sto.fe:30:5
+   ┌─ sized_vals_in_sto.fe:28:5
    │  
-30 │ ╭     pub fn write_str(self, x: String<26>) {
-31 │ │         self.str = x
-32 │ │     }
+28 │ ╭     pub fn write_str(self, x: String<26>) {
+29 │ │         self.str = x
+30 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: String<26> }] -> ()
 
 note: 
-   ┌─ sized_vals_in_sto.fe:31:9
+   ┌─ sized_vals_in_sto.fe:29:9
    │
-31 │         self.str = x
+29 │         self.str = x
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:31:9
+   ┌─ sized_vals_in_sto.fe:29:9
    │
-31 │         self.str = x
+29 │         self.str = x
    │         ^^^^^^^^   ^ String<26>: Memory
    │         │           
    │         String<26>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:34:5
+   ┌─ sized_vals_in_sto.fe:32:5
    │  
-34 │ ╭     pub fn read_str(self) -> String<26> {
-35 │ │         return self.str.to_mem()
-36 │ │     }
+32 │ ╭     pub fn read_str(self) -> String<26> {
+33 │ │         return self.str.to_mem()
+34 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> String<26>
 
 note: 
-   ┌─ sized_vals_in_sto.fe:35:16
+   ┌─ sized_vals_in_sto.fe:33:16
    │
-35 │         return self.str.to_mem()
+33 │         return self.str.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:35:16
+   ┌─ sized_vals_in_sto.fe:33:16
    │
-35 │         return self.str.to_mem()
+33 │         return self.str.to_mem()
    │                ^^^^^^^^ String<26>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:35:16
+   ┌─ sized_vals_in_sto.fe:33:16
    │
-35 │         return self.str.to_mem()
+33 │         return self.str.to_mem()
    │                ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
 
 note: 
-   ┌─ sized_vals_in_sto.fe:38:5
+   ┌─ sized_vals_in_sto.fe:36:5
    │  
-38 │ ╭     pub fn emit_event(self, ctx: Context) {
-39 │ │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
-40 │ │     }
+36 │ ╭     pub fn emit_event(self, ctx: Context) {
+37 │ │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+38 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ sized_vals_in_sto.fe:39:22
+   ┌─ sized_vals_in_sto.fe:37:22
    │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+37 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                      ^^^       ^^^^ Foo: Value
    │                      │          
    │                      Context: Memory
 
 note: 
-   ┌─ sized_vals_in_sto.fe:39:32
+   ┌─ sized_vals_in_sto.fe:37:32
    │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+37 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                                ^^^^^^^^        ^^^^ Foo: Value
    │                                │                
    │                                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ sized_vals_in_sto.fe:39:48
+   ┌─ sized_vals_in_sto.fe:37:48
    │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+37 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                                                ^^^^^^^^^ Array<u256, 42>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:39:48
+   ┌─ sized_vals_in_sto.fe:37:48
    │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+37 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                                                ^^^^^^^^^^^^^^^^^^       ^^^^ Foo: Value
    │                                                │                         
    │                                                Array<u256, 42>: Storage { nonce: Some(1) } => Memory
 
 note: 
-   ┌─ sized_vals_in_sto.fe:39:73
+   ┌─ sized_vals_in_sto.fe:37:73
    │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+37 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                                                                         ^^^^^^^^ String<26>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ sized_vals_in_sto.fe:39:73
+   ┌─ sized_vals_in_sto.fe:37:73
    │
-39 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
+37 │         emit MyEvent(ctx, num: self.num, nums: self.nums.to_mem(), str: self.str.to_mem())
    │                                                                         ^^^^^^^^^^^^^^^^^ String<26>: Storage { nonce: Some(2) } => Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__strings.snap
+++ b/crates/analyzer/tests/snapshots/analysis__strings.snap
@@ -4,106 +4,106 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-   ┌─ strings.fe:5:9
-   │
- 5 │         s2: String<26>
-   │         ^^^^^^^^^^^^^^ String<26>
- 6 │         u: u256
-   │         ^^^^^^^ u256
- 7 │         s1: String<42>
-   │         ^^^^^^^^^^^^^^ String<42>
- 8 │         s3: String<100>
-   │         ^^^^^^^^^^^^^^^ String<100>
- 9 │         a: address
-   │         ^^^^^^^^^^ address
-10 │         s4: String<18>
-   │         ^^^^^^^^^^^^^^ String<18>
-11 │         s5: String<100>
-   │         ^^^^^^^^^^^^^^^ String<100>
+  ┌─ strings.fe:3:9
+  │
+3 │         s2: String<26>
+  │         ^^^^^^^^^^^^^^ String<26>
+4 │         u: u256
+  │         ^^^^^^^ u256
+5 │         s1: String<42>
+  │         ^^^^^^^^^^^^^^ String<42>
+6 │         s3: String<100>
+  │         ^^^^^^^^^^^^^^^ String<100>
+7 │         a: address
+  │         ^^^^^^^^^^ address
+8 │         s4: String<18>
+  │         ^^^^^^^^^^^^^^ String<18>
+9 │         s5: String<100>
+  │         ^^^^^^^^^^^^^^^ String<100>
 
 note: 
-   ┌─ strings.fe:18:5
+   ┌─ strings.fe:16:5
    │  
-18 │ ╭     pub fn bar(s1: String<100>, s2: String<100>) -> String<100> {
-19 │ │         return s2
-20 │ │     }
+16 │ ╭     pub fn bar(s1: String<100>, s2: String<100>) -> String<100> {
+17 │ │         return s2
+18 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: s1, typ: String<100> }, { label: None, name: s2, typ: String<100> }] -> String<100>
 
 note: 
-   ┌─ strings.fe:19:16
+   ┌─ strings.fe:17:16
    │
-19 │         return s2
+17 │         return s2
    │                ^^ String<100>: Memory
 
 note: 
-   ┌─ strings.fe:22:5
+   ┌─ strings.fe:20:5
    │  
-22 │ ╭     pub fn return_static_string() -> String<43> {
-23 │ │         return "The quick brown fox jumps over the lazy dog"
-24 │ │     }
+20 │ ╭     pub fn return_static_string() -> String<43> {
+21 │ │         return "The quick brown fox jumps over the lazy dog"
+22 │ │     }
    │ ╰─────^ self: None, params: [] -> String<43>
 
 note: 
-   ┌─ strings.fe:23:16
+   ┌─ strings.fe:21:16
    │
-23 │         return "The quick brown fox jumps over the lazy dog"
+21 │         return "The quick brown fox jumps over the lazy dog"
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<43>: Memory
 
 note: 
-   ┌─ strings.fe:26:5
+   ┌─ strings.fe:24:5
    │  
-26 │ ╭     pub fn return_casted_static_string() -> String<100> {
-27 │ │         return String<100>("foo")
-28 │ │     }
+24 │ ╭     pub fn return_casted_static_string() -> String<100> {
+25 │ │         return String<100>("foo")
+26 │ │     }
    │ ╰─────^ self: None, params: [] -> String<100>
 
 note: 
-   ┌─ strings.fe:27:28
+   ┌─ strings.fe:25:28
    │
-27 │         return String<100>("foo")
+25 │         return String<100>("foo")
    │                            ^^^^^ String<3>: Memory
 
 note: 
-   ┌─ strings.fe:27:16
+   ┌─ strings.fe:25:16
    │
-27 │         return String<100>("foo")
+25 │         return String<100>("foo")
    │                ^^^^^^^^^^^^^^^^^^ String<100>: Memory
 
 note: 
-   ┌─ strings.fe:30:5
+   ┌─ strings.fe:28:5
    │  
-30 │ ╭     pub fn shorter_string_assign() {
-31 │ │         let s: String<18> = "fe"
-32 │ │     }
+28 │ ╭     pub fn shorter_string_assign() {
+29 │ │         let s: String<18> = "fe"
+30 │ │     }
    │ ╰─────^ self: None, params: [] -> ()
 
 note: 
-   ┌─ strings.fe:31:13
+   ┌─ strings.fe:29:13
    │
-31 │         let s: String<18> = "fe"
+29 │         let s: String<18> = "fe"
    │             ^ String<18>
 
 note: 
-   ┌─ strings.fe:31:29
+   ┌─ strings.fe:29:29
    │
-31 │         let s: String<18> = "fe"
+29 │         let s: String<18> = "fe"
    │                             ^^^^ String<18>: Memory
 
 note: 
-   ┌─ strings.fe:34:5
+   ┌─ strings.fe:32:5
    │  
-34 │ ╭     pub fn return_special_chars() -> String<18> {
-35 │ │         return "\n\"'\r\t
-36 │ │         foo\\"
-37 │ │     }
+32 │ ╭     pub fn return_special_chars() -> String<18> {
+33 │ │         return "\n\"'\r\t
+34 │ │         foo\\"
+35 │ │     }
    │ ╰─────^ self: None, params: [] -> String<18>
 
 note: 
-   ┌─ strings.fe:35:16
+   ┌─ strings.fe:33:16
    │  
-35 │           return "\n\"'\r\t
+33 │           return "\n\"'\r\t
    │ ╭────────────────^
-36 │ │         foo\\"
+34 │ │         foo\\"
    │ ╰──────────────^ String<18>: Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
+++ b/crates/analyzer/tests/snapshots/analysis__tuple_stress.snap
@@ -4,355 +4,355 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ tuple_stress.fe:4:5
+  ┌─ tuple_stress.fe:2:5
   │
-4 │     my_sto_tuple: (u256, i32)
+2 │     my_sto_tuple: (u256, i32)
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32)
 
 note: 
-  ┌─ tuple_stress.fe:7:9
+  ┌─ tuple_stress.fe:5:9
   │
-7 │         my_tuple: (u256, bool, address)
+5 │         my_tuple: (u256, bool, address)
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address)
 
 note: 
-   ┌─ tuple_stress.fe:10:5
+   ┌─ tuple_stress.fe:8:5
    │  
-10 │ ╭     pub fn build_my_tuple(my_num: u256, my_bool: bool, my_address: address) -> (u256, bool, address) {
-11 │ │         return (my_num, my_bool, my_address)
-12 │ │     }
+ 8 │ ╭     pub fn build_my_tuple(my_num: u256, my_bool: bool, my_address: address) -> (u256, bool, address) {
+ 9 │ │         return (my_num, my_bool, my_address)
+10 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_num, typ: u256 }, { label: None, name: my_bool, typ: bool }, { label: None, name: my_address, typ: address }] -> (u256, bool, address)
 
 note: 
-   ┌─ tuple_stress.fe:11:17
-   │
-11 │         return (my_num, my_bool, my_address)
-   │                 ^^^^^^  ^^^^^^^  ^^^^^^^^^^ address: Value
-   │                 │       │         
-   │                 │       bool: Value
-   │                 u256: Value
+  ┌─ tuple_stress.fe:9:17
+  │
+9 │         return (my_num, my_bool, my_address)
+  │                 ^^^^^^  ^^^^^^^  ^^^^^^^^^^ address: Value
+  │                 │       │         
+  │                 │       bool: Value
+  │                 u256: Value
 
 note: 
-   ┌─ tuple_stress.fe:11:16
-   │
-11 │         return (my_num, my_bool, my_address)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory
+  ┌─ tuple_stress.fe:9:16
+  │
+9 │         return (my_num, my_bool, my_address)
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory
 
 note: 
-   ┌─ tuple_stress.fe:14:5
+   ┌─ tuple_stress.fe:12:5
    │  
-14 │ ╭     pub fn read_my_tuple_item0(my_tuple: (u256, bool, address)) -> u256 {
-15 │ │         return my_tuple.item0
-16 │ │     }
+12 │ ╭     pub fn read_my_tuple_item0(my_tuple: (u256, bool, address)) -> u256 {
+13 │ │         return my_tuple.item0
+14 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> u256
 
 note: 
-   ┌─ tuple_stress.fe:15:16
+   ┌─ tuple_stress.fe:13:16
    │
-15 │         return my_tuple.item0
+13 │         return my_tuple.item0
    │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
-   ┌─ tuple_stress.fe:15:16
+   ┌─ tuple_stress.fe:13:16
    │
-15 │         return my_tuple.item0
+13 │         return my_tuple.item0
    │                ^^^^^^^^^^^^^^ u256: Memory => Value
 
 note: 
-   ┌─ tuple_stress.fe:18:5
+   ┌─ tuple_stress.fe:16:5
    │  
-18 │ ╭     pub fn read_my_tuple_item1(my_tuple: (u256, bool, address)) -> bool {
-19 │ │         return my_tuple.item1
-20 │ │     }
+16 │ ╭     pub fn read_my_tuple_item1(my_tuple: (u256, bool, address)) -> bool {
+17 │ │         return my_tuple.item1
+18 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> bool
 
 note: 
-   ┌─ tuple_stress.fe:19:16
+   ┌─ tuple_stress.fe:17:16
    │
-19 │         return my_tuple.item1
+17 │         return my_tuple.item1
    │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
-   ┌─ tuple_stress.fe:19:16
+   ┌─ tuple_stress.fe:17:16
    │
-19 │         return my_tuple.item1
+17 │         return my_tuple.item1
    │                ^^^^^^^^^^^^^^ bool: Memory => Value
 
 note: 
-   ┌─ tuple_stress.fe:22:5
+   ┌─ tuple_stress.fe:20:5
    │  
-22 │ ╭     pub fn read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address {
-23 │ │         return my_tuple.item2
-24 │ │     }
+20 │ ╭     pub fn read_my_tuple_item2(my_tuple: (u256, bool, address)) -> address {
+21 │ │         return my_tuple.item2
+22 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> address
 
 note: 
-   ┌─ tuple_stress.fe:23:16
+   ┌─ tuple_stress.fe:21:16
    │
-23 │         return my_tuple.item2
+21 │         return my_tuple.item2
    │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
-   ┌─ tuple_stress.fe:23:16
+   ┌─ tuple_stress.fe:21:16
    │
-23 │         return my_tuple.item2
+21 │         return my_tuple.item2
    │                ^^^^^^^^^^^^^^ address: Memory => Value
 
 note: 
-   ┌─ tuple_stress.fe:26:5
+   ┌─ tuple_stress.fe:24:5
    │  
-26 │ ╭     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address {
-27 │ │         return my_tuple.item10
-28 │ │     }
+24 │ ╭     pub fn read_my_tuple_item10(my_tuple: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address)) -> address {
+25 │ │         return my_tuple.item10
+26 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address) }] -> address
 
 note: 
-   ┌─ tuple_stress.fe:27:16
+   ┌─ tuple_stress.fe:25:16
    │
-27 │         return my_tuple.item10
+25 │         return my_tuple.item10
    │                ^^^^^^^^ (u256, u256, u256, u256, u256, u256, u256, u256, u256, u256, address): Memory
 
 note: 
-   ┌─ tuple_stress.fe:27:16
+   ┌─ tuple_stress.fe:25:16
    │
-27 │         return my_tuple.item10
+25 │         return my_tuple.item10
    │                ^^^^^^^^^^^^^^^ address: Memory => Value
 
 note: 
-   ┌─ tuple_stress.fe:30:5
+   ┌─ tuple_stress.fe:28:5
    │  
-30 │ ╭     pub fn emit_my_event(ctx: Context, my_tuple: (u256, bool, address)) {
-31 │ │         emit MyEvent(ctx, my_tuple)
-32 │ │     }
+28 │ ╭     pub fn emit_my_event(ctx: Context, my_tuple: (u256, bool, address)) {
+29 │ │         emit MyEvent(ctx, my_tuple)
+30 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: ctx, typ: Context }, { label: None, name: my_tuple, typ: (u256, bool, address) }] -> ()
 
 note: 
-   ┌─ tuple_stress.fe:31:22
+   ┌─ tuple_stress.fe:29:22
    │
-31 │         emit MyEvent(ctx, my_tuple)
+29 │         emit MyEvent(ctx, my_tuple)
    │                      ^^^  ^^^^^^^^ (u256, bool, address): Memory
    │                      │     
    │                      Context: Memory
 
 note: 
-   ┌─ tuple_stress.fe:34:5
+   ┌─ tuple_stress.fe:32:5
    │  
-34 │ ╭     pub fn set_my_sto_tuple(self, my_u256: u256, my_i32: i32) {
-35 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
-36 │ │         self.my_sto_tuple = (my_u256, my_i32)
-37 │ │     }
+32 │ ╭     pub fn set_my_sto_tuple(self, my_u256: u256, my_i32: i32) {
+33 │ │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+34 │ │         self.my_sto_tuple = (my_u256, my_i32)
+35 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: my_u256, typ: u256 }, { label: None, name: my_i32, typ: i32 }] -> ()
 
 note: 
-   ┌─ tuple_stress.fe:35:16
+   ┌─ tuple_stress.fe:33:16
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ tuple_stress.fe:35:16
+   ┌─ tuple_stress.fe:33:16
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
 
 note: 
-   ┌─ tuple_stress.fe:35:16
+   ┌─ tuple_stress.fe:33:16
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^         ^ u256: Value
    │                │                                
    │                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ tuple_stress.fe:35:43
+   ┌─ tuple_stress.fe:33:43
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                           ^^^^^^^ u256: Value
 
 note: 
-   ┌─ tuple_stress.fe:35:16
+   ┌─ tuple_stress.fe:33:16
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^ Foo: Value
    │                │                                       
    │                bool: Value
 
 note: 
-   ┌─ tuple_stress.fe:35:55
+   ┌─ tuple_stress.fe:33:55
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                       ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
 
 note: 
-   ┌─ tuple_stress.fe:35:55
+   ┌─ tuple_stress.fe:33:55
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                       ^^^^^^^^^^^^^^^^^^^^^^^        ^ i32: Value
    │                                                       │                               
    │                                                       i32: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ tuple_stress.fe:35:82
+   ┌─ tuple_stress.fe:33:82
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                                                  ^^^^^^ i32: Value
 
 note: 
-   ┌─ tuple_stress.fe:35:55
+   ┌─ tuple_stress.fe:33:55
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-   ┌─ tuple_stress.fe:35:16
+   ┌─ tuple_stress.fe:33:16
    │
-35 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
+33 │         assert self.my_sto_tuple.item0 == u256(0) and self.my_sto_tuple.item1 == i32(0)
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-36 │         self.my_sto_tuple = (my_u256, my_i32)
+34 │         self.my_sto_tuple = (my_u256, my_i32)
    │         ^^^^ Foo: Value
 
 note: 
-   ┌─ tuple_stress.fe:36:9
+   ┌─ tuple_stress.fe:34:9
    │
-36 │         self.my_sto_tuple = (my_u256, my_i32)
+34 │         self.my_sto_tuple = (my_u256, my_i32)
    │         ^^^^^^^^^^^^^^^^^    ^^^^^^^  ^^^^^^ i32: Value
    │         │                    │         
    │         │                    u256: Value
    │         (u256, i32): Storage { nonce: Some(0) }
 
 note: 
-   ┌─ tuple_stress.fe:36:29
+   ┌─ tuple_stress.fe:34:29
    │
-36 │         self.my_sto_tuple = (my_u256, my_i32)
+34 │         self.my_sto_tuple = (my_u256, my_i32)
    │                             ^^^^^^^^^^^^^^^^^ (u256, i32): Memory
 
 note: 
-   ┌─ tuple_stress.fe:39:5
+   ┌─ tuple_stress.fe:37:5
    │  
-39 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32) {
-40 │ │         return self.my_sto_tuple.to_mem()
-41 │ │     }
+37 │ ╭     pub fn get_my_sto_tuple(self) -> (u256, i32) {
+38 │ │         return self.my_sto_tuple.to_mem()
+39 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> (u256, i32)
 
 note: 
-   ┌─ tuple_stress.fe:40:16
+   ┌─ tuple_stress.fe:38:16
    │
-40 │         return self.my_sto_tuple.to_mem()
+38 │         return self.my_sto_tuple.to_mem()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ tuple_stress.fe:40:16
+   ┌─ tuple_stress.fe:38:16
    │
-40 │         return self.my_sto_tuple.to_mem()
+38 │         return self.my_sto_tuple.to_mem()
    │                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
 
 note: 
-   ┌─ tuple_stress.fe:40:16
+   ┌─ tuple_stress.fe:38:16
    │
-40 │         return self.my_sto_tuple.to_mem()
+38 │         return self.my_sto_tuple.to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) } => Memory
 
 note: 
-   ┌─ tuple_stress.fe:43:5
+   ┌─ tuple_stress.fe:41:5
    │  
-43 │ ╭     pub fn build_tuple_and_emit(self, ctx: Context) {
-44 │ │         let my_num: u256 = self.my_sto_tuple.item0
-45 │ │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
-46 │ │         emit_my_event(ctx, my_tuple)
-47 │ │     }
+41 │ ╭     pub fn build_tuple_and_emit(self, ctx: Context) {
+42 │ │         let my_num: u256 = self.my_sto_tuple.item0
+43 │ │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+44 │ │         emit_my_event(ctx, my_tuple)
+45 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-   ┌─ tuple_stress.fe:44:13
+   ┌─ tuple_stress.fe:42:13
    │
-44 │         let my_num: u256 = self.my_sto_tuple.item0
+42 │         let my_num: u256 = self.my_sto_tuple.item0
    │             ^^^^^^ u256
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │             ^^^^^^^^ (u256, bool, address)
 
 note: 
-   ┌─ tuple_stress.fe:44:28
+   ┌─ tuple_stress.fe:42:28
    │
-44 │         let my_num: u256 = self.my_sto_tuple.item0
+42 │         let my_num: u256 = self.my_sto_tuple.item0
    │                            ^^^^ Foo: Value
 
 note: 
-   ┌─ tuple_stress.fe:44:28
+   ┌─ tuple_stress.fe:42:28
    │
-44 │         let my_num: u256 = self.my_sto_tuple.item0
+42 │         let my_num: u256 = self.my_sto_tuple.item0
    │                            ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
 
 note: 
-   ┌─ tuple_stress.fe:44:28
+   ┌─ tuple_stress.fe:42:28
    │
-44 │         let my_num: u256 = self.my_sto_tuple.item0
+42 │         let my_num: u256 = self.my_sto_tuple.item0
    │                            ^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(0) } => Value
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │                                                ^^^^ Foo: Value
 
 note: 
-   ┌─ tuple_stress.fe:45:48
+   ┌─ tuple_stress.fe:43:48
    │
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │                                                ^^^^^^^^^^^^^^^^^ (u256, i32): Storage { nonce: Some(0) }
 
 note: 
-   ┌─ tuple_stress.fe:45:48
+   ┌─ tuple_stress.fe:43:48
    │
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │                                                ^^^^^^^^^^^^^^^^^^^^^^^  ^^^^     ^^^^^ bool: Value
    │                                                │                        │         
    │                                                │                        bool: Value
    │                                                u256: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ tuple_stress.fe:45:73
+   ┌─ tuple_stress.fe:43:73
    │
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │                                                                         ^^^^^^^^^^^^^^          ^^ u256: Value
    │                                                                         │                        
    │                                                                         bool: Value
 
 note: 
-   ┌─ tuple_stress.fe:45:89
+   ┌─ tuple_stress.fe:43:89
    │
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │                                                                                         ^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ tuple_stress.fe:45:47
+   ┌─ tuple_stress.fe:43:47
    │
-45 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
+43 │         let my_tuple: (u256, bool, address) = (self.my_sto_tuple.item0, true and false, address(26))
    │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, bool, address): Memory
-46 │         emit_my_event(ctx, my_tuple)
+44 │         emit_my_event(ctx, my_tuple)
    │                       ^^^  ^^^^^^^^ (u256, bool, address): Memory
    │                       │     
    │                       Context: Memory
 
 note: 
-   ┌─ tuple_stress.fe:46:9
+   ┌─ tuple_stress.fe:44:9
    │
-46 │         emit_my_event(ctx, my_tuple)
+44 │         emit_my_event(ctx, my_tuple)
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
 
 note: 
-   ┌─ tuple_stress.fe:49:5
+   ┌─ tuple_stress.fe:47:5
    │  
-49 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> Array<u8, 96> {
-50 │ │         return my_tuple.abi_encode()
-51 │ │     }
+47 │ ╭     pub fn encode_my_tuple(my_tuple: (u256, bool, address)) -> Array<u8, 96> {
+48 │ │         return my_tuple.abi_encode()
+49 │ │     }
    │ ╰─────^ self: None, params: [{ label: None, name: my_tuple, typ: (u256, bool, address) }] -> Array<u8, 96>
 
 note: 
-   ┌─ tuple_stress.fe:50:16
+   ┌─ tuple_stress.fe:48:16
    │
-50 │         return my_tuple.abi_encode()
+48 │         return my_tuple.abi_encode()
    │                ^^^^^^^^ (u256, bool, address): Memory
 
 note: 
-   ┌─ tuple_stress.fe:50:16
+   ┌─ tuple_stress.fe:48:16
    │
-50 │         return my_tuple.abi_encode()
+48 │         return my_tuple.abi_encode()
    │                ^^^^^^^^^^^^^^^^^^^^^ Array<u8, 96>: Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
+++ b/crates/analyzer/tests/snapshots/analysis__two_contracts.snap
@@ -4,143 +4,143 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ two_contracts.fe:4:5
+  ┌─ two_contracts.fe:2:5
   │
-4 │     other: Bar
+2 │     other: Bar
   │     ^^^^^^^^^^ Bar
 
 note: 
-   ┌─ two_contracts.fe:10:5
+   ┌─ two_contracts.fe:8:5
    │  
-10 │ ╭     pub fn foo(self, ctx: Context) -> u256 {
-11 │ │         self.other.set_foo_addr(ctx.self_address())
-12 │ │         return self.other.answer()
-13 │ │     }
+ 8 │ ╭     pub fn foo(self, ctx: Context) -> u256 {
+ 9 │ │         self.other.set_foo_addr(ctx.self_address())
+10 │ │         return self.other.answer()
+11 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> u256
 
 note: 
-   ┌─ two_contracts.fe:11:9
-   │
-11 │         self.other.set_foo_addr(ctx.self_address())
-   │         ^^^^ Foo: Value
+  ┌─ two_contracts.fe:9:9
+  │
+9 │         self.other.set_foo_addr(ctx.self_address())
+  │         ^^^^ Foo: Value
 
 note: 
-   ┌─ two_contracts.fe:11:9
-   │
-11 │         self.other.set_foo_addr(ctx.self_address())
-   │         ^^^^^^^^^^              ^^^ Context: Memory
-   │         │                        
-   │         Bar: Storage { nonce: Some(0) } => Value
+  ┌─ two_contracts.fe:9:9
+  │
+9 │         self.other.set_foo_addr(ctx.self_address())
+  │         ^^^^^^^^^^              ^^^ Context: Memory
+  │         │                        
+  │         Bar: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ two_contracts.fe:11:33
-   │
-11 │         self.other.set_foo_addr(ctx.self_address())
-   │                                 ^^^^^^^^^^^^^^^^^^ address: Value
+  ┌─ two_contracts.fe:9:33
+  │
+9 │         self.other.set_foo_addr(ctx.self_address())
+  │                                 ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ two_contracts.fe:11:9
+   ┌─ two_contracts.fe:9:9
    │
-11 │         self.other.set_foo_addr(ctx.self_address())
+ 9 │         self.other.set_foo_addr(ctx.self_address())
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-12 │         return self.other.answer()
+10 │         return self.other.answer()
    │                ^^^^ Foo: Value
 
 note: 
-   ┌─ two_contracts.fe:12:16
+   ┌─ two_contracts.fe:10:16
    │
-12 │         return self.other.answer()
+10 │         return self.other.answer()
    │                ^^^^^^^^^^ Bar: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ two_contracts.fe:12:16
+   ┌─ two_contracts.fe:10:16
    │
-12 │         return self.other.answer()
+10 │         return self.other.answer()
    │                ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-   ┌─ two_contracts.fe:15:5
+   ┌─ two_contracts.fe:13:5
    │  
-15 │ ╭     pub fn add(self, _ x: u256, _ y: u256) -> u256 {
-16 │ │         return x + y
-17 │ │     }
+13 │ ╭     pub fn add(self, _ x: u256, _ y: u256) -> u256 {
+14 │ │         return x + y
+15 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
-   ┌─ two_contracts.fe:16:16
+   ┌─ two_contracts.fe:14:16
    │
-16 │         return x + y
+14 │         return x + y
    │                ^   ^ u256: Value
    │                │    
    │                u256: Value
 
 note: 
-   ┌─ two_contracts.fe:16:16
+   ┌─ two_contracts.fe:14:16
    │
-16 │         return x + y
+14 │         return x + y
    │                ^^^^^ u256: Value
 
 note: 
-   ┌─ two_contracts.fe:21:5
+   ┌─ two_contracts.fe:19:5
    │
-21 │     other: Foo
+19 │     other: Foo
    │     ^^^^^^^^^^ Foo
 
 note: 
-   ┌─ two_contracts.fe:23:5
+   ┌─ two_contracts.fe:21:5
    │  
-23 │ ╭     pub fn set_foo_addr(self, _ addr: address) {
-24 │ │         self.other = Foo(addr)
-25 │ │     }
+21 │ ╭     pub fn set_foo_addr(self, _ addr: address) {
+22 │ │         self.other = Foo(addr)
+23 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: addr, typ: address }] -> ()
 
 note: 
-   ┌─ two_contracts.fe:24:9
+   ┌─ two_contracts.fe:22:9
    │
-24 │         self.other = Foo(addr)
+22 │         self.other = Foo(addr)
    │         ^^^^ Bar: Value
 
 note: 
-   ┌─ two_contracts.fe:24:9
+   ┌─ two_contracts.fe:22:9
    │
-24 │         self.other = Foo(addr)
+22 │         self.other = Foo(addr)
    │         ^^^^^^^^^^       ^^^^ address: Value
    │         │                 
    │         Foo: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ two_contracts.fe:24:22
+   ┌─ two_contracts.fe:22:22
    │
-24 │         self.other = Foo(addr)
+22 │         self.other = Foo(addr)
    │                      ^^^^^^^^^ Foo: Value
 
 note: 
-   ┌─ two_contracts.fe:27:5
+   ┌─ two_contracts.fe:25:5
    │  
-27 │ ╭     pub fn answer(self) -> u256 {
-28 │ │         return self.other.add(20, 22)
-29 │ │     }
+25 │ ╭     pub fn answer(self) -> u256 {
+26 │ │         return self.other.add(20, 22)
+27 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
-   ┌─ two_contracts.fe:28:16
+   ┌─ two_contracts.fe:26:16
    │
-28 │         return self.other.add(20, 22)
+26 │         return self.other.add(20, 22)
    │                ^^^^ Bar: Value
 
 note: 
-   ┌─ two_contracts.fe:28:16
+   ┌─ two_contracts.fe:26:16
    │
-28 │         return self.other.add(20, 22)
+26 │         return self.other.add(20, 22)
    │                ^^^^^^^^^^     ^^  ^^ u256: Value
    │                │              │    
    │                │              u256: Value
    │                Foo: Storage { nonce: Some(0) } => Value
 
 note: 
-   ┌─ two_contracts.fe:28:16
+   ┌─ two_contracts.fe:26:16
    │
-28 │         return self.other.add(20, 22)
+26 │         return self.other.add(20, 22)
    │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
+++ b/crates/analyzer/tests/snapshots/analysis__type_aliases.snap
@@ -4,234 +4,234 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
+  ┌─ type_aliases.fe:1:1
+  │
+1 │ type Posts = Map<PostId, PostBody>
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<u256, String<32>>
+
+note: 
   ┌─ type_aliases.fe:3:1
   │
-3 │ type Posts = Map<PostId, PostBody>
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<u256, String<32>>
+3 │ type Scoreboard = Map<PostId, Score>
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<u256, u64>
 
 note: 
   ┌─ type_aliases.fe:5:1
   │
-5 │ type Scoreboard = Map<PostId, Score>
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<u256, u64>
+5 │ type AuthorPosts = Map<Author, PostId>
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
 
 note: 
   ┌─ type_aliases.fe:7:1
   │
-7 │ type AuthorPosts = Map<Author, PostId>
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
+7 │ type Author = address
+  │ ^^^^^^^^^^^^^^^^^^^^^ address
 
 note: 
   ┌─ type_aliases.fe:9:1
   │
-9 │ type Author = address
-  │ ^^^^^^^^^^^^^^^^^^^^^ address
+9 │ type Score = u64
+  │ ^^^^^^^^^^^^^^^^ u64
 
 note: 
    ┌─ type_aliases.fe:11:1
    │
-11 │ type Score = u64
-   │ ^^^^^^^^^^^^^^^^ u64
+11 │ type PostId = u256
+   │ ^^^^^^^^^^^^^^^^^^ u256
 
 note: 
    ┌─ type_aliases.fe:13:1
    │
-13 │ type PostId = u256
-   │ ^^^^^^^^^^^^^^^^^^ u256
-
-note: 
-   ┌─ type_aliases.fe:15:1
-   │
-15 │ type PostBody = String<32>
+13 │ type PostBody = String<32>
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^ String<32>
 
 note: 
-   ┌─ type_aliases.fe:18:5
+   ┌─ type_aliases.fe:16:5
    │
-18 │     posts: Posts
+16 │     posts: Posts
    │     ^^^^^^^^^^^^ Map<u256, String<32>>
-19 │     authors: AuthorPosts
+17 │     authors: AuthorPosts
    │     ^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-20 │     scoreboard: Scoreboard
+18 │     scoreboard: Scoreboard
    │     ^^^^^^^^^^^^^^^^^^^^^^ Map<u256, u64>
 
 note: 
-   ┌─ type_aliases.fe:22:5
+   ┌─ type_aliases.fe:20:5
    │  
-22 │ ╭     pub fn post(self, ctx: Context, body: PostBody) {
-23 │ │         let id: PostId = 0
-24 │ │         self.posts[id] = body
-25 │ │         self.authors[ctx.msg_sender()]
-26 │ │         self.scoreboard[id] = 0
-27 │ │     }
+20 │ ╭     pub fn post(self, ctx: Context, body: PostBody) {
+21 │ │         let id: PostId = 0
+22 │ │         self.posts[id] = body
+23 │ │         self.authors[ctx.msg_sender()]
+24 │ │         self.scoreboard[id] = 0
+25 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: body, typ: String<32> }] -> ()
 
 note: 
-   ┌─ type_aliases.fe:23:13
+   ┌─ type_aliases.fe:21:13
    │
-23 │         let id: PostId = 0
+21 │         let id: PostId = 0
    │             ^^ u256
 
 note: 
-   ┌─ type_aliases.fe:23:26
+   ┌─ type_aliases.fe:21:26
    │
-23 │         let id: PostId = 0
+21 │         let id: PostId = 0
    │                          ^ u256: Value
-24 │         self.posts[id] = body
+22 │         self.posts[id] = body
    │         ^^^^ Forum: Value
 
 note: 
-   ┌─ type_aliases.fe:24:9
+   ┌─ type_aliases.fe:22:9
    │
-24 │         self.posts[id] = body
+22 │         self.posts[id] = body
    │         ^^^^^^^^^^ ^^ u256: Value
    │         │           
    │         Map<u256, String<32>>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ type_aliases.fe:24:9
+   ┌─ type_aliases.fe:22:9
    │
-24 │         self.posts[id] = body
+22 │         self.posts[id] = body
    │         ^^^^^^^^^^^^^^   ^^^^ String<32>: Memory
    │         │                 
    │         String<32>: Storage { nonce: None }
-25 │         self.authors[ctx.msg_sender()]
+23 │         self.authors[ctx.msg_sender()]
    │         ^^^^ Forum: Value
 
 note: 
-   ┌─ type_aliases.fe:25:9
+   ┌─ type_aliases.fe:23:9
    │
-25 │         self.authors[ctx.msg_sender()]
+23 │         self.authors[ctx.msg_sender()]
    │         ^^^^^^^^^^^^ ^^^ Context: Memory
    │         │             
    │         Map<address, u256>: Storage { nonce: Some(1) }
 
 note: 
-   ┌─ type_aliases.fe:25:22
+   ┌─ type_aliases.fe:23:22
    │
-25 │         self.authors[ctx.msg_sender()]
+23 │         self.authors[ctx.msg_sender()]
    │                      ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ type_aliases.fe:25:9
+   ┌─ type_aliases.fe:23:9
    │
-25 │         self.authors[ctx.msg_sender()]
+23 │         self.authors[ctx.msg_sender()]
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None }
-26 │         self.scoreboard[id] = 0
+24 │         self.scoreboard[id] = 0
    │         ^^^^ Forum: Value
 
 note: 
-   ┌─ type_aliases.fe:26:9
+   ┌─ type_aliases.fe:24:9
    │
-26 │         self.scoreboard[id] = 0
+24 │         self.scoreboard[id] = 0
    │         ^^^^^^^^^^^^^^^ ^^ u256: Value
    │         │                
    │         Map<u256, u64>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ type_aliases.fe:26:9
+   ┌─ type_aliases.fe:24:9
    │
-26 │         self.scoreboard[id] = 0
+24 │         self.scoreboard[id] = 0
    │         ^^^^^^^^^^^^^^^^^^^   ^ u64: Value
    │         │                      
    │         u64: Storage { nonce: None }
 
 note: 
-   ┌─ type_aliases.fe:29:5
+   ┌─ type_aliases.fe:27:5
    │  
-29 │ ╭     pub fn upvote(self, id: PostId) -> Score {
-30 │ │         let score: Score = self.scoreboard[id] + 1
-31 │ │         self.scoreboard[id] = score
-32 │ │         return score
-33 │ │     }
+27 │ ╭     pub fn upvote(self, id: PostId) -> Score {
+28 │ │         let score: Score = self.scoreboard[id] + 1
+29 │ │         self.scoreboard[id] = score
+30 │ │         return score
+31 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: id, typ: u256 }] -> u64
 
 note: 
-   ┌─ type_aliases.fe:30:13
+   ┌─ type_aliases.fe:28:13
    │
-30 │         let score: Score = self.scoreboard[id] + 1
+28 │         let score: Score = self.scoreboard[id] + 1
    │             ^^^^^ u64
 
 note: 
-   ┌─ type_aliases.fe:30:28
+   ┌─ type_aliases.fe:28:28
    │
-30 │         let score: Score = self.scoreboard[id] + 1
+28 │         let score: Score = self.scoreboard[id] + 1
    │                            ^^^^ Forum: Value
 
 note: 
-   ┌─ type_aliases.fe:30:28
+   ┌─ type_aliases.fe:28:28
    │
-30 │         let score: Score = self.scoreboard[id] + 1
+28 │         let score: Score = self.scoreboard[id] + 1
    │                            ^^^^^^^^^^^^^^^ ^^ u256: Value
    │                            │                
    │                            Map<u256, u64>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ type_aliases.fe:30:28
+   ┌─ type_aliases.fe:28:28
    │
-30 │         let score: Score = self.scoreboard[id] + 1
+28 │         let score: Score = self.scoreboard[id] + 1
    │                            ^^^^^^^^^^^^^^^^^^^   ^ u64: Value
    │                            │                      
    │                            u64: Storage { nonce: None } => Value
 
 note: 
-   ┌─ type_aliases.fe:30:28
+   ┌─ type_aliases.fe:28:28
    │
-30 │         let score: Score = self.scoreboard[id] + 1
+28 │         let score: Score = self.scoreboard[id] + 1
    │                            ^^^^^^^^^^^^^^^^^^^^^^^ u64: Value
-31 │         self.scoreboard[id] = score
+29 │         self.scoreboard[id] = score
    │         ^^^^ Forum: Value
 
 note: 
-   ┌─ type_aliases.fe:31:9
+   ┌─ type_aliases.fe:29:9
    │
-31 │         self.scoreboard[id] = score
+29 │         self.scoreboard[id] = score
    │         ^^^^^^^^^^^^^^^ ^^ u256: Value
    │         │                
    │         Map<u256, u64>: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ type_aliases.fe:31:9
+   ┌─ type_aliases.fe:29:9
    │
-31 │         self.scoreboard[id] = score
+29 │         self.scoreboard[id] = score
    │         ^^^^^^^^^^^^^^^^^^^   ^^^^^ u64: Value
    │         │                      
    │         u64: Storage { nonce: None }
-32 │         return score
+30 │         return score
    │                ^^^^^ u64: Value
 
 note: 
-   ┌─ type_aliases.fe:35:5
+   ┌─ type_aliases.fe:33:5
    │  
-35 │ ╭     pub fn get_post(self, id: PostId) -> PostBody {
-36 │ │         return self.posts[id].to_mem()
-37 │ │     }
+33 │ ╭     pub fn get_post(self, id: PostId) -> PostBody {
+34 │ │         return self.posts[id].to_mem()
+35 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: id, typ: u256 }] -> String<32>
 
 note: 
-   ┌─ type_aliases.fe:36:16
+   ┌─ type_aliases.fe:34:16
    │
-36 │         return self.posts[id].to_mem()
+34 │         return self.posts[id].to_mem()
    │                ^^^^ Forum: Value
 
 note: 
-   ┌─ type_aliases.fe:36:16
+   ┌─ type_aliases.fe:34:16
    │
-36 │         return self.posts[id].to_mem()
+34 │         return self.posts[id].to_mem()
    │                ^^^^^^^^^^ ^^ u256: Value
    │                │           
    │                Map<u256, String<32>>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ type_aliases.fe:36:16
+   ┌─ type_aliases.fe:34:16
    │
-36 │         return self.posts[id].to_mem()
+34 │         return self.posts[id].to_mem()
    │                ^^^^^^^^^^^^^^ String<32>: Storage { nonce: None }
 
 note: 
-   ┌─ type_aliases.fe:36:16
+   ┌─ type_aliases.fe:34:16
    │
-36 │         return self.posts[id].to_mem()
+34 │         return self.posts[id].to_mem()
    │                ^^^^^^^^^^^^^^^^^^^^^^^ String<32>: Storage { nonce: None } => Memory
 
 

--- a/crates/analyzer/tests/snapshots/analysis__uniswap.snap
+++ b/crates/analyzer/tests/snapshots/analysis__uniswap.snap
@@ -4,426 +4,426 @@ expression: "build_snapshot(&db, module)"
 
 ---
 note: 
-  ┌─ uniswap.fe:4:5
+  ┌─ uniswap.fe:2:5
   │  
-4 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
-5 │ │         return 0
-6 │ │     }
+2 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
+3 │ │         return 0
+4 │ │     }
   │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
-  ┌─ uniswap.fe:5:16
+  ┌─ uniswap.fe:3:16
   │
-5 │         return 0
+3 │         return 0
   │                ^ u256: Value
 
 note: 
-   ┌─ uniswap.fe:8:5
-   │  
- 8 │ ╭     pub fn transfer(self, to: address, _ amount: u256) -> bool {
- 9 │ │         return false
-10 │ │     }
-   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: to, typ: address }, { label: Some("_"), name: amount, typ: u256 }] -> bool
+  ┌─ uniswap.fe:6:5
+  │  
+6 │ ╭     pub fn transfer(self, to: address, _ amount: u256) -> bool {
+7 │ │         return false
+8 │ │     }
+  │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: to, typ: address }, { label: Some("_"), name: amount, typ: u256 }] -> bool
 
 note: 
-  ┌─ uniswap.fe:9:16
+  ┌─ uniswap.fe:7:16
   │
-9 │         return false
+7 │         return false
   │                ^^^^^ bool: Value
 
 note: 
-   ┌─ uniswap.fe:17:5
+   ┌─ uniswap.fe:15:5
    │
-17 │     balances: Map<address, u256>
+15 │     balances: Map<address, u256>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-18 │     allowances: Map<address, Map<address, u256>>
+16 │     allowances: Map<address, Map<address, u256>>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, u256>>
-19 │     total_supply: u256
+17 │     total_supply: u256
    │     ^^^^^^^^^^^^^^^^^^ u256
-20 │ 
-21 │     nonces: Map<address, u256>
+18 │ 
+19 │     nonces: Map<address, u256>
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, u256>
-22 │ 
-23 │     factory: address
+20 │ 
+21 │     factory: address
    │     ^^^^^^^^^^^^^^^^ address
-24 │     token0: ERC20
+22 │     token0: ERC20
    │     ^^^^^^^^^^^^^ ERC20
-25 │     token1: ERC20
+23 │     token1: ERC20
    │     ^^^^^^^^^^^^^ ERC20
-26 │ 
-27 │     reserve0: u256
+24 │ 
+25 │     reserve0: u256
    │     ^^^^^^^^^^^^^^ u256
-28 │     reserve1: u256
+26 │     reserve1: u256
    │     ^^^^^^^^^^^^^^ u256
-29 │     block_timestamp_last: u256
+27 │     block_timestamp_last: u256
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
-30 │ 
-31 │     price0_cumulative_last: u256
+28 │ 
+29 │     price0_cumulative_last: u256
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
-32 │     price1_cumulative_last: u256
+30 │     price1_cumulative_last: u256
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256
-33 │     k_last: u256
+31 │     k_last: u256
    │     ^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ uniswap.fe:36:9
+   ┌─ uniswap.fe:34:9
    │
-36 │         idx owner: address
+34 │         idx owner: address
    │         ^^^^^^^^^^^^^^^^^^ address
-37 │         idx spender: address
+35 │         idx spender: address
    │         ^^^^^^^^^^^^^^^^^^^^ address
-38 │         value: u256
+36 │         value: u256
    │         ^^^^^^^^^^^ u256
 
 note: 
-   ┌─ uniswap.fe:42:9
+   ┌─ uniswap.fe:40:9
    │
-42 │         idx from: address
+40 │         idx from: address
    │         ^^^^^^^^^^^^^^^^^ address
-43 │         idx to: address
+41 │         idx to: address
    │         ^^^^^^^^^^^^^^^ address
-44 │         value: u256
+42 │         value: u256
    │         ^^^^^^^^^^^ u256
 
 note: 
-   ┌─ uniswap.fe:48:9
+   ┌─ uniswap.fe:46:9
    │
-48 │         idx sender: address
+46 │         idx sender: address
    │         ^^^^^^^^^^^^^^^^^^^ address
-49 │         amount0: u256
+47 │         amount0: u256
    │         ^^^^^^^^^^^^^ u256
-50 │         amount1: u256
+48 │         amount1: u256
    │         ^^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ uniswap.fe:54:9
+   ┌─ uniswap.fe:52:9
    │
-54 │         idx sender: address
+52 │         idx sender: address
    │         ^^^^^^^^^^^^^^^^^^^ address
-55 │         amount0: u256
+53 │         amount0: u256
    │         ^^^^^^^^^^^^^ u256
-56 │         amount1: u256
+54 │         amount1: u256
    │         ^^^^^^^^^^^^^ u256
-57 │         idx to: address
+55 │         idx to: address
    │         ^^^^^^^^^^^^^^^ address
 
 note: 
-   ┌─ uniswap.fe:61:9
+   ┌─ uniswap.fe:59:9
    │
-61 │         idx sender: address
+59 │         idx sender: address
    │         ^^^^^^^^^^^^^^^^^^^ address
-62 │         amount0_in: u256
+60 │         amount0_in: u256
    │         ^^^^^^^^^^^^^^^^ u256
-63 │         amount1_in: u256
+61 │         amount1_in: u256
    │         ^^^^^^^^^^^^^^^^ u256
-64 │         amount0_out: u256
+62 │         amount0_out: u256
    │         ^^^^^^^^^^^^^^^^^ u256
-65 │         amount1_out: u256
+63 │         amount1_out: u256
    │         ^^^^^^^^^^^^^^^^^ u256
-66 │         idx to: address
+64 │         idx to: address
    │         ^^^^^^^^^^^^^^^ address
 
 note: 
-   ┌─ uniswap.fe:70:9
+   ┌─ uniswap.fe:68:9
    │
-70 │         reserve0: u256
+68 │         reserve0: u256
    │         ^^^^^^^^^^^^^^ u256
-71 │         reserve1: u256
+69 │         reserve1: u256
    │         ^^^^^^^^^^^^^^ u256
 
 note: 
-   ┌─ uniswap.fe:78:5
+   ┌─ uniswap.fe:76:5
    │  
-78 │ ╭     pub fn factory(self) -> address {
-79 │ │         return self.factory
-80 │ │     }
+76 │ ╭     pub fn factory(self) -> address {
+77 │ │         return self.factory
+78 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-   ┌─ uniswap.fe:79:16
+   ┌─ uniswap.fe:77:16
    │
-79 │         return self.factory
+77 │         return self.factory
    │                ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:79:16
+   ┌─ uniswap.fe:77:16
    │
-79 │         return self.factory
+77 │         return self.factory
    │                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Value
 
 note: 
-   ┌─ uniswap.fe:82:5
+   ┌─ uniswap.fe:80:5
    │  
-82 │ ╭     pub fn token0(self) -> address {
-83 │ │         return address(self.token0)
-84 │ │     }
+80 │ ╭     pub fn token0(self) -> address {
+81 │ │         return address(self.token0)
+82 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-   ┌─ uniswap.fe:83:24
+   ┌─ uniswap.fe:81:24
    │
-83 │         return address(self.token0)
+81 │         return address(self.token0)
    │                        ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:83:24
+   ┌─ uniswap.fe:81:24
    │
-83 │         return address(self.token0)
+81 │         return address(self.token0)
    │                        ^^^^^^^^^^^ ERC20: Storage { nonce: Some(5) } => Value
 
 note: 
-   ┌─ uniswap.fe:83:16
+   ┌─ uniswap.fe:81:16
    │
-83 │         return address(self.token0)
+81 │         return address(self.token0)
    │                ^^^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ uniswap.fe:86:5
+   ┌─ uniswap.fe:84:5
    │  
-86 │ ╭     pub fn token1(self) -> address {
-87 │ │         return address(self.token1)
-88 │ │     }
+84 │ ╭     pub fn token1(self) -> address {
+85 │ │         return address(self.token1)
+86 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-   ┌─ uniswap.fe:87:24
+   ┌─ uniswap.fe:85:24
    │
-87 │         return address(self.token1)
+85 │         return address(self.token1)
    │                        ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:87:24
+   ┌─ uniswap.fe:85:24
    │
-87 │         return address(self.token1)
+85 │         return address(self.token1)
    │                        ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
 
 note: 
-   ┌─ uniswap.fe:87:16
+   ┌─ uniswap.fe:85:16
    │
-87 │         return address(self.token1)
+85 │         return address(self.token1)
    │                ^^^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-   ┌─ uniswap.fe:90:5
+   ┌─ uniswap.fe:88:5
    │  
-90 │ ╭     fn _mint(self, ctx: Context, to: address, value: u256) {
-91 │ │         self.total_supply = self.total_supply + value
-92 │ │         self.balances[to] = self.balances[to] + value
-93 │ │         emit Transfer(ctx, from: address(0), to, value)
-94 │ │     }
+88 │ ╭     fn _mint(self, ctx: Context, to: address, value: u256) {
+89 │ │         self.total_supply = self.total_supply + value
+90 │ │         self.balances[to] = self.balances[to] + value
+91 │ │         emit Transfer(ctx, from: address(0), to, value)
+92 │ │     }
    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-   ┌─ uniswap.fe:91:9
+   ┌─ uniswap.fe:89:9
    │
-91 │         self.total_supply = self.total_supply + value
+89 │         self.total_supply = self.total_supply + value
    │         ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:91:9
+   ┌─ uniswap.fe:89:9
    │
-91 │         self.total_supply = self.total_supply + value
+89 │         self.total_supply = self.total_supply + value
    │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
    │         │                    
    │         u256: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ uniswap.fe:91:29
+   ┌─ uniswap.fe:89:29
    │
-91 │         self.total_supply = self.total_supply + value
+89 │         self.total_supply = self.total_supply + value
    │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                             │                    
    │                             u256: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ uniswap.fe:91:29
+   ┌─ uniswap.fe:89:29
    │
-91 │         self.total_supply = self.total_supply + value
+89 │         self.total_supply = self.total_supply + value
    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-92 │         self.balances[to] = self.balances[to] + value
+90 │         self.balances[to] = self.balances[to] + value
    │         ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:92:9
+   ┌─ uniswap.fe:90:9
    │
-92 │         self.balances[to] = self.balances[to] + value
+90 │         self.balances[to] = self.balances[to] + value
    │         ^^^^^^^^^^^^^ ^^ address: Value
    │         │              
    │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ uniswap.fe:92:9
+   ┌─ uniswap.fe:90:9
    │
-92 │         self.balances[to] = self.balances[to] + value
+90 │         self.balances[to] = self.balances[to] + value
    │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
    │         │                    
    │         u256: Storage { nonce: None }
 
 note: 
-   ┌─ uniswap.fe:92:29
+   ┌─ uniswap.fe:90:29
    │
-92 │         self.balances[to] = self.balances[to] + value
+90 │         self.balances[to] = self.balances[to] + value
    │                             ^^^^^^^^^^^^^ ^^ address: Value
    │                             │              
    │                             Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ uniswap.fe:92:29
+   ┌─ uniswap.fe:90:29
    │
-92 │         self.balances[to] = self.balances[to] + value
+90 │         self.balances[to] = self.balances[to] + value
    │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                             │                    
    │                             u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ uniswap.fe:92:29
+   ┌─ uniswap.fe:90:29
    │
-92 │         self.balances[to] = self.balances[to] + value
+90 │         self.balances[to] = self.balances[to] + value
    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-93 │         emit Transfer(ctx, from: address(0), to, value)
+91 │         emit Transfer(ctx, from: address(0), to, value)
    │                       ^^^                ^ u256: Value
    │                       │                   
    │                       Context: Memory
 
 note: 
-   ┌─ uniswap.fe:93:34
+   ┌─ uniswap.fe:91:34
    │
-93 │         emit Transfer(ctx, from: address(0), to, value)
+91 │         emit Transfer(ctx, from: address(0), to, value)
    │                                  ^^^^^^^^^^  ^^  ^^^^^ u256: Value
    │                                  │           │    
    │                                  │           address: Value
    │                                  address: Value
 
 note: 
-    ┌─ uniswap.fe:96:5
-    │  
- 96 │ ╭     fn _burn(self, ctx: Context, from: address, value: u256) {
- 97 │ │         self.balances[from] = self.balances[from] - value
- 98 │ │         self.total_supply = self.total_supply - value
- 99 │ │         emit Transfer(ctx, from, to: address(0), value)
-100 │ │     }
-    │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: value, typ: u256 }] -> ()
+   ┌─ uniswap.fe:94:5
+   │  
+94 │ ╭     fn _burn(self, ctx: Context, from: address, value: u256) {
+95 │ │         self.balances[from] = self.balances[from] - value
+96 │ │         self.total_supply = self.total_supply - value
+97 │ │         emit Transfer(ctx, from, to: address(0), value)
+98 │ │     }
+   │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-   ┌─ uniswap.fe:97:9
+   ┌─ uniswap.fe:95:9
    │
-97 │         self.balances[from] = self.balances[from] - value
+95 │         self.balances[from] = self.balances[from] - value
    │         ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:97:9
+   ┌─ uniswap.fe:95:9
    │
-97 │         self.balances[from] = self.balances[from] - value
+95 │         self.balances[from] = self.balances[from] - value
    │         ^^^^^^^^^^^^^ ^^^^ address: Value
    │         │              
    │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ uniswap.fe:97:9
+   ┌─ uniswap.fe:95:9
    │
-97 │         self.balances[from] = self.balances[from] - value
+95 │         self.balances[from] = self.balances[from] - value
    │         ^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
    │         │                      
    │         u256: Storage { nonce: None }
 
 note: 
-   ┌─ uniswap.fe:97:31
+   ┌─ uniswap.fe:95:31
    │
-97 │         self.balances[from] = self.balances[from] - value
+95 │         self.balances[from] = self.balances[from] - value
    │                               ^^^^^^^^^^^^^ ^^^^ address: Value
    │                               │              
    │                               Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-   ┌─ uniswap.fe:97:31
+   ┌─ uniswap.fe:95:31
    │
-97 │         self.balances[from] = self.balances[from] - value
+95 │         self.balances[from] = self.balances[from] - value
    │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                               │                      
    │                               u256: Storage { nonce: None } => Value
 
 note: 
-   ┌─ uniswap.fe:97:31
+   ┌─ uniswap.fe:95:31
    │
-97 │         self.balances[from] = self.balances[from] - value
+95 │         self.balances[from] = self.balances[from] - value
    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-98 │         self.total_supply = self.total_supply - value
+96 │         self.total_supply = self.total_supply - value
    │         ^^^^ UniswapV2Pair: Value
 
 note: 
-   ┌─ uniswap.fe:98:9
+   ┌─ uniswap.fe:96:9
    │
-98 │         self.total_supply = self.total_supply - value
+96 │         self.total_supply = self.total_supply - value
    │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
    │         │                    
    │         u256: Storage { nonce: Some(2) }
 
 note: 
-   ┌─ uniswap.fe:98:29
+   ┌─ uniswap.fe:96:29
    │
-98 │         self.total_supply = self.total_supply - value
+96 │         self.total_supply = self.total_supply - value
    │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
    │                             │                    
    │                             u256: Storage { nonce: Some(2) } => Value
 
 note: 
-   ┌─ uniswap.fe:98:29
+   ┌─ uniswap.fe:96:29
    │
-98 │         self.total_supply = self.total_supply - value
+96 │         self.total_supply = self.total_supply - value
    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-99 │         emit Transfer(ctx, from, to: address(0), value)
+97 │         emit Transfer(ctx, from, to: address(0), value)
    │                       ^^^  ^^^^              ^ u256: Value
    │                       │    │                  
    │                       │    address: Value
    │                       Context: Memory
 
 note: 
-   ┌─ uniswap.fe:99:38
+   ┌─ uniswap.fe:97:38
    │
-99 │         emit Transfer(ctx, from, to: address(0), value)
+97 │         emit Transfer(ctx, from, to: address(0), value)
    │                                      ^^^^^^^^^^  ^^^^^ u256: Value
    │                                      │            
    │                                      address: Value
 
 note: 
-    ┌─ uniswap.fe:102:5
+    ┌─ uniswap.fe:100:5
     │  
-102 │ ╭     fn _approve(self, ctx: Context, owner: address, spender: address, value: u256) {
-103 │ │         self.allowances[owner][spender] = value
-104 │ │         emit Approval(ctx, owner, spender, value)
-105 │ │     }
+100 │ ╭     fn _approve(self, ctx: Context, owner: address, spender: address, value: u256) {
+101 │ │         self.allowances[owner][spender] = value
+102 │ │         emit Approval(ctx, owner, spender, value)
+103 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: owner, typ: address }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-    ┌─ uniswap.fe:103:9
+    ┌─ uniswap.fe:101:9
     │
-103 │         self.allowances[owner][spender] = value
+101 │         self.allowances[owner][spender] = value
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:103:9
+    ┌─ uniswap.fe:101:9
     │
-103 │         self.allowances[owner][spender] = value
+101 │         self.allowances[owner][spender] = value
     │         ^^^^^^^^^^^^^^^ ^^^^^ address: Value
     │         │                
     │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-    ┌─ uniswap.fe:103:9
+    ┌─ uniswap.fe:101:9
     │
-103 │         self.allowances[owner][spender] = value
+101 │         self.allowances[owner][spender] = value
     │         ^^^^^^^^^^^^^^^^^^^^^^ ^^^^^^^ address: Value
     │         │                       
     │         Map<address, u256>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:103:9
+    ┌─ uniswap.fe:101:9
     │
-103 │         self.allowances[owner][spender] = value
+101 │         self.allowances[owner][spender] = value
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │         │                                  
     │         u256: Storage { nonce: None }
-104 │         emit Approval(ctx, owner, spender, value)
+102 │         emit Approval(ctx, owner, spender, value)
     │                       ^^^  ^^^^^  ^^^^^^^  ^^^^^ u256: Value
     │                       │    │      │         
     │                       │    │      address: Value
@@ -431,99 +431,99 @@ note:
     │                       Context: Memory
 
 note: 
-    ┌─ uniswap.fe:107:5
+    ┌─ uniswap.fe:105:5
     │  
-107 │ ╭     fn _transfer(self, ctx: Context, from: address, to: address, value: u256) {
-108 │ │         self.balances[from] = self.balances[from] - value
-109 │ │         self.balances[to] = self.balances[to] + value
-110 │ │         emit Transfer(ctx, from, to, value)
-111 │ │     }
+105 │ ╭     fn _transfer(self, ctx: Context, from: address, to: address, value: u256) {
+106 │ │         self.balances[from] = self.balances[from] - value
+107 │ │         self.balances[to] = self.balances[to] + value
+108 │ │         emit Transfer(ctx, from, to, value)
+109 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> ()
 
 note: 
-    ┌─ uniswap.fe:108:9
+    ┌─ uniswap.fe:106:9
     │
-108 │         self.balances[from] = self.balances[from] - value
+106 │         self.balances[from] = self.balances[from] - value
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:108:9
+    ┌─ uniswap.fe:106:9
     │
-108 │         self.balances[from] = self.balances[from] - value
+106 │         self.balances[from] = self.balances[from] - value
     │         ^^^^^^^^^^^^^ ^^^^ address: Value
     │         │              
     │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:108:9
+    ┌─ uniswap.fe:106:9
     │
-108 │         self.balances[from] = self.balances[from] - value
+106 │         self.balances[from] = self.balances[from] - value
     │         ^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │         │                      
     │         u256: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:108:31
+    ┌─ uniswap.fe:106:31
     │
-108 │         self.balances[from] = self.balances[from] - value
+106 │         self.balances[from] = self.balances[from] - value
     │                               ^^^^^^^^^^^^^ ^^^^ address: Value
     │                               │              
     │                               Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:108:31
+    ┌─ uniswap.fe:106:31
     │
-108 │         self.balances[from] = self.balances[from] - value
+106 │         self.balances[from] = self.balances[from] - value
     │                               ^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │                               │                      
     │                               u256: Storage { nonce: None } => Value
 
 note: 
-    ┌─ uniswap.fe:108:31
+    ┌─ uniswap.fe:106:31
     │
-108 │         self.balances[from] = self.balances[from] - value
+106 │         self.balances[from] = self.balances[from] - value
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-109 │         self.balances[to] = self.balances[to] + value
+107 │         self.balances[to] = self.balances[to] + value
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:109:9
+    ┌─ uniswap.fe:107:9
     │
-109 │         self.balances[to] = self.balances[to] + value
+107 │         self.balances[to] = self.balances[to] + value
     │         ^^^^^^^^^^^^^ ^^ address: Value
     │         │              
     │         Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:109:9
+    ┌─ uniswap.fe:107:9
     │
-109 │         self.balances[to] = self.balances[to] + value
+107 │         self.balances[to] = self.balances[to] + value
     │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │         │                    
     │         u256: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:109:29
+    ┌─ uniswap.fe:107:29
     │
-109 │         self.balances[to] = self.balances[to] + value
+107 │         self.balances[to] = self.balances[to] + value
     │                             ^^^^^^^^^^^^^ ^^ address: Value
     │                             │              
     │                             Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:109:29
+    ┌─ uniswap.fe:107:29
     │
-109 │         self.balances[to] = self.balances[to] + value
+107 │         self.balances[to] = self.balances[to] + value
     │                             ^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │                             │                    
     │                             u256: Storage { nonce: None } => Value
 
 note: 
-    ┌─ uniswap.fe:109:29
+    ┌─ uniswap.fe:107:29
     │
-109 │         self.balances[to] = self.balances[to] + value
+107 │         self.balances[to] = self.balances[to] + value
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-110 │         emit Transfer(ctx, from, to, value)
+108 │         emit Transfer(ctx, from, to, value)
     │                       ^^^  ^^^^  ^^  ^^^^^ u256: Value
     │                       │    │     │    
     │                       │    │     address: Value
@@ -531,196 +531,196 @@ note:
     │                       Context: Memory
 
 note: 
-    ┌─ uniswap.fe:113:5
+    ┌─ uniswap.fe:111:5
     │  
-113 │ ╭     pub fn approve(self, ctx: Context, spender: address, value: u256) -> bool {
-114 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
-115 │ │         return true
-116 │ │     }
+111 │ ╭     pub fn approve(self, ctx: Context, spender: address, value: u256) -> bool {
+112 │ │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+113 │ │         return true
+114 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: spender, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
-    ┌─ uniswap.fe:114:9
+    ┌─ uniswap.fe:112:9
     │
-114 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+112 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
     │         ^^^^          ^^^         ^^^ Context: Memory
     │         │             │            
     │         │             Context: Memory
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:114:35
+    ┌─ uniswap.fe:112:35
     │
-114 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+112 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
     │                                   ^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^^ u256: Value
     │                                   │                 │         
     │                                   │                 address: Value
     │                                   address: Value
 
 note: 
-    ┌─ uniswap.fe:114:9
+    ┌─ uniswap.fe:112:9
     │
-114 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
+112 │         self._approve(ctx, owner: ctx.msg_sender(), spender, value)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-115 │         return true
+113 │         return true
     │                ^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:118:5
+    ┌─ uniswap.fe:116:5
     │  
-118 │ ╭     pub fn transfer(self, ctx: Context, to: address, value: u256) -> bool {
-119 │ │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
-120 │ │         return true
-121 │ │     }
+116 │ ╭     pub fn transfer(self, ctx: Context, to: address, value: u256) -> bool {
+117 │ │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
+118 │ │         return true
+119 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
-    ┌─ uniswap.fe:119:9
+    ┌─ uniswap.fe:117:9
     │
-119 │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
+117 │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
     │         ^^^^           ^^^        ^^^ Context: Memory
     │         │              │           
     │         │              Context: Memory
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:119:35
+    ┌─ uniswap.fe:117:35
     │
-119 │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
+117 │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
     │                                   ^^^^^^^^^^^^^^^^  ^^  ^^^^^ u256: Value
     │                                   │                 │    
     │                                   │                 address: Value
     │                                   address: Value
 
 note: 
-    ┌─ uniswap.fe:119:9
+    ┌─ uniswap.fe:117:9
     │
-119 │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
+117 │         self._transfer(ctx, from: ctx.msg_sender(), to, value)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-120 │         return true
+118 │         return true
     │                ^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:123:5
+    ┌─ uniswap.fe:121:5
     │  
-123 │ ╭     pub fn transferFrom(self, ctx: Context, from: address, to: address, value: u256) -> bool {
-124 │ │         assert self.allowances[from][ctx.msg_sender()] >= value
-125 │ │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
-126 │ │         self._transfer(ctx, from, to, value)
-127 │ │         return true
-128 │ │     }
+121 │ ╭     pub fn transferFrom(self, ctx: Context, from: address, to: address, value: u256) -> bool {
+122 │ │         assert self.allowances[from][ctx.msg_sender()] >= value
+123 │ │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+124 │ │         self._transfer(ctx, from, to, value)
+125 │ │         return true
+126 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: from, typ: address }, { label: None, name: to, typ: address }, { label: None, name: value, typ: u256 }] -> bool
 
 note: 
-    ┌─ uniswap.fe:124:16
+    ┌─ uniswap.fe:122:16
     │
-124 │         assert self.allowances[from][ctx.msg_sender()] >= value
+122 │         assert self.allowances[from][ctx.msg_sender()] >= value
     │                ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:124:16
+    ┌─ uniswap.fe:122:16
     │
-124 │         assert self.allowances[from][ctx.msg_sender()] >= value
+122 │         assert self.allowances[from][ctx.msg_sender()] >= value
     │                ^^^^^^^^^^^^^^^ ^^^^ address: Value
     │                │                
     │                Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-    ┌─ uniswap.fe:124:16
+    ┌─ uniswap.fe:122:16
     │
-124 │         assert self.allowances[from][ctx.msg_sender()] >= value
+122 │         assert self.allowances[from][ctx.msg_sender()] >= value
     │                ^^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
     │                │                      
     │                Map<address, u256>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:124:38
+    ┌─ uniswap.fe:122:38
     │
-124 │         assert self.allowances[from][ctx.msg_sender()] >= value
+122 │         assert self.allowances[from][ctx.msg_sender()] >= value
     │                                      ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:124:16
+    ┌─ uniswap.fe:122:16
     │
-124 │         assert self.allowances[from][ctx.msg_sender()] >= value
+122 │         assert self.allowances[from][ctx.msg_sender()] >= value
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^ u256: Value
     │                │                                           
     │                u256: Storage { nonce: None } => Value
 
 note: 
-    ┌─ uniswap.fe:124:16
+    ┌─ uniswap.fe:122:16
     │
-124 │         assert self.allowances[from][ctx.msg_sender()] >= value
+122 │         assert self.allowances[from][ctx.msg_sender()] >= value
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:125:9
+    ┌─ uniswap.fe:123:9
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │         ^^^^^^^^^^^^^^^ ^^^^ address: Value
     │         │                
     │         Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-    ┌─ uniswap.fe:125:9
+    ┌─ uniswap.fe:123:9
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │         ^^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
     │         │                      
     │         Map<address, u256>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:125:31
+    ┌─ uniswap.fe:123:31
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │                               ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:125:9
+    ┌─ uniswap.fe:123:9
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │         │                                          
     │         u256: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:125:51
+    ┌─ uniswap.fe:123:51
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │                                                   ^^^^^^^^^^^^^^^ ^^^^ address: Value
     │                                                   │                
     │                                                   Map<address, Map<address, u256>>: Storage { nonce: Some(1) }
 
 note: 
-    ┌─ uniswap.fe:125:51
+    ┌─ uniswap.fe:123:51
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │                                                   ^^^^^^^^^^^^^^^^^^^^^ ^^^ Context: Memory
     │                                                   │                      
     │                                                   Map<address, u256>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:125:73
+    ┌─ uniswap.fe:123:73
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │                                                                         ^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:125:51
+    ┌─ uniswap.fe:123:51
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^ u256: Value
     │                                                   │                                          
     │                                                   u256: Storage { nonce: None } => Value
 
 note: 
-    ┌─ uniswap.fe:125:51
+    ┌─ uniswap.fe:123:51
     │
-125 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
+123 │         self.allowances[from][ctx.msg_sender()] = self.allowances[from][ctx.msg_sender()] - value
     │                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-126 │         self._transfer(ctx, from, to, value)
+124 │         self._transfer(ctx, from, to, value)
     │         ^^^^           ^^^  ^^^^  ^^  ^^^^^ u256: Value
     │         │              │    │     │    
     │         │              │    │     address: Value
@@ -729,561 +729,561 @@ note:
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:126:9
+    ┌─ uniswap.fe:124:9
     │
-126 │         self._transfer(ctx, from, to, value)
+124 │         self._transfer(ctx, from, to, value)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-127 │         return true
+125 │         return true
     │                ^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:130:5
+    ┌─ uniswap.fe:128:5
     │  
-130 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
-131 │ │         return self.balances[account]
-132 │ │     }
+128 │ ╭     pub fn balanceOf(self, _ account: address) -> u256 {
+129 │ │         return self.balances[account]
+130 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: Some("_"), name: account, typ: address }] -> u256
 
 note: 
-    ┌─ uniswap.fe:131:16
+    ┌─ uniswap.fe:129:16
     │
-131 │         return self.balances[account]
+129 │         return self.balances[account]
     │                ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:131:16
+    ┌─ uniswap.fe:129:16
     │
-131 │         return self.balances[account]
+129 │         return self.balances[account]
     │                ^^^^^^^^^^^^^ ^^^^^^^ address: Value
     │                │              
     │                Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:131:16
+    ┌─ uniswap.fe:129:16
     │
-131 │         return self.balances[account]
+129 │         return self.balances[account]
     │                ^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
 
 note: 
-    ┌─ uniswap.fe:134:5
+    ┌─ uniswap.fe:132:5
     │  
-134 │ ╭     pub fn get_reserves(self) -> (u256, u256, u256) {
-135 │ │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
-136 │ │     }
+132 │ ╭     pub fn get_reserves(self) -> (u256, u256, u256) {
+133 │ │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+134 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [] -> (u256, u256, u256)
 
 note: 
-    ┌─ uniswap.fe:135:17
+    ┌─ uniswap.fe:133:17
     │
-135 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+133 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
     │                 ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:135:17
+    ┌─ uniswap.fe:133:17
     │
-135 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+133 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
     │                 ^^^^^^^^^^^^^  ^^^^ UniswapV2Pair: Value
     │                 │               
     │                 u256: Storage { nonce: Some(7) } => Value
 
 note: 
-    ┌─ uniswap.fe:135:32
+    ┌─ uniswap.fe:133:32
     │
-135 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+133 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
     │                                ^^^^^^^^^^^^^  ^^^^ UniswapV2Pair: Value
     │                                │               
     │                                u256: Storage { nonce: Some(8) } => Value
 
 note: 
-    ┌─ uniswap.fe:135:47
+    ┌─ uniswap.fe:133:47
     │
-135 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+133 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
     │                                               ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Value
 
 note: 
-    ┌─ uniswap.fe:135:16
+    ┌─ uniswap.fe:133:16
     │
-135 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
+133 │         return (self.reserve0, self.reserve1, self.block_timestamp_last)
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (u256, u256, u256): Memory
 
 note: 
-    ┌─ uniswap.fe:139:5
+    ┌─ uniswap.fe:137:5
     │  
-139 │ ╭     pub fn initialize(self, ctx: Context, token0: ERC20, token1: ERC20) {
-140 │ │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
-141 │ │         self.token0 = token0
-142 │ │         self.token1 = token1
-143 │ │     }
+137 │ ╭     pub fn initialize(self, ctx: Context, token0: ERC20, token1: ERC20) {
+138 │ │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
+139 │ │         self.token0 = token0
+140 │ │         self.token1 = token1
+141 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: token0, typ: ERC20 }, { label: None, name: token1, typ: ERC20 }] -> ()
 
 note: 
-    ┌─ uniswap.fe:140:16
+    ┌─ uniswap.fe:138:16
     │
-140 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
+138 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
     │                ^^^ Context: Memory
 
 note: 
-    ┌─ uniswap.fe:140:16
+    ┌─ uniswap.fe:138:16
     │
-140 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
+138 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^^^^^^^    ^^^^ UniswapV2Pair: Value
     │                │                    
     │                address: Value
 
 note: 
-    ┌─ uniswap.fe:140:36
+    ┌─ uniswap.fe:138:36
     │
-140 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
+138 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
     │                                    ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Value
 
 note: 
-    ┌─ uniswap.fe:140:16
+    ┌─ uniswap.fe:138:16
     │
-140 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
+138 │         assert ctx.msg_sender() == self.factory, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory
     │                │                                  
     │                bool: Value
-141 │         self.token0 = token0
+139 │         self.token0 = token0
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:141:9
+    ┌─ uniswap.fe:139:9
     │
-141 │         self.token0 = token0
+139 │         self.token0 = token0
     │         ^^^^^^^^^^^   ^^^^^^ ERC20: Value
     │         │              
     │         ERC20: Storage { nonce: Some(5) }
-142 │         self.token1 = token1
+140 │         self.token1 = token1
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:142:9
+    ┌─ uniswap.fe:140:9
     │
-142 │         self.token1 = token1
+140 │         self.token1 = token1
     │         ^^^^^^^^^^^   ^^^^^^ ERC20: Value
     │         │              
     │         ERC20: Storage { nonce: Some(6) }
 
 note: 
-    ┌─ uniswap.fe:146:5
+    ┌─ uniswap.fe:144:5
     │  
-146 │ ╭     fn _update(self, ctx: Context, balance0: u256, balance1: u256, reserve0: u256, reserve1: u256) {
-147 │ │         // changed from u32s
-148 │ │         // TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
-149 │ │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
+144 │ ╭     fn _update(self, ctx: Context, balance0: u256, balance1: u256, reserve0: u256, reserve1: u256) {
+145 │ │         // changed from u32s
+146 │ │         // TODO: reproduce desired overflow (https://github.com/ethereum/fe/issues/286)
+147 │ │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     · │
-158 │ │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
-159 │ │     }
+156 │ │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
+157 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: balance0, typ: u256 }, { label: None, name: balance1, typ: u256 }, { label: None, name: reserve0, typ: u256 }, { label: None, name: reserve1, typ: u256 }] -> ()
 
 note: 
-    ┌─ uniswap.fe:149:13
+    ┌─ uniswap.fe:147:13
     │
-149 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
+147 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     │             ^^^^^^^^^^^^^^^ u256
-150 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
+148 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
     │             ^^^^^^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:149:37
+    ┌─ uniswap.fe:147:37
     │
-149 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
+147 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     │                                     ^^^ Context: Memory
 
 note: 
-    ┌─ uniswap.fe:149:37
+    ┌─ uniswap.fe:147:37
     │
-149 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
+147 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     │                                     ^^^^^^^^^^^^^^^^^^^^^   ^    ^^ u256: Value
     │                                     │                       │     
     │                                     │                       u256: Value
     │                                     u256: Value
 
 note: 
-    ┌─ uniswap.fe:149:61
+    ┌─ uniswap.fe:147:61
     │
-149 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
+147 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     │                                                             ^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:149:37
+    ┌─ uniswap.fe:147:37
     │
-149 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
+147 │         let block_timestamp: u256 = ctx.block_timestamp() % 2 ** 32
     │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-150 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
+148 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
     │                                  ^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                                  │                  
     │                                  u256: Value
 
 note: 
-    ┌─ uniswap.fe:150:52
+    ┌─ uniswap.fe:148:52
     │
-150 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
+148 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
     │                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(9) } => Value
 
 note: 
-    ┌─ uniswap.fe:150:34
+    ┌─ uniswap.fe:148:34
     │
-150 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
+148 │         let time_elapsed: u256 = block_timestamp - self.block_timestamp_last
     │                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-151 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
+149 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
     │            ^^^^^^^^^^^^   ^ u256: Value
     │            │               
     │            u256: Value
 
 note: 
-    ┌─ uniswap.fe:151:12
+    ┌─ uniswap.fe:149:12
     │
-151 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
+149 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
     │            ^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value
     │            │                    │            
     │            │                    u256: Value
     │            bool: Value
 
 note: 
-    ┌─ uniswap.fe:151:33
+    ┌─ uniswap.fe:149:33
     │
-151 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
+149 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
     │                                 ^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:151:12
+    ┌─ uniswap.fe:149:12
     │
-151 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
+149 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
     │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^    ^ u256: Value
     │            │                                      │            
     │            │                                      u256: Value
     │            bool: Value
 
 note: 
-    ┌─ uniswap.fe:151:51
+    ┌─ uniswap.fe:149:51
     │
-151 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
+149 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
     │                                                   ^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:151:12
+    ┌─ uniswap.fe:149:12
     │
-151 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
+149 │         if time_elapsed > 0 and reserve0 != 0 and reserve1 != 0 {
     │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-152 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
+150 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
     │             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:152:13
+    ┌─ uniswap.fe:150:13
     │
-152 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
+150 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │             │                              
     │             u256: Storage { nonce: Some(10) }
 
 note: 
-    ┌─ uniswap.fe:152:43
+    ┌─ uniswap.fe:150:43
     │
-152 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
+150 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │                                           │                             │           
     │                                           │                             u256: Value
     │                                           u256: Storage { nonce: Some(10) } => Value
 
 note: 
-    ┌─ uniswap.fe:152:73
+    ┌─ uniswap.fe:150:73
     │
-152 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
+150 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
     │                                                                         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                                                                         │                      
     │                                                                         u256: Value
 
 note: 
-    ┌─ uniswap.fe:152:73
+    ┌─ uniswap.fe:150:73
     │
-152 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
+150 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
     │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:152:43
+    ┌─ uniswap.fe:150:43
     │
-152 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
+150 │             self.price0_cumulative_last = self.price0_cumulative_last + reserve1 / reserve0 * time_elapsed
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-153 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
+151 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
     │             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:153:13
+    ┌─ uniswap.fe:151:13
     │
-153 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
+151 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │             │                              
     │             u256: Storage { nonce: Some(11) }
 
 note: 
-    ┌─ uniswap.fe:153:43
+    ┌─ uniswap.fe:151:43
     │
-153 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
+151 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │                                           │                             │           
     │                                           │                             u256: Value
     │                                           u256: Storage { nonce: Some(11) } => Value
 
 note: 
-    ┌─ uniswap.fe:153:73
+    ┌─ uniswap.fe:151:73
     │
-153 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
+151 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
     │                                                                         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                                                                         │                      
     │                                                                         u256: Value
 
 note: 
-    ┌─ uniswap.fe:153:73
+    ┌─ uniswap.fe:151:73
     │
-153 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
+151 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
     │                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:153:43
+    ┌─ uniswap.fe:151:43
     │
-153 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
+151 │             self.price1_cumulative_last = self.price1_cumulative_last + reserve0 / reserve1 * time_elapsed
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-154 │         }
-155 │         self.reserve0 = balance0
+152 │         }
+153 │         self.reserve0 = balance0
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ uniswap.fe:153:9
+    │
+153 │         self.reserve0 = balance0
+    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
+    │         │                
+    │         u256: Storage { nonce: Some(7) }
+154 │         self.reserve1 = balance1
+    │         ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ uniswap.fe:154:9
+    │
+154 │         self.reserve1 = balance1
+    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
+    │         │                
+    │         u256: Storage { nonce: Some(8) }
+155 │         self.block_timestamp_last = block_timestamp
     │         ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:155:9
     │
-155 │         self.reserve0 = balance0
-    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
-    │         │                
-    │         u256: Storage { nonce: Some(7) }
-156 │         self.reserve1 = balance1
-    │         ^^^^ UniswapV2Pair: Value
-
-note: 
-    ┌─ uniswap.fe:156:9
-    │
-156 │         self.reserve1 = balance1
-    │         ^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
-    │         │                
-    │         u256: Storage { nonce: Some(8) }
-157 │         self.block_timestamp_last = block_timestamp
-    │         ^^^^ UniswapV2Pair: Value
-
-note: 
-    ┌─ uniswap.fe:157:9
-    │
-157 │         self.block_timestamp_last = block_timestamp
+155 │         self.block_timestamp_last = block_timestamp
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^ u256: Value
     │         │                            
     │         u256: Storage { nonce: Some(9) }
-158 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
+156 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
     │                   ^^^            ^^^^ UniswapV2Pair: Value
     │                   │               
     │                   Context: Memory
 
 note: 
-    ┌─ uniswap.fe:158:34
+    ┌─ uniswap.fe:156:34
     │
-158 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
+156 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
     │                                  ^^^^^^^^^^^^^            ^^^^ UniswapV2Pair: Value
     │                                  │                         
     │                                  u256: Storage { nonce: Some(7) } => Value
 
 note: 
-    ┌─ uniswap.fe:158:59
+    ┌─ uniswap.fe:156:59
     │
-158 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
+156 │         emit Sync(ctx, reserve0: self.reserve0, reserve1: self.reserve1)
     │                                                           ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
-    ┌─ uniswap.fe:161:5
+    ┌─ uniswap.fe:159:5
     │  
-161 │ ╭     fn _mint_fee(self, ctx: Context, reserve0: u256, reserve1: u256) -> bool {
-162 │ │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
-163 │ │         let fee_on: bool = fee_to != address(0)
-164 │ │         let k_last: u256 = self.k_last
+159 │ ╭     fn _mint_fee(self, ctx: Context, reserve0: u256, reserve1: u256) -> bool {
+160 │ │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+161 │ │         let fee_on: bool = fee_to != address(0)
+162 │ │         let k_last: u256 = self.k_last
     · │
-181 │ │         return fee_on
-182 │ │     }
+179 │ │         return fee_on
+180 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: reserve0, typ: u256 }, { label: None, name: reserve1, typ: u256 }] -> bool
 
 note: 
-    ┌─ uniswap.fe:162:13
+    ┌─ uniswap.fe:160:13
     │
-162 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+160 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
     │             ^^^^^^ address
-163 │         let fee_on: bool = fee_to != address(0)
+161 │         let fee_on: bool = fee_to != address(0)
     │             ^^^^^^ bool
-164 │         let k_last: u256 = self.k_last
+162 │         let k_last: u256 = self.k_last
     │             ^^^^^^ u256
     ·
-167 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+165 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
     │                     ^^^^^^ u256
-168 │                 let root_k_last: u256 = sqrt(k_last)
+166 │                 let root_k_last: u256 = sqrt(k_last)
     │                     ^^^^^^^^^^^ u256
-169 │                 if root_k > root_k_last {
-170 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+167 │                 if root_k > root_k_last {
+168 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
     │                         ^^^^^^^^^ u256
-171 │                     let denominator: u256 = root_k * 5 + root_k_last
+169 │                     let denominator: u256 = root_k * 5 + root_k_last
     │                         ^^^^^^^^^^^ u256
-172 │                     let liquidity: u256 = numerator / denominator
+170 │                     let liquidity: u256 = numerator / denominator
     │                         ^^^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:162:48
+    ┌─ uniswap.fe:160:48
     │
-162 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+160 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
     │                                                ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:162:48
+    ┌─ uniswap.fe:160:48
     │
-162 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+160 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
     │                                                ^^^^^^^^^^^^ address: Storage { nonce: Some(4) } => Value
 
 note: 
-    ┌─ uniswap.fe:162:31
+    ┌─ uniswap.fe:160:31
     │
-162 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+160 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:162:31
+    ┌─ uniswap.fe:160:31
     │
-162 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
+160 │         let fee_to: address = UniswapV2Factory(self.factory).fee_to()
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value
-163 │         let fee_on: bool = fee_to != address(0)
+161 │         let fee_on: bool = fee_to != address(0)
     │                            ^^^^^^            ^ u256: Value
     │                            │                  
     │                            address: Value
 
 note: 
-    ┌─ uniswap.fe:163:38
+    ┌─ uniswap.fe:161:38
     │
-163 │         let fee_on: bool = fee_to != address(0)
+161 │         let fee_on: bool = fee_to != address(0)
     │                                      ^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:163:28
+    ┌─ uniswap.fe:161:28
     │
-163 │         let fee_on: bool = fee_to != address(0)
+161 │         let fee_on: bool = fee_to != address(0)
     │                            ^^^^^^^^^^^^^^^^^^^^ bool: Value
-164 │         let k_last: u256 = self.k_last
+162 │         let k_last: u256 = self.k_last
     │                            ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:164:28
+    ┌─ uniswap.fe:162:28
     │
-164 │         let k_last: u256 = self.k_last
+162 │         let k_last: u256 = self.k_last
     │                            ^^^^^^^^^^^ u256: Storage { nonce: Some(12) } => Value
-165 │         if fee_on {
+163 │         if fee_on {
     │            ^^^^^^ bool: Value
-166 │             if k_last != 0 {
+164 │             if k_last != 0 {
     │                ^^^^^^    ^ u256: Value
     │                │          
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:166:16
+    ┌─ uniswap.fe:164:16
     │
-166 │             if k_last != 0 {
+164 │             if k_last != 0 {
     │                ^^^^^^^^^^^ bool: Value
-167 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+165 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
     │                                         ^^^^^^^^   ^^^^^^^^ u256: Value
     │                                         │           
     │                                         u256: Value
 
 note: 
-    ┌─ uniswap.fe:167:41
+    ┌─ uniswap.fe:165:41
     │
-167 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+165 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
     │                                         ^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:167:36
+    ┌─ uniswap.fe:165:36
     │
-167 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
+165 │                 let root_k: u256 = sqrt(reserve0 * reserve1)
     │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-168 │                 let root_k_last: u256 = sqrt(k_last)
+166 │                 let root_k_last: u256 = sqrt(k_last)
     │                                              ^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:168:41
+    ┌─ uniswap.fe:166:41
     │
-168 │                 let root_k_last: u256 = sqrt(k_last)
+166 │                 let root_k_last: u256 = sqrt(k_last)
     │                                         ^^^^^^^^^^^^ u256: Value
-169 │                 if root_k > root_k_last {
+167 │                 if root_k > root_k_last {
     │                    ^^^^^^   ^^^^^^^^^^^ u256: Value
     │                    │         
     │                    u256: Value
 
 note: 
-    ┌─ uniswap.fe:169:20
+    ┌─ uniswap.fe:167:20
     │
-169 │                 if root_k > root_k_last {
+167 │                 if root_k > root_k_last {
     │                    ^^^^^^^^^^^^^^^^^^^^ bool: Value
-170 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+168 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
     │                                           ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:170:43
+    ┌─ uniswap.fe:168:43
     │
-170 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+168 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
     │                                           ^^^^^^^^^^^^^^^^^   ^^^^^^ u256: Value
     │                                           │                    
     │                                           u256: Storage { nonce: Some(2) } => Value
 
 note: 
-    ┌─ uniswap.fe:170:43
+    ┌─ uniswap.fe:168:43
     │
-170 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+168 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                           │                             
     │                                           u256: Value
 
 note: 
-    ┌─ uniswap.fe:170:43
+    ┌─ uniswap.fe:168:43
     │
-170 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
+168 │                     let numerator: u256 = self.total_supply * root_k - root_k_last
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-171 │                     let denominator: u256 = root_k * 5 + root_k_last
+169 │                     let denominator: u256 = root_k * 5 + root_k_last
     │                                             ^^^^^^   ^ u256: Value
     │                                             │         
     │                                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:171:45
+    ┌─ uniswap.fe:169:45
     │
-171 │                     let denominator: u256 = root_k * 5 + root_k_last
+169 │                     let denominator: u256 = root_k * 5 + root_k_last
     │                                             ^^^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                             │             
     │                                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:171:45
+    ┌─ uniswap.fe:169:45
     │
-171 │                     let denominator: u256 = root_k * 5 + root_k_last
+169 │                     let denominator: u256 = root_k * 5 + root_k_last
     │                                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-172 │                     let liquidity: u256 = numerator / denominator
+170 │                     let liquidity: u256 = numerator / denominator
     │                                           ^^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                           │            
     │                                           u256: Value
 
 note: 
-    ┌─ uniswap.fe:172:43
+    ┌─ uniswap.fe:170:43
     │
-172 │                     let liquidity: u256 = numerator / denominator
+170 │                     let liquidity: u256 = numerator / denominator
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-173 │                     if liquidity > 0 {
+171 │                     if liquidity > 0 {
     │                        ^^^^^^^^^   ^ u256: Value
     │                        │            
     │                        u256: Value
 
 note: 
-    ┌─ uniswap.fe:173:24
+    ┌─ uniswap.fe:171:24
     │
-173 │                     if liquidity > 0 {
+171 │                     if liquidity > 0 {
     │                        ^^^^^^^^^^^^^ bool: Value
-174 │                         self._mint(ctx, to: fee_to, value: liquidity)
+172 │                         self._mint(ctx, to: fee_to, value: liquidity)
     │                         ^^^^       ^^^      ^^^^^^         ^^^^^^^^^ u256: Value
     │                         │          │        │               
     │                         │          │        address: Value
@@ -1291,169 +1291,169 @@ note:
     │                         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:174:25
+    ┌─ uniswap.fe:172:25
     │
-174 │                         self._mint(ctx, to: fee_to, value: liquidity)
+172 │                         self._mint(ctx, to: fee_to, value: liquidity)
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
     ·
-178 │         } else if k_last != 0 {
+176 │         } else if k_last != 0 {
     │                   ^^^^^^    ^ u256: Value
     │                   │          
     │                   u256: Value
 
 note: 
-    ┌─ uniswap.fe:178:19
+    ┌─ uniswap.fe:176:19
     │
-178 │         } else if k_last != 0 {
+176 │         } else if k_last != 0 {
     │                   ^^^^^^^^^^^ bool: Value
-179 │             self.k_last = 0
+177 │             self.k_last = 0
     │             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:179:13
+    ┌─ uniswap.fe:177:13
     │
-179 │             self.k_last = 0
+177 │             self.k_last = 0
     │             ^^^^^^^^^^^   ^ u256: Value
     │             │              
     │             u256: Storage { nonce: Some(12) }
-180 │         }
-181 │         return fee_on
+178 │         }
+179 │         return fee_on
     │                ^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:185:5
+    ┌─ uniswap.fe:183:5
     │  
-185 │ ╭     pub fn mint(self, ctx: Context, to: address) -> u256 {
-186 │ │         let MINIMUM_LIQUIDITY: u256 = 1000
-187 │ │         let reserve0: u256 = self.reserve0
-188 │ │         let reserve1: u256 = self.reserve1
+183 │ ╭     pub fn mint(self, ctx: Context, to: address) -> u256 {
+184 │ │         let MINIMUM_LIQUIDITY: u256 = 1000
+185 │ │         let reserve0: u256 = self.reserve0
+186 │ │         let reserve1: u256 = self.reserve1
     · │
-209 │ │         return liquidity
-210 │ │     }
+207 │ │         return liquidity
+208 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }] -> u256
 
 note: 
-    ┌─ uniswap.fe:186:13
+    ┌─ uniswap.fe:184:13
     │
-186 │         let MINIMUM_LIQUIDITY: u256 = 1000
+184 │         let MINIMUM_LIQUIDITY: u256 = 1000
     │             ^^^^^^^^^^^^^^^^^ u256
-187 │         let reserve0: u256 = self.reserve0
+185 │         let reserve0: u256 = self.reserve0
     │             ^^^^^^^^ u256
-188 │         let reserve1: u256 = self.reserve1
+186 │         let reserve1: u256 = self.reserve1
     │             ^^^^^^^^ u256
-189 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
+187 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
     │             ^^^^^^^^ u256
-190 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
+188 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
     │             ^^^^^^^^ u256
-191 │         let amount0: u256 = balance0 - self.reserve0
+189 │         let amount0: u256 = balance0 - self.reserve0
     │             ^^^^^^^ u256
-192 │         let amount1: u256 = balance1 - self.reserve1
+190 │         let amount1: u256 = balance1 - self.reserve1
     │             ^^^^^^^ u256
-193 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
+191 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │             ^^^^^^ bool
-194 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
+192 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
     │             ^^^^^^^^^^^^ u256
-195 │         let liquidity: u256 = 0
+193 │         let liquidity: u256 = 0
     │             ^^^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:186:39
+    ┌─ uniswap.fe:184:39
     │
-186 │         let MINIMUM_LIQUIDITY: u256 = 1000
+184 │         let MINIMUM_LIQUIDITY: u256 = 1000
     │                                       ^^^^ u256: Value
-187 │         let reserve0: u256 = self.reserve0
+185 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ uniswap.fe:185:30
+    │
+185 │         let reserve0: u256 = self.reserve0
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
+186 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ uniswap.fe:186:30
+    │
+186 │         let reserve1: u256 = self.reserve1
+    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
+187 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
     │                              ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:187:30
     │
-187 │         let reserve0: u256 = self.reserve0
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
-188 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^ UniswapV2Pair: Value
-
-note: 
-    ┌─ uniswap.fe:188:30
-    │
-188 │         let reserve1: u256 = self.reserve1
-    │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
-189 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
-    │                              ^^^^ UniswapV2Pair: Value
-
-note: 
-    ┌─ uniswap.fe:189:30
-    │
-189 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
+187 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^           ^^^ Context: Memory
     │                              │                      
     │                              ERC20: Storage { nonce: Some(5) } => Value
 
 note: 
-    ┌─ uniswap.fe:189:52
+    ┌─ uniswap.fe:187:52
     │
-189 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
+187 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
     │                                                    ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:189:30
+    ┌─ uniswap.fe:187:30
     │
-189 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
+187 │         let balance0: u256 = self.token0.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-190 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
+188 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
     │                              ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:190:30
+    ┌─ uniswap.fe:188:30
     │
-190 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
+188 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^           ^^^ Context: Memory
     │                              │                      
     │                              ERC20: Storage { nonce: Some(6) } => Value
 
 note: 
-    ┌─ uniswap.fe:190:52
+    ┌─ uniswap.fe:188:52
     │
-190 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
+188 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
     │                                                    ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:190:30
+    ┌─ uniswap.fe:188:30
     │
-190 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
+188 │         let balance1: u256 = self.token1.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-191 │         let amount0: u256 = balance0 - self.reserve0
+189 │         let amount0: u256 = balance0 - self.reserve0
     │                             ^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │           
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:191:40
+    ┌─ uniswap.fe:189:40
     │
-191 │         let amount0: u256 = balance0 - self.reserve0
+189 │         let amount0: u256 = balance0 - self.reserve0
     │                                        ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
 
 note: 
-    ┌─ uniswap.fe:191:29
+    ┌─ uniswap.fe:189:29
     │
-191 │         let amount0: u256 = balance0 - self.reserve0
+189 │         let amount0: u256 = balance0 - self.reserve0
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-192 │         let amount1: u256 = balance1 - self.reserve1
+190 │         let amount1: u256 = balance1 - self.reserve1
     │                             ^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │           
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:192:40
+    ┌─ uniswap.fe:190:40
     │
-192 │         let amount1: u256 = balance1 - self.reserve1
+190 │         let amount1: u256 = balance1 - self.reserve1
     │                                        ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
-    ┌─ uniswap.fe:192:29
+    ┌─ uniswap.fe:190:29
     │
-192 │         let amount1: u256 = balance1 - self.reserve1
+190 │         let amount1: u256 = balance1 - self.reserve1
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-193 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
+191 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │                            ^^^^           ^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
     │                            │              │    │          
     │                            │              │    u256: Value
@@ -1461,131 +1461,131 @@ note:
     │                            UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:193:28
+    ┌─ uniswap.fe:191:28
     │
-193 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
+191 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-194 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
+192 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
     │                                  ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:194:34
+    ┌─ uniswap.fe:192:34
     │
-194 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
+192 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since totalSupply can update in _mintFee
     │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
-195 │         let liquidity: u256 = 0
+193 │         let liquidity: u256 = 0
     │                               ^ u256: Value
-196 │         if total_supply == 0 {
+194 │         if total_supply == 0 {
     │            ^^^^^^^^^^^^    ^ u256: Value
     │            │                
     │            u256: Value
 
 note: 
-    ┌─ uniswap.fe:196:12
+    ┌─ uniswap.fe:194:12
     │
-196 │         if total_supply == 0 {
+194 │         if total_supply == 0 {
     │            ^^^^^^^^^^^^^^^^^ bool: Value
-197 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+195 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │             ^^^^^^^^^        ^^^^^^^   ^^^^^^^ u256: Value
     │             │                │          
     │             │                u256: Value
     │             u256: Value
 
 note: 
-    ┌─ uniswap.fe:197:30
+    ┌─ uniswap.fe:195:30
     │
-197 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+195 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │                              ^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:197:25
+    ┌─ uniswap.fe:195:25
     │
-197 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+195 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │                         ^^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value
     │                         │                          
     │                         u256: Value
 
 note: 
-    ┌─ uniswap.fe:197:25
+    ┌─ uniswap.fe:195:25
     │
-197 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
+195 │             liquidity = sqrt(amount0 * amount1) - MINIMUM_LIQUIDITY
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
+196 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
     │             ^^^^       ^^^              ^ u256: Value
     │             │          │                 
     │             │          Context: Memory
     │             UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:198:33
+    ┌─ uniswap.fe:196:33
     │
-198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
+196 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
     │                                 ^^^^^^^^^^         ^^^^^^^^^^^^^^^^^ u256: Value
     │                                 │                   
     │                                 address: Value
 
 note: 
-    ┌─ uniswap.fe:198:13
+    ┌─ uniswap.fe:196:13
     │
-198 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
+196 │             self._mint(ctx, to: address(0), value: MINIMUM_LIQUIDITY) // permanently lock the first MINIMUM_LIQUIDITY tokens
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-199 │         } else {
-200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
+197 │         } else {
+198 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
     │             ^^^^^^^^^       ^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │             │               │          
     │             │               u256: Value
     │             u256: Value
 
 note: 
-    ┌─ uniswap.fe:200:29
+    ┌─ uniswap.fe:198:29
     │
-200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
+198 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
     │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                             │                         
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:200:29
+    ┌─ uniswap.fe:198:29
     │
-200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
+198 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                                  │          
     │                             │                                  u256: Value
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:200:64
+    ┌─ uniswap.fe:198:64
     │
-200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
+198 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
     │                                                                ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                                                                │                         
     │                                                                u256: Value
 
 note: 
-    ┌─ uniswap.fe:200:64
+    ┌─ uniswap.fe:198:64
     │
-200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
+198 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
     │                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:200:25
+    ┌─ uniswap.fe:198:25
     │
-200 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
+198 │             liquidity = min(amount0 * total_supply / reserve0, amount1 * total_supply / reserve1)
     │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-201 │         }
-202 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
+199 │         }
+200 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
     │                ^^^^^^^^^   ^ u256: Value
     │                │            
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:202:16
+    ┌─ uniswap.fe:200:16
     │
-202 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
+200 │         assert liquidity > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_MINTED"
     │                ^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory
     │                │               
     │                bool: Value
-203 │         self._mint(ctx, to, value: liquidity)
+201 │         self._mint(ctx, to, value: liquidity)
     │         ^^^^       ^^^  ^^         ^^^^^^^^^ u256: Value
     │         │          │    │           
     │         │          │    address: Value
@@ -1593,11 +1593,11 @@ note:
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:203:9
+    ┌─ uniswap.fe:201:9
     │
-203 │         self._mint(ctx, to, value: liquidity)
+201 │         self._mint(ctx, to, value: liquidity)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-204 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
+202 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
     │         ^^^^         ^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
     │         │            │    │         │         │          
     │         │            │    │         │         u256: Value
@@ -1607,176 +1607,176 @@ note:
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:204:9
+    ┌─ uniswap.fe:202:9
     │
-204 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
+202 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-205 │         if fee_on {
+203 │         if fee_on {
     │            ^^^^^^ bool: Value
-206 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
+204 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
     │             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:206:13
+    ┌─ uniswap.fe:204:13
     │
-206 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
+204 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
     │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │             │             │           
     │             │             u256: Value
     │             u256: Storage { nonce: Some(12) }
 
 note: 
-    ┌─ uniswap.fe:206:27
+    ┌─ uniswap.fe:204:27
     │
-206 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
+204 │             self.k_last = reserve0 * reserve1 // reserve0 and reserve1 are up-to-date
     │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
-207 │         }
-208 │         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
+205 │         }
+206 │         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
     │                   ^^^          ^^^ Context: Memory
     │                   │             
     │                   Context: Memory
 
 note: 
-    ┌─ uniswap.fe:208:32
+    ┌─ uniswap.fe:206:32
     │
-208 │         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
+206 │         emit Mint(ctx, sender: ctx.msg_sender(), amount0, amount1)
     │                                ^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^^^^ u256: Value
     │                                │                 │         
     │                                │                 u256: Value
     │                                address: Value
-209 │         return liquidity
+207 │         return liquidity
     │                ^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:213:5
+    ┌─ uniswap.fe:211:5
     │  
-213 │ ╭     pub fn burn(self, ctx: Context, to: address) -> (u256, u256) {
-214 │ │         let reserve0: u256 = self.reserve0
-215 │ │         let reserve1: u256 = self.reserve1
-216 │ │         let token0: ERC20 = self.token0
+211 │ ╭     pub fn burn(self, ctx: Context, to: address) -> (u256, u256) {
+212 │ │         let reserve0: u256 = self.reserve0
+213 │ │         let reserve1: u256 = self.reserve1
+214 │ │         let token0: ERC20 = self.token0
     · │
-237 │ │         return (amount0, amount1)
-238 │ │     }
+235 │ │         return (amount0, amount1)
+236 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }] -> (u256, u256)
 
 note: 
-    ┌─ uniswap.fe:214:13
+    ┌─ uniswap.fe:212:13
     │
-214 │         let reserve0: u256 = self.reserve0
+212 │         let reserve0: u256 = self.reserve0
     │             ^^^^^^^^ u256
-215 │         let reserve1: u256 = self.reserve1
+213 │         let reserve1: u256 = self.reserve1
     │             ^^^^^^^^ u256
-216 │         let token0: ERC20 = self.token0
+214 │         let token0: ERC20 = self.token0
     │             ^^^^^^ ERC20
-217 │         let token1: ERC20 = self.token1
+215 │         let token1: ERC20 = self.token1
     │             ^^^^^^ ERC20
-218 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+216 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │             ^^^^^^^^ u256
-219 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+217 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │             ^^^^^^^^ u256
-220 │         let liquidity: u256 = self.balances[ctx.self_address()]
+218 │         let liquidity: u256 = self.balances[ctx.self_address()]
     │             ^^^^^^^^^ u256
-221 │ 
-222 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
+219 │ 
+220 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │             ^^^^^^ bool
-223 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
+221 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
     │             ^^^^^^^^^^^^ u256
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
+222 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │             ^^^^^^^ u256
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
+223 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │             ^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:214:30
+    ┌─ uniswap.fe:212:30
     │
-214 │         let reserve0: u256 = self.reserve0
+212 │         let reserve0: u256 = self.reserve0
     │                              ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:214:30
+    ┌─ uniswap.fe:212:30
     │
-214 │         let reserve0: u256 = self.reserve0
+212 │         let reserve0: u256 = self.reserve0
     │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
-215 │         let reserve1: u256 = self.reserve1
+213 │         let reserve1: u256 = self.reserve1
     │                              ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:215:30
+    ┌─ uniswap.fe:213:30
     │
-215 │         let reserve1: u256 = self.reserve1
+213 │         let reserve1: u256 = self.reserve1
     │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
-216 │         let token0: ERC20 = self.token0
+214 │         let token0: ERC20 = self.token0
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:216:29
+    ┌─ uniswap.fe:214:29
     │
-216 │         let token0: ERC20 = self.token0
+214 │         let token0: ERC20 = self.token0
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(5) } => Value
-217 │         let token1: ERC20 = self.token1
+215 │         let token1: ERC20 = self.token1
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:217:29
+    ┌─ uniswap.fe:215:29
     │
-217 │         let token1: ERC20 = self.token1
+215 │         let token1: ERC20 = self.token1
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
-218 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+216 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │                              ^^^^^^           ^^^ Context: Memory
     │                              │                 
     │                              ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:218:47
+    ┌─ uniswap.fe:216:47
     │
-218 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+216 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │                                               ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:218:30
+    ┌─ uniswap.fe:216:30
     │
-218 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+216 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-219 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+217 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │                              ^^^^^^           ^^^ Context: Memory
     │                              │                 
     │                              ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:219:47
+    ┌─ uniswap.fe:217:47
     │
-219 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+217 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │                                               ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:219:30
+    ┌─ uniswap.fe:217:30
     │
-219 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+217 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-220 │         let liquidity: u256 = self.balances[ctx.self_address()]
+218 │         let liquidity: u256 = self.balances[ctx.self_address()]
     │                               ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:220:31
+    ┌─ uniswap.fe:218:31
     │
-220 │         let liquidity: u256 = self.balances[ctx.self_address()]
+218 │         let liquidity: u256 = self.balances[ctx.self_address()]
     │                               ^^^^^^^^^^^^^ ^^^ Context: Memory
     │                               │              
     │                               Map<address, u256>: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:220:45
+    ┌─ uniswap.fe:218:45
     │
-220 │         let liquidity: u256 = self.balances[ctx.self_address()]
+218 │         let liquidity: u256 = self.balances[ctx.self_address()]
     │                                             ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:220:31
+    ┌─ uniswap.fe:218:31
     │
-220 │         let liquidity: u256 = self.balances[ctx.self_address()]
+218 │         let liquidity: u256 = self.balances[ctx.self_address()]
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Storage { nonce: None } => Value
-221 │ 
-222 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
+219 │ 
+220 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │                            ^^^^           ^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
     │                            │              │    │          
     │                            │              │    u256: Value
@@ -1784,157 +1784,157 @@ note:
     │                            UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:222:28
+    ┌─ uniswap.fe:220:28
     │
-222 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
+220 │         let fee_on: bool = self._mint_fee(ctx, reserve0, reserve1)
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-223 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
+221 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
     │                                  ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:223:34
+    ┌─ uniswap.fe:221:34
     │
-223 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
+221 │         let total_supply: u256 = self.total_supply // gas savings, must be defined here since total_supply can update in _mintFee
     │                                  ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(2) } => Value
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
+222 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │                              ^^^^^^^^^   ^^^^^^^^ u256: Value
     │                              │            
     │                              u256: Value
 
 note: 
-    ┌─ uniswap.fe:224:29
+    ┌─ uniswap.fe:222:29
     │
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
+222 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                         
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:224:29
+    ┌─ uniswap.fe:222:29
     │
-224 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
+222 │         let amount0: u256 = (liquidity * balance0) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
+223 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │                              ^^^^^^^^^   ^^^^^^^^ u256: Value
     │                              │            
     │                              u256: Value
 
 note: 
-    ┌─ uniswap.fe:225:29
+    ┌─ uniswap.fe:223:29
     │
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
+223 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^ u256: Value
     │                             │                         
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:225:29
+    ┌─ uniswap.fe:223:29
     │
-225 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
+223 │         let amount1: u256 = (liquidity * balance1) / total_supply // using balances ensures pro-rata distribution
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-226 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+224 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
     │                ^^^^^^^   ^ u256: Value
     │                │          
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:226:16
+    ┌─ uniswap.fe:224:16
     │
-226 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+224 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
     │                ^^^^^^^^^^^     ^^^^^^^   ^ u256: Value
     │                │               │          
     │                │               u256: Value
     │                bool: Value
 
 note: 
-    ┌─ uniswap.fe:226:32
+    ┌─ uniswap.fe:224:32
     │
-226 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+224 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
     │                                ^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:226:16
+    ┌─ uniswap.fe:224:16
     │
-226 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
+224 │         assert amount0 > 0 and amount1 > 0, "UniswapV2: INSUFFICIENT_LIQUIDITY_BURNED"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<40>: Memory
     │                │                             
     │                bool: Value
-227 │         self._burn(ctx, from: ctx.self_address(), value: liquidity)
+225 │         self._burn(ctx, from: ctx.self_address(), value: liquidity)
     │         ^^^^       ^^^        ^^^ Context: Memory
     │         │          │           
     │         │          Context: Memory
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:227:31
+    ┌─ uniswap.fe:225:31
     │
-227 │         self._burn(ctx, from: ctx.self_address(), value: liquidity)
+225 │         self._burn(ctx, from: ctx.self_address(), value: liquidity)
     │                               ^^^^^^^^^^^^^^^^^^         ^^^^^^^^^ u256: Value
     │                               │                           
     │                               address: Value
 
 note: 
+    ┌─ uniswap.fe:225:9
+    │
+225 │         self._burn(ctx, from: ctx.self_address(), value: liquidity)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
+226 │         token0.transfer(to, amount0)
+    │         ^^^^^^          ^^  ^^^^^^^ u256: Value
+    │         │               │    
+    │         │               address: Value
+    │         ERC20: Value
+
+note: 
+    ┌─ uniswap.fe:226:9
+    │
+226 │         token0.transfer(to, amount0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+227 │         token1.transfer(to, amount1)
+    │         ^^^^^^          ^^  ^^^^^^^ u256: Value
+    │         │               │    
+    │         │               address: Value
+    │         ERC20: Value
+
+note: 
     ┌─ uniswap.fe:227:9
     │
-227 │         self._burn(ctx, from: ctx.self_address(), value: liquidity)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-228 │         token0.transfer(to, amount0)
-    │         ^^^^^^          ^^  ^^^^^^^ u256: Value
-    │         │               │    
-    │         │               address: Value
-    │         ERC20: Value
-
-note: 
-    ┌─ uniswap.fe:228:9
-    │
-228 │         token0.transfer(to, amount0)
+227 │         token1.transfer(to, amount1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-229 │         token1.transfer(to, amount1)
-    │         ^^^^^^          ^^  ^^^^^^^ u256: Value
-    │         │               │    
-    │         │               address: Value
-    │         ERC20: Value
-
-note: 
-    ┌─ uniswap.fe:229:9
-    │
-229 │         token1.transfer(to, amount1)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-230 │         balance0 = token0.balanceOf(ctx.self_address())
+228 │         balance0 = token0.balanceOf(ctx.self_address())
     │         ^^^^^^^^   ^^^^^^           ^^^ Context: Memory
     │         │          │                 
     │         │          ERC20: Value
     │         u256: Value
 
 note: 
-    ┌─ uniswap.fe:230:37
+    ┌─ uniswap.fe:228:37
     │
-230 │         balance0 = token0.balanceOf(ctx.self_address())
+228 │         balance0 = token0.balanceOf(ctx.self_address())
     │                                     ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:230:20
+    ┌─ uniswap.fe:228:20
     │
-230 │         balance0 = token0.balanceOf(ctx.self_address())
+228 │         balance0 = token0.balanceOf(ctx.self_address())
     │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-231 │         balance1 = token1.balanceOf(ctx.self_address())
+229 │         balance1 = token1.balanceOf(ctx.self_address())
     │         ^^^^^^^^   ^^^^^^           ^^^ Context: Memory
     │         │          │                 
     │         │          ERC20: Value
     │         u256: Value
 
 note: 
-    ┌─ uniswap.fe:231:37
+    ┌─ uniswap.fe:229:37
     │
-231 │         balance1 = token1.balanceOf(ctx.self_address())
+229 │         balance1 = token1.balanceOf(ctx.self_address())
     │                                     ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:231:20
+    ┌─ uniswap.fe:229:20
     │
-231 │         balance1 = token1.balanceOf(ctx.self_address())
+229 │         balance1 = token1.balanceOf(ctx.self_address())
     │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-232 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
+230 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
     │         ^^^^         ^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
     │         │            │    │         │         │          
     │         │            │    │         │         u256: Value
@@ -1944,514 +1944,514 @@ note:
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:232:9
+    ┌─ uniswap.fe:230:9
     │
-232 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
+230 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-233 │         if fee_on {
+231 │         if fee_on {
     │            ^^^^^^ bool: Value
-234 │             self.k_last = reserve0 * reserve1
+232 │             self.k_last = reserve0 * reserve1
     │             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:234:13
+    ┌─ uniswap.fe:232:13
     │
-234 │             self.k_last = reserve0 * reserve1
+232 │             self.k_last = reserve0 * reserve1
     │             ^^^^^^^^^^^   ^^^^^^^^   ^^^^^^^^ u256: Value
     │             │             │           
     │             │             u256: Value
     │             u256: Storage { nonce: Some(12) }
 
 note: 
-    ┌─ uniswap.fe:234:27
+    ┌─ uniswap.fe:232:27
     │
-234 │             self.k_last = reserve0 * reserve1
+232 │             self.k_last = reserve0 * reserve1
     │                           ^^^^^^^^^^^^^^^^^^^ u256: Value
-235 │         }
-236 │         emit Burn(ctx, sender: ctx.msg_sender(), amount0, amount1, to)
+233 │         }
+234 │         emit Burn(ctx, sender: ctx.msg_sender(), amount0, amount1, to)
     │                   ^^^          ^^^ Context: Memory
     │                   │             
     │                   Context: Memory
 
 note: 
-    ┌─ uniswap.fe:236:32
+    ┌─ uniswap.fe:234:32
     │
-236 │         emit Burn(ctx, sender: ctx.msg_sender(), amount0, amount1, to)
+234 │         emit Burn(ctx, sender: ctx.msg_sender(), amount0, amount1, to)
     │                                ^^^^^^^^^^^^^^^^  ^^^^^^^  ^^^^^^^  ^^ address: Value
     │                                │                 │        │         
     │                                │                 │        u256: Value
     │                                │                 u256: Value
     │                                address: Value
-237 │         return (amount0, amount1)
+235 │         return (amount0, amount1)
     │                 ^^^^^^^  ^^^^^^^ u256: Value
     │                 │         
     │                 u256: Value
 
 note: 
-    ┌─ uniswap.fe:237:16
+    ┌─ uniswap.fe:235:16
     │
-237 │         return (amount0, amount1)
+235 │         return (amount0, amount1)
     │                ^^^^^^^^^^^^^^^^^^ (u256, u256): Memory
 
 note: 
-    ┌─ uniswap.fe:243:5
+    ┌─ uniswap.fe:241:5
     │  
-243 │ ╭     pub fn swap(self, ctx: Context, amount0_out: u256, amount1_out: u256, to: address) {
-244 │ │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
-245 │ │         let reserve0: u256 = self.reserve0
-246 │ │         let reserve1: u256 = self.reserve1
+241 │ ╭     pub fn swap(self, ctx: Context, amount0_out: u256, amount1_out: u256, to: address) {
+242 │ │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+243 │ │         let reserve0: u256 = self.reserve0
+244 │ │         let reserve1: u256 = self.reserve1
     · │
-279 │ │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
-280 │ │     }
+277 │ │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
+278 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: amount0_out, typ: u256 }, { label: None, name: amount1_out, typ: u256 }, { label: None, name: to, typ: address }] -> ()
 
 note: 
-    ┌─ uniswap.fe:245:13
+    ┌─ uniswap.fe:243:13
     │
-245 │         let reserve0: u256 = self.reserve0
+243 │         let reserve0: u256 = self.reserve0
     │             ^^^^^^^^ u256
-246 │         let reserve1: u256 = self.reserve1
+244 │         let reserve1: u256 = self.reserve1
     │             ^^^^^^^^ u256
     ·
-249 │         let token0: ERC20 = self.token0
+247 │         let token0: ERC20 = self.token0
     │             ^^^^^^ ERC20
-250 │         let token1: ERC20 = self.token1
+248 │         let token1: ERC20 = self.token1
     │             ^^^^^^ ERC20
     ·
-265 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+263 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │             ^^^^^^^^ u256
-266 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+264 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │             ^^^^^^^^ u256
-267 │ 
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+265 │ 
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │             ^^^^^^^^^^ u256
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │             ^^^^^^^^^^ u256
     ·
-273 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+271 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │             ^^^^^^^^^^^^^^^^^ u256
-274 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+272 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │             ^^^^^^^^^^^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:244:16
+    ┌─ uniswap.fe:242:16
     │
-244 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+242 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
     │                ^^^^^^^^^^^   ^ u256: Value
     │                │              
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:244:16
+    ┌─ uniswap.fe:242:16
     │
-244 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+242 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
     │                ^^^^^^^^^^^^^^^    ^^^^^^^^^^^   ^ u256: Value
     │                │                  │              
     │                │                  u256: Value
     │                bool: Value
 
 note: 
-    ┌─ uniswap.fe:244:35
+    ┌─ uniswap.fe:242:35
     │
-244 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+242 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
     │                                   ^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:244:16
+    ┌─ uniswap.fe:242:16
     │
-244 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
+242 │         assert amount0_out > 0 or amount1_out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<37>: Memory
     │                │                                    
     │                bool: Value
-245 │         let reserve0: u256 = self.reserve0
+243 │         let reserve0: u256 = self.reserve0
     │                              ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:245:30
+    ┌─ uniswap.fe:243:30
     │
-245 │         let reserve0: u256 = self.reserve0
+243 │         let reserve0: u256 = self.reserve0
     │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
-246 │         let reserve1: u256 = self.reserve1
+244 │         let reserve1: u256 = self.reserve1
     │                              ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:246:30
+    ┌─ uniswap.fe:244:30
     │
-246 │         let reserve1: u256 = self.reserve1
+244 │         let reserve1: u256 = self.reserve1
     │                              ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
-247 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+245 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
     │                ^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                │              
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:247:16
+    ┌─ uniswap.fe:245:16
     │
-247 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+245 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
     │                ^^^^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^   ^^^^^^^^ u256: Value
     │                │                          │              
     │                │                          u256: Value
     │                bool: Value
 
 note: 
-    ┌─ uniswap.fe:247:43
+    ┌─ uniswap.fe:245:43
     │
-247 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+245 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
     │                                           ^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:247:16
+    ┌─ uniswap.fe:245:16
     │
-247 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
+245 │         assert amount0_out < reserve0 and amount1_out < reserve1, "UniswapV2: INSUFFICIENT_LIQUIDITY"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<33>: Memory
     │                │                                                   
     │                bool: Value
-248 │ 
-249 │         let token0: ERC20 = self.token0
+246 │ 
+247 │         let token0: ERC20 = self.token0
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:249:29
+    ┌─ uniswap.fe:247:29
     │
-249 │         let token0: ERC20 = self.token0
+247 │         let token0: ERC20 = self.token0
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(5) } => Value
-250 │         let token1: ERC20 = self.token1
+248 │         let token1: ERC20 = self.token1
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:250:29
+    ┌─ uniswap.fe:248:29
     │
-250 │         let token1: ERC20 = self.token1
+248 │         let token1: ERC20 = self.token1
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
     ·
-253 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+251 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
     │                ^^            ^^^^^^ ERC20: Value
     │                │              
     │                address: Value
 
 note: 
-    ┌─ uniswap.fe:253:22
+    ┌─ uniswap.fe:251:22
     │
-253 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+251 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
     │                      ^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:253:16
+    ┌─ uniswap.fe:251:16
     │
-253 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+251 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
     │                ^^^^^^^^^^^^^^^^^^^^^     ^^            ^^^^^^ ERC20: Value
     │                │                         │              
     │                │                         address: Value
     │                bool: Value
 
 note: 
-    ┌─ uniswap.fe:253:48
+    ┌─ uniswap.fe:251:48
     │
-253 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+251 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
     │                                                ^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:253:42
+    ┌─ uniswap.fe:251:42
     │
-253 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+251 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
     │                                          ^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:253:16
+    ┌─ uniswap.fe:251:16
     │
-253 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
+251 │         assert to != address(token0) and to != address(token1), "UniswapV2: INVALID_TO"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^ String<21>: Memory
     │                │                                                 
     │                bool: Value
-254 │ 
-255 │         if amount0_out > 0 {
+252 │ 
+253 │         if amount0_out > 0 {
     │            ^^^^^^^^^^^   ^ u256: Value
     │            │              
     │            u256: Value
 
 note: 
-    ┌─ uniswap.fe:255:12
+    ┌─ uniswap.fe:253:12
     │
-255 │         if amount0_out > 0 {
+253 │         if amount0_out > 0 {
     │            ^^^^^^^^^^^^^^^ bool: Value
-256 │             token0.transfer(to, amount0_out) // optimistically transfer tokens
+254 │             token0.transfer(to, amount0_out) // optimistically transfer tokens
     │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value
     │             │               │    
     │             │               address: Value
     │             ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:256:13
+    ┌─ uniswap.fe:254:13
     │
-256 │             token0.transfer(to, amount0_out) // optimistically transfer tokens
+254 │             token0.transfer(to, amount0_out) // optimistically transfer tokens
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-257 │         }
-258 │         if amount1_out > 0 {
+255 │         }
+256 │         if amount1_out > 0 {
     │            ^^^^^^^^^^^   ^ u256: Value
     │            │              
     │            u256: Value
 
 note: 
-    ┌─ uniswap.fe:258:12
+    ┌─ uniswap.fe:256:12
     │
-258 │         if amount1_out > 0 {
+256 │         if amount1_out > 0 {
     │            ^^^^^^^^^^^^^^^ bool: Value
-259 │             token1.transfer(to, amount1_out) // optimistically transfer tokens
+257 │             token1.transfer(to, amount1_out) // optimistically transfer tokens
     │             ^^^^^^          ^^  ^^^^^^^^^^^ u256: Value
     │             │               │    
     │             │               address: Value
     │             ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:259:13
+    ┌─ uniswap.fe:257:13
     │
-259 │             token1.transfer(to, amount1_out) // optimistically transfer tokens
+257 │             token1.transfer(to, amount1_out) // optimistically transfer tokens
     │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     ·
-265 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+263 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │                              ^^^^^^           ^^^ Context: Memory
     │                              │                 
     │                              ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:265:47
+    ┌─ uniswap.fe:263:47
     │
-265 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+263 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │                                               ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:265:30
+    ┌─ uniswap.fe:263:30
     │
-265 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
+263 │         let balance0: u256 = token0.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-266 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+264 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │                              ^^^^^^           ^^^ Context: Memory
     │                              │                 
     │                              ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:266:47
+    ┌─ uniswap.fe:264:47
     │
-266 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+264 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │                                               ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:266:30
+    ┌─ uniswap.fe:264:30
     │
-266 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
+264 │         let balance1: u256 = token1.balanceOf(ctx.self_address())
     │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-267 │ 
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+265 │ 
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                                                       │          │           
     │                                                                       │          u256: Value
     │                                                                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:268:82
+    ┌─ uniswap.fe:266:82
     │
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:268:32
+    ┌─ uniswap.fe:266:32
     │
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     │                                │                                       
     │                                u256: Value
 
 note: 
-    ┌─ uniswap.fe:268:44
+    ┌─ uniswap.fe:266:44
     │
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                            │           
     │                                            u256: Value
 
 note: 
-    ┌─ uniswap.fe:268:43
+    ┌─ uniswap.fe:266:43
     │
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:268:32
+    ┌─ uniswap.fe:266:32
     │
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value
     │                                │                                                                              
     │                                u256: Value
 
 note: 
-    ┌─ uniswap.fe:268:32
+    ┌─ uniswap.fe:266:32
     │
-268 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
+266 │         let amount0_in: u256 = balance0 - (reserve0 - amount0_out) if balance0 > reserve0 - amount0_out else 0
     │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                                                       ^^^^^^^^   ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                                                       │          │           
     │                                                                       │          u256: Value
     │                                                                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:269:82
+    ┌─ uniswap.fe:267:82
     │
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                                                                  ^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:269:32
+    ┌─ uniswap.fe:267:32
     │
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                ^^^^^^^^                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
     │                                │                                       
     │                                u256: Value
 
 note: 
-    ┌─ uniswap.fe:269:44
+    ┌─ uniswap.fe:267:44
     │
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                            ^^^^^^^^   ^^^^^^^^^^^ u256: Value
     │                                            │           
     │                                            u256: Value
 
 note: 
-    ┌─ uniswap.fe:269:43
+    ┌─ uniswap.fe:267:43
     │
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                           ^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:269:32
+    ┌─ uniswap.fe:267:32
     │
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                           ^ u256: Value
     │                                │                                                                              
     │                                u256: Value
 
 note: 
-    ┌─ uniswap.fe:269:32
+    ┌─ uniswap.fe:267:32
     │
-269 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
+267 │         let amount1_in: u256 = balance1 - (reserve1 - amount1_out) if balance1 > reserve1 - amount1_out else 0
     │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-270 │ 
-271 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+268 │ 
+269 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
     │                ^^^^^^^^^^   ^ u256: Value
     │                │             
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:271:16
+    ┌─ uniswap.fe:269:16
     │
-271 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+269 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
     │                ^^^^^^^^^^^^^^    ^^^^^^^^^^   ^ u256: Value
     │                │                 │             
     │                │                 u256: Value
     │                bool: Value
 
 note: 
-    ┌─ uniswap.fe:271:34
+    ┌─ uniswap.fe:269:34
     │
-271 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+269 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
     │                                  ^^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:271:16
+    ┌─ uniswap.fe:269:16
     │
-271 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
+269 │         assert amount0_in > 0 or amount1_in > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<36>: Memory
     │                │                                  
     │                bool: Value
-272 │ 
-273 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+270 │ 
+271 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │                                       ^^^^^^^^   ^^^^ u256: Value
     │                                       │           
     │                                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:273:39
+    ┌─ uniswap.fe:271:39
     │
-273 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+271 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value
     │                                       │                 │             
     │                                       │                 u256: Value
     │                                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:273:57
+    ┌─ uniswap.fe:271:57
     │
-273 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+271 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │                                                         ^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:273:39
+    ┌─ uniswap.fe:271:39
     │
-273 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
+271 │         let balance0_adjusted: u256 = balance0 * 1000 - amount0_in * 3
     │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-274 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+272 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │                                       ^^^^^^^^   ^^^^ u256: Value
     │                                       │           
     │                                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:274:39
+    ┌─ uniswap.fe:272:39
     │
-274 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+272 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │                                       ^^^^^^^^^^^^^^^   ^^^^^^^^^^   ^ u256: Value
     │                                       │                 │             
     │                                       │                 u256: Value
     │                                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:274:57
+    ┌─ uniswap.fe:272:57
     │
-274 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+272 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │                                                         ^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:274:39
+    ┌─ uniswap.fe:272:39
     │
-274 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
+272 │         let balance1_adjusted: u256 = balance1 * 1000 - amount1_in * 3
     │                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-275 │ 
-276 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+273 │ 
+274 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                ^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^ u256: Value
     │                │                    
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:276:16
+    ┌─ uniswap.fe:274:16
     │
-276 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+274 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    ^^^^^^^^   ^^^^^^^^ u256: Value
     │                │                                        │           
     │                │                                        u256: Value
     │                u256: Value
 
 note: 
-    ┌─ uniswap.fe:276:57
+    ┌─ uniswap.fe:274:57
     │
-276 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+274 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                                                         ^^^^^^^^^^^^^^^^^^^   ^^^^^^^ u256: Value
     │                                                         │                      
     │                                                         u256: Value
 
 note: 
-    ┌─ uniswap.fe:276:57
+    ┌─ uniswap.fe:274:57
     │
-276 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+274 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:276:16
+    ┌─ uniswap.fe:274:16
     │
-276 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
+274 │         assert balance0_adjusted * balance1_adjusted >= reserve0 * reserve1 * 1000000, "UniswapV2: K"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^ String<12>: Memory
     │                │                                                                        
     │                bool: Value
-277 │ 
-278 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
+275 │ 
+276 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
     │         ^^^^         ^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^  ^^^^^^^^ u256: Value
     │         │            │    │         │         │          
     │         │            │    │         │         u256: Value
@@ -2461,19 +2461,19 @@ note:
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:278:9
+    ┌─ uniswap.fe:276:9
     │
-278 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
+276 │         self._update(ctx, balance0, balance1, reserve0, reserve1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-279 │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
+277 │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
     │                   ^^^          ^^^ Context: Memory
     │                   │             
     │                   Context: Memory
 
 note: 
-    ┌─ uniswap.fe:279:32
+    ┌─ uniswap.fe:277:32
     │
-279 │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
+277 │         emit Swap(ctx, sender: ctx.msg_sender(), amount0_in, amount1_in, amount0_out, amount1_out, to)
     │                                ^^^^^^^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^  ^^ address: Value
     │                                │                 │           │           │            │             
     │                                │                 │           │           │            u256: Value
@@ -2483,627 +2483,627 @@ note:
     │                                address: Value
 
 note: 
-    ┌─ uniswap.fe:283:5
+    ┌─ uniswap.fe:281:5
     │  
-283 │ ╭     pub fn skim(self, ctx: Context, to: address) {
-284 │ │         let token0: ERC20 = self.token0 // gas savings
-285 │ │         let token1: ERC20 = self.token1 // gas savings
-286 │ │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
-287 │ │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
-288 │ │     }
+281 │ ╭     pub fn skim(self, ctx: Context, to: address) {
+282 │ │         let token0: ERC20 = self.token0 // gas savings
+283 │ │         let token1: ERC20 = self.token1 // gas savings
+284 │ │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+285 │ │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
+286 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: to, typ: address }] -> ()
 
 note: 
-    ┌─ uniswap.fe:284:13
+    ┌─ uniswap.fe:282:13
     │
-284 │         let token0: ERC20 = self.token0 // gas savings
+282 │         let token0: ERC20 = self.token0 // gas savings
     │             ^^^^^^ ERC20
-285 │         let token1: ERC20 = self.token1 // gas savings
+283 │         let token1: ERC20 = self.token1 // gas savings
     │             ^^^^^^ ERC20
 
 note: 
-    ┌─ uniswap.fe:284:29
+    ┌─ uniswap.fe:282:29
     │
-284 │         let token0: ERC20 = self.token0 // gas savings
+282 │         let token0: ERC20 = self.token0 // gas savings
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:284:29
+    ┌─ uniswap.fe:282:29
     │
-284 │         let token0: ERC20 = self.token0 // gas savings
+282 │         let token0: ERC20 = self.token0 // gas savings
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(5) } => Value
-285 │         let token1: ERC20 = self.token1 // gas savings
+283 │         let token1: ERC20 = self.token1 // gas savings
     │                             ^^^^ UniswapV2Pair: Value
+
+note: 
+    ┌─ uniswap.fe:283:29
+    │
+283 │         let token1: ERC20 = self.token1 // gas savings
+    │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
+284 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+    │         ^^^^^^          ^^  ^^^^^^           ^^^ Context: Memory
+    │         │               │   │                 
+    │         │               │   ERC20: Value
+    │         │               address: Value
+    │         ERC20: Value
+
+note: 
+    ┌─ uniswap.fe:284:46
+    │
+284 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+    │                                              ^^^^^^^^^^^^^^^^^^ address: Value
+
+note: 
+    ┌─ uniswap.fe:284:29
+    │
+284 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
+    │                             │                                       
+    │                             u256: Value
+
+note: 
+    ┌─ uniswap.fe:284:68
+    │
+284 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+    │                                                                    ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
+
+note: 
+    ┌─ uniswap.fe:284:29
+    │
+284 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+    ┌─ uniswap.fe:284:9
+    │
+284 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
+285 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
+    │         ^^^^^^          ^^  ^^^^^^           ^^^ Context: Memory
+    │         │               │   │                 
+    │         │               │   ERC20: Value
+    │         │               address: Value
+    │         ERC20: Value
+
+note: 
+    ┌─ uniswap.fe:285:46
+    │
+285 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
+    │                                              ^^^^^^^^^^^^^^^^^^ address: Value
 
 note: 
     ┌─ uniswap.fe:285:29
     │
-285 │         let token1: ERC20 = self.token1 // gas savings
-    │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
-286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
-    │         ^^^^^^          ^^  ^^^^^^           ^^^ Context: Memory
-    │         │               │   │                 
-    │         │               │   ERC20: Value
-    │         │               address: Value
-    │         ERC20: Value
-
-note: 
-    ┌─ uniswap.fe:286:46
-    │
-286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
-    │                                              ^^^^^^^^^^^^^^^^^^ address: Value
-
-note: 
-    ┌─ uniswap.fe:286:29
-    │
-286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
+285 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
     │                             │                                       
     │                             u256: Value
 
 note: 
-    ┌─ uniswap.fe:286:68
+    ┌─ uniswap.fe:285:68
     │
-286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
-    │                                                                    ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
-
-note: 
-    ┌─ uniswap.fe:286:29
-    │
-286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-
-note: 
-    ┌─ uniswap.fe:286:9
-    │
-286 │         token0.transfer(to, token0.balanceOf(ctx.self_address()) - self.reserve0)
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
-287 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
-    │         ^^^^^^          ^^  ^^^^^^           ^^^ Context: Memory
-    │         │               │   │                 
-    │         │               │   ERC20: Value
-    │         │               address: Value
-    │         ERC20: Value
-
-note: 
-    ┌─ uniswap.fe:287:46
-    │
-287 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
-    │                                              ^^^^^^^^^^^^^^^^^^ address: Value
-
-note: 
-    ┌─ uniswap.fe:287:29
-    │
-287 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
-    │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Pair: Value
-    │                             │                                       
-    │                             u256: Value
-
-note: 
-    ┌─ uniswap.fe:287:68
-    │
-287 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
+285 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
     │                                                                    ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
-    ┌─ uniswap.fe:287:29
+    ┌─ uniswap.fe:285:29
     │
-287 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
+285 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
     │                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:287:9
+    ┌─ uniswap.fe:285:9
     │
-287 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
+285 │         token1.transfer(to, token1.balanceOf(ctx.self_address()) - self.reserve1)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ bool: Value
 
 note: 
-    ┌─ uniswap.fe:291:5
+    ┌─ uniswap.fe:289:5
     │  
-291 │ ╭     pub fn sync(self, ctx: Context) {
-292 │ │         let token0: ERC20 = self.token0
-293 │ │         let token1: ERC20 = self.token1
-294 │ │         self._update(ctx,
+289 │ ╭     pub fn sync(self, ctx: Context) {
+290 │ │         let token0: ERC20 = self.token0
+291 │ │         let token1: ERC20 = self.token1
+292 │ │         self._update(ctx,
     · │
-298 │ │                      reserve1: self.reserve1)
-299 │ │     }
+296 │ │                      reserve1: self.reserve1)
+297 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }] -> ()
 
 note: 
-    ┌─ uniswap.fe:292:13
+    ┌─ uniswap.fe:290:13
     │
-292 │         let token0: ERC20 = self.token0
+290 │         let token0: ERC20 = self.token0
     │             ^^^^^^ ERC20
-293 │         let token1: ERC20 = self.token1
+291 │         let token1: ERC20 = self.token1
     │             ^^^^^^ ERC20
 
 note: 
-    ┌─ uniswap.fe:292:29
+    ┌─ uniswap.fe:290:29
     │
-292 │         let token0: ERC20 = self.token0
+290 │         let token0: ERC20 = self.token0
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:292:29
+    ┌─ uniswap.fe:290:29
     │
-292 │         let token0: ERC20 = self.token0
+290 │         let token0: ERC20 = self.token0
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(5) } => Value
-293 │         let token1: ERC20 = self.token1
+291 │         let token1: ERC20 = self.token1
     │                             ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:293:29
+    ┌─ uniswap.fe:291:29
     │
-293 │         let token1: ERC20 = self.token1
+291 │         let token1: ERC20 = self.token1
     │                             ^^^^^^^^^^^ ERC20: Storage { nonce: Some(6) } => Value
-294 │         self._update(ctx,
+292 │         self._update(ctx,
     │         ^^^^         ^^^ Context: Memory
     │         │             
     │         UniswapV2Pair: Value
-295 │                      balance0: token0.balanceOf(ctx.self_address()),
+293 │                      balance0: token0.balanceOf(ctx.self_address()),
     │                                ^^^^^^           ^^^ Context: Memory
     │                                │                 
     │                                ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:295:49
+    ┌─ uniswap.fe:293:49
     │
-295 │                      balance0: token0.balanceOf(ctx.self_address()),
+293 │                      balance0: token0.balanceOf(ctx.self_address()),
     │                                                 ^^^^^^^^^^^^^^^^^^ address: Value
+
+note: 
+    ┌─ uniswap.fe:293:32
+    │
+293 │                      balance0: token0.balanceOf(ctx.self_address()),
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+294 │                      balance1: token1.balanceOf(ctx.self_address()),
+    │                                ^^^^^^           ^^^ Context: Memory
+    │                                │                 
+    │                                ERC20: Value
+
+note: 
+    ┌─ uniswap.fe:294:49
+    │
+294 │                      balance1: token1.balanceOf(ctx.self_address()),
+    │                                                 ^^^^^^^^^^^^^^^^^^ address: Value
+
+note: 
+    ┌─ uniswap.fe:294:32
+    │
+294 │                      balance1: token1.balanceOf(ctx.self_address()),
+    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+295 │                      reserve0: self.reserve0,
+    │                                ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:295:32
     │
-295 │                      balance0: token0.balanceOf(ctx.self_address()),
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-296 │                      balance1: token1.balanceOf(ctx.self_address()),
-    │                                ^^^^^^           ^^^ Context: Memory
-    │                                │                 
-    │                                ERC20: Value
-
-note: 
-    ┌─ uniswap.fe:296:49
-    │
-296 │                      balance1: token1.balanceOf(ctx.self_address()),
-    │                                                 ^^^^^^^^^^^^^^^^^^ address: Value
+295 │                      reserve0: self.reserve0,
+    │                                ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
+296 │                      reserve1: self.reserve1)
+    │                                ^^^^ UniswapV2Pair: Value
 
 note: 
     ┌─ uniswap.fe:296:32
     │
-296 │                      balance1: token1.balanceOf(ctx.self_address()),
-    │                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-297 │                      reserve0: self.reserve0,
-    │                                ^^^^ UniswapV2Pair: Value
-
-note: 
-    ┌─ uniswap.fe:297:32
-    │
-297 │                      reserve0: self.reserve0,
-    │                                ^^^^^^^^^^^^^ u256: Storage { nonce: Some(7) } => Value
-298 │                      reserve1: self.reserve1)
-    │                                ^^^^ UniswapV2Pair: Value
-
-note: 
-    ┌─ uniswap.fe:298:32
-    │
-298 │                      reserve1: self.reserve1)
+296 │                      reserve1: self.reserve1)
     │                                ^^^^^^^^^^^^^ u256: Storage { nonce: Some(8) } => Value
 
 note: 
-    ┌─ uniswap.fe:294:9
+    ┌─ uniswap.fe:292:9
     │  
-294 │ ╭         self._update(ctx,
-295 │ │                      balance0: token0.balanceOf(ctx.self_address()),
-296 │ │                      balance1: token1.balanceOf(ctx.self_address()),
-297 │ │                      reserve0: self.reserve0,
-298 │ │                      reserve1: self.reserve1)
+292 │ ╭         self._update(ctx,
+293 │ │                      balance0: token0.balanceOf(ctx.self_address()),
+294 │ │                      balance1: token1.balanceOf(ctx.self_address()),
+295 │ │                      reserve0: self.reserve0,
+296 │ │                      reserve1: self.reserve1)
     │ ╰─────────────────────────────────────────────^ (): Value
 
 note: 
-    ┌─ uniswap.fe:303:5
+    ┌─ uniswap.fe:301:5
     │
-303 │     fee_to: address
+301 │     fee_to: address
     │     ^^^^^^^^^^^^^^^ address
-304 │     fee_to_setter: address
+302 │     fee_to_setter: address
     │     ^^^^^^^^^^^^^^^^^^^^^^ address
-305 │ 
-306 │     pairs: Map<address, Map<address, address>>
+303 │ 
+304 │     pairs: Map<address, Map<address, address>>
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Map<address, Map<address, address>>
-307 │ 
-308 │     all_pairs: Array<address, 100>
+305 │ 
+306 │     all_pairs: Array<address, 100>
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<address, 100>
-309 │     pair_counter: u256
+307 │     pair_counter: u256
     │     ^^^^^^^^^^^^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:312:9
+    ┌─ uniswap.fe:310:9
     │
-312 │         idx token0: address
+310 │         idx token0: address
     │         ^^^^^^^^^^^^^^^^^^^ address
-313 │         idx token1: address
+311 │         idx token1: address
     │         ^^^^^^^^^^^^^^^^^^^ address
-314 │         pair: address
+312 │         pair: address
     │         ^^^^^^^^^^^^^ address
-315 │         index: u256
+313 │         index: u256
     │         ^^^^^^^^^^^ u256
 
 note: 
-    ┌─ uniswap.fe:322:5
+    ┌─ uniswap.fe:320:5
     │  
-322 │ ╭     pub fn fee_to(self) -> address {
-323 │ │         return self.fee_to
-324 │ │     }
+320 │ ╭     pub fn fee_to(self) -> address {
+321 │ │         return self.fee_to
+322 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-    ┌─ uniswap.fe:323:16
+    ┌─ uniswap.fe:321:16
     │
-323 │         return self.fee_to
+321 │         return self.fee_to
     │                ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:323:16
+    ┌─ uniswap.fe:321:16
     │
-323 │         return self.fee_to
+321 │         return self.fee_to
     │                ^^^^^^^^^^^ address: Storage { nonce: Some(0) } => Value
 
 note: 
-    ┌─ uniswap.fe:326:5
+    ┌─ uniswap.fe:324:5
     │  
-326 │ ╭     pub fn fee_to_setter(self) -> address {
-327 │ │         return self.fee_to_setter
-328 │ │     }
+324 │ ╭     pub fn fee_to_setter(self) -> address {
+325 │ │         return self.fee_to_setter
+326 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [] -> address
 
 note: 
-    ┌─ uniswap.fe:327:16
+    ┌─ uniswap.fe:325:16
     │
-327 │         return self.fee_to_setter
+325 │         return self.fee_to_setter
     │                ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:327:16
+    ┌─ uniswap.fe:325:16
     │
-327 │         return self.fee_to_setter
+325 │         return self.fee_to_setter
     │                ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Value
 
 note: 
-    ┌─ uniswap.fe:330:5
+    ┌─ uniswap.fe:328:5
     │  
-330 │ ╭     pub fn all_pairs_length(self) -> u256 {
-331 │ │         return self.pair_counter
-332 │ │     }
+328 │ ╭     pub fn all_pairs_length(self) -> u256 {
+329 │ │         return self.pair_counter
+330 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [] -> u256
 
 note: 
-    ┌─ uniswap.fe:331:16
+    ┌─ uniswap.fe:329:16
     │
-331 │         return self.pair_counter
+329 │         return self.pair_counter
     │                ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:331:16
+    ┌─ uniswap.fe:329:16
     │
-331 │         return self.pair_counter
+329 │         return self.pair_counter
     │                ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
 
 note: 
-    ┌─ uniswap.fe:334:5
+    ┌─ uniswap.fe:332:5
     │  
-334 │ ╭     pub fn create_pair(self, ctx: Context, _ token_a: address, _ token_b: address) -> address {
-335 │ │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
-336 │ │ 
-337 │ │         let token0: address = token_a if token_a < token_b else token_b
+332 │ ╭     pub fn create_pair(self, ctx: Context, _ token_a: address, _ token_b: address) -> address {
+333 │ │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
+334 │ │ 
+335 │ │         let token0: address = token_a if token_a < token_b else token_b
     · │
-352 │ │         return address(pair)
-353 │ │     }
+350 │ │         return address(pair)
+351 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: Some("_"), name: token_a, typ: address }, { label: Some("_"), name: token_b, typ: address }] -> address
 
 note: 
-    ┌─ uniswap.fe:337:13
+    ┌─ uniswap.fe:335:13
     │
-337 │         let token0: address = token_a if token_a < token_b else token_b
+335 │         let token0: address = token_a if token_a < token_b else token_b
     │             ^^^^^^ address
-338 │         let token1: address = token_a if token_a > token_b else token_b
+336 │         let token1: address = token_a if token_a > token_b else token_b
     │             ^^^^^^ address
     ·
-342 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+340 │         let salt: u256 = keccak256((token0, token1).abi_encode())
     │             ^^^^ u256
-343 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
+341 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
     │             ^^^^ UniswapV2Pair
 
 note: 
-    ┌─ uniswap.fe:335:16
+    ┌─ uniswap.fe:333:16
     │
-335 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
+333 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
     │                ^^^^^^^    ^^^^^^^ address: Value
     │                │           
     │                address: Value
 
 note: 
-    ┌─ uniswap.fe:335:16
+    ┌─ uniswap.fe:333:16
     │
-335 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
+333 │         assert token_a != token_b, "UniswapV2: IDENTICAL_ADDRESSES"
     │                ^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ String<30>: Memory
     │                │                    
     │                bool: Value
-336 │ 
-337 │         let token0: address = token_a if token_a < token_b else token_b
+334 │ 
+335 │         let token0: address = token_a if token_a < token_b else token_b
     │                                          ^^^^^^^   ^^^^^^^ address: Value
     │                                          │          
     │                                          address: Value
 
 note: 
-    ┌─ uniswap.fe:337:31
+    ┌─ uniswap.fe:335:31
     │
-337 │         let token0: address = token_a if token_a < token_b else token_b
+335 │         let token0: address = token_a if token_a < token_b else token_b
     │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value
     │                               │          │                       
     │                               │          bool: Value
     │                               address: Value
 
 note: 
-    ┌─ uniswap.fe:337:31
+    ┌─ uniswap.fe:335:31
     │
-337 │         let token0: address = token_a if token_a < token_b else token_b
+335 │         let token0: address = token_a if token_a < token_b else token_b
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value
-338 │         let token1: address = token_a if token_a > token_b else token_b
+336 │         let token1: address = token_a if token_a > token_b else token_b
     │                                          ^^^^^^^   ^^^^^^^ address: Value
     │                                          │          
     │                                          address: Value
 
 note: 
-    ┌─ uniswap.fe:338:31
+    ┌─ uniswap.fe:336:31
     │
-338 │         let token1: address = token_a if token_a > token_b else token_b
+336 │         let token1: address = token_a if token_a > token_b else token_b
     │                               ^^^^^^^    ^^^^^^^^^^^^^^^^^      ^^^^^^^ address: Value
     │                               │          │                       
     │                               │          bool: Value
     │                               address: Value
 
 note: 
-    ┌─ uniswap.fe:338:31
+    ┌─ uniswap.fe:336:31
     │
-338 │         let token1: address = token_a if token_a > token_b else token_b
+336 │         let token1: address = token_a if token_a > token_b else token_b
     │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ address: Value
-339 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
+337 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
     │                ^^^^^^            ^ u256: Value
     │                │                  
     │                address: Value
 
 note: 
-    ┌─ uniswap.fe:339:26
+    ┌─ uniswap.fe:337:26
     │
-339 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
+337 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
     │                          ^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:339:16
+    ┌─ uniswap.fe:337:16
     │
-339 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
+337 │         assert token0 != address(0), "UniswapV2: ZERO_ADDRESS"
     │                ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^ String<23>: Memory
     │                │                      
     │                bool: Value
-340 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+338 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
     │                ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:340:16
+    ┌─ uniswap.fe:338:16
     │
-340 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+338 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
     │                ^^^^^^^^^^ ^^^^^^ address: Value
     │                │           
     │                Map<address, Map<address, address>>: Storage { nonce: Some(2) }
 
 note: 
-    ┌─ uniswap.fe:340:16
+    ┌─ uniswap.fe:338:16
     │
-340 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+338 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
     │                ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
     │                │                   
     │                Map<address, address>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:340:16
+    ┌─ uniswap.fe:338:16
     │
-340 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+338 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^            ^ u256: Value
     │                │                                      
     │                address: Storage { nonce: None } => Value
 
 note: 
-    ┌─ uniswap.fe:340:46
+    ┌─ uniswap.fe:338:46
     │
-340 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+338 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
     │                                              ^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:340:16
+    ┌─ uniswap.fe:338:16
     │
-340 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
+338 │         assert self.pairs[token0][token1] == address(0), "UniswapV2: PAIR_EXISTS"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^ String<22>: Memory
     │                │                                          
     │                bool: Value
-341 │ 
-342 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+339 │ 
+340 │         let salt: u256 = keccak256((token0, token1).abi_encode())
     │                                     ^^^^^^  ^^^^^^ address: Value
     │                                     │        
     │                                     address: Value
 
 note: 
-    ┌─ uniswap.fe:342:36
+    ┌─ uniswap.fe:340:36
     │
-342 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+340 │         let salt: u256 = keccak256((token0, token1).abi_encode())
     │                                    ^^^^^^^^^^^^^^^^ (address, address): Memory
 
 note: 
-    ┌─ uniswap.fe:342:36
+    ┌─ uniswap.fe:340:36
     │
-342 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+340 │         let salt: u256 = keccak256((token0, token1).abi_encode())
     │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 64>: Memory
 
 note: 
-    ┌─ uniswap.fe:342:26
+    ┌─ uniswap.fe:340:26
     │
-342 │         let salt: u256 = keccak256((token0, token1).abi_encode())
+340 │         let salt: u256 = keccak256((token0, token1).abi_encode())
     │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
-343 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
+341 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
     │                                                         ^^^  ^  ^^^^ u256: Value
     │                                                         │    │   
     │                                                         │    u256: Value
     │                                                         Context: Memory
 
 note: 
-    ┌─ uniswap.fe:343:35
+    ┌─ uniswap.fe:341:35
     │
-343 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
+341 │         let pair: UniswapV2Pair = UniswapV2Pair.create2(ctx, 0, salt)
     │                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UniswapV2Pair: Value
-344 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
+342 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
     │         ^^^^            ^^^                ^^^^^^ address: Value
     │         │               │                   
     │         │               Context: Memory
     │         UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:344:38
+    ┌─ uniswap.fe:342:38
     │
-344 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
+342 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
     │                                      ^^^^^^^^^^^^^                ^^^^^^ address: Value
     │                                      │                             
     │                                      ERC20: Value
 
 note: 
-    ┌─ uniswap.fe:344:61
+    ┌─ uniswap.fe:342:61
     │
-344 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
+342 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
     │                                                             ^^^^^^^^^^^^^ ERC20: Value
+
+note: 
+    ┌─ uniswap.fe:342:9
+    │
+342 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
+343 │ 
+344 │         self.pairs[token0][token1] = address(pair)
+    │         ^^^^ UniswapV2Factory: Value
 
 note: 
     ┌─ uniswap.fe:344:9
     │
-344 │         pair.initialize(ctx, token0: ERC20(token0), token1: ERC20(token1))
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (): Value
-345 │ 
-346 │         self.pairs[token0][token1] = address(pair)
-    │         ^^^^ UniswapV2Factory: Value
-
-note: 
-    ┌─ uniswap.fe:346:9
-    │
-346 │         self.pairs[token0][token1] = address(pair)
+344 │         self.pairs[token0][token1] = address(pair)
     │         ^^^^^^^^^^ ^^^^^^ address: Value
     │         │           
     │         Map<address, Map<address, address>>: Storage { nonce: Some(2) }
 
 note: 
-    ┌─ uniswap.fe:346:9
+    ┌─ uniswap.fe:344:9
     │
-346 │         self.pairs[token0][token1] = address(pair)
+344 │         self.pairs[token0][token1] = address(pair)
     │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
     │         │                   
     │         Map<address, address>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:346:9
+    ┌─ uniswap.fe:344:9
     │
-346 │         self.pairs[token0][token1] = address(pair)
+344 │         self.pairs[token0][token1] = address(pair)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │                                     
     │         address: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:346:38
+    ┌─ uniswap.fe:344:38
     │
-346 │         self.pairs[token0][token1] = address(pair)
+344 │         self.pairs[token0][token1] = address(pair)
     │                                      ^^^^^^^^^^^^^ address: Value
-347 │         self.pairs[token1][token0] = address(pair)
+345 │         self.pairs[token1][token0] = address(pair)
     │         ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:347:9
+    ┌─ uniswap.fe:345:9
     │
-347 │         self.pairs[token1][token0] = address(pair)
+345 │         self.pairs[token1][token0] = address(pair)
     │         ^^^^^^^^^^ ^^^^^^ address: Value
     │         │           
     │         Map<address, Map<address, address>>: Storage { nonce: Some(2) }
 
 note: 
-    ┌─ uniswap.fe:347:9
+    ┌─ uniswap.fe:345:9
     │
-347 │         self.pairs[token1][token0] = address(pair)
+345 │         self.pairs[token1][token0] = address(pair)
     │         ^^^^^^^^^^^^^^^^^^ ^^^^^^ address: Value
     │         │                   
     │         Map<address, address>: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:347:9
+    ┌─ uniswap.fe:345:9
     │
-347 │         self.pairs[token1][token0] = address(pair)
+345 │         self.pairs[token1][token0] = address(pair)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │                                     
     │         address: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:347:38
+    ┌─ uniswap.fe:345:38
     │
-347 │         self.pairs[token1][token0] = address(pair)
+345 │         self.pairs[token1][token0] = address(pair)
     │                                      ^^^^^^^^^^^^^ address: Value
-348 │         self.all_pairs[self.pair_counter] = address(pair)
+346 │         self.all_pairs[self.pair_counter] = address(pair)
     │         ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:348:9
+    ┌─ uniswap.fe:346:9
     │
-348 │         self.all_pairs[self.pair_counter] = address(pair)
+346 │         self.all_pairs[self.pair_counter] = address(pair)
     │         ^^^^^^^^^^^^^^ ^^^^ UniswapV2Factory: Value
     │         │               
     │         Array<address, 100>: Storage { nonce: Some(3) }
 
 note: 
-    ┌─ uniswap.fe:348:24
+    ┌─ uniswap.fe:346:24
     │
-348 │         self.all_pairs[self.pair_counter] = address(pair)
+346 │         self.all_pairs[self.pair_counter] = address(pair)
     │                        ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
 
 note: 
-    ┌─ uniswap.fe:348:9
+    ┌─ uniswap.fe:346:9
     │
-348 │         self.all_pairs[self.pair_counter] = address(pair)
+346 │         self.all_pairs[self.pair_counter] = address(pair)
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^           ^^^^ UniswapV2Pair: Value
     │         │                                            
     │         address: Storage { nonce: None }
 
 note: 
-    ┌─ uniswap.fe:348:45
+    ┌─ uniswap.fe:346:45
     │
-348 │         self.all_pairs[self.pair_counter] = address(pair)
+346 │         self.all_pairs[self.pair_counter] = address(pair)
     │                                             ^^^^^^^^^^^^^ address: Value
-349 │         self.pair_counter = self.pair_counter + 1
+347 │         self.pair_counter = self.pair_counter + 1
     │         ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:349:9
+    ┌─ uniswap.fe:347:9
     │
-349 │         self.pair_counter = self.pair_counter + 1
+347 │         self.pair_counter = self.pair_counter + 1
     │         ^^^^^^^^^^^^^^^^^   ^^^^ UniswapV2Factory: Value
     │         │                    
     │         u256: Storage { nonce: Some(4) }
 
 note: 
-    ┌─ uniswap.fe:349:29
+    ┌─ uniswap.fe:347:29
     │
-349 │         self.pair_counter = self.pair_counter + 1
+347 │         self.pair_counter = self.pair_counter + 1
     │                             ^^^^^^^^^^^^^^^^^   ^ u256: Value
     │                             │                    
     │                             u256: Storage { nonce: Some(4) } => Value
 
 note: 
-    ┌─ uniswap.fe:349:29
+    ┌─ uniswap.fe:347:29
     │
-349 │         self.pair_counter = self.pair_counter + 1
+347 │         self.pair_counter = self.pair_counter + 1
     │                             ^^^^^^^^^^^^^^^^^^^^^ u256: Value
-350 │ 
-351 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
+348 │ 
+349 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
     │                          ^^^  ^^^^^^  ^^^^^^                ^^^^ UniswapV2Pair: Value
     │                          │    │       │                      
     │                          │    │       address: Value
@@ -3111,260 +3111,260 @@ note:
     │                          Context: Memory
 
 note: 
-    ┌─ uniswap.fe:351:53
+    ┌─ uniswap.fe:349:53
     │
-351 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
+349 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
     │                                                     ^^^^^^^^^^^^^         ^^^^ UniswapV2Factory: Value
     │                                                     │                      
     │                                                     address: Value
 
 note: 
-    ┌─ uniswap.fe:351:75
+    ┌─ uniswap.fe:349:75
     │
-351 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
+349 │         emit PairCreated(ctx, token0, token1, pair: address(pair), index: self.pair_counter)
     │                                                                           ^^^^^^^^^^^^^^^^^ u256: Storage { nonce: Some(4) } => Value
-352 │         return address(pair)
+350 │         return address(pair)
     │                        ^^^^ UniswapV2Pair: Value
 
 note: 
-    ┌─ uniswap.fe:352:16
+    ┌─ uniswap.fe:350:16
     │
-352 │         return address(pair)
+350 │         return address(pair)
     │                ^^^^^^^^^^^^^ address: Value
 
 note: 
-    ┌─ uniswap.fe:355:5
+    ┌─ uniswap.fe:353:5
     │  
-355 │ ╭     pub fn set_fee_to(self, ctx: Context, fee_to: address) {
-356 │ │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
-357 │ │         self.fee_to = fee_to
-358 │ │     }
+353 │ ╭     pub fn set_fee_to(self, ctx: Context, fee_to: address) {
+354 │ │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+355 │ │         self.fee_to = fee_to
+356 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: fee_to, typ: address }] -> ()
 
 note: 
-    ┌─ uniswap.fe:356:16
+    ┌─ uniswap.fe:354:16
     │
-356 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+354 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^ Context: Memory
 
 note: 
-    ┌─ uniswap.fe:356:16
+    ┌─ uniswap.fe:354:16
     │
-356 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+354 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^^^^^^^    ^^^^ UniswapV2Factory: Value
     │                │                    
     │                address: Value
 
 note: 
-    ┌─ uniswap.fe:356:36
+    ┌─ uniswap.fe:354:36
     │
-356 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+354 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
     │                                    ^^^^^^^^^^^^^^^^^^ address: Storage { nonce: Some(1) } => Value
 
 note: 
-    ┌─ uniswap.fe:356:16
+    ┌─ uniswap.fe:354:16
     │
-356 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
+354 │         assert ctx.msg_sender() == self.fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory
     │                │                                        
     │                bool: Value
-357 │         self.fee_to = fee_to
+355 │         self.fee_to = fee_to
     │         ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:357:9
+    ┌─ uniswap.fe:355:9
     │
-357 │         self.fee_to = fee_to
+355 │         self.fee_to = fee_to
     │         ^^^^^^^^^^^   ^^^^^^ address: Value
     │         │              
     │         address: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ uniswap.fe:360:5
+    ┌─ uniswap.fe:358:5
     │  
-360 │ ╭     pub fn set_fee_to_setter(self, ctx: Context, fee_to_setter: address) {
-361 │ │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
-362 │ │         self.fee_to_setter = fee_to_setter
-363 │ │     }
+358 │ ╭     pub fn set_fee_to_setter(self, ctx: Context, fee_to_setter: address) {
+359 │ │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
+360 │ │         self.fee_to_setter = fee_to_setter
+361 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: ctx, typ: Context }, { label: None, name: fee_to_setter, typ: address }] -> ()
 
 note: 
-    ┌─ uniswap.fe:361:16
+    ┌─ uniswap.fe:359:16
     │
-361 │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
+359 │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^ Context: Memory
 
 note: 
-    ┌─ uniswap.fe:361:16
+    ┌─ uniswap.fe:359:16
     │
-361 │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
+359 │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^^^^^^^    ^^^^^^^^^^^^^ address: Value
     │                │                    
     │                address: Value
 
 note: 
-    ┌─ uniswap.fe:361:16
+    ┌─ uniswap.fe:359:16
     │
-361 │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
+359 │         assert ctx.msg_sender() == fee_to_setter, "UniswapV2: FORBIDDEN"
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^ String<20>: Memory
     │                │                                   
     │                bool: Value
-362 │         self.fee_to_setter = fee_to_setter
+360 │         self.fee_to_setter = fee_to_setter
     │         ^^^^ UniswapV2Factory: Value
 
 note: 
-    ┌─ uniswap.fe:362:9
+    ┌─ uniswap.fe:360:9
     │
-362 │         self.fee_to_setter = fee_to_setter
+360 │         self.fee_to_setter = fee_to_setter
     │         ^^^^^^^^^^^^^^^^^^   ^^^^^^^^^^^^^ address: Value
     │         │                     
     │         address: Storage { nonce: Some(1) }
 
 note: 
-    ┌─ uniswap.fe:366:1
+    ┌─ uniswap.fe:364:1
     │  
-366 │ ╭ fn sqrt(_ val: u256) -> u256 {
-367 │ │     let z: u256
-368 │ │     if val > 3 {
-369 │ │         z = val
+364 │ ╭ fn sqrt(_ val: u256) -> u256 {
+365 │ │     let z: u256
+366 │ │     if val > 3 {
+367 │ │         z = val
     · │
-378 │ │     return z
-379 │ │ }
+376 │ │     return z
+377 │ │ }
     │ ╰─^ self: None, params: [{ label: Some("_"), name: val, typ: u256 }] -> u256
 
 note: 
-    ┌─ uniswap.fe:367:9
+    ┌─ uniswap.fe:365:9
     │
-367 │     let z: u256
+365 │     let z: u256
     │         ^ u256
     ·
-370 │         let x: u256 = val / 2 + 1
+368 │         let x: u256 = val / 2 + 1
     │             ^ u256
 
 note: 
-    ┌─ uniswap.fe:368:8
+    ┌─ uniswap.fe:366:8
     │
-368 │     if val > 3 {
+366 │     if val > 3 {
     │        ^^^   ^ u256: Value
     │        │      
     │        u256: Value
 
 note: 
-    ┌─ uniswap.fe:368:8
+    ┌─ uniswap.fe:366:8
     │
-368 │     if val > 3 {
+366 │     if val > 3 {
     │        ^^^^^^^ bool: Value
-369 │         z = val
+367 │         z = val
     │         ^   ^^^ u256: Value
     │         │    
     │         u256: Value
-370 │         let x: u256 = val / 2 + 1
+368 │         let x: u256 = val / 2 + 1
     │                       ^^^   ^ u256: Value
     │                       │      
     │                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:370:23
+    ┌─ uniswap.fe:368:23
     │
-370 │         let x: u256 = val / 2 + 1
+368 │         let x: u256 = val / 2 + 1
     │                       ^^^^^^^   ^ u256: Value
     │                       │          
     │                       u256: Value
 
 note: 
-    ┌─ uniswap.fe:370:23
+    ┌─ uniswap.fe:368:23
     │
-370 │         let x: u256 = val / 2 + 1
+368 │         let x: u256 = val / 2 + 1
     │                       ^^^^^^^^^^^ u256: Value
-371 │         while x < z {
+369 │         while x < z {
     │               ^   ^ u256: Value
     │               │    
     │               u256: Value
 
 note: 
-    ┌─ uniswap.fe:371:15
+    ┌─ uniswap.fe:369:15
     │
-371 │         while x < z {
+369 │         while x < z {
     │               ^^^^^ bool: Value
-372 │             z = x
+370 │             z = x
     │             ^   ^ u256: Value
     │             │    
     │             u256: Value
-373 │             x = (val / x + x) / 2
+371 │             x = (val / x + x) / 2
     │             ^    ^^^   ^ u256: Value
     │             │    │      
     │             │    u256: Value
     │             u256: Value
 
 note: 
-    ┌─ uniswap.fe:373:18
+    ┌─ uniswap.fe:371:18
     │
-373 │             x = (val / x + x) / 2
+371 │             x = (val / x + x) / 2
     │                  ^^^^^^^   ^ u256: Value
     │                  │          
     │                  u256: Value
 
 note: 
-    ┌─ uniswap.fe:373:17
+    ┌─ uniswap.fe:371:17
     │
-373 │             x = (val / x + x) / 2
+371 │             x = (val / x + x) / 2
     │                 ^^^^^^^^^^^^^   ^ u256: Value
     │                 │                
     │                 u256: Value
 
 note: 
-    ┌─ uniswap.fe:373:17
+    ┌─ uniswap.fe:371:17
     │
-373 │             x = (val / x + x) / 2
+371 │             x = (val / x + x) / 2
     │                 ^^^^^^^^^^^^^^^^^ u256: Value
-374 │         }
-375 │     } else if val != 0 {
+372 │         }
+373 │     } else if val != 0 {
     │               ^^^    ^ u256: Value
     │               │       
     │               u256: Value
 
 note: 
-    ┌─ uniswap.fe:375:15
+    ┌─ uniswap.fe:373:15
     │
-375 │     } else if val != 0 {
+373 │     } else if val != 0 {
     │               ^^^^^^^^ bool: Value
-376 │         z = 1
+374 │         z = 1
     │         ^   ^ u256: Value
     │         │    
     │         u256: Value
-377 │     }
-378 │     return z
+375 │     }
+376 │     return z
     │            ^ u256: Value
 
 note: 
-    ┌─ uniswap.fe:381:1
+    ┌─ uniswap.fe:379:1
     │  
-381 │ ╭ fn min(_ x: u256, _ y: u256) -> u256 {
-382 │ │     return x if x < y else y
-383 │ │ }
+379 │ ╭ fn min(_ x: u256, _ y: u256) -> u256 {
+380 │ │     return x if x < y else y
+381 │ │ }
     │ ╰─^ self: None, params: [{ label: Some("_"), name: x, typ: u256 }, { label: Some("_"), name: y, typ: u256 }] -> u256
 
 note: 
-    ┌─ uniswap.fe:382:17
+    ┌─ uniswap.fe:380:17
     │
-382 │     return x if x < y else y
+380 │     return x if x < y else y
     │                 ^   ^ u256: Value
     │                 │    
     │                 u256: Value
 
 note: 
-    ┌─ uniswap.fe:382:12
+    ┌─ uniswap.fe:380:12
     │
-382 │     return x if x < y else y
+380 │     return x if x < y else y
     │            ^    ^^^^^      ^ u256: Value
     │            │    │           
     │            │    bool: Value
     │            u256: Value
 
 note: 
-    ┌─ uniswap.fe:382:12
+    ┌─ uniswap.fe:380:12
     │
-382 │     return x if x < y else y
+380 │     return x if x < y else y
     │            ^^^^^^^^^^^^^^^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
@@ -4,9 +4,9 @@ expression: error_string_ingot(&path)
 
 ---
 error: the type `MyInt` is private
-  ┌─ compile_errors/bad_visibility/src/main.fe:8:33
+  ┌─ compile_errors/bad_visibility/src/main.fe:7:33
   │
-8 │     pub fn priv_type_alias() -> MyInt {
+7 │     pub fn priv_type_alias() -> MyInt {
   │                                 ^^^^^ this type is not `pub`
   │
   ┌─ compile_errors/bad_visibility/src/foo.fe:1:6
@@ -18,9 +18,9 @@ error: the type `MyInt` is private
   = Hint: use `pub` to make `MyInt` visible from outside of `foo`
 
 error: the type `MyInt` is private
-  ┌─ compile_errors/bad_visibility/src/main.fe:9:16
+  ┌─ compile_errors/bad_visibility/src/main.fe:8:16
   │
-9 │         let x: MyInt = 1
+8 │         let x: MyInt = 1
   │                ^^^^^ this type is not `pub`
   │
   ┌─ compile_errors/bad_visibility/src/foo.fe:1:6
@@ -32,9 +32,9 @@ error: the type `MyInt` is private
   = Hint: use `pub` to make `MyInt` visible from outside of `foo`
 
 error: the constant `MY_CONST` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:14:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:13:16
    │
-14 │         return MY_CONST
+13 │         return MY_CONST
    │                ^^^^^^^^ this constant is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:3:7
@@ -46,9 +46,9 @@ error: the constant `MY_CONST` is private
    = Hint: use `pub` to make `MY_CONST` visible from outside of `foo`
 
 error: the constant `MY_CONST` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:14:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:13:16
    │
-14 │         return MY_CONST
+13 │         return MY_CONST
    │                ^^^^^^^^ this constant is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:3:1
@@ -60,9 +60,9 @@ error: the constant `MY_CONST` is private
    = Hint: use `pub const MY_CONST` to make `MY_CONST` visible from outside of `foo`
 
 error: the event `MyEvent` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:18:14
+   ┌─ compile_errors/bad_visibility/src/main.fe:17:14
    │
-18 │         emit MyEvent(ctx, x: 1)
+17 │         emit MyEvent(ctx, x: 1)
    │              ^^^^^^^ this event is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:7:7
@@ -74,9 +74,9 @@ error: the event `MyEvent` is private
    = Hint: use `pub` to make `MyEvent` visible from outside of `foo`
 
 error: the event `MyEvent` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:18:14
+   ┌─ compile_errors/bad_visibility/src/main.fe:17:14
    │
-18 │         emit MyEvent(ctx, x: 1)
+17 │         emit MyEvent(ctx, x: 1)
    │              ^^^^^^^ this event is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:7:1
@@ -90,15 +90,15 @@ error: the event `MyEvent` is private
    = Hint: use `pub event MyEvent` to make `MyEvent` visible from outside of `foo`
 
 error: cannot find value `ctx` in this scope
-   ┌─ compile_errors/bad_visibility/src/main.fe:18:22
+   ┌─ compile_errors/bad_visibility/src/main.fe:17:22
    │
-18 │         emit MyEvent(ctx, x: 1)
+17 │         emit MyEvent(ctx, x: 1)
    │                      ^^^ undefined
 
 error: the struct `MyStruct` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:22:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:21:16
    │
-22 │         let s: MyStruct = MyStruct(x: 1)
+21 │         let s: MyStruct = MyStruct(x: 1)
    │                ^^^^^^^^ this struct is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:11:8
@@ -110,9 +110,9 @@ error: the struct `MyStruct` is private
    = Hint: use `pub` to make `MyStruct` visible from outside of `foo`
 
 error: the struct `MyStruct` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:22:27
+   ┌─ compile_errors/bad_visibility/src/main.fe:21:27
    │
-22 │         let s: MyStruct = MyStruct(x: 1)
+21 │         let s: MyStruct = MyStruct(x: 1)
    │                           ^^^^^^^^ this struct is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:11:8
@@ -132,9 +132,9 @@ error: Can not call private constructor of struct `MyStruct`
    = Suggestion: implement a method `new(...)` on struct `MyStruct` to call the constructor and return the struct
 
 error: the function `my_func` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:26:9
+   ┌─ compile_errors/bad_visibility/src/main.fe:25:9
    │
-26 │         my_func()
+25 │         my_func()
    │         ^^^^^^^ this function is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:15:4
@@ -146,9 +146,9 @@ error: the function `my_func` is private
    = Hint: use `pub` to make `my_func` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:30:16
+   ┌─ compile_errors/bad_visibility/src/main.fe:29:16
    │
-30 │         let _: MyContract = MyContract(addr)
+29 │         let _: MyContract = MyContract(addr)
    │                ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:17:10
@@ -160,9 +160,9 @@ error: the type `MyContract` is private
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:30:29
+   ┌─ compile_errors/bad_visibility/src/main.fe:29:29
    │
-30 │         let _: MyContract = MyContract(addr)
+29 │         let _: MyContract = MyContract(addr)
    │                             ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:17:10
@@ -174,9 +174,9 @@ error: the type `MyContract` is private
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:31:9
+   ┌─ compile_errors/bad_visibility/src/main.fe:30:9
    │
-31 │         MyContract.create(ctx, 1)
+30 │         MyContract.create(ctx, 1)
    │         ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:17:10

--- a/crates/analyzer/tests/snapshots/errors__call_call_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_call_on_external_contract.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `__call__()` is not directly callable
-   ┌─ compile_errors/call_call_on_external_contract.fe:12:13
+   ┌─ compile_errors/call_call_on_external_contract.fe:10:13
    │
-12 │         foo.__call__()
+10 │         foo.__call__()
    │             ^^^^^^^^
    │
    = Note: `__call__` is not part of the contract's interface, and can't be called.

--- a/crates/analyzer/tests/snapshots/errors__call_create2_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_create2_with_wrong_type.snap
@@ -4,23 +4,23 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: incorrect type for argument to `Bar.create2`
-  ┌─ compile_errors/call_create2_with_wrong_type.fe:7:26
+  ┌─ compile_errors/call_create2_with_wrong_type.fe:5:26
   │
-7 │         Bar.create2(ctx, true, 1)
+5 │         Bar.create2(ctx, true, 1)
   │                          ^^^^ this has type `bool`; expected a number
 
 error: `create2` expects 3 arguments, but 2 were provided
-  ┌─ compile_errors/call_create2_with_wrong_type.fe:8:13
+  ┌─ compile_errors/call_create2_with_wrong_type.fe:6:13
   │
-8 │         Bar.create2(ctx, 1)  // agroce //447
+6 │         Bar.create2(ctx, 1)  // agroce //447
   │             ^^^^^^^ ---  - supplied 2 arguments
   │             │             
   │             expects 3 arguments
 
 error: `create2` expects 3 arguments, but 1 was provided
-  ┌─ compile_errors/call_create2_with_wrong_type.fe:9:13
+  ┌─ compile_errors/call_create2_with_wrong_type.fe:7:13
   │
-9 │         Bar.create2(ctx)
+7 │         Bar.create2(ctx)
   │             ^^^^^^^ --- supplied 1 argument
   │             │        
   │             expects 3 arguments

--- a/crates/analyzer/tests/snapshots/errors__call_create_with_wrong_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_create_with_wrong_type.snap
@@ -4,15 +4,15 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: incorrect type for argument to `Bar.create`
-  ┌─ compile_errors/call_create_with_wrong_type.fe:7:25
+  ┌─ compile_errors/call_create_with_wrong_type.fe:5:25
   │
-7 │         Bar.create(ctx, true)
+5 │         Bar.create(ctx, true)
   │                         ^^^^ this has type `bool`; expected a number
 
 error: `create` expects 2 arguments, but 1 was provided
-  ┌─ compile_errors/call_create_with_wrong_type.fe:8:13
+  ┌─ compile_errors/call_create_with_wrong_type.fe:6:13
   │
-8 │         Bar.create(ctx)     // agroce //447
+6 │         Bar.create(ctx)     // agroce //447
   │             ^^^^^^ --- supplied 1 argument
   │             │       
   │             expects 2 arguments

--- a/crates/analyzer/tests/snapshots/errors__call_event_with_wrong_types.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_event_with_wrong_types.snap
@@ -4,15 +4,15 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: incorrect type for `MyEvent` argument `val_1`
-   ┌─ compile_errors/call_event_with_wrong_types.fe:10:34
-   │
-10 │         emit MyEvent(ctx, val_1: "foo bar", val_2: 1000)
-   │                                  ^^^^^^^^^ this has type `String<7>`; expected type `String<5>`
+  ┌─ compile_errors/call_event_with_wrong_types.fe:8:34
+  │
+8 │         emit MyEvent(ctx, val_1: "foo bar", val_2: 1000)
+  │                                  ^^^^^^^^^ this has type `String<7>`; expected type `String<5>`
 
 error: literal out of range for `u8`
-   ┌─ compile_errors/call_event_with_wrong_types.fe:10:52
-   │
-10 │         emit MyEvent(ctx, val_1: "foo bar", val_2: 1000)
-   │                                                    ^^^^ does not fit into type `u8`
+  ┌─ compile_errors/call_event_with_wrong_types.fe:8:52
+  │
+8 │         emit MyEvent(ctx, val_1: "foo bar", val_2: 1000)
+  │                                                    ^^^^ does not fit into type `u8`
 
 

--- a/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_non_pub_fn_on_external_contract.snap
@@ -4,12 +4,12 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: the function `do_private_thingz` on `type Foo` is private
-   ┌─ compile_errors/call_non_pub_fn_on_external_contract.fe:13:25
+   ┌─ compile_errors/call_non_pub_fn_on_external_contract.fe:11:25
    │
- 6 │     fn do_private_thingz(self) {
+ 4 │     fn do_private_thingz(self) {
    │        ----------------- `do_private_thingz` is defined here
    ·
-13 │         Foo(address(0)).do_private_thingz()
+11 │         Foo(address(0)).do_private_thingz()
    │                         ^^^^^^^^^^^^^^^^^ this function is not `pub`
    │
    = `do_private_thingz` can only be called from other functions within `Foo`

--- a/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_undefined_function_on_external_contract.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: No function `doesnt_exist` exists on type `Foo`
-  ┌─ compile_errors/call_undefined_function_on_external_contract.fe:9:25
+  ┌─ compile_errors/call_undefined_function_on_external_contract.fe:7:25
   │
-9 │         Foo(address(0)).doesnt_exist()
+7 │         Foo(address(0)).doesnt_exist()
   │                         ^^^^^^^^^^^^ undefined function
 
 

--- a/crates/analyzer/tests/snapshots/errors__circular_dependency_create.snap
+++ b/crates/analyzer/tests/snapshots/errors__circular_dependency_create.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `Foo.create(...)` called within `Foo` creates an illegal circular dependency
-  ┌─ compile_errors/circular_dependency_create.fe:5:28
+  ┌─ compile_errors/circular_dependency_create.fe:3:28
   │
-5 │         let foo: Foo = Foo.create(ctx, 0)
+3 │         let foo: Foo = Foo.create(ctx, 0)
   │                            ^^^^^^ Contract creation
   │
   = Note: Consider using a dedicated factory contract to create instances of `Foo`

--- a/crates/analyzer/tests/snapshots/errors__circular_dependency_create2.snap
+++ b/crates/analyzer/tests/snapshots/errors__circular_dependency_create2.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `Foo.create2(...)` called within `Foo` creates an illegal circular dependency
-  ┌─ compile_errors/circular_dependency_create2.fe:5:28
+  ┌─ compile_errors/circular_dependency_create2.fe:3:28
   │
-5 │         let foo: Foo = Foo.create2(ctx, 2, 0)
+3 │         let foo: Foo = Foo.create2(ctx, 2, 0)
   │                            ^^^^^^^ Contract creation
   │
   = Note: Consider using a dedicated factory contract to create instances of `Foo`

--- a/crates/analyzer/tests/snapshots/errors__ctx_builtins_param_incorrect_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_builtins_param_incorrect_type.snap
@@ -4,37 +4,37 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `Barn` expects 1 argument, but 2 were provided
-   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:13:35
+   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:11:35
    │
-13 │         let existing_barn: Barn = Barn("hello world", address(0))
+11 │         let existing_barn: Barn = Barn("hello world", address(0))
    │                                   ^^^^ -------------  ---------- supplied 2 arguments
    │                                   │                    
    │                                   expects 1 argument
 
 error: type mismatch
-   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:13:40
+   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:11:40
    │
-13 │         let existing_barn: Barn = Barn("hello world", address(0))
+11 │         let existing_barn: Barn = Barn("hello world", address(0))
    │                                        ^^^^^^^^^^^^^ this has type `String<11>`; expected type `address`
 
 error: incorrect type for argument to `Barn.create`
-   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:14:46
+   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:12:46
    │
-14 │         let created_barn: Barn = Barn.create(address(26), 0)
+12 │         let created_barn: Barn = Barn.create(address(26), 0)
    │                                              ^^^^^^^^^^^ this has type `address`; expected `Context`
 
 error: missing argument label
-   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:15:27
+   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:13:27
    │
-15 │         emit WorldMessage(42, message: "hello world")
+13 │         emit WorldMessage(42, message: "hello world")
    │                           ^ add `ctx:` here
    │
    = Note: this label is optional if the argument is a variable named `ctx`.
 
 error: incorrect type for `WorldMessage` argument `ctx`
-   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:15:27
+   ┌─ compile_errors/ctx_builtins_param_incorrect_type.fe:13:27
    │
-15 │         emit WorldMessage(42, message: "hello world")
+13 │         emit WorldMessage(42, message: "hello world")
    │                           ^^ this has type `u256`; expected type `Context`
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_init.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_init.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: unsafe function `Context` can only be called in an unsafe function or block
-  ┌─ compile_errors/ctx_init.fe:5:33
+  ┌─ compile_errors/ctx_init.fe:3:33
   │
-5 │         let fake_ctx: Context = Context()
+3 │         let fake_ctx: Context = Context()
   │                                 ^^^^^^^ call to unsafe function
   │
   = Hint: put this call in an `unsafe` block if you're confident that it's safe to use here

--- a/crates/analyzer/tests/snapshots/errors__ctx_missing_create.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_missing_create.snap
@@ -4,17 +4,17 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `create` expects 2 arguments, but 1 was provided
-  ┌─ compile_errors/ctx_missing_create.fe:9:13
+  ┌─ compile_errors/ctx_missing_create.fe:7:13
   │
-9 │         Foo.create(0)
+7 │         Foo.create(0)
   │             ^^^^^^ - supplied 1 argument
   │             │       
   │             expects 2 arguments
 
 error: incorrect type for argument to `Foo.create`
-  ┌─ compile_errors/ctx_missing_create.fe:9:20
+  ┌─ compile_errors/ctx_missing_create.fe:7:20
   │
-9 │         Foo.create(0)
+7 │         Foo.create(0)
   │                    ^ this has type `u256`; expected `Context`
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_missing_event.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_missing_event.snap
@@ -4,25 +4,25 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `HelloWorld` expects 2 arguments, but 1 was provided
-  ┌─ compile_errors/ctx_missing_event.fe:9:14
+  ┌─ compile_errors/ctx_missing_event.fe:7:14
   │
-9 │         emit HelloWorld(message: "hello world")
+7 │         emit HelloWorld(message: "hello world")
   │              ^^^^^^^^^^ ---------------------- supplied 1 argument
   │              │           
   │              expects 2 arguments
 
 error: argument label mismatch
-  ┌─ compile_errors/ctx_missing_event.fe:9:25
+  ┌─ compile_errors/ctx_missing_event.fe:7:25
   │
-9 │         emit HelloWorld(message: "hello world")
+7 │         emit HelloWorld(message: "hello world")
   │                         ^^^^^^^ expected `ctx`
   │
   = Note: arguments must be provided in order.
 
 error: incorrect type for `HelloWorld` argument `ctx`
-  ┌─ compile_errors/ctx_missing_event.fe:9:34
+  ┌─ compile_errors/ctx_missing_event.fe:7:34
   │
-9 │         emit HelloWorld(message: "hello world")
+7 │         emit HelloWorld(message: "hello world")
   │                                  ^^^^^^^^^^^^^ this has type `String<11>`; expected type `Context`
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_missing_internal_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_missing_internal_call.snap
@@ -4,12 +4,12 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `bar` expects 1 argument, but 0 were provided
-   ┌─ compile_errors/ctx_missing_internal_call.fe:6:12
-   │
- 6 │     pub fn bar(ctx: Context) -> u256 {
-   │            ^^^ expects 1 argument
-   ·
-11 │         self.favorite_number = bar()
-   │                                   -- supplied 0 arguments
+  ┌─ compile_errors/ctx_missing_internal_call.fe:4:12
+  │
+4 │     pub fn bar(ctx: Context) -> u256 {
+  │            ^^^ expects 1 argument
+  ·
+9 │         self.favorite_number = bar()
+  │                                   -- supplied 0 arguments
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_missing_load.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_missing_load.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: type mismatch
-  ┌─ compile_errors/ctx_missing_load.fe:9:13
+  ┌─ compile_errors/ctx_missing_load.fe:7:13
   │
-9 │         Foo(0)
+7 │         Foo(0)
   │             ^ this has type `u256`; expected type `address`
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_not_after_self.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_not_after_self.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: invalid parameter order
-  ┌─ compile_errors/ctx_not_after_self.fe:4:33
+  ┌─ compile_errors/ctx_not_after_self.fe:2:33
   │
-4 │     pub fn bar(self, baz: u256, ctx: Context) {}
+2 │     pub fn bar(self, baz: u256, ctx: Context) {}
   │                                 ^^^^^^^^^^^^ `ctx: Context` must be placed after the `self` parameter
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_not_first.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_not_first.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: invalid parameter order
-  ┌─ compile_errors/ctx_not_first.fe:4:27
+  ┌─ compile_errors/ctx_not_first.fe:2:27
   │
-4 │     pub fn bar(baz: u256, ctx: Context) {}
+2 │     pub fn bar(baz: u256, ctx: Context) {}
   │                           ^^^^^^^^^^^^ `ctx: Context` must be the first parameter
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_pure.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_pure.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `ctx` cannot be passed into pure functions
-  ┌─ compile_errors/ctx_pure.fe:3:12
+  ┌─ compile_errors/ctx_pure.fe:1:12
   │
-3 │ pub fn foo(ctx: Context) {}
+1 │ pub fn foo(ctx: Context) {}
   │            ^^^^^^^^^^^^ `ctx` can only be passed into contract functions
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_undeclared.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_undeclared.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: cannot find value `ctx` in this scope
-  ┌─ compile_errors/ctx_undeclared.fe:5:16
+  ┌─ compile_errors/ctx_undeclared.fe:3:16
   │
-5 │         return ctx.block_number()
+3 │         return ctx.block_number()
   │                ^^^ undefined
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_undefined_create.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_undefined_create.snap
@@ -11,18 +11,10 @@ error: `create` expects 2 arguments, but 1 was provided
   │             │       
   │             expects 2 arguments
 
-error: `Context` is not defined
-  ┌─ compile_errors/ctx_undefined_create.fe:5:19
+error: incorrect type for argument to `Bar.create`
+  ┌─ compile_errors/ctx_undefined_create.fe:5:20
   │
-4 │     pub fn baz() {
-  │            ---
-  │            │
-  │            Note: declare `ctx` in this function signature
-  │            Example: `pub fn foo(ctx: Context, ...)`
 5 │         Bar.create(0)
-  │                   ^^^ `ctx` must be defined and passed into the function
-  │
-  = Note: import context with `use std::context::Context`
-  = Example: `MyContract.create(ctx, 0)`
+  │                    ^ this has type `u256`; expected `Context`
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_undefined_create2.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_undefined_create2.snap
@@ -11,18 +11,10 @@ error: `create2` expects 3 arguments, but 2 were provided
   │             │           
   │             expects 3 arguments
 
-error: `Context` is not defined
-  ┌─ compile_errors/ctx_undefined_create2.fe:5:20
+error: incorrect type for argument to `Bar.create2`
+  ┌─ compile_errors/ctx_undefined_create2.fe:5:21
   │
-4 │     pub fn baz() {
-  │            ---
-  │            │
-  │            Note: declare `ctx` in this function signature
-  │            Example: `pub fn foo(ctx: Context, ...)`
 5 │         Bar.create2(0, 0)
-  │                    ^^^^^^ `ctx` must be defined and passed into the function
-  │
-  = Note: import context with `use std::context::Context`
-  = Example: `MyContract.create(ctx, 0)`
+  │                     ^ this has type `u256`; expected `Context`
 
 

--- a/crates/analyzer/tests/snapshots/errors__ctx_undefined_event.snap
+++ b/crates/analyzer/tests/snapshots/errors__ctx_undefined_event.snap
@@ -3,18 +3,26 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
-error: `Context` is not defined
-  ┌─ compile_errors/ctx_undefined_event.fe:7:9
+error: `YouWin` expects 2 arguments, but 1 was provided
+  ┌─ compile_errors/ctx_undefined_event.fe:7:14
   │
-6 │     pub fn bar() {
-  │            ---
-  │            │
-  │            Note: declare `ctx` in this function signature
-  │            Example: `pub fn foo(ctx: Context, ...)`
 7 │         emit YouWin(amount: 42)
-  │         ^^^^^^^^^^^^^^^^^^^^^^^ `ctx` must be defined and passed into the event
+  │              ^^^^^^ ---------- supplied 1 argument
+  │              │       
+  │              expects 2 arguments
+
+error: argument label mismatch
+  ┌─ compile_errors/ctx_undefined_event.fe:7:21
   │
-  = Note: import context with `use std::context::Context`
-  = Example: emit MyEvent(ctx, ...)
+7 │         emit YouWin(amount: 42)
+  │                     ^^^^^^ expected `ctx`
+  │
+  = Note: arguments must be provided in order.
+
+error: incorrect type for `YouWin` argument `ctx`
+  ┌─ compile_errors/ctx_undefined_event.fe:7:29
+  │
+7 │         emit YouWin(amount: 42)
+  │                             ^^ this has type `u256`; expected type `Context`
 
 

--- a/crates/analyzer/tests/snapshots/errors__emit_bad_args.snap
+++ b/crates/analyzer/tests/snapshots/errors__emit_bad_args.snap
@@ -4,41 +4,41 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `Foo` expects 4 arguments, but 5 were provided
-   ┌─ compile_errors/emit_bad_args.fe:11:14
-   │
-11 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
-   │              ^^^ ---  ------  -----  -------  ---- supplied 5 arguments
-   │              │                                 
-   │              expects 4 arguments
+  ┌─ compile_errors/emit_bad_args.fe:9:14
+  │
+9 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
+  │              ^^^ ---  ------  -----  -------  ---- supplied 5 arguments
+  │              │                                 
+  │              expects 4 arguments
 
 error: missing argument label
-   ┌─ compile_errors/emit_bad_args.fe:11:23
-   │
-11 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
-   │                       ^ add `x:` here
-   │
-   = Note: this label is optional if the argument is a variable named `x`.
+  ┌─ compile_errors/emit_bad_args.fe:9:23
+  │
+9 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
+  │                       ^ add `x:` here
+  │
+  = Note: this label is optional if the argument is a variable named `x`.
 
 error: incorrect type for `Foo` argument `x`
-   ┌─ compile_errors/emit_bad_args.fe:11:23
-   │
-11 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
-   │                       ^^^^^^ this has type `(u256, u256)`; expected type `address`
+  ┌─ compile_errors/emit_bad_args.fe:9:23
+  │
+9 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
+  │                       ^^^^^^ this has type `(u256, u256)`; expected type `address`
 
 error: argument label mismatch
-   ┌─ compile_errors/emit_bad_args.fe:11:31
-   │
-11 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
-   │                               ^ expected `y`
-   │
-   = Note: arguments must be provided in order.
+  ┌─ compile_errors/emit_bad_args.fe:9:31
+  │
+9 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
+  │                               ^ expected `y`
+  │
+  = Note: arguments must be provided in order.
 
 error: argument label mismatch
-   ┌─ compile_errors/emit_bad_args.fe:11:38
-   │
-11 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
-   │                                      ^ expected `z`
-   │
-   = Note: arguments must be provided in order.
+  ┌─ compile_errors/emit_bad_args.fe:9:38
+  │
+9 │         emit Foo(ctx, (1, 2), z: 10, y: true, x: 5)
+  │                                      ^ expected `z`
+  │
+  = Note: arguments must be provided in order.
 
 

--- a/crates/analyzer/tests/snapshots/errors__external_call_type_error.snap
+++ b/crates/analyzer/tests/snapshots/errors__external_call_type_error.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: incorrect type for `bar` argument at position 0
-  ┌─ compile_errors/external_call_type_error.fe:9:29
+  ┌─ compile_errors/external_call_type_error.fe:7:29
   │
-9 │         Foo(address(0)).bar("hello world")
+7 │         Foo(address(0)).bar("hello world")
   │                             ^^^^^^^^^^^^^ this has type `String<11>`; expected type `u256`
 
 

--- a/crates/analyzer/tests/snapshots/errors__external_call_wrong_number_of_params.snap
+++ b/crates/analyzer/tests/snapshots/errors__external_call_wrong_number_of_params.snap
@@ -4,17 +4,17 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `bar` expects 2 arguments, but 1 was provided
-  ┌─ compile_errors/external_call_wrong_number_of_params.fe:9:25
+  ┌─ compile_errors/external_call_wrong_number_of_params.fe:7:25
   │
-9 │         Foo(address(0)).bar(42)
+7 │         Foo(address(0)).bar(42)
   │                         ^^^ -- supplied 1 argument
   │                         │    
   │                         expects 2 arguments
 
 error: missing argument label
-  ┌─ compile_errors/external_call_wrong_number_of_params.fe:9:29
+  ┌─ compile_errors/external_call_wrong_number_of_params.fe:7:29
   │
-9 │         Foo(address(0)).bar(42)
+7 │         Foo(address(0)).bar(42)
   │                             ^ add `a:` here
   │
   = Note: this label is optional if the argument is a variable named `a`.

--- a/crates/analyzer/tests/snapshots/errors__init_call_on_external_contract.snap
+++ b/crates/analyzer/tests/snapshots/errors__init_call_on_external_contract.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `__init__()` is not directly callable
-   ┌─ compile_errors/init_call_on_external_contract.fe:13:13
+   ┌─ compile_errors/init_call_on_external_contract.fe:11:13
    │
-13 │         foo.__init__()
+11 │         foo.__init__()
    │             ^^^^^^^^
    │
    = Note: `__init__` is the constructor function, and can't be called at runtime.

--- a/crates/analyzer/tests/snapshots/errors__invalid_impl_location.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_impl_location.snap
@@ -4,9 +4,9 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: illegal `impl`. Either type or trait must be in the same ingot as the `impl`
-  ┌─ compile_errors/invalid_impl_location.fe:4:1
+  ┌─ compile_errors/invalid_impl_location.fe:3:1
   │
-4 │ impl Dummy for Context {}
+3 │ impl Dummy for Context {}
   │ ^^^^^^^^^^^^^^^^^^^^^^ Neither `Context` nor `Dummy` are in the ingot of the `impl` block
 
 

--- a/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_external_contract_call.snap
+++ b/crates/analyzer/tests/snapshots/errors__mislabeled_call_args_external_contract_call.snap
@@ -4,29 +4,29 @@ expression: "error_string(&path, test_files::fixture(path))"
 
 ---
 error: `Foo` expects 1 argument, but 2 were provided
-   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:11:9
-   │
-11 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
-   │         ^^^ ---  ---------- supplied 2 arguments
-   │         │         
-   │         expects 1 argument
+  ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:9:9
+  │
+9 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
+  │         ^^^ ---  ---------- supplied 2 arguments
+  │         │         
+  │         expects 1 argument
 
 error: type mismatch
-   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:11:13
-   │
-11 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
-   │             ^^^ this has type `Context`; expected type `address`
+  ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:9:13
+  │
+9 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
+  │             ^^^ this has type `Context`; expected type `address`
 
 error: argument label mismatch
-   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:11:34
-   │
-11 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
-   │                                  ^^^^^^^^^^^^ expected `val1`
+  ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:9:34
+  │
+9 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
+  │                                  ^^^^^^^^^^^^ expected `val1`
 
 error: argument label mismatch
-   ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:11:51
-   │
-11 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
-   │                                                   ^^^^^^^^^^ expected `val2`
+  ┌─ compile_errors/mislabeled_call_args_external_contract_call.fe:9:51
+  │
+9 │         Foo(ctx, address(0)).baz(doesnt_exist: 1, me_neither: 4)
+  │                                                   ^^^^^^^^^^ expected `val2`
 
 

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -252,8 +252,6 @@ contract GuestBook {
 }"# }
 
 test_parse! { module_level_events, try_parse_module, r#"
-use std::context::Context
-
 event Transfer {
     idx sender: address
     idx receiver: address

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__module_level_events.snap
@@ -1,60 +1,18 @@
 ---
 source: crates/parser/tests/cases/parse_ast.rs
-expression: "ast_string(stringify!(module_level_events), try_parse_module,\n    r#\"\nuse std::context::Context\n\nevent Transfer {\n    idx sender: address\n    idx receiver: address\n    value: u256\n}\ncontract Foo {\n    fn transfer(ctx: Context, to: address, value: u256) {\n        emit Transfer(ctx, sender: msg.sender, receiver: to, value)\n    }\n}\n\"#)"
+expression: "ast_string(stringify!(module_level_events), try_parse_module,\n    r#\"\nevent Transfer {\n    idx sender: address\n    idx receiver: address\n    value: u256\n}\ncontract Foo {\n    fn transfer(ctx: Context, to: address, value: u256) {\n        emit Transfer(ctx, sender: msg.sender, receiver: to, value)\n    }\n}\n\"#)"
 
 ---
 Node(
   kind: Module(
     body: [
-      Use(Node(
-        kind: Use(
-          tree: Node(
-            kind: Simple(
-              path: Path(
-                segments: [
-                  Node(
-                    kind: "std",
-                    span: Span(
-                      start: 5,
-                      end: 8,
-                    ),
-                  ),
-                  Node(
-                    kind: "context",
-                    span: Span(
-                      start: 10,
-                      end: 17,
-                    ),
-                  ),
-                  Node(
-                    kind: "Context",
-                    span: Span(
-                      start: 19,
-                      end: 26,
-                    ),
-                  ),
-                ],
-              ),
-              rename: None,
-            ),
-            span: Span(
-              start: 5,
-              end: 26,
-            ),
-          ),
-        ),
-        span: Span(
-          start: 1,
-          end: 26,
-        ),
-      )),
       Event(Node(
         kind: Event(
           name: Node(
             kind: "Transfer",
             span: Span(
-              start: 34,
-              end: 42,
+              start: 7,
+              end: 15,
             ),
           ),
           fields: [
@@ -64,8 +22,8 @@ Node(
                 name: Node(
                   kind: "sender",
                   span: Span(
-                    start: 53,
-                    end: 59,
+                    start: 26,
+                    end: 32,
                   ),
                 ),
                 typ: Node(
@@ -73,14 +31,14 @@ Node(
                     base: "address",
                   ),
                   span: Span(
-                    start: 61,
-                    end: 68,
+                    start: 34,
+                    end: 41,
                   ),
                 ),
               ),
               span: Span(
-                start: 49,
-                end: 68,
+                start: 22,
+                end: 41,
               ),
             ),
             Node(
@@ -89,8 +47,8 @@ Node(
                 name: Node(
                   kind: "receiver",
                   span: Span(
-                    start: 77,
-                    end: 85,
+                    start: 50,
+                    end: 58,
                   ),
                 ),
                 typ: Node(
@@ -98,14 +56,14 @@ Node(
                     base: "address",
                   ),
                   span: Span(
-                    start: 87,
-                    end: 94,
+                    start: 60,
+                    end: 67,
                   ),
                 ),
               ),
               span: Span(
-                start: 73,
-                end: 94,
+                start: 46,
+                end: 67,
               ),
             ),
             Node(
@@ -114,8 +72,8 @@ Node(
                 name: Node(
                   kind: "value",
                   span: Span(
-                    start: 99,
-                    end: 104,
+                    start: 72,
+                    end: 77,
                   ),
                 ),
                 typ: Node(
@@ -123,22 +81,22 @@ Node(
                     base: "u256",
                   ),
                   span: Span(
-                    start: 106,
-                    end: 110,
+                    start: 79,
+                    end: 83,
                   ),
                 ),
               ),
               span: Span(
-                start: 99,
-                end: 110,
+                start: 72,
+                end: 83,
               ),
             ),
           ],
           pub_qual: None,
         ),
         span: Span(
-          start: 28,
-          end: 112,
+          start: 1,
+          end: 85,
         ),
       )),
       Contract(Node(
@@ -146,8 +104,8 @@ Node(
           name: Node(
             kind: "Foo",
             span: Span(
-              start: 122,
-              end: 125,
+              start: 95,
+              end: 98,
             ),
           ),
           fields: [],
@@ -161,15 +119,15 @@ Node(
                     name: Node(
                       kind: "transfer",
                       span: Span(
-                        start: 135,
-                        end: 143,
+                        start: 108,
+                        end: 116,
                       ),
                     ),
                     generic_params: Node(
                       kind: [],
                       span: Span(
-                        start: 135,
-                        end: 143,
+                        start: 108,
+                        end: 116,
                       ),
                     ),
                     args: [
@@ -179,8 +137,8 @@ Node(
                           name: Node(
                             kind: "ctx",
                             span: Span(
-                              start: 144,
-                              end: 147,
+                              start: 117,
+                              end: 120,
                             ),
                           ),
                           typ: Node(
@@ -188,14 +146,14 @@ Node(
                               base: "Context",
                             ),
                             span: Span(
-                              start: 149,
-                              end: 156,
+                              start: 122,
+                              end: 129,
                             ),
                           ),
                         )),
                         span: Span(
-                          start: 144,
-                          end: 156,
+                          start: 117,
+                          end: 129,
                         ),
                       ),
                       Node(
@@ -204,8 +162,8 @@ Node(
                           name: Node(
                             kind: "to",
                             span: Span(
-                              start: 158,
-                              end: 160,
+                              start: 131,
+                              end: 133,
                             ),
                           ),
                           typ: Node(
@@ -213,14 +171,14 @@ Node(
                               base: "address",
                             ),
                             span: Span(
-                              start: 162,
-                              end: 169,
+                              start: 135,
+                              end: 142,
                             ),
                           ),
                         )),
                         span: Span(
-                          start: 158,
-                          end: 169,
+                          start: 131,
+                          end: 142,
                         ),
                       ),
                       Node(
@@ -229,8 +187,8 @@ Node(
                           name: Node(
                             kind: "value",
                             span: Span(
-                              start: 171,
-                              end: 176,
+                              start: 144,
+                              end: 149,
                             ),
                           ),
                           typ: Node(
@@ -238,22 +196,22 @@ Node(
                               base: "u256",
                             ),
                             span: Span(
-                              start: 178,
-                              end: 182,
+                              start: 151,
+                              end: 155,
                             ),
                           ),
                         )),
                         span: Span(
-                          start: 171,
-                          end: 182,
+                          start: 144,
+                          end: 155,
                         ),
                       ),
                     ],
                     return_type: None,
                   ),
                   span: Span(
-                    start: 132,
-                    end: 183,
+                    start: 105,
+                    end: 156,
                   ),
                 ),
                 body: [
@@ -262,8 +220,8 @@ Node(
                       name: Node(
                         kind: "Transfer",
                         span: Span(
-                          start: 199,
-                          end: 207,
+                          start: 172,
+                          end: 180,
                         ),
                       ),
                       args: Node(
@@ -274,14 +232,14 @@ Node(
                               value: Node(
                                 kind: Name("ctx"),
                                 span: Span(
-                                  start: 208,
-                                  end: 211,
+                                  start: 181,
+                                  end: 184,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 208,
-                              end: 211,
+                              start: 181,
+                              end: 184,
                             ),
                           ),
                           Node(
@@ -289,8 +247,8 @@ Node(
                               label: Some(Node(
                                 kind: "sender",
                                 span: Span(
-                                  start: 213,
-                                  end: 219,
+                                  start: 186,
+                                  end: 192,
                                 ),
                               )),
                               value: Node(
@@ -298,27 +256,27 @@ Node(
                                   value: Node(
                                     kind: Name("msg"),
                                     span: Span(
-                                      start: 221,
-                                      end: 224,
+                                      start: 194,
+                                      end: 197,
                                     ),
                                   ),
                                   attr: Node(
                                     kind: "sender",
                                     span: Span(
-                                      start: 225,
-                                      end: 231,
+                                      start: 198,
+                                      end: 204,
                                     ),
                                   ),
                                 ),
                                 span: Span(
-                                  start: 221,
-                                  end: 231,
+                                  start: 194,
+                                  end: 204,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 213,
-                              end: 231,
+                              start: 186,
+                              end: 204,
                             ),
                           ),
                           Node(
@@ -326,21 +284,21 @@ Node(
                               label: Some(Node(
                                 kind: "receiver",
                                 span: Span(
-                                  start: 233,
-                                  end: 241,
+                                  start: 206,
+                                  end: 214,
                                 ),
                               )),
                               value: Node(
                                 kind: Name("to"),
                                 span: Span(
-                                  start: 243,
-                                  end: 245,
+                                  start: 216,
+                                  end: 218,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 233,
-                              end: 245,
+                              start: 206,
+                              end: 218,
                             ),
                           ),
                           Node(
@@ -349,47 +307,47 @@ Node(
                               value: Node(
                                 kind: Name("value"),
                                 span: Span(
-                                  start: 247,
-                                  end: 252,
+                                  start: 220,
+                                  end: 225,
                                 ),
                               ),
                             ),
                             span: Span(
-                              start: 247,
-                              end: 252,
+                              start: 220,
+                              end: 225,
                             ),
                           ),
                         ],
                         span: Span(
-                          start: 207,
-                          end: 253,
+                          start: 180,
+                          end: 226,
                         ),
                       ),
                     ),
                     span: Span(
-                      start: 194,
-                      end: 253,
+                      start: 167,
+                      end: 226,
                     ),
                   ),
                 ],
               ),
               span: Span(
-                start: 132,
-                end: 259,
+                start: 105,
+                end: 232,
               ),
             )),
           ],
           pub_qual: None,
         ),
         span: Span(
-          start: 113,
-          end: 261,
+          start: 86,
+          end: 234,
         ),
       )),
     ],
   ),
   span: Span(
     start: 0,
-    end: 261,
+    end: 234,
   ),
 )

--- a/crates/parser/tests/cases/snapshots/cases__print_ast__erc20.snap
+++ b/crates/parser/tests/cases/snapshots/cases__print_ast__erc20.snap
@@ -3,8 +3,6 @@ source: crates/parser/tests/cases/print_ast.rs
 expression: "parse_and_print(\"demos/erc20_token.fe\", src)"
 
 ---
-use std::context::Context
-
 contract ERC20 {
     _balances: Map<address, u256>
     _allowances: Map<address, Map<address, u256>>

--- a/crates/parser/tests/cases/snapshots/cases__print_ast__guest_book.snap
+++ b/crates/parser/tests/cases/snapshots/cases__print_ast__guest_book.snap
@@ -3,8 +3,6 @@ source: crates/parser/tests/cases/print_ast.rs
 expression: "parse_and_print(\"demos/guest_book.fe\", src)"
 
 ---
-use std::context::Context
-
 contract GuestBook {
     messages: Map<address, String<100>>
 

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
@@ -1,5 +1,4 @@
 use foo::{MyInt, MY_CONST, MyEvent, MyStruct, MyTrait, my_func, MyContract}
-use std::context::Context
 
 struct SomeThing {}
 impl MyTrait for SomeThing {}

--- a/crates/test-files/fixtures/compile_errors/call_call_on_external_contract.fe
+++ b/crates/test-files/fixtures/compile_errors/call_call_on_external_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn __call__() {}
 

--- a/crates/test-files/fixtures/compile_errors/call_create2_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_create2_with_wrong_type.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Bar {}
 
 contract Foo {

--- a/crates/test-files/fixtures/compile_errors/call_create_with_wrong_type.fe
+++ b/crates/test-files/fixtures/compile_errors/call_create_with_wrong_type.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Bar {}
 
 contract Foo {

--- a/crates/test-files/fixtures/compile_errors/call_event_with_wrong_types.fe
+++ b/crates/test-files/fixtures/compile_errors/call_event_with_wrong_types.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     event MyEvent {
         val_1: String<5>

--- a/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_external_contract.fe
+++ b/crates/test-files/fixtures/compile_errors/call_non_pub_fn_on_external_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     val: u8
 

--- a/crates/test-files/fixtures/compile_errors/call_undefined_function_on_external_contract.fe
+++ b/crates/test-files/fixtures/compile_errors/call_undefined_function_on_external_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     val: u8
 }

--- a/crates/test-files/fixtures/compile_errors/circular_dependency_create.fe
+++ b/crates/test-files/fixtures/compile_errors/circular_dependency_create.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(ctx: Context) -> address {
         let foo: Foo = Foo.create(ctx, 0)

--- a/crates/test-files/fixtures/compile_errors/circular_dependency_create2.fe
+++ b/crates/test-files/fixtures/compile_errors/circular_dependency_create2.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(ctx: Context) -> address {
         let foo: Foo = Foo.create2(ctx, 2, 0)

--- a/crates/test-files/fixtures/compile_errors/ctx_builtins_param_incorrect_type.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_builtins_param_incorrect_type.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 event WorldMessage {
     message: String<42>
 }

--- a/crates/test-files/fixtures/compile_errors/ctx_init.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_init.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar() {
         let fake_ctx: Context = Context()

--- a/crates/test-files/fixtures/compile_errors/ctx_missing_create.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_missing_create.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar() {}
 }

--- a/crates/test-files/fixtures/compile_errors/ctx_missing_event.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_missing_event.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 event HelloWorld {
     message: String<26>
 }

--- a/crates/test-files/fixtures/compile_errors/ctx_missing_internal_call.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_missing_internal_call.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     favorite_number: u256
 

--- a/crates/test-files/fixtures/compile_errors/ctx_missing_load.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_missing_load.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar() {}
 }

--- a/crates/test-files/fixtures/compile_errors/ctx_not_after_self.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_not_after_self.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(self, baz: u256, ctx: Context) {}
 }

--- a/crates/test-files/fixtures/compile_errors/ctx_not_first.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_not_first.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(baz: u256, ctx: Context) {}
 }

--- a/crates/test-files/fixtures/compile_errors/ctx_pure.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_pure.fe
@@ -1,3 +1,1 @@
-use std::context::Context
-
 pub fn foo(ctx: Context) {}

--- a/crates/test-files/fixtures/compile_errors/ctx_undeclared.fe
+++ b/crates/test-files/fixtures/compile_errors/ctx_undeclared.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar() -> u256 {
         return ctx.block_number()

--- a/crates/test-files/fixtures/compile_errors/emit_bad_args.fe
+++ b/crates/test-files/fixtures/compile_errors/emit_bad_args.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Bar {
     event Foo {
         idx x: address

--- a/crates/test-files/fixtures/compile_errors/external_call_type_error.fe
+++ b/crates/test-files/fixtures/compile_errors/external_call_type_error.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(self, _ a: u256) {}
 }

--- a/crates/test-files/fixtures/compile_errors/external_call_wrong_number_of_params.fe
+++ b/crates/test-files/fixtures/compile_errors/external_call_wrong_number_of_params.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(self, a: u256, b: u256) {}
 }

--- a/crates/test-files/fixtures/compile_errors/init_call_on_external_contract.fe
+++ b/crates/test-files/fixtures/compile_errors/init_call_on_external_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn __init__() {}
 

--- a/crates/test-files/fixtures/compile_errors/invalid_impl_location.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_impl_location.fe
@@ -1,4 +1,3 @@
 use std::traits::Dummy
-use std::context::Context
 
 impl Dummy for Context {}

--- a/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
+++ b/crates/test-files/fixtures/compile_errors/mislabeled_call_args_external_contract_call.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     val: u8
 

--- a/crates/test-files/fixtures/demos/erc20_token.fe
+++ b/crates/test-files/fixtures/demos/erc20_token.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract ERC20 {
     _balances: Map<address, u256>
     _allowances: Map<address, Map<address, u256>>

--- a/crates/test-files/fixtures/demos/guest_book.fe
+++ b/crates/test-files/fixtures/demos/guest_book.fe
@@ -1,7 +1,3 @@
-// Context is a struct provided by the standard library
-// that gives access to various features of the EVM
-use std::context::Context
-
 // The `contract` keyword defines a new contract type
 contract GuestBook {
     // Strings are generic over a constant number
@@ -13,6 +9,8 @@ contract GuestBook {
         book_msg: String<100>
     }
 
+    // Context is a struct provided by the standard library
+    // that gives access to various features of the EVM
     pub fn sign(self, ctx: Context, book_msg: String<100>) {
         // All storage access is explicit using `self.<some-key>`
         self.messages[ctx.msg_sender()] = book_msg

--- a/crates/test-files/fixtures/demos/simple_open_auction.fe
+++ b/crates/test-files/fixtures/demos/simple_open_auction.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 // errors
 struct AuctionAlreadyEnded {}
 struct AuctionNotYetEnded {}

--- a/crates/test-files/fixtures/demos/uniswap.fe
+++ b/crates/test-files/fixtures/demos/uniswap.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract ERC20 {
     pub fn balanceOf(self, _ account: address) -> u256 {
         return 0

--- a/crates/test-files/fixtures/differential/storage_and_memory.fe
+++ b/crates/test-files/fixtures/differential/storage_and_memory.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 struct MyStruct {
     my_num: u256
     my_num2: u8

--- a/crates/test-files/fixtures/features/balances.fe
+++ b/crates/test-files/fixtures/features/balances.fe
@@ -1,5 +1,4 @@
 use std::evm::{balance, balance_of}
-use std::context::Context
 
 contract Foo {
     pub fn my_balance(self, ctx: Context) -> u256 {

--- a/crates/test-files/fixtures/features/create2_contract.fe
+++ b/crates/test-files/fixtures/features/create2_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn get_my_num() -> u256 {
         return 42

--- a/crates/test-files/fixtures/features/create_contract.fe
+++ b/crates/test-files/fixtures/features/create_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn get_my_num() -> u256 {
         return 42

--- a/crates/test-files/fixtures/features/create_contract_from_init.fe
+++ b/crates/test-files/fixtures/features/create_contract_from_init.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn get_my_num() -> u256 {
         return 42

--- a/crates/test-files/fixtures/features/ctx_init_in_call.fe
+++ b/crates/test-files/fixtures/features/ctx_init_in_call.fe
@@ -1,4 +1,3 @@
-use std::context::Context
 use std::evm
 
 contract Foo {

--- a/crates/test-files/fixtures/features/ctx_param_external_func_call.fe
+++ b/crates/test-files/fixtures/features/ctx_param_external_func_call.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     my_num: u256
 

--- a/crates/test-files/fixtures/features/ctx_param_internal_func_call.fe
+++ b/crates/test-files/fixtures/features/ctx_param_internal_func_call.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     is_true: bool
 

--- a/crates/test-files/fixtures/features/ctx_param_simple.fe
+++ b/crates/test-files/fixtures/features/ctx_param_simple.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(self, ctx: Context) -> u256 {
         return ctx.block_number()

--- a/crates/test-files/fixtures/features/events.fe
+++ b/crates/test-files/fixtures/features/events.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     event Nums {
         idx num1: u256

--- a/crates/test-files/fixtures/features/external_contract.fe
+++ b/crates/test-files/fixtures/features/external_contract.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     event MyEvent {
         my_num: u256

--- a/crates/test-files/fixtures/features/module_level_events.fe
+++ b/crates/test-files/fixtures/features/module_level_events.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 event Transfer {
     idx sender: address
     idx receiver: address

--- a/crates/test-files/fixtures/features/ownable.fe
+++ b/crates/test-files/fixtures/features/ownable.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Ownable {
     _owner: address
 

--- a/crates/test-files/fixtures/features/return_builtin_attributes.fe
+++ b/crates/test-files/fixtures/features/return_builtin_attributes.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn base_fee(ctx: Context) -> u256 {
         return ctx.base_fee()

--- a/crates/test-files/fixtures/features/return_msg_sig.fe
+++ b/crates/test-files/fixtures/features/return_msg_sig.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn bar(ctx: Context) -> u256 {
         return ctx.msg_sig()

--- a/crates/test-files/fixtures/features/revert.fe
+++ b/crates/test-files/fixtures/features/revert.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 struct OtherError {
     pub msg: u256
     pub val: bool

--- a/crates/test-files/fixtures/features/self_address.fe
+++ b/crates/test-files/fixtures/features/self_address.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn my_address(ctx: Context) -> address {
         return ctx.self_address()

--- a/crates/test-files/fixtures/features/send_value.fe
+++ b/crates/test-files/fixtures/features/send_value.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     pub fn send_them_wei(ctx: Context, to: address, wei: u256) {
         ctx.send_value(to, wei)

--- a/crates/test-files/fixtures/features/sized_vals_in_sto.fe
+++ b/crates/test-files/fixtures/features/sized_vals_in_sto.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     num: u256
     nums: Array<u256, 42>

--- a/crates/test-files/fixtures/features/strings.fe
+++ b/crates/test-files/fixtures/features/strings.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     event MyEvent {
         s2: String<26>

--- a/crates/test-files/fixtures/features/two_contracts.fe
+++ b/crates/test-files/fixtures/features/two_contracts.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     other: Bar
 

--- a/crates/test-files/fixtures/features/type_aliases.fe
+++ b/crates/test-files/fixtures/features/type_aliases.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 type Posts = Map<PostId, PostBody>
 
 type Scoreboard = Map<PostId, Score>

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/main.fe
@@ -4,7 +4,6 @@ use bing::Bing as Bong
 use bing::get_42_backend
 use ding::{dang::Dang as Dung, dong}
 use bing::BingContract
-use std::context::Context
 
 contract Foo {
     pub fn get_my_baz() -> Baz {

--- a/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
+++ b/crates/test-files/fixtures/ingots/pub_contract_ingot/src/main.fe
@@ -1,5 +1,4 @@
 use foo::{Foo, Bar, FooBar}
-use std::context::Context
 
 contract FooBarBing {
     pub fn get_bar() -> Bar {

--- a/crates/test-files/fixtures/lowering/base_tuple.fe
+++ b/crates/test-files/fixtures/lowering/base_tuple.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     my_tuple_field: (bool, address)
 

--- a/crates/test-files/fixtures/lowering/module_level_events.fe
+++ b/crates/test-files/fixtures/lowering/module_level_events.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 event Transfer {
     idx sender: address
     idx receiver: address

--- a/crates/test-files/fixtures/stress/abi_encoding_stress.fe
+++ b/crates/test-files/fixtures/stress/abi_encoding_stress.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 struct MyStruct {
     pub my_num: u256
     pub my_num2: u8

--- a/crates/test-files/fixtures/stress/data_copying_stress.fe
+++ b/crates/test-files/fixtures/stress/data_copying_stress.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     my_string: String<42>
     my_other_string: String<42>

--- a/crates/test-files/fixtures/stress/external_calls.fe
+++ b/crates/test-files/fixtures/stress/external_calls.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 struct SomeError {
     pub code: u256
 }

--- a/crates/test-files/fixtures/stress/tuple_stress.fe
+++ b/crates/test-files/fixtures/stress/tuple_stress.fe
@@ -1,5 +1,3 @@
-use std::context::Context
-
 contract Foo {
     my_sto_tuple: (u256, i32)
 

--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -35,8 +35,6 @@ ethsign import --keystore ~/.ethereum/keystore/
 Let's recall that we finished our guest book in the previous chapter with the following code.
 
 ```fe
-use std::context::Context
-
 contract GuestBook {
   messages: Map<address, String<100>>
 

--- a/docs/src/quickstart/first_contract.md
+++ b/docs/src/quickstart/first_contract.md
@@ -53,8 +53,6 @@ We don't need to do anything further yet with these files that the compiler prod
 Let's focus on the functionality of our world changing application and add a method to sign the guestbook.
 
 ```fe
-use std::context::Context
-
 contract GuestBook {
   messages: Map<address, String<100>>
 
@@ -101,8 +99,6 @@ Since our contract now has a public `sign` method the corresponding ABI has chan
 To make the guest book more useful we will also add a method `get_msg` to read entries from a given address.
 
 ```fe,ignore
-use std::context::Context
-
 contract GuestBook {
   messages: Map<address, String<100>>
 
@@ -137,8 +133,6 @@ When we try to return a reference type such as an array from the storage of the 
 The code should compile fine when we change it accordingly.
 
 ```fe
-use std::context::Context
-
 contract GuestBook {
   messages: Map<address, String<100>>
 

--- a/docs/src/release_notes.md
+++ b/docs/src/release_notes.md
@@ -45,7 +45,7 @@ Fe is moving fast. Read up on all the latest improvements.
   Example:
 
   ```fe
-  use std::context::Context # see issue #679
+  use std::context::Context // see issue #679
 
   contract Foo {
     pub fn emit_stuff(ctx: Context) {
@@ -165,7 +165,7 @@ Fe is moving fast. Read up on all the latest improvements.
   struct Pair {
       pub x: i256
       pub y: i256
-    
+
       pub fn new(_ x: i256, _ y: i256) -> Pair {
           return Pair(x, y)
       }
@@ -203,7 +203,7 @@ Fe is moving fast. Read up on all the latest improvements.
   e.g.
 
   ```
-  let my_array: Array<bool, 42> = [bool; 42] 
+  let my_array: Array<bool, 42> = [bool; 42]
   ```
 
   Also added checks to ensure array and struct types are initialized. These checks are currently performed at the declaration site, but will be loosened in the future. ([#747](https://github.com/ethereum/fe/issues/747))
@@ -228,16 +228,16 @@ Fe is moving fast. Read up on all the latest improvements.
 - Fix a bug that causes ICE when nested if-statement has multiple exit point.
 
   E.g. the following code would previously crash the compiler but shouldn't:
-  ```fe
+  ```fe,ignore
    pub fn foo(self) {
       if true {
-          if self.something { 
-              return 
+          if self.something {
+              return
           }
       }
       if true {
-          if self.something { 
-              return 
+          if self.something {
+              return
           }
       }
   }
@@ -268,7 +268,7 @@ Fe is moving fast. Read up on all the latest improvements.
 
 - Support for underscores in numbers to improve readability e.g. `100_000`.
 
-  Example 
+  Example
 
   ```
       let num: u256 = 1000_000_000_000
@@ -296,14 +296,14 @@ Fe is moving fast. Read up on all the latest improvements.
   ([#590](https://github.com/ethereum/fe/issues/590))
 - Reject unary minus operation if the target type is an unsigned integer number.
 
-  Code below should be reject by `fe` compiler: 
+  Code below should be reject by `fe` compiler:
 
-  ```python 
+  ```python
   contract Foo:
       pub fn bar(self) -> u32:
           let unsigned: u32 = 1
           return -unsigned
-    
+
       pub fn foo():
           let a: i32 = 1
           let b: u32 = -a
@@ -316,8 +316,8 @@ Fe is moving fast. Read up on all the latest improvements.
   ```
   struct MyArray:
       pub x: Array<i32, 2>
-    
-    
+
+
   contract Foo:
       pub fn bar(my_arr: MyArray):
           pass
@@ -329,7 +329,7 @@ Fe is moving fast. Read up on all the latest improvements.
 - Return instead of revert when contract is called without data.
 
   If a contract is called without data so that no function is invoked,
-  we would previously `revert` but that would leave us without a 
+  we would previously `revert` but that would leave us without a
   way to send ETH to a contract so instead it will cause a `return` now. ([#694](https://github.com/ethereum/fe/issues/694))
 - Resolve compiler crash when using certain reserved YUL words as struct field names.
 
@@ -418,7 +418,8 @@ Fe is moving fast. Read up on all the latest improvements.
 
     pub fn demo(self):
       transfer(address(0), wei: add(1000, 42))
-  ``` ([#397](https://github.com/ethereum/fe/issues/397))
+  ```
+  ([#397](https://github.com/ethereum/fe/issues/397))
 
 
 ### Bugfixes
@@ -449,7 +450,9 @@ Fe is moving fast. Read up on all the latest improvements.
   contract Bar:
       fn transferBar(to: address, value: u256):
           emit Transfer(sender: msg.sender, receiver: to, value)
-  ``` ([#80](https://github.com/ethereum/fe/issues/80))
+  ```
+  ([#80](https://github.com/ethereum/fe/issues/80))
+
 - The Fe standard library now includes a `std::evm` module, which provides functions that perform low-level evm operations.
   Many of these are marked `unsafe`, and thus can only be used inside of an `unsafe` function or an `unsafe` block.
 
@@ -465,7 +468,10 @@ Fe is moving fast. Read up on all the latest improvements.
   ```
 
   The global functions `balance` and `balance_of` have been removed; these can now be called as `std::evm::balance()`, etc.
-  The global function `send_value` has been ported to Fe, and is now available as `std::send_value`. ([#629](https://github.com/ethereum/fe/issues/629))
+  The global function `send_value` has been ported to Fe, and is now available
+  as `std::send_value`.
+  ([#629](https://github.com/ethereum/fe/issues/629))
+
 - Support structs that have non-base type fields in storage.
 
   Example:
@@ -532,8 +538,10 @@ Fe is moving fast. Read up on all the latest improvements.
           assert self.my_bar.something.item1
 
           return self.my_bar.name.to_mem()
-  ``` ([#636](https://github.com/ethereum/fe/issues/636))
-- Features that read and modify state outside of contracts are now implemented on a struct 
+  ```
+  ([#636](https://github.com/ethereum/fe/issues/636))
+
+- Features that read and modify state outside of contracts are now implemented on a struct
   named "Context". `Context` is included in the standard library and can be imported with
   `use std::context::Context`. Instances of `Context` are created by calls to public functions
   that declare it in the signature or by unsafe code.
@@ -588,7 +596,9 @@ Fe is moving fast. Read up on all the latest improvements.
 
       fn bar(ctx: Context) -> address:
           return ctx.self_address()
-  ``` ([#638](https://github.com/ethereum/fe/issues/638))
+  ```
+  ([#638](https://github.com/ethereum/fe/issues/638))
+
 - # Features
 
   ## Support local constant
@@ -646,7 +656,9 @@ Fe is moving fast. Read up on all the latest improvements.
   contract FOO:
       pub fn bar():
           BAR = 10
-  ``` ([#649](https://github.com/ethereum/fe/issues/649))
+  ```
+  ([#649](https://github.com/ethereum/fe/issues/649))
+
 - Argument label syntax now uses `:` instead of `=`. Example:
 
   ```
@@ -656,7 +668,9 @@ Fe is moving fast. Read up on all the latest improvements.
 
   let x: MyStruct = MyStruct(x: 10, y: 11)
   # previously:     MyStruct(x = 10, y = 11)
-  ``` ([#665](https://github.com/ethereum/fe/issues/665))
+  ```
+  ([#665](https://github.com/ethereum/fe/issues/665))
+
 - Support module-level `pub` modifier, now default visibility of items in a module is private.
 
   Example:
@@ -667,7 +681,8 @@ Fe is moving fast. Read up on all the latest improvements.
 
   # This constant can NOT be used outside of the module.
   const PRIVATE: i32 = 1
-  ``` ([#677](https://github.com/ethereum/fe/issues/677))
+  ```
+  ([#677](https://github.com/ethereum/fe/issues/677))
 
 
 ### Internal Changes - for Fe Contributors
@@ -710,7 +725,8 @@ Fe is moving fast. Read up on all the latest improvements.
       self.house = House::new(price, size)
       let can_access_price: u256 = self.house.price
       # can not access `self.house.vacant` because the field is private
-  ``` ([#214](https://github.com/ethereum/fe/issues/214))
+  ```
+  ([#214](https://github.com/ethereum/fe/issues/214))
 - Support non-base type fields in structs
 
   Support is currently limited in two ways:
@@ -721,8 +737,9 @@ Fe is moving fast. Read up on all the latest improvements.
   ```
   fn f(addr: address) -> u256:
     return u256(addr)
-  ``` ([#621](https://github.com/ethereum/fe/issues/621))
-- A special function named `__call__` can now be defined in contracts. 
+  ```
+  ([#621](https://github.com/ethereum/fe/issues/621))
+- A special function named `__call__` can now be defined in contracts.
 
   The body of this function will execute in place of the standard dispatcher when the contract is called.
 
@@ -736,7 +753,8 @@ Fe is moving fast. Read up on all the latest improvements.
                   __revert(0, 0)
               else:
                   __return(0, 0)
-  ``` ([#622](https://github.com/ethereum/fe/issues/622))
+  ```
+  ([#622](https://github.com/ethereum/fe/issues/622))
 
 
 ### Bugfixes
@@ -755,7 +773,8 @@ Fe is moving fast. Read up on all the latest improvements.
 
   fn fail():
     revert Error(code = BAD_MOJO)
-  ``` ([#619](https://github.com/ethereum/fe/issues/619))
+  ```
+  ([#619](https://github.com/ethereum/fe/issues/619))
 - Fixed a regression where an empty list expression (`[]`) would lead to a compiler crash. ([#623](https://github.com/ethereum/fe/issues/623))
 - Fixed a bug where int array elements were not sign extended in their ABI encodings. ([#633](https://github.com/ethereum/fe/issues/633))
 
@@ -822,8 +841,8 @@ Fe is moving fast. Read up on all the latest improvements.
 
 - Added a globally available *dummy* std lib.
 
-  This library contains a single `get_42` function, which can be called using `std::get_42()`. Once 
-  low-level intrinsics have been added to the language, we can delete `get_42` and start adding 
+  This library contains a single `get_42` function, which can be called using `std::get_42()`. Once
+  low-level intrinsics have been added to the language, we can delete `get_42` and start adding
   useful code. ([#601](https://github.com/ethereum/fe/issues/601))
 
 
@@ -897,7 +916,8 @@ Fe is moving fast. Read up on all the latest improvements.
     let p3: Point = p1.add(p2)
 
     assert p3.x == 6 and p3.y == 12
-  ``` ([#577](https://github.com/ethereum/fe/issues/577))
+  ```
+  ([#577](https://github.com/ethereum/fe/issues/577))
 
 
 ### Bugfixes
@@ -908,7 +928,7 @@ Fe is moving fast. Read up on all the latest improvements.
   Example:
 
   ```
-  let my_array: i256[1] = [-1 << 1] 
+  let my_array: i256[1] = [-1 << 1]
   ```
 
   Previous to this fix, the given example would lead to an ICE. ([#550](https://github.com/ethereum/fe/issues/550))
@@ -972,7 +992,8 @@ Fe is moving fast. Read up on all the latest improvements.
 
       pub fn add_points(self, user: address, val: u256):
           self.points[user] += add_bonus(val)
-  ``` ([#566](https://github.com/ethereum/fe/issues/566))
+  ```
+  ([#566](https://github.com/ethereum/fe/issues/566))
 - Implemented a `send_value(to: address, value_in_wei: u256)` function.
 
   The function is similar to the [`sendValue` function by OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5b28259dacf47fc208e03611eb3ba8eeaed63cc0/contracts/utils/Address.sol#L54-L59) with the differences being that:
@@ -1116,13 +1137,14 @@ Fe is moving fast. Read up on all the latest improvements.
 
       pub fn bar(self, my_num: u256):
           self.my_stored_num = my_num
-        
+
       pub fn baz(self):
           self.bar(my_pure_func())
-        
+
       pub fn my_pure_func() -> u256:
           return 42 + 26
-  ``` ([#520](https://github.com/ethereum/fe/issues/520))
+  ```
+  ([#520](https://github.com/ethereum/fe/issues/520))
 - The analyzer now disallows defining a type, variable, or function whose
   name conflicts with a built-in type, function, or object.
 
@@ -1134,7 +1156,8 @@ Fe is moving fast. Read up on all the latest improvements.
   │
   1 │ type u256 = u8
   │      ^^^^ `u256` is a built-in type
-  ``` ([#539](https://github.com/ethereum/fe/issues/539))
+  ```
+  ([#539](https://github.com/ethereum/fe/issues/539))
 
 
 ### Bugfixes
@@ -1207,14 +1230,14 @@ Fe is moving fast. Read up on all the latest improvements.
 
   This can be especially problematic if gives developers the impression
   that they could apply function arguments in any order as long as they
-  are named which is **not** the case. 
+  are named which is **not** the case.
 
   ```
   contract Foo:
 
       pub fn baz():
           self.bar(val2=1, doesnt_even_exist=2)
-    
+
       pub fn bar(val1: u256, val2: u256):
           pass
   ```
@@ -1439,12 +1462,12 @@ Fe is moving fast. Read up on all the latest improvements.
       pass
 
   ...
-    
+
   contract MyContract:
       pass
-   
+
   ...
-    
+
   struct MyStruct:
       pass
   ```
@@ -1472,7 +1495,7 @@ Fe is moving fast. Read up on all the latest improvements.
 - Analyzer now disallows using `context.add_` methods to update attributes. ([#392](https://github.com/ethereum/fe/issues/392))
 - `()` now represents a distinct type internally called the unit type, instead of an empty tuple.
 
-  The lowering pass now does the following: Valueless return statements are given a `()` value and 
+  The lowering pass now does the following: Valueless return statements are given a `()` value and
   functions without a return value are given explicit `()` returns. ([#406](https://github.com/ethereum/fe/issues/406))
 - Add CI check to ensure fragment files always end with a new line ([#4711](https://github.com/ethereum/fe/issues/4711))
 
@@ -1637,7 +1660,7 @@ Fe is moving fast. Read up on all the latest improvements.
     pub fn implicit_a2() ->():
       pass
   ```
-  
+
 - The JSON ABI builder now supports structs as both input and output. ([#296](https://github.com/ethereum/fe/issues/296))
 - Make subsequently defined contracts visible.
 
@@ -1743,7 +1766,7 @@ Fe is moving fast. Read up on all the latest improvements.
   i.e.
 
   ```
-  # Would both overwrite output files and run the Yul optimizer. 
+  # Would both overwrite output files and run the Yul optimizer.
   $ fe my_contract.fe --overwrite
   ```
 
@@ -1830,9 +1853,9 @@ Fe is moving fast. Read up on all the latest improvements.
           assert building.vacant
 
           return building.price
-  ``` 
-- Added support for external contract calls. Contract definitions now 
-  add a type to the module scope, which may be used to create contract 
+  ```
+- Added support for external contract calls. Contract definitions now
+  add a type to the module scope, which may be used to create contract
   values with the contract's public functions as callable attributes. ([#204](https://github.com/ethereum/fe/issues/204))
 
   Example:
@@ -1912,7 +1935,7 @@ Fe is moving fast. Read up on all the latest improvements.
   ```
    pub fn update_house_price(price: u256):
           self.my_house.price = price
-  ``` 
+  ```
 - Implement global `keccak256` method. The method expects one parameter of `bytes[n]`
   and returns the hash as an `u256`. In a future version `keccak256` will most likely
   be moved behind an import so that it has to be imported (e.g. `from std.crypto import keccak256`). ([#255](https://github.com/ethereum/fe/issues/255))
@@ -1950,8 +1973,8 @@ Fe is moving fast. Read up on all the latest improvements.
 
   With this change all additions (e.g `x + y`) for signed and unsigned
   integers check for over- and underflows and revert if necessary. ([#265](https://github.com/ethereum/fe/issues/265))
-- Added a builtin function `abi_encode()` that can be used to encode structs. The return type is a 
-  fixed-size array of bytes that is equal in size to the encoding. The type system does not support 
+- Added a builtin function `abi_encode()` that can be used to encode structs. The return type is a
+  fixed-size array of bytes that is equal in size to the encoding. The type system does not support
   dynamically-sized arrays yet, which is why we used fixed. ([#266](https://github.com/ethereum/fe/issues/266))
 
   Example:
@@ -1962,7 +1985,7 @@ Fe is moving fast. Read up on all the latest improvements.
       size: u256
       rooms: u8
       vacant: bool
-    
+
   contract Foo:
       pub fn hashed_house() -> u256:
           house: House = House(
@@ -1976,7 +1999,7 @@ Fe is moving fast. Read up on all the latest improvements.
 - Perform over/underflow checks for subtractions (SafeMath). ([#267](https://github.com/ethereum/fe/issues/267))
 
   With this change all subtractions (e.g `x - y`) for signed and unsigned
-  integers check for over- and underflows and revert if necessary. 
+  integers check for over- and underflows and revert if necessary.
 - Support for the boolean operations `and` and `or`. ([#270](https://github.com/ethereum/fe/issues/270))
 
   Examples:
@@ -2128,5 +2151,3 @@ This is the first **alpha** release and kicks off our release schedule which wil
 
 - Updated the Solidity backend to v0.8.0. ([#169](https://github.com/ethereum/fe/issues/169))
 - Run CI tests on Mac and support creating Mac binaries for releases. ([#178](https://github.com/ethereum/fe/issues/178))
-
-

--- a/docs/src/spec/data_layout/memory/clone_function.md
+++ b/docs/src/spec/data_layout/memory/clone_function.md
@@ -6,20 +6,20 @@ Example:
 
 ```fe
 fn f() {
-    # with clone
+    // with clone
     let bar: Array<u256, 4> = [1, 2, 3, 4]
-    let foo: Array<u256, 4> = bar.clone() # `foo` points to a new segment of memory
+    let foo: Array<u256, 4> = bar.clone() // `foo` points to a new segment of memory
     assert foo[1] == bar[1]
     foo[1] = 42
-    assert foo[1] != bar[1] # modifying `foo` does not modify bar
+    assert foo[1] != bar[1] // modifying `foo` does not modify bar
 }
 
 fn g() {
-    # without clone
+    // without clone
     let bar: Array<u256, 4> = [1, 2, 3, 4]
-    let foo: Array<u256, 4> = bar # `foo` and `bar` point to the same segment of memory
+    let foo: Array<u256, 4> = bar // `foo` and `bar` point to the same segment of memory
     assert foo[1] == bar[1]
     foo[1] = 42
-    assert foo[1] == bar[1] # modifying `foo` also modifies `bar`
+    assert foo[1] == bar[1] // modifying `foo` also modifies `bar`
 }
 ```

--- a/docs/src/spec/data_layout/memory/sequence_types_in_memory.md
+++ b/docs/src/spec/data_layout/memory/sequence_types_in_memory.md
@@ -7,7 +7,7 @@ Example:
 
 ```fe
 fn f() {
-    let foo: Array<u256, 100> # foo is a pointer that references 100 * 256 bits in memory.
+    let foo: Array<u256, 100> = [0; 100] // foo is a pointer that references 100 * 256 bits in memory.
 }
 ```
 

--- a/docs/src/spec/data_layout/stack.md
+++ b/docs/src/spec/data_layout/stack.md
@@ -12,7 +12,7 @@ Example:
 
 ```fe
 fn f() {
-    let foo: u256 = 42 # foo is stored on the stack
-    let bar: Array<u256, 100> # bar is a memory pointer stored on the stack
+    let foo: u256 = 42 // foo is stored on the stack
+    let bar: Array<u256, 100> = [0; 100] // bar is a memory pointer stored on the stack
 }
 ```

--- a/docs/src/spec/data_layout/storage/constant_size_values_in_storage.md
+++ b/docs/src/spec/data_layout/storage/constant_size_values_in_storage.md
@@ -6,7 +6,7 @@ Example:
 
 ```fe
 contract Cats {
-   population: u256 # assigned a static location by the compiler
+   population: u256 // assigned a static location by the compiler
 }
 ```
 

--- a/docs/src/spec/data_layout/storage/maps_in_storage.md
+++ b/docs/src/spec/data_layout/storage/maps_in_storage.md
@@ -7,8 +7,8 @@ Example:
 
 ```fe
 contract Foo {
-  bar: Map<address, u256> # bar is assigned a static nonce by the compiler
-  baz: Map<address, Map<address, u256>> # baz is assigned a static nonce by the compiler
+  bar: Map<address, u256> // bar is assigned a static nonce by the compiler
+  baz: Map<address, Map<address, u256>> // baz is assigned a static nonce by the compiler
 }
 ```
 

--- a/docs/src/spec/expressions/attribute.md
+++ b/docs/src/spec/expressions/attribute.md
@@ -26,7 +26,7 @@ contract Foo {
     }
 
     pub fn baz(some_point: Point, some_tuple: (bool, u256)) {
-        # Different examples of attribute expressions
+        // Different examples of attribute expressions
         let bool_1: bool = some_tuple.item0
         let x1: u256 = some_point.x
         let point1: u256 = get_point().x

--- a/docs/src/spec/expressions/boolean_operators.md
+++ b/docs/src/spec/expressions/boolean_operators.md
@@ -10,7 +10,7 @@ The operators `or` and `and` may be applied to operands of boolean type. The `or
 Example:
 
 ```fe
-const x: bool = false or true # true
+const x: bool = false or true // true
 ```
 
 [_Expression_]: ./index.md

--- a/docs/src/spec/expressions/indexing.md
+++ b/docs/src/spec/expressions/indexing.md
@@ -15,15 +15,15 @@ contract Foo {
     balances: Map<address, u256>
 
     pub fn baz(self, values: Array<u256, 10>) {
-        # Assign value at slot 5
+        // Assign value at slot 5
         values[5] = 1000
-        # Read value at slot 5
+        // Read value at slot 5
         let val1: u256 = values[5]
 
-        # Assign value for address zero
+        // Assign value for address zero
         self.balances[address(0)] = 10000
 
-        # Read balance of address zero
+        // Read balance of address zero
         let bal: u256 = self.balances[address(0)]
     }
 }

--- a/docs/src/spec/expressions/list.md
+++ b/docs/src/spec/expressions/list.md
@@ -31,7 +31,7 @@ contract Foo {
 
     pub fn baz() {
         let val1: u256 = 2
-        # A list expression
+        // A list expression
         let foo: Array<u256, 3> = [1, val1, get_val3()]
     }
 }

--- a/docs/src/spec/expressions/literal.md
+++ b/docs/src/spec/expressions/literal.md
@@ -10,9 +10,9 @@ A _literal expression_ consists of one of the [literal][LITERAL] forms described
 It directly describes a number, string or boolean value.
 
 ```fe,ignore
-"hello"   # string type
-5         # integer type
-true      # boolean type
+"hello"   // string type
+5         // integer type
+true      // boolean type
 ```
 
 [LITERAL]: ../lexical_structure/tokens.md#literals

--- a/docs/src/spec/expressions/name.md
+++ b/docs/src/spec/expressions/name.md
@@ -11,7 +11,7 @@ Example:
 ```fe
 contract Foo {
     pub fn baz(foo: u256) {
-        # name expression resolving to the value of `foo`
+        // name expression resolving to the value of `foo`
         foo
     }
 }

--- a/docs/src/spec/expressions/tuple.md
+++ b/docs/src/spec/expressions/tuple.md
@@ -35,10 +35,10 @@ Example:
 ```fe
 contract Foo {
     pub fn bar() {
-        # Creating a tuple via a tuple expression
+        // Creating a tuple via a tuple expression
         let some_tuple: (u256, bool) = (1, false)
 
-        # Accessing the first tuple field via the `item0` field
+        // Accessing the first tuple field via the `item0` field
         baz(input: some_tuple.item0)
     }
     pub fn baz(input: u256) {}

--- a/docs/src/spec/expressions/unary_operators.md
+++ b/docs/src/spec/expressions/unary_operators.md
@@ -12,9 +12,9 @@ Example:
 
 ```fe
 fn f() {
-  let x: bool = not true  # false
+  let x: bool = not true  // false
   let y: i256 = -1
-  let z: i256 = i256(~1)  # -2
+  let z: i256 = i256(~1)  // -2
 }
 ```
 

--- a/docs/src/spec/items/contracts.md
+++ b/docs/src/spec/items/contracts.md
@@ -28,8 +28,6 @@
 An example of a `contract`:
 
 ```fe
-use std::context::Context
-
 contract GuestBook {
     messages: Map<address, String<100>>
 

--- a/docs/src/spec/items/events.md
+++ b/docs/src/spec/items/events.md
@@ -17,8 +17,6 @@ An _event_ is a nominal [event type] defined with the keyword `event`. It is emi
 An example of a `event` item and its use:
 
 ```fe
-use std::context::Context
-
 contract Foo {
     event Transfer {
         idx sender: address
@@ -27,8 +25,8 @@ contract Foo {
     }
 
     fn transfer(ctx: Context, to: address, value: u256) {
-        # Heavy logic here
-        # All done, log the event for listeners
+        // Heavy logic here
+        // All done, log the event for listeners
         emit Transfer(ctx, sender: ctx.msg_sender(), receiver: to, value)
     }
 }

--- a/docs/src/spec/lexical_structure/tokens.md
+++ b/docs/src/spec/lexical_structure/tokens.md
@@ -119,9 +119,9 @@ An _integer literal_ has one of four forms:
 Examples of integer literals of various forms:
 
 ```fe,ignore
-123                      # type u256
-0xff                     # type u256
-0o70                     # type u256
-0b1111_1111_1001_0000    # type u256
-0b1111_1111_1001_0000i64 # type u256
+123                      // type u256
+0xff                     // type u256
+0o70                     // type u256
+0b1111_1111_1001_0000    // type u256
+0b1111_1111_1001_0000i64 // type u256
 ```

--- a/docs/src/spec/statements/assign.md
+++ b/docs/src/spec/statements/assign.md
@@ -15,14 +15,14 @@ contract Foo {
 
   pub fn bar(self) {
     let val1: u256 = 10
-    # Assignment of stack variable
+    // Assignment of stack variable
     val1 = 10
 
     let values: (u256, u256) = (1, 2)
-    # Assignment of tuple item
+    // Assignment of tuple item
     values.item0 = 3
 
-    # Assignment of storage array slot
+    // Assignment of storage array slot
     self.some_array[5] = 1000
   }
 }

--- a/docs/src/spec/statements/break.md
+++ b/docs/src/spec/statements/break.md
@@ -27,7 +27,7 @@ contract Foo {
     }
 
     fn some_abort_condition() -> bool {
-        # some complex logic
+        // some complex logic
         return true
     }
 }
@@ -51,7 +51,7 @@ contract Foo {
     }
 
     fn some_abort_condition() -> bool {
-        # some complex logic
+        // some complex logic
         return true
     }
 }

--- a/docs/src/spec/statements/continue.md
+++ b/docs/src/spec/statements/continue.md
@@ -28,7 +28,7 @@ contract Foo {
     }
 
     fn some_skip_condition() -> bool {
-        # some complex logic
+        // some complex logic
         return true
     }
 }
@@ -52,7 +52,7 @@ contract Foo {
     }
 
     fn some_skip_condition() -> bool {
-        # some complex logic
+        // some complex logic
         return true
     }
 }

--- a/docs/src/spec/statements/emit.md
+++ b/docs/src/spec/statements/emit.md
@@ -23,8 +23,6 @@ The `emit` statement is used to create [log entries] in the blockchain. The `emi
 Examples:
 
 ```fe
-use std::context::Context
-
 contract Foo {
     event Mix {
         num1: u256

--- a/docs/src/spec/statements/return.md
+++ b/docs/src/spec/statements/return.md
@@ -19,7 +19,7 @@ contract Foo {
     }
 
     fn in_whitelist(self, to: address) -> bool {
-        # revert used as placeholder for actual logic
+        // revert used as placeholder for actual logic
         revert
     }
 }
@@ -36,7 +36,7 @@ contract Foo {
     }
 
     fn in_whitelist(self, to: address) -> bool {
-        # revert used as placeholder for actual logic
+        // revert used as placeholder for actual logic
         revert
     }
 }

--- a/docs/src/spec/statements/revert.md
+++ b/docs/src/spec/statements/revert.md
@@ -16,7 +16,7 @@ contract Foo {
         if not self.in_whitelist(addr: to) {
             revert
         }
-        # more logic here
+        // more logic here
     }
 
     fn in_whitelist(self, addr: address) -> bool {
@@ -37,7 +37,7 @@ contract Foo {
         if not self.in_whitelist(addr: to) {
             revert ApplicationError(code: 5)
         }
-        # more logic here
+        // more logic here
     }
 
     fn in_whitelist(self, addr: address) -> bool {

--- a/docs/src/spec/type_system/types/address.md
+++ b/docs/src/spec/type_system/types/address.md
@@ -6,11 +6,11 @@ Example:
 
 ```fe
 contract Example {
-  # An address in storage
+  // An address in storage
   someone: address
 
   fn do_something() {
-    # A plain address (not part of a tuple, struct etc) remains on the stack
+    // A plain address (not part of a tuple, struct etc) remains on the stack
     let dai_contract: address = address(0x6b175474e89094c44da98b954eedeac495271d0f)
   }
 }

--- a/docs/src/spec/type_system/types/array.md
+++ b/docs/src/spec/type_system/types/array.md
@@ -13,11 +13,11 @@ Examples:
 
 ```fe
 contract Foo {
-  # An array in storage
+  // An array in storage
   bar: Array<u8, 10>
 
   fn do_something() {
-    # An array in memory
+    // An array in memory
     let values: Array<u256, 3> = [10, 100, 100]
   }
 }

--- a/docs/src/spec/type_system/types/contract.md
+++ b/docs/src/spec/type_system/types/contract.md
@@ -10,8 +10,6 @@ attribute functions `create` or `create2`.
 Example:
 
 ```fe
-use std::context::Context
-
 contract Foo {
     pub fn get_my_num() -> u256 {
         return 42
@@ -20,7 +18,7 @@ contract Foo {
 
 contract FooFactory {
     pub fn create2_foo(ctx: Context) -> address {
-        # `0` is the value being sent and `52` is the address salt
+        // `0` is the value being sent and `52` is the address salt
         let foo: Foo = Foo.create2(ctx, 0, 52)
         return address(foo)
     }

--- a/docs/src/spec/type_system/types/struct.md
+++ b/docs/src/spec/type_system/types/struct.md
@@ -17,12 +17,12 @@ struct Rectangle {
 }
 
 contract Example {
-  # A Rectangle in storage
+  // A Rectangle in storage
   area: Rectangle
 
   fn do_something() {
     let length: u256 = 20
-    # A rectangle in memory
+    // A rectangle in memory
     let square: Rectangle = Rectangle(width: 10, length)
   }
 }

--- a/docs/validate_doc_examples.py
+++ b/docs/validate_doc_examples.py
@@ -57,7 +57,7 @@ def create_fe_file(snippet: CodeSnippet) -> pathlib.Path:
     return fe_snippet_path
 
 def run_snippet(path: pathlib.Path) -> 'subprocess.CompletedProcess[bytes]':
-    return subprocess.run(["./target/debug/fe", str(path), '--overwrite', '-e', 'abi'])
+    return subprocess.run(["./target/debug/fe", "check", str(path)])
 
 def validate_code_examples() -> None:
     TMP_SNIPPET_DIR.mkdir(exist_ok=True)

--- a/newsfragments/779.feature.md
+++ b/newsfragments/779.feature.md
@@ -1,0 +1,3 @@
+The contents of the `std::prelude` module (currently just the `Context` struct)
+are now automatically `use`d by every module, so `use std::context::Context` is
+no longer required.

--- a/website/index.html
+++ b/website/index.html
@@ -51,7 +51,7 @@
         <a href="https://blog.fe-lang.org" class="transition duration-100 ease-in-out mt-1 text-lg block px-2 py-2 hover:bg-gray-700 hover:text-white rounded-sm sm:mt-0 sm:ml-2 sm:px-4" title="Blog">Blog</a>
       </nav>
     </div>
-  </header> 
+  </header>
   <main role="main">
     <section class="px-4 py-12 pt-12 sm:py-16 lg:pt-24 max-w-screen-lg xl:max-w-screen-xl mx-auto md:flex justify-between lg:justify-around items-center bg-red-500 rounded-sm">
       <img class="h-52 lg:h-72 lg:ml-8 xl:ml-0 hidden sm:block" src="fe-logo.svg" alt="Fe Programming language">
@@ -196,10 +196,6 @@
 
                       </div>
                       <code class="language-fe flex-auto relative block text-white pt-4 pb-4 px-4 overflow-auto">
-// Context is a struct provided by the standard library
-// that gives access to various features of the EVM
-use std::context::Context
-
 // The `contract` keyword defines a new contract type
 contract GuestBook {
     // Strings are generic over a constant number
@@ -211,6 +207,8 @@ contract GuestBook {
         book_msg: String&lt;100&gt;
     }
 
+    // Context is a struct provided by the standard library
+    // that gives access to various features of the EVM
     pub fn sign(self, ctx: Context, book_msg: String&lt;100&gt;) {
         // All storage access is explicit using `self.&lt;some-key&gt;`
         self.messages[ctx.msg_sender()] = book_msg


### PR DESCRIPTION
### What was wrong?

Closes #679

### How was it fixed?

Not very elegantly. See queries/module.rs

Also updated the doc example code to comply with recent changes.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
