### PR TITLE
Struct pattern

### DIFF
--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -1880,7 +1880,7 @@ impl TraitId {
     pub fn is_implemented_for(&self, db: &dyn AnalyzerDb, ty: TypeId) -> bool {
         // All encodable structs automagically implement the Emittable trait
         // TODO: Remove this when we have the `Encode / Decode` trait.
-        if self.is_std_trait(db, EMITTABLE_TRAIT_NAME) && ty.is_emitable(db) {
+        if self.is_std_trait(db, EMITTABLE_TRAIT_NAME) && ty.is_emittable(db) {
             return true;
         }
 

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -159,8 +159,9 @@ impl TypeId {
     }
 
     /// Returns `true` if the type qualifies to implement the `Emittable` trait
-    /// TODO: This function should be removed when we add `Encode / Decode` trait
-    pub fn is_emitable(self, db: &dyn AnalyzerDb) -> bool {
+    /// TODO: This function should be removed when we add `Encode / Decode`
+    /// trait
+    pub fn is_emittable(self, db: &dyn AnalyzerDb) -> bool {
         matches!(self.typ(db), Type::Struct(_)) && self.is_encodable(db).unwrap_or(false)
     }
 

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -483,7 +483,7 @@ fn struct_pattern(
                 let err = scope.fancy_error(
                     &format!("field `{}` is not public field", f_name),
                     vec![
-                        Label::primary(span, "missing field"),
+                        Label::primary(span, format!("`{}` is not public", f_name)),
                         Label::secondary(field.span(scope.db()), "field is defined here"),
                     ],
                     vec![],

--- a/crates/analyzer/tests/snapshots/analysis__enum_match.snap
+++ b/crates/analyzer/tests/snapshots/analysis__enum_match.snap
@@ -37,70 +37,36 @@ note:
 note: 
    ┌─ enum_match.fe:22:5
    │
-22 │     my_enum: MyEnumNested
+22 │     pub x: i32
+   │     ^^^^^^^^^^ i32
+23 │     pub y: i32
+   │     ^^^^^^^^^^ i32
+24 │     pub b: bool
+   │     ^^^^^^^^^^^ bool
+
+note: 
+   ┌─ enum_match.fe:28:5
+   │
+28 │     pub x: u256
+   │     ^^^^^^^^^^^ u256
+29 │     pub y: u256
+   │     ^^^^^^^^^^^ u256
+30 │     pub e: MyEnum
+   │     ^^^^^^^^^^^^^ MyEnum
+
+note: 
+   ┌─ enum_match.fe:34:5
+   │
+34 │     my_enum: MyEnumNested
    │     ^^^^^^^^^^^^^^^^^^^^^ MyEnumNested
-
-note: 
-   ┌─ enum_match.fe:24:5
-   │  
-24 │ ╭     pub fn simple_match(x: u32, y: u256) -> u256 {
-25 │ │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
-26 │ │         match my_enum {
-27 │ │             MyEnum::Unit | MyEnum::UnitTuple() => {
-   · │
-33 │ │         }
-34 │ │     }
-   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u32 }, { label: None, name: y, typ: u256 }] -> u256
-
-note: 
-   ┌─ enum_match.fe:25:13
-   │
-25 │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
-   │             ^^^^^^^ MyEnum
-
-note: 
-   ┌─ enum_match.fe:25:45
-   │
-25 │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
-   │                                             ^  ^ u256: Value
-   │                                             │   
-   │                                             u32: Value
-
-note: 
-   ┌─ enum_match.fe:25:31
-   │
-25 │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
-   │                               ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
-26 │         match my_enum {
-   │               ^^^^^^^ MyEnum: Memory
-27 │             MyEnum::Unit | MyEnum::UnitTuple() => {
-28 │                 return 0
-   │                        ^ u256: Value
-   ·
-31 │                 return u256(x1) + y1
-   │                             ^^ u32: Value
-
-note: 
-   ┌─ enum_match.fe:31:24
-   │
-31 │                 return u256(x1) + y1
-   │                        ^^^^^^^^   ^^ u256: Value
-   │                        │           
-   │                        u256: Value
-
-note: 
-   ┌─ enum_match.fe:31:24
-   │
-31 │                 return u256(x1) + y1
-   │                        ^^^^^^^^^^^^^ u256: Value
 
 note: 
    ┌─ enum_match.fe:36:5
    │  
-36 │ ╭     pub fn nested_match(x: u32, y: u256) -> u256 {
-37 │ │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
-38 │ │         match nested {
-39 │ │             MyEnumNested::Tuple(x1, y1) | MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) => {
+36 │ ╭     pub fn simple_match(x: u32, y: u256) -> u256 {
+37 │ │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
+38 │ │         match my_enum {
+39 │ │             MyEnum::Unit | MyEnum::UnitTuple() => {
    · │
 45 │ │         }
 46 │ │     }
@@ -109,253 +75,269 @@ note:
 note: 
    ┌─ enum_match.fe:37:13
    │
-37 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
-   │             ^^^^^^ MyEnumNested
+37 │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
+   │             ^^^^^^^ MyEnum
 
 note: 
-   ┌─ enum_match.fe:37:71
+   ┌─ enum_match.fe:37:45
    │
-37 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
-   │                                                                       ^  ^ u256: Value
-   │                                                                       │   
-   │                                                                       u32: Value
+37 │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
+   │                                             ^  ^ u256: Value
+   │                                             │   
+   │                                             u32: Value
 
 note: 
-   ┌─ enum_match.fe:37:57
+   ┌─ enum_match.fe:37:31
    │
-37 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
-   │                                                         ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
-
-note: 
-   ┌─ enum_match.fe:37:36
-   │
-37 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
-   │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyEnumNested: Memory
-38 │         match nested {
-   │               ^^^^^^ MyEnumNested: Memory
-39 │             MyEnumNested::Tuple(x1, y1) | MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) => {
-40 │                 return u256(x1) + y1
+37 │         let my_enum: MyEnum = MyEnum::Tuple(x, y);
+   │                               ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
+38 │         match my_enum {
+   │               ^^^^^^^ MyEnum: Memory
+39 │             MyEnum::Unit | MyEnum::UnitTuple() => {
+40 │                 return 0
+   │                        ^ u256: Value
+   ·
+43 │                 return u256(x1) + y1
    │                             ^^ u32: Value
 
 note: 
-   ┌─ enum_match.fe:40:24
+   ┌─ enum_match.fe:43:24
    │
-40 │                 return u256(x1) + y1
+43 │                 return u256(x1) + y1
    │                        ^^^^^^^^   ^^ u256: Value
    │                        │           
    │                        u256: Value
 
 note: 
-   ┌─ enum_match.fe:40:24
+   ┌─ enum_match.fe:43:24
    │
-40 │                 return u256(x1) + y1
+43 │                 return u256(x1) + y1
    │                        ^^^^^^^^^^^^^ u256: Value
-   ·
-43 │                 return 0
-   │                        ^ u256: Value
 
 note: 
    ┌─ enum_match.fe:48:5
    │  
-48 │ ╭     pub fn nested_match2() -> u256 {
-49 │ │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
-50 │ │         let res: u256 = 0
-51 │ │         match tup {
+48 │ ╭     pub fn nested_match(x: u32, y: u256) -> u256 {
+49 │ │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+50 │ │         match nested {
+51 │ │             MyEnumNested::Tuple(x1, y1) | MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) => {
    · │
-60 │ │         return res
-61 │ │     }
-   │ ╰─────^ self: None, params: [] -> u256
+57 │ │         }
+58 │ │     }
+   │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u32 }, { label: None, name: y, typ: u256 }] -> u256
 
 note: 
    ┌─ enum_match.fe:49:13
    │
-49 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+49 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+   │             ^^^^^^ MyEnumNested
+
+note: 
+   ┌─ enum_match.fe:49:71
+   │
+49 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+   │                                                                       ^  ^ u256: Value
+   │                                                                       │   
+   │                                                                       u32: Value
+
+note: 
+   ┌─ enum_match.fe:49:57
+   │
+49 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+   │                                                         ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
+
+note: 
+   ┌─ enum_match.fe:49:36
+   │
+49 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+   │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyEnumNested: Memory
+50 │         match nested {
+   │               ^^^^^^ MyEnumNested: Memory
+51 │             MyEnumNested::Tuple(x1, y1) | MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) => {
+52 │                 return u256(x1) + y1
+   │                             ^^ u32: Value
+
+note: 
+   ┌─ enum_match.fe:52:24
+   │
+52 │                 return u256(x1) + y1
+   │                        ^^^^^^^^   ^^ u256: Value
+   │                        │           
+   │                        u256: Value
+
+note: 
+   ┌─ enum_match.fe:52:24
+   │
+52 │                 return u256(x1) + y1
+   │                        ^^^^^^^^^^^^^ u256: Value
+   ·
+55 │                 return 0
+   │                        ^ u256: Value
+
+note: 
+   ┌─ enum_match.fe:60:5
+   │  
+60 │ ╭     pub fn nested_match2() -> u256 {
+61 │ │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+62 │ │         let res: u256 = 0
+63 │ │         match tup {
+   · │
+72 │ │         return res
+73 │ │     }
+   │ ╰─────^ self: None, params: [] -> u256
+
+note: 
+   ┌─ enum_match.fe:61:13
+   │
+61 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │             ^^^ Tuple2
-50 │         let res: u256 = 0
+62 │         let res: u256 = 0
    │             ^^^ u256
 
 note: 
-   ┌─ enum_match.fe:49:55
+   ┌─ enum_match.fe:61:55
    │
-49 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+61 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │                                                       ^  ^ u256: Value
    │                                                       │   
    │                                                       u32: Value
 
 note: 
-   ┌─ enum_match.fe:49:41
+   ┌─ enum_match.fe:61:41
    │
-49 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+61 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │                                         ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
    │                                         │                     
    │                                         MyEnum: Memory
 
 note: 
-   ┌─ enum_match.fe:49:27
+   ┌─ enum_match.fe:61:27
    │
-49 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+61 │         let tup: Tuple2 = Tuple2::Value(MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Tuple2: Memory
-50 │         let res: u256 = 0
+62 │         let res: u256 = 0
    │                         ^ u256: Value
-51 │         match tup {
+63 │         match tup {
    │               ^^^ Tuple2: Memory
-52 │             Tuple2::Value(MyEnum::Unit, MyEnum::Tuple(x, y)) | Tuple2::Value(MyEnum::Tuple(x, y), MyEnum::UnitTuple()) => {
-53 │                 res = u256(x) + y
+64 │             Tuple2::Value(MyEnum::Unit, MyEnum::Tuple(x, y)) | Tuple2::Value(MyEnum::Tuple(x, y), MyEnum::UnitTuple()) => {
+65 │                 res = u256(x) + y
    │                 ^^^        ^ u32: Value
    │                 │           
    │                 u256: Value
 
 note: 
-   ┌─ enum_match.fe:53:23
+   ┌─ enum_match.fe:65:23
    │
-53 │                 res = u256(x) + y
+65 │                 res = u256(x) + y
    │                       ^^^^^^^   ^ u256: Value
    │                       │          
    │                       u256: Value
 
 note: 
-   ┌─ enum_match.fe:53:23
+   ┌─ enum_match.fe:65:23
    │
-53 │                 res = u256(x) + y
+65 │                 res = u256(x) + y
    │                       ^^^^^^^^^^^ u256: Value
    ·
-56 │                 return 0
+68 │                 return 0
    │                        ^ u256: Value
    ·
-60 │         return res
+72 │         return res
    │                ^^^ u256: Value
 
 note: 
-   ┌─ enum_match.fe:63:5
+   ┌─ enum_match.fe:75:5
    │  
-63 │ ╭     pub fn tuple_match() -> u256 {
-64 │ │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
-65 │ │         match tup {
-66 │ │             (MyEnum::Unit, MyEnum::Tuple(x, y)) | (MyEnum::Tuple(x, y), MyEnum::UnitTuple()) => {
+75 │ ╭     pub fn tuple_match() -> u256 {
+76 │ │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+77 │ │         match tup {
+78 │ │             (MyEnum::Unit, MyEnum::Tuple(x, y)) | (MyEnum::Tuple(x, y), MyEnum::UnitTuple()) => {
    · │
-73 │ │         }
-74 │ │     }
+85 │ │         }
+86 │ │     }
    │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-   ┌─ enum_match.fe:64:13
+   ┌─ enum_match.fe:76:13
    │
-64 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+76 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │             ^^^ (MyEnum, MyEnum)
 
 note: 
-   ┌─ enum_match.fe:64:52
+   ┌─ enum_match.fe:76:52
    │
-64 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+76 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │                                                    ^  ^ u256: Value
    │                                                    │   
    │                                                    u32: Value
 
 note: 
-   ┌─ enum_match.fe:64:38
+   ┌─ enum_match.fe:76:38
    │
-64 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+76 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │                                      ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
    │                                      │                     
    │                                      MyEnum: Memory
 
 note: 
-   ┌─ enum_match.fe:64:37
+   ┌─ enum_match.fe:76:37
    │
-64 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
+76 │         let tup: (MyEnum, MyEnum) = (MyEnum::Tuple(1, 2), MyEnum::UnitTuple())
    │                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (MyEnum, MyEnum): Memory
-65 │         match tup {
+77 │         match tup {
    │               ^^^ (MyEnum, MyEnum): Memory
-66 │             (MyEnum::Unit, MyEnum::Tuple(x, y)) | (MyEnum::Tuple(x, y), MyEnum::UnitTuple()) => {
-67 │                 return u256(x) + y
+78 │             (MyEnum::Unit, MyEnum::Tuple(x, y)) | (MyEnum::Tuple(x, y), MyEnum::UnitTuple()) => {
+79 │                 return u256(x) + y
    │                             ^ u32: Value
 
 note: 
-   ┌─ enum_match.fe:67:24
+   ┌─ enum_match.fe:79:24
    │
-67 │                 return u256(x) + y
+79 │                 return u256(x) + y
    │                        ^^^^^^^   ^ u256: Value
    │                        │          
    │                        u256: Value
 
 note: 
-   ┌─ enum_match.fe:67:24
+   ┌─ enum_match.fe:79:24
    │
-67 │                 return u256(x) + y
+79 │                 return u256(x) + y
    │                        ^^^^^^^^^^^ u256: Value
    ·
-71 │                 return 0
+83 │                 return 0
    │                        ^ u256: Value
 
 note: 
-   ┌─ enum_match.fe:76:5
-   │  
-76 │ ╭     pub fn boolean_literal_match(b1: bool, b2: bool) -> u256 {
-77 │ │         match (b1, b2) {
-78 │ │             (true, true) => {
-79 │ │                 return 2
-   · │
-87 │ │         }
-88 │ │     }
-   │ ╰─────^ self: None, params: [{ label: None, name: b1, typ: bool }, { label: None, name: b2, typ: bool }] -> u256
+    ┌─ enum_match.fe:88:5
+    │  
+ 88 │ ╭     pub fn boolean_literal_match(b1: bool, b2: bool) -> u256 {
+ 89 │ │         match (b1, b2) {
+ 90 │ │             (true, true) => {
+ 91 │ │                 return 2
+    · │
+ 99 │ │         }
+100 │ │     }
+    │ ╰─────^ self: None, params: [{ label: None, name: b1, typ: bool }, { label: None, name: b2, typ: bool }] -> u256
 
 note: 
-   ┌─ enum_match.fe:77:16
+   ┌─ enum_match.fe:89:16
    │
-77 │         match (b1, b2) {
+89 │         match (b1, b2) {
    │                ^^  ^^ bool: Value
    │                │    
    │                bool: Value
 
 note: 
-   ┌─ enum_match.fe:77:15
+   ┌─ enum_match.fe:89:15
    │
-77 │         match (b1, b2) {
+89 │         match (b1, b2) {
    │               ^^^^^^^^ (bool, bool): Memory
-78 │             (true, true) => {
-79 │                 return 2
+90 │             (true, true) => {
+91 │                 return 2
    │                        ^ u256: Value
    ·
-82 │                 return 1
+94 │                 return 1
    │                        ^ u256: Value
-   ·
-85 │                 return 0
-   │                        ^ u256: Value
-
-note: 
-    ┌─ enum_match.fe:90:5
-    │  
- 90 │ ╭     pub fn wild_card() -> u256 {
- 91 │ │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
- 92 │ │         match nested {
- 93 │ │             MyEnumNested::Nested(MyEnum::UnitTuple() | MyEnum::Tuple(_, _)) => {
-    · │
- 99 │ │         }
-100 │ │     }
-    │ ╰─────^ self: None, params: [] -> u256
-
-note: 
-   ┌─ enum_match.fe:91:13
-   │
-91 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
-   │             ^^^^^^ MyEnumNested
-
-note: 
-   ┌─ enum_match.fe:91:57
-   │
-91 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
-   │                                                         ^^^^^^^^^^^^ MyEnum: Memory
-
-note: 
-   ┌─ enum_match.fe:91:36
-   │
-91 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
-   │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyEnumNested: Memory
-92 │         match nested {
-   │               ^^^^^^ MyEnumNested: Memory
-93 │             MyEnumNested::Nested(MyEnum::UnitTuple() | MyEnum::Tuple(_, _)) => {
-94 │                 return 100
-   │                        ^^^ u256: Value
    ·
 97 │                 return 0
    │                        ^ u256: Value
@@ -363,254 +345,229 @@ note:
 note: 
     ┌─ enum_match.fe:102:5
     │  
-102 │ ╭     pub fn match_in_if() -> u256 {
-103 │ │         let res: u256 = 0
-104 │ │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
-105 │ │ 
+102 │ ╭     pub fn wild_card() -> u256 {
+103 │ │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
+104 │ │         match nested {
+105 │ │             MyEnumNested::Nested(MyEnum::UnitTuple() | MyEnum::Tuple(_, _)) => {
     · │
-121 │ │ 
-122 │ │     }
+111 │ │         }
+112 │ │     }
     │ ╰─────^ self: None, params: [] -> u256
 
 note: 
     ┌─ enum_match.fe:103:13
     │
-103 │         let res: u256 = 0
+103 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
+    │             ^^^^^^ MyEnumNested
+
+note: 
+    ┌─ enum_match.fe:103:57
+    │
+103 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
+    │                                                         ^^^^^^^^^^^^ MyEnum: Memory
+
+note: 
+    ┌─ enum_match.fe:103:36
+    │
+103 │         let nested: MyEnumNested = MyEnumNested::Nested(MyEnum::Unit)
+    │                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyEnumNested: Memory
+104 │         match nested {
+    │               ^^^^^^ MyEnumNested: Memory
+105 │             MyEnumNested::Nested(MyEnum::UnitTuple() | MyEnum::Tuple(_, _)) => {
+106 │                 return 100
+    │                        ^^^ u256: Value
+    ·
+109 │                 return 0
+    │                        ^ u256: Value
+
+note: 
+    ┌─ enum_match.fe:114:5
+    │  
+114 │ ╭     pub fn match_in_if() -> u256 {
+115 │ │         let res: u256 = 0
+116 │ │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
+117 │ │ 
+    · │
+133 │ │ 
+134 │ │     }
+    │ ╰─────^ self: None, params: [] -> u256
+
+note: 
+    ┌─ enum_match.fe:115:13
+    │
+115 │         let res: u256 = 0
     │             ^^^ u256
-104 │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
+116 │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
     │             ^^^^^^^ MyEnum
 
 note: 
-    ┌─ enum_match.fe:103:25
+    ┌─ enum_match.fe:115:25
     │
-103 │         let res: u256 = 0
+115 │         let res: u256 = 0
     │                         ^ u256: Value
-104 │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
+116 │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
     │                                             ^  ^ u256: Value
     │                                             │   
     │                                             u32: Value
 
 note: 
-    ┌─ enum_match.fe:104:31
+    ┌─ enum_match.fe:116:31
     │
-104 │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
+116 │         let my_enum: MyEnum = MyEnum::Tuple(1, 2);
     │                               ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
-105 │ 
-106 │         if true {
+117 │ 
+118 │         if true {
     │            ^^^^ bool: Value
-107 │             match my_enum {
+119 │             match my_enum {
     │                   ^^^^^^^ MyEnum: Memory
-108 │                 MyEnum::Tuple(x, y) => {
-109 │                     res = u256(x) + y
+120 │                 MyEnum::Tuple(x, y) => {
+121 │                     res = u256(x) + y
     │                     ^^^        ^ u32: Value
     │                     │           
     │                     u256: Value
 
 note: 
-    ┌─ enum_match.fe:109:27
+    ┌─ enum_match.fe:121:27
     │
-109 │                     res = u256(x) + y
+121 │                     res = u256(x) + y
     │                           ^^^^^^^   ^ u256: Value
     │                           │          
     │                           u256: Value
 
 note: 
-    ┌─ enum_match.fe:109:27
+    ┌─ enum_match.fe:121:27
     │
-109 │                     res = u256(x) + y
+121 │                     res = u256(x) + y
     │                           ^^^^^^^^^^^ u256: Value
     ·
-113 │                     res = 0
+125 │                     res = 0
     │                     ^^^   ^ u256: Value
     │                     │      
     │                     u256: Value
     ·
-117 │             res = 100
+129 │             res = 100
     │             ^^^   ^^^ u256: Value
     │             │      
     │             u256: Value
     ·
-120 │         return res
+132 │         return res
     │                ^^^ u256: Value
 
 note: 
-    ┌─ enum_match.fe:124:5
+    ┌─ enum_match.fe:136:5
     │  
-124 │ ╭     pub fn match_in_loop() -> u256 {
-125 │ │         let res: u256 = 0
-126 │ │         let state: State = State::Continue 
-127 │ │ 
+136 │ ╭     pub fn match_in_loop() -> u256 {
+137 │ │         let res: u256 = 0
+138 │ │         let state: State = State::Continue 
+139 │ │ 
     · │
-147 │ │         return res
-148 │ │     }
+159 │ │         return res
+160 │ │     }
     │ ╰─────^ self: None, params: [] -> u256
 
 note: 
-    ┌─ enum_match.fe:125:13
+    ┌─ enum_match.fe:137:13
     │
-125 │         let res: u256 = 0
+137 │         let res: u256 = 0
     │             ^^^ u256
-126 │         let state: State = State::Continue 
+138 │         let state: State = State::Continue 
     │             ^^^^^ State
-127 │ 
-128 │         let my_array: Array<u256, 3> = [0; 3]
+139 │ 
+140 │         let my_array: Array<u256, 3> = [0; 3]
     │             ^^^^^^^^ Array<u256, 3>
     ·
-133 │         for i in my_array {
+145 │         for i in my_array {
     │             ^ u256
 
 note: 
-    ┌─ enum_match.fe:125:25
+    ┌─ enum_match.fe:137:25
     │
-125 │         let res: u256 = 0
+137 │         let res: u256 = 0
     │                         ^ u256: Value
-126 │         let state: State = State::Continue 
+138 │         let state: State = State::Continue 
     │                            ^^^^^^^^^^^^^^^ State: Memory
-127 │ 
-128 │         let my_array: Array<u256, 3> = [0; 3]
+139 │ 
+140 │         let my_array: Array<u256, 3> = [0; 3]
     │                                         ^  ^ u256: Value
     │                                         │   
     │                                         u256: Value
 
 note: 
-    ┌─ enum_match.fe:128:40
+    ┌─ enum_match.fe:140:40
     │
-128 │         let my_array: Array<u256, 3> = [0; 3]
+140 │         let my_array: Array<u256, 3> = [0; 3]
     │                                        ^^^^^^ Array<u256, 3>: Memory
-129 │         my_array[0] = 5
+141 │         my_array[0] = 5
     │         ^^^^^^^^ ^ u256: Value
     │         │         
     │         Array<u256, 3>: Memory
 
 note: 
-    ┌─ enum_match.fe:129:9
+    ┌─ enum_match.fe:141:9
     │
-129 │         my_array[0] = 5
+141 │         my_array[0] = 5
     │         ^^^^^^^^^^^   ^ u256: Value
     │         │              
     │         u256: Memory
-130 │         my_array[1] = 10
+142 │         my_array[1] = 10
     │         ^^^^^^^^ ^ u256: Value
     │         │         
     │         Array<u256, 3>: Memory
 
 note: 
-    ┌─ enum_match.fe:130:9
+    ┌─ enum_match.fe:142:9
     │
-130 │         my_array[1] = 10
+142 │         my_array[1] = 10
     │         ^^^^^^^^^^^   ^^ u256: Value
     │         │              
     │         u256: Memory
-131 │         my_array[2] = 15
+143 │         my_array[2] = 15
     │         ^^^^^^^^ ^ u256: Value
     │         │         
     │         Array<u256, 3>: Memory
 
 note: 
-    ┌─ enum_match.fe:131:9
+    ┌─ enum_match.fe:143:9
     │
-131 │         my_array[2] = 15
+143 │         my_array[2] = 15
     │         ^^^^^^^^^^^   ^^ u256: Value
     │         │              
     │         u256: Memory
-132 │ 
-133 │         for i in my_array {
+144 │ 
+145 │         for i in my_array {
     │                  ^^^^^^^^ Array<u256, 3>: Memory
-134 │             match state {
+146 │             match state {
     │                   ^^^^^ State: Memory
     ·
-141 │             res += i
+153 │             res += i
     │             ^^^    ^ u256: Value
     │             │       
     │             u256: Value
-142 │             if res == 15 {
+154 │             if res == 15 {
     │                ^^^    ^^ u256: Value
     │                │       
     │                u256: Value
 
 note: 
-    ┌─ enum_match.fe:142:16
+    ┌─ enum_match.fe:154:16
     │
-142 │             if res == 15 {
+154 │             if res == 15 {
     │                ^^^^^^^^^ bool: Value
-143 │                 state = State::Done
+155 │                 state = State::Done
     │                 ^^^^^   ^^^^^^^^^^^ State: Memory
     │                 │        
     │                 State: Memory
     ·
-147 │         return res
+159 │         return res
     │                ^^^ u256: Value
-
-note: 
-    ┌─ enum_match.fe:150:5
-    │  
-150 │ ╭     pub fn rest_pattern_head(x: u32, y: u256) -> u256 {
-151 │ │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
-152 │ │         match pat {
-153 │ │             (.., MyEnum::Tuple(x1, y1)) => {
-    · │
-159 │ │         }
-160 │ │     }
-    │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u32 }, { label: None, name: y, typ: u256 }] -> u256
-
-note: 
-    ┌─ enum_match.fe:151:13
-    │
-151 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
-    │             ^^^ (MyEnum, MyEnum, MyEnum, MyEnum)
-
-note: 
-    ┌─ enum_match.fe:151:54
-    │
-151 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
-    │                                                      ^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^                ^  ^ u256: Value
-    │                                                      │             │             │                           │   
-    │                                                      │             │             │                           u32: Value
-    │                                                      │             │             MyEnum: Memory
-    │                                                      │             MyEnum: Memory
-    │                                                      MyEnum: Memory
-
-note: 
-    ┌─ enum_match.fe:151:96
-    │
-151 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
-    │                                                                                                ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
-
-note: 
-    ┌─ enum_match.fe:151:53
-    │
-151 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
-    │                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
-152 │         match pat {
-    │               ^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
-153 │             (.., MyEnum::Tuple(x1, y1)) => {
-154 │                 return u256(x1) + y1
-    │                             ^^ u32: Value
-
-note: 
-    ┌─ enum_match.fe:154:24
-    │
-154 │                 return u256(x1) + y1
-    │                        ^^^^^^^^   ^^ u256: Value
-    │                        │           
-    │                        u256: Value
-
-note: 
-    ┌─ enum_match.fe:154:24
-    │
-154 │                 return u256(x1) + y1
-    │                        ^^^^^^^^^^^^^ u256: Value
-    ·
-157 │                 return 0
-    │                        ^ u256: Value
 
 note: 
     ┌─ enum_match.fe:162:5
     │  
-162 │ ╭     pub fn rest_pattern_tail(x: u32, y: u256) -> u256 {
-163 │ │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
+162 │ ╭     pub fn rest_pattern_head(x: u32, y: u256) -> u256 {
+163 │ │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
 164 │ │         match pat {
-165 │ │             (MyEnum::Tuple(x1, y1), ..) => {
+165 │ │             (.., MyEnum::Tuple(x1, y1)) => {
     · │
 171 │ │         }
 172 │ │     }
@@ -619,35 +576,34 @@ note:
 note: 
     ┌─ enum_match.fe:163:13
     │
-163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
+163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
     │             ^^^ (MyEnum, MyEnum, MyEnum, MyEnum)
-
-note: 
-    ┌─ enum_match.fe:163:68
-    │
-163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
-    │                                                                    ^  ^ u256: Value
-    │                                                                    │   
-    │                                                                    u32: Value
 
 note: 
     ┌─ enum_match.fe:163:54
     │
-163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
-    │                                                      ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^ MyEnum: Memory
-    │                                                      │                    │             │              
-    │                                                      │                    │             MyEnum: Memory
-    │                                                      │                    MyEnum: Memory
+163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+    │                                                      ^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^                ^  ^ u256: Value
+    │                                                      │             │             │                           │   
+    │                                                      │             │             │                           u32: Value
+    │                                                      │             │             MyEnum: Memory
+    │                                                      │             MyEnum: Memory
     │                                                      MyEnum: Memory
+
+note: 
+    ┌─ enum_match.fe:163:96
+    │
+163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+    │                                                                                                ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
 
 note: 
     ┌─ enum_match.fe:163:53
     │
-163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
+163 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
     │                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
 164 │         match pat {
     │               ^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
-165 │             (MyEnum::Tuple(x1, y1), ..) => {
+165 │             (.., MyEnum::Tuple(x1, y1)) => {
 166 │                 return u256(x1) + y1
     │                             ^^ u32: Value
 
@@ -671,10 +627,10 @@ note:
 note: 
     ┌─ enum_match.fe:174:5
     │  
-174 │ ╭     pub fn rest_pattern_middle(x: u32, y: u256) -> u256 {
-175 │ │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+174 │ ╭     pub fn rest_pattern_tail(x: u32, y: u256) -> u256 {
+175 │ │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
 176 │ │         match pat {
-177 │ │             (MyEnum::Tuple(x1, y1), .., MyEnum::Tuple(x2, y2)) => {
+177 │ │             (MyEnum::Tuple(x1, y1), ..) => {
     · │
 183 │ │         }
 184 │ │     }
@@ -683,13 +639,13 @@ note:
 note: 
     ┌─ enum_match.fe:175:13
     │
-175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
     │             ^^^ (MyEnum, MyEnum, MyEnum, MyEnum)
 
 note: 
     ┌─ enum_match.fe:175:68
     │
-175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
     │                                                                    ^  ^ u256: Value
     │                                                                    │   
     │                                                                    u32: Value
@@ -697,7 +653,71 @@ note:
 note: 
     ┌─ enum_match.fe:175:54
     │
-175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
+    │                                                      ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^ MyEnum: Memory
+    │                                                      │                    │             │              
+    │                                                      │                    │             MyEnum: Memory
+    │                                                      │                    MyEnum: Memory
+    │                                                      MyEnum: Memory
+
+note: 
+    ┌─ enum_match.fe:175:53
+    │
+175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Unit)
+    │                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
+176 │         match pat {
+    │               ^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
+177 │             (MyEnum::Tuple(x1, y1), ..) => {
+178 │                 return u256(x1) + y1
+    │                             ^^ u32: Value
+
+note: 
+    ┌─ enum_match.fe:178:24
+    │
+178 │                 return u256(x1) + y1
+    │                        ^^^^^^^^   ^^ u256: Value
+    │                        │           
+    │                        u256: Value
+
+note: 
+    ┌─ enum_match.fe:178:24
+    │
+178 │                 return u256(x1) + y1
+    │                        ^^^^^^^^^^^^^ u256: Value
+    ·
+181 │                 return 0
+    │                        ^ u256: Value
+
+note: 
+    ┌─ enum_match.fe:186:5
+    │  
+186 │ ╭     pub fn rest_pattern_middle(x: u32, y: u256) -> u256 {
+187 │ │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+188 │ │         match pat {
+189 │ │             (MyEnum::Tuple(x1, y1), .., MyEnum::Tuple(x2, y2)) => {
+    · │
+195 │ │         }
+196 │ │     }
+    │ ╰─────^ self: None, params: [{ label: None, name: x, typ: u32 }, { label: None, name: y, typ: u256 }] -> u256
+
+note: 
+    ┌─ enum_match.fe:187:13
+    │
+187 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+    │             ^^^ (MyEnum, MyEnum, MyEnum, MyEnum)
+
+note: 
+    ┌─ enum_match.fe:187:68
+    │
+187 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+    │                                                                    ^  ^ u256: Value
+    │                                                                    │   
+    │                                                                    u32: Value
+
+note: 
+    ┌─ enum_match.fe:187:54
+    │
+187 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
     │                                                      ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^  ^^^^^^^^^^^^                ^  ^ u256: Value
     │                                                      │                    │             │                           │   
     │                                                      │                    │             │                           u32: Value
@@ -706,146 +726,286 @@ note:
     │                                                      MyEnum: Memory
 
 note: 
-    ┌─ enum_match.fe:175:103
+    ┌─ enum_match.fe:187:103
     │
-175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+187 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
     │                                                                                                       ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
 
 note: 
-    ┌─ enum_match.fe:175:53
+    ┌─ enum_match.fe:187:53
     │
-175 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
+187 │         let pat: (MyEnum, MyEnum, MyEnum, MyEnum) = (MyEnum::Tuple(x, y), MyEnum::Unit, MyEnum::Unit, MyEnum::Tuple(x, y))
     │                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
-176 │         match pat {
+188 │         match pat {
     │               ^^^ (MyEnum, MyEnum, MyEnum, MyEnum): Memory
-177 │             (MyEnum::Tuple(x1, y1), .., MyEnum::Tuple(x2, y2)) => {
-178 │                 return u256(x1) + y1 + u256(x2) + y2
+189 │             (MyEnum::Tuple(x1, y1), .., MyEnum::Tuple(x2, y2)) => {
+190 │                 return u256(x1) + y1 + u256(x2) + y2
     │                             ^^ u32: Value
 
 note: 
-    ┌─ enum_match.fe:178:24
+    ┌─ enum_match.fe:190:24
     │
-178 │                 return u256(x1) + y1 + u256(x2) + y2
+190 │                 return u256(x1) + y1 + u256(x2) + y2
     │                        ^^^^^^^^   ^^ u256: Value
     │                        │           
     │                        u256: Value
 
 note: 
-    ┌─ enum_match.fe:178:24
+    ┌─ enum_match.fe:190:24
     │
-178 │                 return u256(x1) + y1 + u256(x2) + y2
+190 │                 return u256(x1) + y1 + u256(x2) + y2
     │                        ^^^^^^^^^^^^^        ^^ u32: Value
     │                        │                     
     │                        u256: Value
 
 note: 
-    ┌─ enum_match.fe:178:40
+    ┌─ enum_match.fe:190:40
     │
-178 │                 return u256(x1) + y1 + u256(x2) + y2
+190 │                 return u256(x1) + y1 + u256(x2) + y2
     │                                        ^^^^^^^^ u256: Value
 
 note: 
-    ┌─ enum_match.fe:178:24
+    ┌─ enum_match.fe:190:24
     │
-178 │                 return u256(x1) + y1 + u256(x2) + y2
+190 │                 return u256(x1) + y1 + u256(x2) + y2
     │                        ^^^^^^^^^^^^^^^^^^^^^^^^   ^^ u256: Value
     │                        │                           
     │                        u256: Value
 
 note: 
-    ┌─ enum_match.fe:178:24
+    ┌─ enum_match.fe:190:24
     │
-178 │                 return u256(x1) + y1 + u256(x2) + y2
+190 │                 return u256(x1) + y1 + u256(x2) + y2
     │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
     ·
-181 │                 return 0
+193 │                 return 0
     │                        ^ u256: Value
 
 note: 
-    ┌─ enum_match.fe:186:5
+    ┌─ enum_match.fe:198:5
     │  
-186 │ ╭     pub fn enum_storage(self, x:u32, y: u256, b: bool) -> u256 {
-187 │ │         if b {
-188 │ │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
-189 │ │         } else {
+198 │ ╭     pub fn simple_struct(x: i32, y: i32, b: bool) -> i32 {
+199 │ │         let s: SimpleStruct = SimpleStruct(x, y, b)
+200 │ │         match s {
+201 │ │             SimpleStruct{x: x1, y: y1, b: true} => {
     · │
-200 │ │         }
-201 │ │     }
+208 │ │         }
+209 │ │     }
+    │ ╰─────^ self: None, params: [{ label: None, name: x, typ: i32 }, { label: None, name: y, typ: i32 }, { label: None, name: b, typ: bool }] -> i32
+
+note: 
+    ┌─ enum_match.fe:199:13
+    │
+199 │         let s: SimpleStruct = SimpleStruct(x, y, b)
+    │             ^ SimpleStruct
+
+note: 
+    ┌─ enum_match.fe:199:44
+    │
+199 │         let s: SimpleStruct = SimpleStruct(x, y, b)
+    │                                            ^  ^  ^ bool: Value
+    │                                            │  │   
+    │                                            │  i32: Value
+    │                                            i32: Value
+
+note: 
+    ┌─ enum_match.fe:199:31
+    │
+199 │         let s: SimpleStruct = SimpleStruct(x, y, b)
+    │                               ^^^^^^^^^^^^^^^^^^^^^ SimpleStruct: Memory
+200 │         match s {
+    │               ^ SimpleStruct: Memory
+201 │             SimpleStruct{x: x1, y: y1, b: true} => {
+202 │                 return x1 + y1
+    │                        ^^   ^^ i32: Value
+    │                        │     
+    │                        i32: Value
+
+note: 
+    ┌─ enum_match.fe:202:24
+    │
+202 │                 return x1 + y1
+    │                        ^^^^^^^ i32: Value
+    ·
+206 │                 return x1 - y1
+    │                        ^^   ^^ i32: Value
+    │                        │     
+    │                        i32: Value
+
+note: 
+    ┌─ enum_match.fe:206:24
+    │
+206 │                 return x1 - y1
+    │                        ^^^^^^^ i32: Value
+
+note: 
+    ┌─ enum_match.fe:211:5
+    │  
+211 │ ╭     pub fn nested_struct() -> u256 {
+212 │ │         let e: MyEnum = MyEnum::Tuple(1, 2)
+213 │ │         let s: NestedStruct = NestedStruct(x: 3, y: 4, e)
+214 │ │         match s {
+    · │
+222 │ │         }
+223 │ │     }
+    │ ╰─────^ self: None, params: [] -> u256
+
+note: 
+    ┌─ enum_match.fe:212:13
+    │
+212 │         let e: MyEnum = MyEnum::Tuple(1, 2)
+    │             ^ MyEnum
+213 │         let s: NestedStruct = NestedStruct(x: 3, y: 4, e)
+    │             ^ NestedStruct
+
+note: 
+    ┌─ enum_match.fe:212:39
+    │
+212 │         let e: MyEnum = MyEnum::Tuple(1, 2)
+    │                                       ^  ^ u256: Value
+    │                                       │   
+    │                                       u32: Value
+
+note: 
+    ┌─ enum_match.fe:212:25
+    │
+212 │         let e: MyEnum = MyEnum::Tuple(1, 2)
+    │                         ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
+213 │         let s: NestedStruct = NestedStruct(x: 3, y: 4, e)
+    │                                               ^     ^  ^ MyEnum: Memory
+    │                                               │     │   
+    │                                               │     u256: Value
+    │                                               u256: Value
+
+note: 
+    ┌─ enum_match.fe:213:31
+    │
+213 │         let s: NestedStruct = NestedStruct(x: 3, y: 4, e)
+    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ NestedStruct: Memory
+214 │         match s {
+    │               ^ NestedStruct: Memory
+215 │             NestedStruct{e: MyEnum::Unit | MyEnum::UnitTuple(), ..} => {
+216 │                 return 0
+    │                        ^ u256: Value
+    ·
+220 │                 return x1 + y1 + u256(x2) + y2
+    │                        ^^   ^^ u256: Value
+    │                        │     
+    │                        u256: Value
+
+note: 
+    ┌─ enum_match.fe:220:24
+    │
+220 │                 return x1 + y1 + u256(x2) + y2
+    │                        ^^^^^^^        ^^ u32: Value
+    │                        │               
+    │                        u256: Value
+
+note: 
+    ┌─ enum_match.fe:220:34
+    │
+220 │                 return x1 + y1 + u256(x2) + y2
+    │                                  ^^^^^^^^ u256: Value
+
+note: 
+    ┌─ enum_match.fe:220:24
+    │
+220 │                 return x1 + y1 + u256(x2) + y2
+    │                        ^^^^^^^^^^^^^^^^^^   ^^ u256: Value
+    │                        │                     
+    │                        u256: Value
+
+note: 
+    ┌─ enum_match.fe:220:24
+    │
+220 │                 return x1 + y1 + u256(x2) + y2
+    │                        ^^^^^^^^^^^^^^^^^^^^^^^ u256: Value
+
+note: 
+    ┌─ enum_match.fe:225:5
+    │  
+225 │ ╭     pub fn enum_storage(self, x:u32, y: u256, b: bool) -> u256 {
+226 │ │         if b {
+227 │ │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+228 │ │         } else {
+    · │
+239 │ │         }
+240 │ │     }
     │ ╰─────^ self: Some(Mutable), params: [{ label: None, name: x, typ: u32 }, { label: None, name: y, typ: u256 }, { label: None, name: b, typ: bool }] -> u256
 
 note: 
-    ┌─ enum_match.fe:187:12
+    ┌─ enum_match.fe:226:12
     │
-187 │         if b {
+226 │         if b {
     │            ^ bool: Value
-188 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+227 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
     │             ^^^^ Foo: Value
 
 note: 
-    ┌─ enum_match.fe:188:13
+    ┌─ enum_match.fe:227:13
     │
-188 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+227 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
     │             ^^^^^^^^^^^^                                      ^  ^ u256: Value
     │             │                                                 │   
     │             │                                                 u32: Value
     │             MyEnumNested: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ enum_match.fe:188:49
+    ┌─ enum_match.fe:227:49
     │
-188 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+227 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
     │                                                 ^^^^^^^^^^^^^^^^^^^ MyEnum: Memory
 
 note: 
-    ┌─ enum_match.fe:188:28
+    ┌─ enum_match.fe:227:28
     │
-188 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
+227 │             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyEnumNested: Memory
-189 │         } else {
-190 │             self.my_enum = MyEnumNested::Nested(MyEnum::Unit)
+228 │         } else {
+229 │             self.my_enum = MyEnumNested::Nested(MyEnum::Unit)
     │             ^^^^ Foo: Value
 
 note: 
-    ┌─ enum_match.fe:190:13
+    ┌─ enum_match.fe:229:13
     │
-190 │             self.my_enum = MyEnumNested::Nested(MyEnum::Unit)
+229 │             self.my_enum = MyEnumNested::Nested(MyEnum::Unit)
     │             ^^^^^^^^^^^^                        ^^^^^^^^^^^^ MyEnum: Memory
     │             │                                    
     │             MyEnumNested: Storage { nonce: Some(0) }
 
 note: 
-    ┌─ enum_match.fe:190:28
+    ┌─ enum_match.fe:229:28
     │
-190 │             self.my_enum = MyEnumNested::Nested(MyEnum::Unit)
+229 │             self.my_enum = MyEnumNested::Nested(MyEnum::Unit)
     │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ MyEnumNested: Memory
     ·
-193 │         match self.my_enum {
+232 │         match self.my_enum {
     │               ^^^^ Foo: Value
 
 note: 
-    ┌─ enum_match.fe:193:15
+    ┌─ enum_match.fe:232:15
     │
-193 │         match self.my_enum {
+232 │         match self.my_enum {
     │               ^^^^^^^^^^^^ MyEnumNested: Storage { nonce: Some(0) }
-194 │             MyEnumNested::Tuple(x1, y1) | MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) => {
-195 │                 return u256(x1) + y1
+233 │             MyEnumNested::Tuple(x1, y1) | MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) => {
+234 │                 return u256(x1) + y1
     │                             ^^ u32: Value
 
 note: 
-    ┌─ enum_match.fe:195:24
+    ┌─ enum_match.fe:234:24
     │
-195 │                 return u256(x1) + y1
+234 │                 return u256(x1) + y1
     │                        ^^^^^^^^   ^^ u256: Value
     │                        │           
     │                        u256: Value
 
 note: 
-    ┌─ enum_match.fe:195:24
+    ┌─ enum_match.fe:234:24
     │
-195 │                 return u256(x1) + y1
+234 │                 return u256(x1) + y1
     │                        ^^^^^^^^^^^^^ u256: Value
     ·
-198 │                 return 100
+237 │                 return 100
     │                        ^^^ u256: Value
 
 

--- a/crates/analyzer/tests/snapshots/errors__enum_match.snap
+++ b/crates/analyzer/tests/snapshots/errors__enum_match.snap
@@ -2,75 +2,92 @@
 source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 ---
-error: 
-   ┌─ compile_errors/enum_match.fe:22:13
+error: function body is missing a return or revert statement
+   ┌─ compile_errors/enum_match.fe:16:12
    │
-22 │             MyEnumNested::Tuple(x1, y1) => {
+16 │     pub fn new() -> MyS {
+   │            ^^^      --- expected function to return `MyS`
+   │            │         
+   │            all paths of this function must `return` or `revert`
+
+error: 
+   ┌─ compile_errors/enum_match.fe:32:13
+   │
+32 │             MyEnumNested::Tuple(x1, y1) => {
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ this has type `MyEnumNested`; expected type `MyEnum`
 
 error: 
-   ┌─ compile_errors/enum_match.fe:31:33
+   ┌─ compile_errors/enum_match.fe:41:33
    │
-31 │             MyEnumNested::Tuple(MyEnum::Unit, _) => {
+41 │             MyEnumNested::Tuple(MyEnum::Unit, _) => {
    │                                 ^^^^^^^^^^^^ this has type `MyEnum`; expected type `u32`
 
 error: expected a tuple variant
-   ┌─ compile_errors/enum_match.fe:43:13
+   ┌─ compile_errors/enum_match.fe:53:13
    │
  2 │     Unit
    │     ---- Unit is defined here
    ·
-43 │             MyEnum::Unit() => {
+53 │             MyEnum::Unit() => {
    │             ^^^^^^^^^^^^ the variant is defined as unit variant
 
 error: expected an unit variant
-   ┌─ compile_errors/enum_match.fe:46:13
+   ┌─ compile_errors/enum_match.fe:56:13
    │
  3 │     UnitTuple()
    │     ----------- UnitTuple is defined here
    ·
-46 │             MyEnum::UnitTuple => {
+56 │             MyEnum::UnitTuple => {
    │             ^^^^^^^^^^^^^^^^^ the variant is defined as tuple variant
 
 error: the number of tuple variant mismatch
-   ┌─ compile_errors/enum_match.fe:49:13
+   ┌─ compile_errors/enum_match.fe:59:13
    │
  4 │     Tuple(u32, u256)
    │     ---------------- Tuple is defined here
    ·
-49 │             MyEnum::Tuple(y1) => {
+59 │             MyEnum::Tuple(y1) => {
    │             ^^^^^^^^^^^^^^^^^ expected 2 elements, but 1
 
 error: variable `x1` is not bound in all sub patterns
-   ┌─ compile_errors/enum_match.fe:61:37
+   ┌─ compile_errors/enum_match.fe:71:37
    │
-61 │             MyEnum::Tuple(x1, y1) | MyEnum::UnitTuple() => {
+71 │             MyEnum::Tuple(x1, y1) | MyEnum::UnitTuple() => {
    │                                     ^^^^^^^^^^^^^^^^^^^ variable `x1` is not bound here
 
 error: variable `y1` is not bound in all sub patterns
-   ┌─ compile_errors/enum_match.fe:61:37
+   ┌─ compile_errors/enum_match.fe:71:37
    │
-61 │             MyEnum::Tuple(x1, y1) | MyEnum::UnitTuple() => {
+71 │             MyEnum::Tuple(x1, y1) | MyEnum::UnitTuple() => {
    │                                     ^^^^^^^^^^^^^^^^^^^ variable `y1` is not bound here
 
 error: mismatched type for `x1` between sub patterns
-   ┌─ compile_errors/enum_match.fe:70:83
+   ┌─ compile_errors/enum_match.fe:80:83
    │
-70 │             MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) | MyEnumNested::Tuple(y1, x1) => {
+80 │             MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) | MyEnumNested::Tuple(y1, x1) => {
    │                                                                                   ^^ this has type `u256`; expected type `u32`
 
 error: mismatched type for `y1` between sub patterns
-   ┌─ compile_errors/enum_match.fe:70:79
+   ┌─ compile_errors/enum_match.fe:80:79
    │
-70 │             MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) | MyEnumNested::Tuple(y1, x1) => {
+80 │             MyEnumNested::Nested(MyEnum::Tuple(x1, y1)) | MyEnumNested::Tuple(y1, x1) => {
    │                                                                               ^^ this has type `u32`; expected type `u256`
 
 error: multiple rest patterns are not allowed
-   ┌─ compile_errors/enum_match.fe:79:18
+   ┌─ compile_errors/enum_match.fe:89:18
    │
-79 │             (.., ..) => {}
+89 │             (.., ..) => {}
    │              --  ^^ multiple rest patterns are not allowed
    │              │    
    │              first rest pattern is here
+
+error: field `x` is not public field
+   ┌─ compile_errors/enum_match.fe:96:17
+   │
+13 │     x: i32
+   │     ------ field is defined here
+   ·
+96 │             MyS{x: x1, y: y1} => {
+   │                 ^ `x` is not public
 
 

--- a/crates/mir/src/lower/pattern_match/mod.rs
+++ b/crates/mir/src/lower/pattern_match/mod.rs
@@ -192,7 +192,9 @@ impl<'db, 'a, 'b> DecisionTreeLowerHelper<'db, 'a, 'b> {
                 Some(self.builder().make_imm_from_bool(*b, ty))
             }
 
-            Case::Ctor(ConstructorKind::Tuple(_)) | Case::Default => None,
+            Case::Ctor(ConstructorKind::Tuple(_))
+            | Case::Ctor(ConstructorKind::Struct(_))
+            | Case::Default => None,
         }
     }
 
@@ -217,13 +219,14 @@ impl<'db, 'a, 'b> DecisionTreeLowerHelper<'db, 'a, 'b> {
                     .register_occurrence(occurrence.clone(), value)
             }
 
-            Case::Ctor(ConstructorKind::Tuple(_)) | Case::Default => {}
+            Case::Ctor(ConstructorKind::Tuple(_))
+            | Case::Ctor(ConstructorKind::Struct(_))
+            | Case::Default => {}
         }
     }
 
     fn extract_disc(&mut self, value: ValueId) -> ValueId {
         let value_ty = self.builder().value_ty(value);
-
         match value_ty {
             _ if value_ty.is_enum(self.helper.db) => {
                 let disc_ty = value_ty.enum_disc_type(self.helper.db);

--- a/crates/mir/src/lower/pattern_match/tree_vis.rs
+++ b/crates/mir/src/lower/pattern_match/tree_vis.rs
@@ -94,6 +94,7 @@ impl<'db> dot2::Labeller<'db> for TreeRenderer<'db> {
                 variant.name_with_parent(self.db).to_string()
             }
             Case::Ctor(ConstructorKind::Tuple(_)) => "()".to_string(),
+            Case::Ctor(ConstructorKind::Struct(sid)) => sid.name(self.db).into(),
             Case::Ctor(ConstructorKind::Literal((lit, _))) => lit.to_string(),
             Case::Default => "_".into(),
         };

--- a/crates/parser/tests/cases/errors.rs
+++ b/crates/parser/tests/cases/errors.rs
@@ -102,6 +102,11 @@ test_parse_err! { self_struct, module::parse_module, "struct self {}" }
 test_parse_err! { self_fn, module::parse_module, "pub fn self() {}" }
 test_parse_err! { self_use1, module::parse_module, "use self as bar" }
 test_parse_err! { self_use2, module::parse_module, "use bar as self" }
+test_parse_err! { stmt_match1, functions::parse_stmt, r#"match my_enum {
+    mymod::MyS {.., x: x, y: true}  => {
+        return x
+    }
+}"# }
 
 // assert_snapshot! doesn't like the invalid escape code
 #[test]

--- a/crates/parser/tests/cases/parse_ast.rs
+++ b/crates/parser/tests/cases/parse_ast.rs
@@ -143,6 +143,22 @@ test_parse! { stmt_match2, functions::parse_stmt, r#"match my_enum {
         return -1
     }
 }"# }
+test_parse! { stmt_match3, functions::parse_stmt, r#"match my_enum {
+    mymod::MyS {x: x, y: true}  => {
+        return x
+    }
+    mymod::MyS {x: _, y: false} => {
+        return 0
+    }
+    mymod::MyS {x: x, ..} => {
+        return x - 1
+    }
+}"# }
+test_parse! { stmt_match4, functions::parse_stmt, r#"match my_enum {
+    mymod::MyS {}  => {
+        return 1
+    }
+}"# }
 test_parse! { stmt_while, functions::parse_stmt, "while a > 5 { \n a -= 1 }" }
 test_parse! { stmt_for, functions::parse_stmt, "for a in b[0] {}" }
 test_parse! { stmt_var_decl_name, functions::parse_stmt, "let foo: u256 = 1" }

--- a/crates/parser/tests/cases/snapshots/cases__errors__stmt_match1.snap
+++ b/crates/parser/tests/cases/snapshots/cases__errors__stmt_match1.snap
@@ -1,0 +1,11 @@
+---
+source: crates/parser/tests/cases/errors.rs
+expression: "err_string(stringify!(stmt_match1), functions::parse_stmt,\n    r#\"match my_enum {\n    mymod::MyS {.., x: x, y: true}  => {\n        return x\n    }\n}\"#)"
+---
+error: `..` pattern should be the last position in the struct pattern
+  ┌─ stmt_match1:2:19
+  │
+2 │     mymod::MyS {.., x: x, y: true}  => {
+  │                   ^ expected symbol `}`, found symbol `,`
+
+

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_match3.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_match3.snap
@@ -1,0 +1,332 @@
+---
+source: crates/parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_match3), functions::parse_stmt,\n    r#\"match my_enum {\n    mymod::MyS {x: x, y: true}  => {\n        return x\n    }\n    mymod::MyS {x: _, y: false} => {\n        return 0\n    }\n    mymod::MyS {x: x, ..} => {\n        return x - 1\n    }\n}\"#)"
+---
+Node(
+  kind: Match(
+    expr: Node(
+      kind: Name("my_enum"),
+      span: Span(
+        start: 6,
+        end: 13,
+      ),
+    ),
+    arms: [
+      Node(
+        kind: MatchArm(
+          pat: Node(
+            kind: PathStruct(
+              path: Node(
+                kind: Path(
+                  segments: [
+                    Node(
+                      kind: "mymod",
+                      span: Span(
+                        start: 20,
+                        end: 25,
+                      ),
+                    ),
+                    Node(
+                      kind: "MyS",
+                      span: Span(
+                        start: 27,
+                        end: 30,
+                      ),
+                    ),
+                  ],
+                ),
+                span: Span(
+                  start: 20,
+                  end: 30,
+                ),
+              ),
+              fields: [
+                (Node(
+                  kind: "x",
+                  span: Span(
+                    start: 32,
+                    end: 33,
+                  ),
+                ), Node(
+                  kind: Path(Node(
+                    kind: Path(
+                      segments: [
+                        Node(
+                          kind: "x",
+                          span: Span(
+                            start: 35,
+                            end: 36,
+                          ),
+                        ),
+                      ],
+                    ),
+                    span: Span(
+                      start: 35,
+                      end: 36,
+                    ),
+                  )),
+                  span: Span(
+                    start: 35,
+                    end: 36,
+                  ),
+                )),
+                (Node(
+                  kind: "y",
+                  span: Span(
+                    start: 38,
+                    end: 39,
+                  ),
+                ), Node(
+                  kind: Literal(Node(
+                    kind: Bool(true),
+                    span: Span(
+                      start: 41,
+                      end: 45,
+                    ),
+                  )),
+                  span: Span(
+                    start: 41,
+                    end: 45,
+                  ),
+                )),
+              ],
+              has_rest: false,
+            ),
+            span: Span(
+              start: 31,
+              end: 46,
+            ),
+          ),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: Name("x"),
+                  span: Span(
+                    start: 68,
+                    end: 69,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 61,
+                end: 69,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 31,
+          end: 75,
+        ),
+      ),
+      Node(
+        kind: MatchArm(
+          pat: Node(
+            kind: PathStruct(
+              path: Node(
+                kind: Path(
+                  segments: [
+                    Node(
+                      kind: "mymod",
+                      span: Span(
+                        start: 80,
+                        end: 85,
+                      ),
+                    ),
+                    Node(
+                      kind: "MyS",
+                      span: Span(
+                        start: 87,
+                        end: 90,
+                      ),
+                    ),
+                  ],
+                ),
+                span: Span(
+                  start: 80,
+                  end: 90,
+                ),
+              ),
+              fields: [
+                (Node(
+                  kind: "x",
+                  span: Span(
+                    start: 92,
+                    end: 93,
+                  ),
+                ), Node(
+                  kind: WildCard,
+                  span: Span(
+                    start: 95,
+                    end: 96,
+                  ),
+                )),
+                (Node(
+                  kind: "y",
+                  span: Span(
+                    start: 98,
+                    end: 99,
+                  ),
+                ), Node(
+                  kind: Literal(Node(
+                    kind: Bool(false),
+                    span: Span(
+                      start: 101,
+                      end: 106,
+                    ),
+                  )),
+                  span: Span(
+                    start: 101,
+                    end: 106,
+                  ),
+                )),
+              ],
+              has_rest: false,
+            ),
+            span: Span(
+              start: 91,
+              end: 107,
+            ),
+          ),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: Num("0"),
+                  span: Span(
+                    start: 128,
+                    end: 129,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 121,
+                end: 129,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 91,
+          end: 135,
+        ),
+      ),
+      Node(
+        kind: MatchArm(
+          pat: Node(
+            kind: PathStruct(
+              path: Node(
+                kind: Path(
+                  segments: [
+                    Node(
+                      kind: "mymod",
+                      span: Span(
+                        start: 140,
+                        end: 145,
+                      ),
+                    ),
+                    Node(
+                      kind: "MyS",
+                      span: Span(
+                        start: 147,
+                        end: 150,
+                      ),
+                    ),
+                  ],
+                ),
+                span: Span(
+                  start: 140,
+                  end: 150,
+                ),
+              ),
+              fields: [
+                (Node(
+                  kind: "x",
+                  span: Span(
+                    start: 152,
+                    end: 153,
+                  ),
+                ), Node(
+                  kind: Path(Node(
+                    kind: Path(
+                      segments: [
+                        Node(
+                          kind: "x",
+                          span: Span(
+                            start: 155,
+                            end: 156,
+                          ),
+                        ),
+                      ],
+                    ),
+                    span: Span(
+                      start: 155,
+                      end: 156,
+                    ),
+                  )),
+                  span: Span(
+                    start: 155,
+                    end: 156,
+                  ),
+                )),
+              ],
+              has_rest: true,
+            ),
+            span: Span(
+              start: 151,
+              end: 161,
+            ),
+          ),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: BinOperation(
+                    left: Node(
+                      kind: Name("x"),
+                      span: Span(
+                        start: 182,
+                        end: 183,
+                      ),
+                    ),
+                    op: Node(
+                      kind: Sub,
+                      span: Span(
+                        start: 184,
+                        end: 185,
+                      ),
+                    ),
+                    right: Node(
+                      kind: Num("1"),
+                      span: Span(
+                        start: 186,
+                        end: 187,
+                      ),
+                    ),
+                  ),
+                  span: Span(
+                    start: 182,
+                    end: 187,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 175,
+                end: 187,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 151,
+          end: 193,
+        ),
+      ),
+    ],
+  ),
+  span: Span(
+    start: 0,
+    end: 195,
+  ),
+)

--- a/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_match4.snap
+++ b/crates/parser/tests/cases/snapshots/cases__parse_ast__stmt_match4.snap
@@ -1,0 +1,80 @@
+---
+source: crates/parser/tests/cases/parse_ast.rs
+expression: "ast_string(stringify!(stmt_match4), functions::parse_stmt,\n    r#\"match my_enum {\n    mymod::MyS {}  => {\n        return 1\n    }\n}\"#)"
+---
+Node(
+  kind: Match(
+    expr: Node(
+      kind: Name("my_enum"),
+      span: Span(
+        start: 6,
+        end: 13,
+      ),
+    ),
+    arms: [
+      Node(
+        kind: MatchArm(
+          pat: Node(
+            kind: PathStruct(
+              path: Node(
+                kind: Path(
+                  segments: [
+                    Node(
+                      kind: "mymod",
+                      span: Span(
+                        start: 20,
+                        end: 25,
+                      ),
+                    ),
+                    Node(
+                      kind: "MyS",
+                      span: Span(
+                        start: 27,
+                        end: 30,
+                      ),
+                    ),
+                  ],
+                ),
+                span: Span(
+                  start: 20,
+                  end: 30,
+                ),
+              ),
+              fields: [],
+              has_rest: false,
+            ),
+            span: Span(
+              start: 31,
+              end: 33,
+            ),
+          ),
+          body: [
+            Node(
+              kind: Return(
+                value: Some(Node(
+                  kind: Num("1"),
+                  span: Span(
+                    start: 55,
+                    end: 56,
+                  ),
+                )),
+              ),
+              span: Span(
+                start: 48,
+                end: 56,
+              ),
+            ),
+          ],
+        ),
+        span: Span(
+          start: 31,
+          end: 62,
+        ),
+      ),
+    ],
+  ),
+  span: Span(
+    start: 0,
+    end: 64,
+  ),
+)

--- a/crates/test-files/fixtures/compile_errors/enum_match.fe
+++ b/crates/test-files/fixtures/compile_errors/enum_match.fe
@@ -9,6 +9,16 @@ pub enum MyEnumNested  {
     Nested(MyEnum)
 }
 
+struct MyS {
+    x: i32
+    pub y: i32
+    
+    pub fn new() -> MyS {
+        MyS(x: 0, y: 0)
+    }
+}
+
+
 contract Foo {
     pub fn variant_type_mismatch(x: u32, y: u256) -> u256 {
         let my_enum: MyEnum = MyEnum::Tuple(x, y);
@@ -77,6 +87,15 @@ contract Foo {
         let my_enum: (MyEnum, MyEnum) = (MyEnum::Unit, MyEnum::Unit)
         match my_enum {
             (.., ..) => {}
+        }
+    }
+    
+    pub fn private_field() {
+        let s: MyS = MyS::new()
+        match s {
+            MyS{x: x1, y: y1} => {
+                return x1 + y1
+            }
         }
     }
 }

--- a/crates/test-files/fixtures/features/enum_match.fe
+++ b/crates/test-files/fixtures/features/enum_match.fe
@@ -18,6 +18,18 @@ pub enum State {
     Done
 }
 
+pub struct SimpleStruct {
+    pub x: i32
+    pub y: i32
+    pub b: bool
+}
+
+pub struct NestedStruct {
+    pub x: u256
+    pub y: u256
+    pub e: MyEnum
+}
+
 contract Foo {
     my_enum: MyEnumNested
     
@@ -183,6 +195,33 @@ contract Foo {
         }
     }
 
+    pub fn simple_struct(x: i32, y: i32, b: bool) -> i32 {
+        let s: SimpleStruct = SimpleStruct(x, y, b)
+        match s {
+            SimpleStruct{x: x1, y: y1, b: true} => {
+                return x1 + y1
+            }
+
+            SimpleStruct{x: x1, y: y1, b: false} => {
+                return x1 - y1
+            }
+        }
+    }
+    
+    pub fn nested_struct() -> u256 {
+        let e: MyEnum = MyEnum::Tuple(1, 2)
+        let s: NestedStruct = NestedStruct(x: 3, y: 4, e)
+        match s {
+            NestedStruct{e: MyEnum::Unit | MyEnum::UnitTuple(), ..} => {
+                return 0
+            }
+
+            NestedStruct{x: x1, y: y1, e: MyEnum::Tuple(x2, y2)} => {
+                return x1 + y1 + u256(x2) + y2
+            }
+        }
+    }
+
     pub fn enum_storage(self, x:u32, y: u256, b: bool) -> u256 {
         if b {
             self.my_enum = MyEnumNested::Nested(MyEnum::Tuple(x, y))
@@ -199,4 +238,5 @@ contract Foo {
             }
         }
     }
+    
 }

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -876,6 +876,21 @@ fn enum_match() {
 
         harness.test_function(
             &mut executor,
+            "simple_struct",
+            &[int_token(1), int_token(2), bool_token(true)],
+            Some(&int_token(3)),
+        );
+        harness.test_function(
+            &mut executor,
+            "simple_struct",
+            &[int_token(1), int_token(2), bool_token(false)],
+            Some(&int_token(-1)),
+        );
+
+        harness.test_function(&mut executor, "nested_struct", &[], Some(&uint_token(10)));
+
+        harness.test_function(
+            &mut executor,
             "enum_storage",
             &[uint_token(1), uint_token(2), bool_token(true)],
             Some(&uint_token(3)),

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__enum_match.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__enum_match.snap
@@ -16,5 +16,8 @@ match_in_loop([]) used 1567 gas
 rest_pattern_head([Uint(1), Uint(2)]) used 2765 gas
 rest_pattern_tail([Uint(1), Uint(2)]) used 2778 gas
 rest_pattern_middle([Uint(1), Uint(2)]) used 3234 gas
-enum_storage([Uint(1), Uint(2), Bool(true)]) used 90794 gas
+simple_struct([Int(1), Int(2), Bool(true)]) used 1024 gas
+simple_struct([Int(1), Int(2), Bool(false)]) used 1038 gas
+nested_struct([]) used 1461 gas
+enum_storage([Uint(1), Uint(2), Bool(true)]) used 90839 gas
 

--- a/docs/src/spec/statements/match.md
+++ b/docs/src/spec/statements/match.md
@@ -11,10 +11,18 @@
 > &nbsp;&nbsp; _PatternElem_ ( `|` _PatternElem_ )<sup>*</sup>\
 >
 > _PatternElem_ : \
-> &nbsp;&nbsp; [_IDENTIFIER_] | [_BOOLEAN_LITERAL_] | `_` |  `..` | [_Path_] | [_Path_]`(` _TuplePatterns_<sup>?</sup> `)` | `(` _TuplePatterns_<sup>?</sup> `)`\
+> &nbsp;&nbsp; [_IDENTIFIER_] | [_BOOLEAN_LITERAL_] | `_` |  `..` | [_Path_] \|\
+> &nbsp;&nbsp; [_Path_]`(` _TuplePatterns_<sup>?</sup> `)` |`(` _TuplePatterns_<sup>?</sup> `)` \|\
+> &nbsp;&nbsp; [_Path_]`{` _StructPatterns_<sup>?</sup> `}`\
 > 
-> _TuplePatterns_ :\
-> &nbsp;&nbsp; _Pattern_ ( `,` _Pattern_ )<sup>\*</sup>
+> _TuplePatterns_ : \
+> &nbsp;&nbsp; _Pattern_ ( `,` _Pattern_ )<sup>\*</sup>\
+>
+> _StructPatterns_ : \
+> &nbsp;&nbsp; _Field_ ( `,` _Field_)<sup>\*</sup>(`,` `..`)<sup>?</sup>\
+>
+> _Field_ : \
+> &nbsp;&nbsp; [_IDENTIFIER_] `:` _Pattern_\
 
 
 A `match` statements compares `expression` with patterns, then executes body of the matched arm.

--- a/newsfragments/770.feature.md
+++ b/newsfragments/770.feature.md
@@ -40,6 +40,7 @@ For now, available patterns are restricted to
 * Boolean literal(`true` and `false`)
 * Enum variant. e.g., `MyEnum::Tuple(a, b, c)`
 * Tuple pattern. e.g., `(a, b, c)`
+* Struct pattern. e.g., `MyStruct {x: x1, y: y1, b: true}` 
 * Rest pattern(`..`), which matches the rest of the pattern. e.g., `MyEnum::Tuple(.., true)`
 * Or pattern(|). e.g., MyEnum::Unit | MyEnum::Tuple(.., true)
 


### PR DESCRIPTION
## Add struct pattern
Add a struct pattern that can be used in `match` statements.
e.g.,
```rust
struct MyS {
    pub x: i32
    pub b: bool

    fn eval(self) -> i32 {
        match self {
            MyS {x: x, b: true} => {
                return x
            }
            MyS {x: x, b: false} => {
                return -x
            }
        }
    }
}
```

#### NOTE 
1. Currently, field labels are required even if a binding name is the same as the field name.
2. To bind a field, the fields must be `pub`. Otherwise, the compiler complains about it.

## FIx #794 
```rust
enum Accumulator {
    Zero
    Int(u32)
    Clo(i32, i32)
}

struct MyStruct {
    pub acc: Accumulator
    pub y: i32
}

contract Bar {
}
```

I noticed the above example still causes an ICE even in the current master.
In #798, I overlooked that we should modify `codegen/abi.rs` so that non-emittable structs are excluded from abi events.
I fixed the problem in this PR for testing a nested struct pattern. 


[//]: # (Stay ahead of things, add list items here!)
- [x] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [x] Clean up commit history
