### PR TITLE
Forbid returning unencodable types from public contract functions

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -45,6 +45,9 @@ impl<T> Analysis<T> {
     pub fn sink_diagnostics(&self, sink: &mut impl DiagnosticSink) {
         self.diagnostics.iter().for_each(|diag| sink.push(diag))
     }
+    pub fn has_diag(&self) -> bool {
+        !self.diagnostics.is_empty()
+    }
 }
 
 pub trait AnalyzerContext {

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -134,7 +134,7 @@ pub fn contract_init_function(
     let all_fns = db.contract_all_functions(contract);
     let mut init_fns = all_fns.iter().filter_map(|func| {
         let def = &func.data(db).ast;
-        (def.name() == "__init__").then(|| (func, def.span))
+        (def.name() == "__init__").then_some((func, def.span))
     });
 
     let mut diagnostics = vec![];
@@ -186,7 +186,7 @@ pub fn contract_call_function(
     let all_fns = db.contract_all_functions(contract);
     let mut call_fns = all_fns.iter().filter_map(|func| {
         let def = &func.data(db).ast;
-        (def.name() == "__call__").then(|| (func, def.span))
+        (def.name() == "__call__").then_some((func, def.span))
     });
 
     let mut diagnostics = vec![];

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -50,7 +50,8 @@ pub fn struct_field_map(
             indexed_count += 1;
         }
 
-        // Multiple attributes are currently still rejected by the parser so we only need to check the name here
+        // Multiple attributes are currently still rejected by the parser so we only
+        // need to check the name here
         if !field.attributes(db).is_empty() && !field.is_indexed(db) {
             let span = field.data(db).ast.kind.attributes.first().unwrap().span;
             scope.error(

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -155,7 +155,7 @@ impl TypeId {
 
     pub fn self_function(&self, db: &dyn AnalyzerDb, name: &str) -> Option<FunctionSigId> {
         let fun = self.function_sig(db, name)?;
-        fun.takes_self(db).then(|| fun)
+        fun.takes_self(db).then_some(fun)
     }
 
     /// Returns `true` if the type is encodable in Solidity ABI.

--- a/crates/analyzer/tests/snapshots/errors__contract_function_with_generic_params.snap
+++ b/crates/analyzer/tests/snapshots/errors__contract_function_with_generic_params.snap
@@ -1,8 +1,13 @@
 ---
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
-
 ---
+error: can't use unencodable type as a public contract function argument
+  ┌─ compile_errors/contract_function_with_generic_params.fe:4:31
+  │
+4 │     pub fn bar<T: Dummy>(val: T) {}
+  │                               ^ can't use `T` here
+
 error: generic function parameters aren't yet supported outside of struct functions
   ┌─ compile_errors/contract_function_with_generic_params.fe:4:15
   │

--- a/crates/analyzer/tests/snapshots/errors__enum_in_public_contract_sig.snap
+++ b/crates/analyzer/tests/snapshots/errors__enum_in_public_contract_sig.snap
@@ -2,13 +2,13 @@
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 ---
-error: can't return enum type from public contract function
+error: can't return unencodable type from public contract function
   ┌─ compile_errors/enum_in_public_contract_sig.fe:7:41
   │
 7 │     pub fn enum_ret(x: i32, y: u256) -> MyEnum {
   │                                         ^^^^^^ can't return `MyEnum` here
 
-error: can't use enum type as a public contract function argument
+error: can't use unencodable type as a public contract function argument
    ┌─ compile_errors/enum_in_public_contract_sig.fe:12:32
    │
 12 │     pub fn enum_arg(x: i32, y: MyEnum) {

--- a/crates/analyzer/tests/snapshots/errors__struct_recursive_cycles.snap
+++ b/crates/analyzer/tests/snapshots/errors__struct_recursive_cycles.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
-
 ---
 error: recursive struct `Foo`
   ┌─ compile_errors/struct_recursive_cycles.fe:3:8
@@ -20,5 +19,23 @@ error: recursive struct `Foo2`
    │
 13 │ struct Foo2 {
    │        ^^^^ struct `Foo2` has infinite size due to recursive definition
+
+error: can't use unencodable type as a public contract function argument
+   ┌─ compile_errors/struct_recursive_cycles.fe:24:22
+   │
+24 │     pub fn func(foo: Foo, foo2: Foo2, bar2: Bar2) {}
+   │                      ^^^ can't use `Foo` here
+
+error: can't use unencodable type as a public contract function argument
+   ┌─ compile_errors/struct_recursive_cycles.fe:24:33
+   │
+24 │     pub fn func(foo: Foo, foo2: Foo2, bar2: Bar2) {}
+   │                                 ^^^^ can't use `Foo2` here
+
+error: can't use unencodable type as a public contract function argument
+   ┌─ compile_errors/struct_recursive_cycles.fe:24:45
+   │
+24 │     pub fn func(foo: Foo, foo2: Foo2, bar2: Bar2) {}
+   │                                             ^^^^ can't use `Bar2` here
 
 


### PR DESCRIPTION
fixes #795 
