### PR TITLE
Implement trait associated functions

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -52,8 +52,13 @@ impl<T> Analysis<T> {
 
 pub trait AnalyzerContext {
     fn resolve_name(&self, name: &str, span: Span) -> Result<Option<NamedThing>, IncompleteItem>;
+    /// Resolves the given path and registers all errors
     fn resolve_path(&self, path: &ast::Path, span: Span) -> Result<NamedThing, FatalError>;
-    fn maybe_resolve_path(&self, path: &ast::Path) -> Option<NamedThing>;
+    /// Resolves the given path only if it is visible. Does not register any errors
+    fn resolve_visible_path(&self, path: &ast::Path) -> Option<NamedThing>;
+    /// Resolves the given path. Does not register any errors
+    fn resolve_any_path(&self, path: &ast::Path) -> Option<NamedThing>;
+
     fn add_diagnostic(&self, diag: Diagnostic);
     fn db(&self) -> &dyn AnalyzerDb;
 
@@ -319,7 +324,11 @@ impl AnalyzerContext for TempContext {
         panic!("TempContext can't resolve paths")
     }
 
-    fn maybe_resolve_path(&self, _path: &ast::Path) -> Option<NamedThing> {
+    fn resolve_visible_path(&self, _path: &ast::Path) -> Option<NamedThing> {
+        panic!("TempContext can't resolve paths")
+    }
+
+    fn resolve_any_path(&self, _path: &ast::Path) -> Option<NamedThing> {
         panic!("TempContext can't resolve paths")
     }
 

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -441,6 +441,14 @@ pub fn module_used_item_map(
                 diagnostics.extend(items.diagnostics.iter().cloned());
 
                 for (name, (name_span, item)) in items.value.iter() {
+                    if !item.is_public(db) {
+                        diagnostics.push(errors::error(
+                            &format!("{} {} is private", item.item_kind_display_name(), name,),
+                            *name_span,
+                            name.as_str(),
+                        ));
+                    }
+
                     if let Some((other_name_span, other_item)) =
                         accum.insert(name.clone(), (*name_span, *item))
                     {

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -979,7 +979,7 @@ fn expr_call_path<T: std::fmt::Display>(
     generic_args: &Option<Node<Vec<fe::GenericArg>>>,
     args: &Node<Vec<Node<fe::CallArg>>>,
 ) -> Result<(ExpressionAttributes, CallType), FatalError> {
-    match context.resolve_any_path(path) {
+    match context.resolve_visible_path(path) {
         Some(named_thing) => {
             check_visibility(context, &named_thing, func.span);
             validate_has_no_conflicting_trait_in_scope(context, &named_thing, path, func)?;
@@ -1106,6 +1106,10 @@ fn expr_call_trait_associated_function<T: std::fmt::Display>(
             return expr_call_pure(context, fun, func.span, generic_args, args);
         }
     }
+
+    // At this point, we will have an error so we run `resolve_path` to register any errors that we
+    // did not report yet
+    context.resolve_path(path, func.span)?;
 
     Err(FatalError::new(context.error(
         "unresolved path item",

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -208,7 +208,7 @@ fn match_pattern(
             tuple_pattern(scope, elts, &expected_elts, pat.span, None)
         }
 
-        Pattern::Path(path) => match scope.maybe_resolve_path(&path.kind) {
+        Pattern::Path(path) => match scope.resolve_visible_path(&path.kind) {
             Some(NamedThing::EnumVariant(variant)) => {
                 let db = scope.db();
                 let parent_type = variant.parent(db).as_type(db);

--- a/crates/analyzer/src/traversal/pattern_analysis.rs
+++ b/crates/analyzer/src/traversal/pattern_analysis.rs
@@ -638,7 +638,7 @@ fn simplify_pattern(
             }
         }
 
-        Pattern::Path(path) => match scope.maybe_resolve_path(&path.kind) {
+        Pattern::Path(path) => match scope.resolve_visible_path(&path.kind) {
             Some(NamedThing::EnumVariant(variant)) => SimplifiedPatternKind::Constructor {
                 kind: ConstructorKind::Enum(variant),
                 fields: vec![],
@@ -650,7 +650,7 @@ fn simplify_pattern(
         },
 
         Pattern::PathTuple(path, elts) => {
-            let variant = match scope.maybe_resolve_path(&path.kind).unwrap() {
+            let variant = match scope.resolve_visible_path(&path.kind).unwrap() {
                 NamedThing::EnumVariant(variant) => variant,
                 _ => unreachable!(),
             };
@@ -668,7 +668,7 @@ fn simplify_pattern(
             fields: pat_fields,
             ..
         } => {
-            let (sid, ctor_kind) = match scope.maybe_resolve_path(&path.kind).unwrap() {
+            let (sid, ctor_kind) = match scope.resolve_visible_path(&path.kind).unwrap() {
                 NamedThing::Item(Item::Type(TypeDef::Struct(sid))) => {
                     (sid, ConstructorKind::Struct(sid))
                 }

--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -209,7 +209,11 @@ test_stmt! { invert_non_numeric, "~true" }
 
 test_file! { ambiguous_traits }
 test_file! { ambiguous_traits2 }
+test_file! { ambiguous_traits3 }
+test_file! { ambiguous_traits4 }
 test_ingot! { trait_not_in_scope }
+test_ingot! { trait_not_in_scope2 }
+test_ingot! { call_trait_assoc_fn_on_invisible_type }
 test_file! { bad_enums }
 test_file! { enum_match }
 test_file! { enum_name_conflict }
@@ -302,7 +306,6 @@ test_file! { struct_call_bad_args }
 test_file! { struct_call_without_kw_args }
 test_file! { struct_recursive_cycles }
 test_file! { trait_impl_mismatch }
-test_file! { trait_fn_without_self }
 test_file! { trait_fn_with_generic_params }
 test_file! { traits_as_fields }
 test_file! { trait_conflicting_impls }

--- a/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
+++ b/crates/analyzer/tests/snapshots/analysis__basic_ingot.snap
@@ -313,8 +313,8 @@ note:
 note: 
   ┌─ ingots/basic_ingot/src/ding/dang.fe:1:1
   │
-1 │ type Dang = Array<u256, 42>
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
+1 │ pub type Dang = Array<u256, 42>
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Array<u256, 42>
 
 
 note: 

--- a/crates/analyzer/tests/snapshots/errors__ambiguous_traits3.snap
+++ b/crates/analyzer/tests/snapshots/errors__ambiguous_traits3.snap
@@ -1,0 +1,17 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: multiple applicable items in scope
+   ┌─ compile_errors/ambiguous_traits3.fe:11:6
+   │
+11 │   fn do() {
+   │      ^^ candidate #1 is defined here on trait `DoThing`
+   ·
+16 │   fn do() {
+   │      ^^ candidate #2 is defined here on trait `DoOtherThing`
+   │
+   = Hint: Rename one of the methods or make sure only one of them is in scope
+
+

--- a/crates/analyzer/tests/snapshots/errors__ambiguous_traits4.snap
+++ b/crates/analyzer/tests/snapshots/errors__ambiguous_traits4.snap
@@ -1,0 +1,17 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: "error_string(&path, test_files::fixture(path))"
+
+---
+error: multiple applicable items in scope
+   ┌─ compile_errors/ambiguous_traits4.fe:6:10
+   │
+ 6 │   pub fn do() {
+   │          ^^ candidate 1 is defined here on the struct
+   ·
+12 │   fn do() {
+   │      ^^ candidate #2 is defined here on trait `DoThing`
+   │
+   = Hint: Rename one of the methods or make sure only one of them is in scope
+
+

--- a/crates/analyzer/tests/snapshots/errors__bad_ingot.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_ingot.snap
@@ -94,10 +94,10 @@ error: the struct `Foo` is private
   = `Foo` can only be used within `foo`
   = Hint: use `pub` to make `Foo` visible from outside of `foo`
 
-error: incorrect type for `Foo` argument `my_num`
-  ┌─ compile_errors/bad_ingot/src/main.fe:8:33
+error: unresolved path item
+  ┌─ compile_errors/bad_ingot/src/main.fe:8:16
   │
 8 │         return foo::Foo(my_num: true)
-  │                                 ^^^^ this has type `bool`; expected type `u256`
+  │                ^^^^^^^^ not found
 
 

--- a/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
+++ b/crates/analyzer/tests/snapshots/errors__bad_visibility.snap
@@ -3,11 +3,47 @@ source: crates/analyzer/tests/errors.rs
 expression: error_string_ingot(&path)
 
 ---
-error: unresolved path item
+error: type MyInt is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:11
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │           ^^^^^ MyInt
+
+error: constant MY_CONST is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:18
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                  ^^^^^^^^ MY_CONST
+
+error: struct MyStruct is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:28
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                            ^^^^^^^^ MyStruct
+
+error: trait MyTrait is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:38
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                                      ^^^^^^^ MyTrait
+
+error: function my_func is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:47
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                                               ^^^^^^^ my_func
+
+error: type MyContract is private
+  ┌─ compile_errors/bad_visibility/src/main.fe:1:56
+  │
+1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
+  │                                                        ^^^^^^^^^^ MyContract
+
+error: type MyEnum is private
   ┌─ compile_errors/bad_visibility/src/main.fe:1:68
   │
 1 │ use foo::{MyInt, MY_CONST, MyStruct, MyTrait, my_func, MyContract, MyEnum }
-  │                                                                    ^^^^^^ not found
+  │                                                                    ^^^^^^ MyEnum
 
 error: the type `MyInt` is private
   ┌─ compile_errors/bad_visibility/src/main.fe:7:33
@@ -101,10 +137,24 @@ error: the function `my_func` is private
    = `my_func` can only be used within `foo`
    = Hint: use `pub` to make `my_func` visible from outside of `foo`
 
-error: the type `MyContract` is private
+error: the type `MyEnum` is private
    ┌─ compile_errors/bad_visibility/src/main.fe:25:16
    │
-25 │         let _: MyContract = MyContract(addr)
+25 │         let e: MyEnum = MyEnum::Some
+   │                ^^^^^^ this type is not `pub`
+   │
+   ┌─ compile_errors/bad_visibility/src/foo.fe:17:6
+   │
+17 │ enum MyEnum {
+   │      ------ `MyEnum` is defined here
+   │
+   = `MyEnum` can only be used within `foo`
+   = Hint: use `pub` to make `MyEnum` visible from outside of `foo`
+
+error: the type `MyContract` is private
+   ┌─ compile_errors/bad_visibility/src/main.fe:29:16
+   │
+29 │         let _: MyContract = MyContract(addr)
    │                ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:13:10
@@ -116,9 +166,9 @@ error: the type `MyContract` is private
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:25:29
+   ┌─ compile_errors/bad_visibility/src/main.fe:29:29
    │
-25 │         let _: MyContract = MyContract(addr)
+29 │         let _: MyContract = MyContract(addr)
    │                             ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:13:10
@@ -130,9 +180,9 @@ error: the type `MyContract` is private
    = Hint: use `pub` to make `MyContract` visible from outside of `foo`
 
 error: the type `MyContract` is private
-   ┌─ compile_errors/bad_visibility/src/main.fe:26:9
+   ┌─ compile_errors/bad_visibility/src/main.fe:30:9
    │
-26 │         MyContract.create(ctx, 1)
+30 │         MyContract.create(ctx, 1)
    │         ^^^^^^^^^^ this type is not `pub`
    │
    ┌─ compile_errors/bad_visibility/src/foo.fe:13:10

--- a/crates/analyzer/tests/snapshots/errors__call_trait_assoc_fn_on_invisible_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__call_trait_assoc_fn_on_invisible_type.snap
@@ -1,0 +1,20 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: error_string_ingot(&path)
+
+---
+error: the struct `Bar` is private
+  ┌─ compile_errors/call_trait_assoc_fn_on_invisible_type/src/main.fe:5:5
+  │
+5 │     foo::Bar::do()
+  │     ^^^^^^^^^^^^ this struct is not `pub`
+  │
+  ┌─ compile_errors/call_trait_assoc_fn_on_invisible_type/src/foo.fe:5:8
+  │
+5 │ struct Bar {}
+  │        --- `Bar` is defined here
+  │
+  = `Bar` can only be used within `foo`
+  = Hint: use `pub` to make `Bar` visible from outside of `foo`
+
+

--- a/crates/analyzer/tests/snapshots/errors__emittable_not_implementable.snap
+++ b/crates/analyzer/tests/snapshots/errors__emittable_not_implementable.snap
@@ -3,6 +3,12 @@ source: crates/analyzer/tests/errors.rs
 expression: "error_string(&path, test_files::fixture(path))"
 
 ---
+error: struct OutOfReachMarker is private
+  ┌─ compile_errors/emittable_not_implementable.fe:1:31
+  │
+1 │ use std::context::{Emittable, OutOfReachMarker}
+  │                               ^^^^^^^^^^^^^^^^ OutOfReachMarker
+
 error: the struct `OutOfReachMarker` is private
   ┌─ compile_errors/emittable_not_implementable.fe:6:24
   │

--- a/crates/analyzer/tests/snapshots/errors__trait_impl_mismatch.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_impl_mismatch.snap
@@ -9,7 +9,7 @@ error: method `this_has_wrong_args_in_impl` has incompatible parameters for `thi
  3 │     fn this_has_wrong_args_in_impl(self, val: u8, val2: bool);
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in trait `Foo`
    ·
-11 │     fn this_has_wrong_args_in_impl(self, val: u16, val2: Array<u8, 10>) {}
+13 │     fn this_has_wrong_args_in_impl(self, val: u16, val2: Array<u8, 10>) {}
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in `impl` block
 
 error: method `this_has_wrong_return_type_in_impl` has an incompatible return type for `this_has_wrong_return_type_in_impl` of trait `Foo`
@@ -18,13 +18,31 @@ error: method `this_has_wrong_return_type_in_impl` has an incompatible return ty
  4 │     fn this_has_wrong_return_type_in_impl(self) -> bool;
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in trait `Foo`
    ·
-12 │     fn this_has_wrong_return_type_in_impl(self) -> u8 {
+14 │     fn this_has_wrong_return_type_in_impl(self) -> u8 {
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ signature of method in `impl` block
 
-error: method `this_does_not_exist_in_trait` is not a member of trait `Foo`
-   ┌─ compile_errors/trait_impl_mismatch.fe:15:5
+error: method `this_has_no_self_in_impl` has a `self` declaration in the trait, but not in the `impl`
+   ┌─ compile_errors/trait_impl_mismatch.fe:5:8
    │
-15 │     fn this_does_not_exist_in_trait() {}
+ 5 │     fn this_has_no_self_in_impl(self);
+   │        ^^^^^^^^^^^^^^^^^^^^^^^^ `self` declared on the `trait`
+   ·
+17 │     fn this_has_no_self_in_impl() {}
+   │        ^^^^^^^^^^^^^^^^^^^^^^^^ no `self` declared on the `impl`
+
+error: method `this_has_self_in_impl` has a `self` declaration in the impl, but not in the `trait`
+   ┌─ compile_errors/trait_impl_mismatch.fe:6:8
+   │
+ 6 │     fn this_has_self_in_impl();
+   │        ^^^^^^^^^^^^^^^^^^^^^ no `self` declared on the `trait`
+   ·
+18 │     fn this_has_self_in_impl(self) {}
+   │        ^^^^^^^^^^^^^^^^^^^^^ `self` declared on the `impl`
+
+error: method `this_does_not_exist_in_trait` is not a member of trait `Foo`
+   ┌─ compile_errors/trait_impl_mismatch.fe:19:5
+   │
+19 │     fn this_does_not_exist_in_trait() {}
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Foo`
 
 error: not all members of trait `Foo` implemented, missing: `this_misses_in_impl`

--- a/crates/analyzer/tests/snapshots/errors__trait_not_in_scope2.snap
+++ b/crates/analyzer/tests/snapshots/errors__trait_not_in_scope2.snap
@@ -1,0 +1,17 @@
+---
+source: crates/analyzer/tests/errors.rs
+expression: error_string_ingot(&path)
+
+---
+error: Applicable items exist but are not in scope
+   ┌─ compile_errors/trait_not_in_scope2/src/foo.fe:11:6
+   │
+11 │   fn do() {
+   │      ^^ candidate #1 is defined here on trait `DoThing`
+   ·
+16 │   fn do() {
+   │      ^^ candidate #2 is defined here on trait `DoOtherThing`
+   │
+   = Hint: Bring one of these candidates in scope via `use module_name::trait_name`
+
+

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -38,6 +38,14 @@ pub struct Path {
     pub segments: Vec<Node<SmolStr>>,
 }
 
+impl Path {
+    pub fn remove_last(&self) -> Path {
+        Path {
+            segments: self.segments[0..self.segments.len() - 1].to_vec(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Use {
     pub tree: Node<UseTree>,

--- a/crates/test-files/fixtures/compile_errors/ambiguous_traits3.fe
+++ b/crates/test-files/fixtures/compile_errors/ambiguous_traits3.fe
@@ -1,0 +1,24 @@
+trait DoThing {
+  fn do();
+}
+
+trait DoOtherThing {
+  fn do();
+}
+
+
+impl DoThing for u256 {
+  fn do() {
+  }
+}
+
+impl DoOtherThing for u256 {
+  fn do() {
+  }
+}
+
+contract Example {
+  pub fn run_test(self) {
+    u256::do()
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/ambiguous_traits4.fe
+++ b/crates/test-files/fixtures/compile_errors/ambiguous_traits4.fe
@@ -1,0 +1,20 @@
+trait DoThing {
+  fn do();
+}
+
+struct Bar {
+  pub fn do() {
+
+  }
+}
+
+impl DoThing for Bar {
+  fn do() {
+  }
+}
+
+contract Example {
+  pub fn run_test(self) {
+    Bar::do()
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/bad_ingot/src/biz/bad.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_ingot/src/biz/bad.fe
@@ -1,3 +1,3 @@
-struct Bur {}
+pub struct Bur {}
 
-struct Bud {}
+pub struct Bud {}

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/foo.fe
@@ -13,3 +13,8 @@ fn my_func() {}
 contract MyContract {
     x: i32
 }
+
+enum MyEnum {
+    Some
+    Thing
+}

--- a/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/bad_visibility/src/main.fe
@@ -21,6 +21,10 @@ contract Main {
         my_func()
     }
 
+    pub fn priv_enum() {
+        let e: MyEnum = MyEnum::Some
+    }
+
     pub fn priv_contract(mut ctx: Context, addr: address) {
         let _: MyContract = MyContract(addr)
         MyContract.create(ctx, 1)

--- a/crates/test-files/fixtures/compile_errors/call_trait_assoc_fn_on_invisible_type/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/call_trait_assoc_fn_on_invisible_type/src/foo.fe
@@ -1,0 +1,12 @@
+pub trait DoThing {
+  fn do();
+}
+
+struct Bar {}
+
+impl DoThing for Bar {
+  fn do() {
+  }
+}
+
+

--- a/crates/test-files/fixtures/compile_errors/call_trait_assoc_fn_on_invisible_type/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/call_trait_assoc_fn_on_invisible_type/src/main.fe
@@ -1,0 +1,7 @@
+use foo::DoThing
+
+contract Example {
+  pub fn run_test(self) {
+    foo::Bar::do()
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/trait_fn_without_self.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_fn_without_self.fe
@@ -1,3 +1,0 @@
-trait Foo {
-    fn this_has_no_self();
-}

--- a/crates/test-files/fixtures/compile_errors/trait_impl_mismatch.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_impl_mismatch.fe
@@ -2,6 +2,8 @@ trait Foo {
     fn this_misses_in_impl(self);
     fn this_has_wrong_args_in_impl(self, val: u8, val2: bool);
     fn this_has_wrong_return_type_in_impl(self) -> bool;
+    fn this_has_no_self_in_impl(self);
+    fn this_has_self_in_impl();
 }
 
 struct Bar {}
@@ -12,5 +14,7 @@ impl Foo for Bar {
     fn this_has_wrong_return_type_in_impl(self) -> u8 {
         return 0
     }
+    fn this_has_no_self_in_impl() {}
+    fn this_has_self_in_impl(self) {}
     fn this_does_not_exist_in_trait() {}
 }

--- a/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src copy/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src copy/foo.fe
@@ -1,0 +1,9 @@
+trait DoThing {
+  fn do(self);
+}
+
+
+impl DoThing for u256 {
+  fn do(self) {
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src copy/main.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_not_in_scope/src copy/main.fe
@@ -1,0 +1,6 @@
+
+contract Example {
+  pub fn run_test(self) {
+    1.do()
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/trait_not_in_scope2/src/foo.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_not_in_scope2/src/foo.fe
@@ -1,0 +1,18 @@
+trait DoThing {
+  fn do();
+}
+
+trait DoOtherThing {
+  fn do();
+}
+
+
+impl DoThing for u256 {
+  fn do() {
+  }
+}
+
+impl DoOtherThing for u256 {
+  fn do() {
+  }
+}

--- a/crates/test-files/fixtures/compile_errors/trait_not_in_scope2/src/main.fe
+++ b/crates/test-files/fixtures/compile_errors/trait_not_in_scope2/src/main.fe
@@ -1,0 +1,6 @@
+
+contract Example {
+  pub fn run_test(self) {
+    u256::do()
+  }
+}

--- a/crates/test-files/fixtures/features/trait_associated_functions.fe
+++ b/crates/test-files/fixtures/features/trait_associated_functions.fe
@@ -1,0 +1,16 @@
+trait Max {
+  fn max() -> u8;
+}
+
+impl Max for u8 {
+  fn max() -> u8 {
+    return u8(255)
+  }
+}
+
+contract Example {
+
+  pub fn run_test(self) {
+    assert u8::max() == 255
+  }
+}

--- a/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dang.fe
+++ b/crates/test-files/fixtures/ingots/basic_ingot/src/ding/dang.fe
@@ -1,1 +1,1 @@
-type Dang = Array<u256, 42>
+pub type Dang = Array<u256, 42>

--- a/crates/test-files/fixtures/ingots/trait_no_ambiguity/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/trait_no_ambiguity/src/foo.fe
@@ -1,0 +1,5 @@
+pub struct MyS {
+    fn x() -> u256 {
+        return 10
+    }
+}

--- a/crates/test-files/fixtures/ingots/trait_no_ambiguity/src/main.fe
+++ b/crates/test-files/fixtures/ingots/trait_no_ambiguity/src/main.fe
@@ -1,0 +1,17 @@
+use foo::MyS
+
+trait Trait {
+    fn x() -> u256;
+}
+
+impl Trait for MyS {
+    fn x() -> u256 {
+        return 10
+    }
+}
+
+contract Foo {
+    pub fn main() -> u256 {
+        return MyS::x()
+    }
+}

--- a/crates/test-files/fixtures/ingots/visibility_ingot/src/foo.fe
+++ b/crates/test-files/fixtures/ingots/visibility_ingot/src/foo.fe
@@ -2,7 +2,7 @@ pub struct Bing {
     pub my_address: address
 }
 
-fn get_42_backend() -> u256 {
+pub fn get_42_backend() -> u256 {
     return 42
 }
 

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -2229,6 +2229,7 @@ fn ctx_init_in_call() {
 #[rstest(
     fixture_file,
     case::simple_traits("simple_traits.fe"),
+    case::trait_associated_functions("trait_associated_functions.fe"),
     case::generic_functions("generic_functions.fe"),
     case::generic_functions_primitves("generic_functions_primitves.fe"),
     case::contract_pure_fns("contract_pure_fns.fe")

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -24,6 +24,13 @@ fn test_ingot_with_visibility() {
 }
 
 #[test]
+fn test_trait_no_ambiguity() {
+    with_executor(&|mut executor| {
+        let _harness = deploy_ingot(&mut executor, "trait_no_ambiguity", "Foo", &[]);
+    })
+}
+
+#[test]
 fn test_ingot_pub_contract() {
     with_executor(&|mut executor| {
         let _harness = deploy_ingot(&mut executor, "visibility_ingot", "Foo", &[]);

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_2_trait_associated_functions.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_2_trait_associated_functions.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 32 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_3_generic_functions.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_3_generic_functions.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 32 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_4_generic_functions_primitves.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_4_generic_functions_primitves.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 32 gas
+

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__case_5_contract_pure_fns.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__case_5_contract_pure_fns.snap
@@ -1,0 +1,7 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+run_test([]) used 35 gas
+

--- a/newsfragments/805.feature.md
+++ b/newsfragments/805.feature.md
@@ -1,0 +1,23 @@
+Trait associated functions
+
+This change allows trait functions that do not take a `self` parameter.
+The following demonstrates a possible trait associated function and its usage:
+
+```
+trait Max {
+  fn max(self) -> u8;
+}
+
+impl Max for u8 {
+  fn max() -> u8 {
+    return u8(255)
+  }
+}
+
+contract Example {
+
+  pub fn run_test(self) {
+    assert u8::max() == 255
+  }
+}
+```

--- a/newsfragments/815.bugfix.md
+++ b/newsfragments/815.bugfix.md
@@ -1,0 +1,5 @@
+Disallow importing private type via `use`
+
+The following was previously allowed but will now error:
+
+`use foo::PrivateStruct`


### PR DESCRIPTION
### What was wrong?

We don't have trait associated functions.

### How was it fixed?

Basically just enhanced `expr_call_path` to keep looking for candidates that are implemented via traits if we can not resolve the path directly on the type.

This also includes #815 which can be reviewed seperately.