### PR TITLE
deploy_contract.md edits

### DIFF
--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -27,7 +27,7 @@ The next thing we need is to create a keystore file for our account so that dapp
 To create the keystore file for your testnet account, you can use `ethsign` to import your private key. Run the following command and follow the instructions.
 
 ```
-ethsign import --keystore ~/.ethereum/keystore/
+ethsign import -key-store ~/.ethereum/keystore/
 ```
 
 ### Making the deployment transaction
@@ -52,17 +52,16 @@ If you haven't already, run `./fe build guest_book.fe --overwrite` to obtain the
 
 To make the deployment, we will need to send a transaction to a node that participates in the Görli network. We can run our own node, sign up at [Infura](https://infura.io/) or [Alchemy](https://www.alchemy.com/) to use one of their nodes or find an open public node such as `https://goerli-light.eth.linkpool.io` which we will use to keep this tutorial as accessible as possible.
 
-Use the following command to deploy the contract. Please note that `<rpc-url>` needs to be replaced with the URL of the node that we connect to and `<our-eth-address>` needs to be replaced with the Ethereum address that we imported in the previous step.
+Use the following command to deploy the contract. Please note that `<rpc-url>` needs to be replaced with the URL of the node that we connect to and `<our-eth-address>` needs to be replaced with the Ethereum address that we imported in the previous step.Adding `ETH_GAS=8000000` to provide enough gas to prevent the transaction from failing.
 
 ```
-$ ETH_RPC_URL=<rpc-url> ETH_FROM=<our-eth-address> seth send --create output/GuestBook/GuestBook.bin
+$ ETH_RPC_URL=<rpc-url> ETH_GAS=8000000 ETH_FROM=<our-eth-address> seth send --create output/GuestBook/GuestBook.bin
 ```
 
 What follows is the actual command and the response that was used when writing the tutorial.
 
 ```
-$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io ETH_FROM=0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 seth send --create output/GuestBook/GuestBook.bin
-seth-send: warning: `ETH_GAS' not set; using default gas amount
+$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io ETH_GAS=8000000 ETH_FROM=0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 seth send --create output/GuestBook/GuestBook.bin
 Ethereum account passphrase (not echoed): seth-send: Published transaction with 681 bytes of calldata.
 seth-send: 0x241ac045170d0612b67b2319fa08ed8be8b79568e00090c4f84146897b83760b
 seth-send: Waiting for transaction receipt...............................
@@ -79,14 +78,13 @@ Now that the guest book is live on the Görli network, everyone can send a trans
 The following command will send a transaction to call `sign(string)` with the message *"We <3 Fe"*.
 
 ```
-ETH_RPC_URL=<rpc-url> ETH_FROM=<our-eth-address> seth send <contract-address> "sign(string)" '"We <3 Fe"'
+ETH_RPC_URL=<rpc-url> ETH_GAS=8000000 ETH_FROM=<our-eth-address> seth send <contract-address> "sign(string)" '"We <3 Fe"'
 ```
 
 What follows is again the actual command and the response that was used when writing the tutorial.
 
 ```
-$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io ETH_FROM=0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 seth send 0xcecd2be6d4d01ed7906f502be6321c3721f38bc6 "sign(string)" '"We <3 Fe"'
-seth-send: warning: `ETH_GAS' not set; using default gas amount
+$ ETH_RPC_URL=https://goerli-light.eth.linkpool.io ETH_GAS=8000000 ETH_FROM=0x4E14AaF86CF0759d6Ec8C7433acd66F07D093293 seth send 0xcecd2be6d4d01ed7906f502be6321c3721f38bc6 "sign(string)" '"We <3 Fe"'
 Ethereum account passphrase (not echoed): seth-send: Published transaction with 100 bytes of calldata.
 seth-send: 0xf61c042064a501939769b802d1455124b0f8665eb1b070c75c2815ca52bd8706
 seth-send: Waiting for transaction receipt.............

--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -52,7 +52,7 @@ If you haven't already, run `./fe build guest_book.fe --overwrite` to obtain the
 
 To make the deployment, we will need to send a transaction to a node that participates in the Görli network. We can run our own node, sign up at [Infura](https://infura.io/) or [Alchemy](https://www.alchemy.com/) to use one of their nodes or find an open public node such as `https://goerli-light.eth.linkpool.io` which we will use to keep this tutorial as accessible as possible.
 
-Use the following command to deploy the contract. Please note that `<rpc-url>` needs to be replaced with the URL of the node that we connect to and `<our-eth-address>` needs to be replaced with the Ethereum address that we imported in the previous step.Adding `ETH_GAS=8000000` to provide enough gas to prevent the transaction from failing.
+Use the following command to deploy the contract. Please note that `<rpc-url>` needs to be replaced with the URL of the node that we connect to and `<our-eth-address>` needs to be replaced with the Ethereum address that we imported in the previous step. Adding `ETH_GAS=8000000` to provide enough gas to prevent the transaction from failing.
 
 ```
 $ ETH_RPC_URL=<rpc-url> ETH_GAS=8000000 ETH_FROM=<our-eth-address> seth send --create output/GuestBook/GuestBook.bin


### PR DESCRIPTION
### What was wrong?
 1.  The prompt command ethsign import --keystore ~/.ethereum/keystore/   will result in an error saying it is an incorrect usage.
 2. Transaction failing and ETH_GAS warning when deploying contract and signing the guest book.
 

### How was it fixed?
1. Changed command to  ethsign import -key-store ~/.ethereum/keystore/
2.  Added ETH_GAS=8000000 in the deploy contract command and signing the guestbook command. Also added an explanation. I also removed the 'seth-send: warning: `ETH_GAS' not set; using default gas amount' description.

(My first PR, I'm a total beginner. Apologies for any mistakes)
