### PR TITLE
Bug

### DIFF
--- a/crates/test-files/fixtures/features/tmp.fe
+++ b/crates/test-files/fixtures/features/tmp.fe
@@ -1,0 +1,12 @@
+pub struct Field {
+    row: u8
+    column: u8
+    value: u8
+}
+
+pub struct Board {
+    state: Array<Array<Field, 4>, 4>
+}
+
+pub contract Foo {
+}

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -729,6 +729,14 @@ fn nested_map() {
 }
 
 #[test]
+fn tmp() {
+    with_executor(&|mut executor| {
+        let harness = deploy_contract(&mut executor, "tmp.fe", "Foo", &[]);
+        assert_harness_gas_report!(harness);
+    })
+}
+
+#[test]
 fn events() {
     with_executor(&|mut executor| {
         let harness = deploy_contract(&mut executor, "events.fe", "Foo", &[]);

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__tmp.snap.new
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__tmp.snap.new
@@ -1,0 +1,6 @@
+---
+source: crates/tests/src/features.rs
+expression: "format!(\"{}\", harness.gas_reporter)"
+
+---
+


### PR DESCRIPTION
### What was wrong?

There seems to be a regression with structs that contain fields that are arrays over complex fields.

This fails with: 

```
unable to load the ABI: SerdeJson(Error("missing field
`components`", line: 36, column: 3))
```



