### PR TITLE
Properly parse struct definition by rejecting invalid public identifiers, Fixes: #787

### DIFF
--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -349,3 +349,4 @@ test_file! { ctx_undefined_create2 }
 test_file! { ctx_undefined_event }
 test_file! { uninit_values }
 test_file! { invalid_repeat_length }
+test_file! { invalid_struct_pub_qualifier }

--- a/crates/analyzer/tests/snapshots/errors__invalid_struct_pub_qualifier.snap
+++ b/crates/analyzer/tests/snapshots/errors__invalid_struct_pub_qualifier.snap
@@ -1,0 +1,11 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+---
+error: failed to parse struct definition
+  ┌─ compile_errors/invalid_struct_pub_qualifier.fe:3:4
+  │
+3 │ pub}
+  │    ^ unexpected token
+
+

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -25,6 +25,7 @@ pub fn parse_struct_def(
     let mut fields = vec![];
     let mut functions = vec![];
     par.enter_block(span, "struct body must start with `{`")?;
+
     loop {
         par.eat_newlines();
         let pub_qual = par.optional(TokenKind::Pub).map(|tok| tok.span);
@@ -42,7 +43,7 @@ pub fn parse_struct_def(
             TokenKind::Fn | TokenKind::Unsafe => {
                 functions.push(parse_fn_def(par, pub_qual)?);
             }
-            TokenKind::BraceClose => {
+            TokenKind::BraceClose if pub_qual.is_none() => {
                 span += par.next()?.span;
                 break;
             }

--- a/crates/test-files/fixtures/compile_errors/invalid_struct_pub_qualifier.fe
+++ b/crates/test-files/fixtures/compile_errors/invalid_struct_pub_qualifier.fe
@@ -1,0 +1,3 @@
+pub struct Bar {
+    pub x: i32
+pub}


### PR DESCRIPTION
Fix #787 
Before, the struct definitions like:
```
pub struct Bar {
    pub x: i32
pub}
```
were not rejected by the parser. (as mentioned in #787 ). This pull request fixes this issue.
Also tests are written to validate this.

@Y-Nak 