### PR TITLE
Add dumb borrow check of fn call args

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -240,7 +240,7 @@ pub enum NamedThing {
     },
     // SelfType // when/if we add a `Self` type keyword
     Variable {
-        name: String,
+        name: SmolStr,
         typ: Result<TypeId, TypeError>,
         is_const: bool,
         span: Span,
@@ -248,6 +248,15 @@ pub enum NamedThing {
 }
 
 impl NamedThing {
+    pub fn name(&self, db: &dyn AnalyzerDb) -> SmolStr {
+        match self {
+            NamedThing::Item(item) => item.name(db),
+            NamedThing::EnumVariant(variant) => variant.name(db),
+            NamedThing::SelfValue { .. } => "self".into(),
+            NamedThing::Variable { name, .. } => name.clone(),
+        }
+    }
+
     pub fn name_span(&self, db: &dyn AnalyzerDb) -> Option<Span> {
         match self {
             NamedThing::Item(item) => item.name_span(db),

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -344,7 +344,7 @@ impl<'a> AnalyzerContext for FunctionScope<'a> {
                     .expect("found param type but not span");
 
                 NamedThing::Variable {
-                    name: name.to_string(),
+                    name: name.into(),
                     typ: param.typ.clone(),
                     is_const: false,
                     span,
@@ -467,7 +467,7 @@ impl AnalyzerContext for BlockScope<'_, '_> {
             self.variable_defs
                 .get(name)
                 .map(|(typ, is_const, span)| NamedThing::Variable {
-                    name: name.to_string(),
+                    name: name.into(),
                     typ: Ok(*typ),
                     is_const: *is_const,
                     span: *span,

--- a/crates/analyzer/src/traversal/borrowck.rs
+++ b/crates/analyzer/src/traversal/borrowck.rs
@@ -1,0 +1,113 @@
+use super::call_args::LabeledParameter;
+use crate::context::{AnalyzerContext, NamedThing};
+use crate::namespace::types::{Type, TypeId};
+use fe_common::diagnostics::Label;
+use fe_parser::ast;
+use fe_parser::node::{Node, Span};
+use smallvec::{smallvec, SmallVec};
+
+// NOTE: This is a temporary solution to the only borrowing bug that's possible
+// in the current semantics of Fe, namely passing a mutable reference to a
+// non-primitive object into a fn call, and another reference to that same
+// object (mutable or otherwise).
+// This is an ugly brute force solution that will definitely not scale
+// beyond this simple case, and doesn't do anything smart like allow
+// disjoint partial borrows.
+// This should be replaced with a proper borrow checker (presumably operating
+// on MIR) when Fe gains some kind of reference/projection type.
+pub fn check_fn_call_arg_borrows(
+    context: &mut dyn AnalyzerContext,
+    fn_name: &str,
+    method_self: Option<(&Node<ast::Expr>, TypeId)>,
+    args: &[Node<ast::CallArg>],
+    params: &[impl LabeledParameter],
+) {
+    // Return early if there are no mut params.
+    // This function doesn't attempt to be efficient.
+    let mut_self = method_self
+        .map(|(_, ty)| ty.is_mut(context.db()))
+        .unwrap_or(false);
+    if !mut_self
+        && !params
+            .iter()
+            .any(|p| p.typ().map(|t| t.is_mut(context.db())).unwrap_or(false))
+    {
+        return;
+    }
+
+    // Allocate a new Vec<(arg, ty)> including the method target (if present)
+    let param_ty = params
+        .iter()
+        .map(|p| p.typ().unwrap_or_else(|_| Type::unit().id(context.db())));
+    let mut args = args
+        .iter()
+        .map(|arg| &arg.kind.value)
+        .zip(param_ty)
+        .collect::<Vec<_>>();
+    if let Some((target_expr, ty)) = method_self {
+        args.insert(0, (target_expr, ty));
+    }
+
+    for (idx, (arg, _)) in args
+        .iter()
+        .enumerate()
+        .filter(|(_, (_, ty))| ty.is_mut(context.db()))
+    {
+        // Find the "root" var of the mut arg expr. Eg the root of a.b.c is `a`.
+        // In the case of a ternary expr, there may be more than one.
+        // Eg foo(a if x else (b if y else c))
+        let vars = resolve_expr_root_vars(context, arg);
+
+        // Check all other non-primitive args for the same root var.
+        for (_, (other, _)) in args
+            .iter()
+            .enumerate()
+            .filter(|(i, (_, ty))| *i != idx && !ty.is_primitive(context.db()))
+        {
+            let other_vars = resolve_expr_root_vars(context, other);
+            for (var, var_span) in &vars {
+                if let Some((_, other_span)) = other_vars.iter().find(|(nt, _)| nt == var) {
+                    let name = var.name(context.db());
+                    context.fancy_error(
+                        &format!("borrow conflict in call to fn `{}`", fn_name),
+                        vec![
+                            Label::primary(*var_span, &format!("`{}` is used mutably here", name)),
+                            Label::secondary(
+                                *other_span,
+                                &format!("`{}` is used again here", name),
+                            ),
+                        ],
+                        vec![],
+                    );
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn resolve_expr_root_vars(
+    context: &dyn AnalyzerContext,
+    expr: &Node<ast::Expr>,
+) -> SmallVec<[(NamedThing, Span); 2]> {
+    match &expr.kind {
+        ast::Expr::Name(name) => match context.resolve_name(name, expr.span) {
+            Ok(
+                Some(nt @ NamedThing::Variable { .. }) | Some(nt @ NamedThing::SelfValue { .. }),
+            ) => smallvec![(nt, expr.span)],
+            _ => smallvec![],
+        },
+
+        ast::Expr::Attribute { value, .. } | ast::Expr::Subscript { value, .. } => {
+            resolve_expr_root_vars(context, value)
+        }
+        ast::Expr::Ternary {
+            if_expr, else_expr, ..
+        } => {
+            let mut left = resolve_expr_root_vars(context, if_expr);
+            left.append(&mut resolve_expr_root_vars(context, else_expr));
+            left
+        }
+        _ => smallvec![],
+    }
+}

--- a/crates/analyzer/src/traversal/mod.rs
+++ b/crates/analyzer/src/traversal/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod const_expr;
 pub(crate) mod expressions;
 
 mod assignments;
+mod borrowck;
 mod call_args;
 mod declarations;
 mod matching_anomaly;

--- a/crates/analyzer/tests/snapshots/analysis__value_semantics.snap
+++ b/crates/analyzer/tests/snapshots/analysis__value_semantics.snap
@@ -10,15 +10,16 @@ note:
   │     ^^^^^^^^^^^^^^^^^^^^^^ Array<u8, 3>
 
 note: 
-  ┌─ value_semantics.fe:4:5
-  │  
-4 │ ╭     pub fn bar(mut self) -> bool {
-5 │ │         self.set_array()
-6 │ │         tuple_of_primitive()
-7 │ │ 
-8 │ │         return true
-9 │ │     }
-  │ ╰─────^ params: [mut self] -> bool
+   ┌─ value_semantics.fe:4:5
+   │  
+ 4 │ ╭     pub fn bar(mut self) -> bool {
+ 5 │ │         self.set_array()
+ 6 │ │         tuple_of_primitive()
+ 7 │ │         tuple_of_structs()
+   · │
+14 │ │         return true
+15 │ │     }
+   │ ╰─────^ params: [mut self] -> bool
 
 note: 
   ┌─ value_semantics.fe:5:9
@@ -27,198 +28,159 @@ note:
   │         ^^^^ mut Foo
 
 note: 
-  ┌─ value_semantics.fe:5:9
-  │
-5 │         self.set_array()
-  │         ^^^^^^^^^^^^^^^^ ()
-6 │         tuple_of_primitive()
-  │         ^^^^^^^^^^^^^^^^^^^^ ()
-7 │ 
-8 │         return true
-  │                ^^^^ bool
+   ┌─ value_semantics.fe:5:9
+   │
+ 5 │         self.set_array()
+   │         ^^^^^^^^^^^^^^^^ ()
+ 6 │         tuple_of_primitive()
+   │         ^^^^^^^^^^^^^^^^^^^^ ()
+ 7 │         tuple_of_structs()
+   │         ^^^^^^^^^^^^^^^^^^ ()
+ 8 │         struct_constructor()
+   │         ^^^^^^^^^^^^^^^^^^^^ ()
+ 9 │         copies()
+   │         ^^^^^^^^ ()
+10 │         struct_field_copies()
+   │         ^^^^^^^^^^^^^^^^^^^^^ ()
+11 │         ternary(true)
+   │                 ^^^^ bool
 
 note: 
-   ┌─ value_semantics.fe:11:5
+   ┌─ value_semantics.fe:11:9
+   │
+11 │         ternary(true)
+   │         ^^^^^^^^^^^^^ ()
+12 │         ternary(false)
+   │                 ^^^^^ bool
+
+note: 
+   ┌─ value_semantics.fe:12:9
+   │
+12 │         ternary(false)
+   │         ^^^^^^^^^^^^^^ ()
+13 │ 
+14 │         return true
+   │                ^^^^ bool
+
+note: 
+   ┌─ value_semantics.fe:17:5
    │  
-11 │ ╭     pub fn set_array(mut self) {
-12 │ │         self.my_array = [42; 3]
-13 │ │     }
+17 │ ╭     pub fn set_array(mut self) {
+18 │ │         self.my_array = [42; 3]
+19 │ │     }
    │ ╰─────^ params: [mut self] -> ()
 
 note: 
-   ┌─ value_semantics.fe:12:9
+   ┌─ value_semantics.fe:18:9
    │
-12 │         self.my_array = [42; 3]
+18 │         self.my_array = [42; 3]
    │         ^^^^ mut Foo
 
 note: 
-   ┌─ value_semantics.fe:12:9
+   ┌─ value_semantics.fe:18:9
    │
-12 │         self.my_array = [42; 3]
+18 │         self.my_array = [42; 3]
    │         ^^^^^^^^^^^^^    ^^  ^ u256
    │         │                │    
    │         │                u8
    │         mut SPtr<Array<u8, 3>>
 
 note: 
-   ┌─ value_semantics.fe:12:25
+   ┌─ value_semantics.fe:18:25
    │
-12 │         self.my_array = [42; 3]
+18 │         self.my_array = [42; 3]
    │                         ^^^^^^^ Array<u8, 3>
 
 note: 
-   ┌─ value_semantics.fe:17:1
+   ┌─ value_semantics.fe:23:1
    │  
-17 │ ╭ fn tuple_of_primitive() {
-18 │ │     let mut tup_a: (u8, u8) = (1, 2);
-19 │ │     let mut tup_b: (u8, u8) = tup_a
-20 │ │     tup_a.item0 = 5
+23 │ ╭ fn tuple_of_primitive() {
+24 │ │     let mut tup_a: (u8, u8) = (1, 2);
+25 │ │     let mut tup_b: (u8, u8) = tup_a
+26 │ │     tup_a.item0 = 5
    · │
-33 │ │     assert tup_imm.item0 == 1
-34 │ │ }
+39 │ │     assert tup_imm.item0 == 1
+40 │ │ }
    │ ╰─^ params: [] -> ()
 
 note: 
-   ┌─ value_semantics.fe:18:13
+   ┌─ value_semantics.fe:24:13
    │
-18 │     let mut tup_a: (u8, u8) = (1, 2);
+24 │     let mut tup_a: (u8, u8) = (1, 2);
    │             ^^^^^ mut (u8, u8)
-19 │     let mut tup_b: (u8, u8) = tup_a
+25 │     let mut tup_b: (u8, u8) = tup_a
    │             ^^^^^ mut (u8, u8)
    ·
-23 │     let tup_imm: (u8, u8) = (1, 2)
+29 │     let tup_imm: (u8, u8) = (1, 2)
    │         ^^^^^^^ (u8, u8)
-24 │     let mut tup_c: (u8, u8) = tup_imm
+30 │     let mut tup_c: (u8, u8) = tup_imm
    │             ^^^^^ mut (u8, u8)
 
 note: 
-   ┌─ value_semantics.fe:18:32
+   ┌─ value_semantics.fe:24:32
    │
-18 │     let mut tup_a: (u8, u8) = (1, 2);
+24 │     let mut tup_a: (u8, u8) = (1, 2);
    │                                ^  ^ u8
    │                                │   
    │                                u8
 
 note: 
-   ┌─ value_semantics.fe:18:31
+   ┌─ value_semantics.fe:24:31
    │
-18 │     let mut tup_a: (u8, u8) = (1, 2);
+24 │     let mut tup_a: (u8, u8) = (1, 2);
    │                               ^^^^^^ (u8, u8)
-19 │     let mut tup_b: (u8, u8) = tup_a
+25 │     let mut tup_b: (u8, u8) = tup_a
    │                               ^^^^^ mut (u8, u8) -Copy-> (u8, u8)
-20 │     tup_a.item0 = 5
-   │     ^^^^^ mut (u8, u8)
-
-note: 
-   ┌─ value_semantics.fe:20:5
-   │
-20 │     tup_a.item0 = 5
-   │     ^^^^^^^^^^^   ^ u8
-   │     │              
-   │     mut u8
-21 │     assert tup_b.item0 == 1
-   │            ^^^^^ mut (u8, u8)
-
-note: 
-   ┌─ value_semantics.fe:21:12
-   │
-21 │     assert tup_b.item0 == 1
-   │            ^^^^^^^^^^^    ^ u8
-   │            │               
-   │            mut u8
-
-note: 
-   ┌─ value_semantics.fe:21:12
-   │
-21 │     assert tup_b.item0 == 1
-   │            ^^^^^^^^^^^^^^^^ bool
-22 │ 
-23 │     let tup_imm: (u8, u8) = (1, 2)
-   │                              ^  ^ u8
-   │                              │   
-   │                              u8
-
-note: 
-   ┌─ value_semantics.fe:23:29
-   │
-23 │     let tup_imm: (u8, u8) = (1, 2)
-   │                             ^^^^^^ (u8, u8)
-24 │     let mut tup_c: (u8, u8) = tup_imm
-   │                               ^^^^^^^ (u8, u8) -Copy-> (u8, u8)
-25 │ 
-26 │     tup_c.item0 = 10
+26 │     tup_a.item0 = 5
    │     ^^^^^ mut (u8, u8)
 
 note: 
    ┌─ value_semantics.fe:26:5
    │
-26 │     tup_c.item0 = 10
-   │     ^^^^^^^^^^^   ^^ u8
+26 │     tup_a.item0 = 5
+   │     ^^^^^^^^^^^   ^ u8
    │     │              
    │     mut u8
-27 │     assert tup_imm.item0 == 1
-   │            ^^^^^^^ (u8, u8)
-
-note: 
-   ┌─ value_semantics.fe:27:12
-   │
-27 │     assert tup_imm.item0 == 1
-   │            ^^^^^^^^^^^^^    ^ u8
-   │            │                 
-   │            u8
-
-note: 
-   ┌─ value_semantics.fe:27:12
-   │
-27 │     assert tup_imm.item0 == 1
-   │            ^^^^^^^^^^^^^^^^^^ bool
-28 │ 
-29 │     tup_c = tup_imm
-   │     ^^^^^   ^^^^^^^ (u8, u8) -Copy-> (u8, u8)
-   │     │        
-   │     mut (u8, u8)
-30 │     assert tup_c.item0 == 1
+27 │     assert tup_b.item0 == 1
    │            ^^^^^ mut (u8, u8)
 
 note: 
-   ┌─ value_semantics.fe:30:12
+   ┌─ value_semantics.fe:27:12
    │
-30 │     assert tup_c.item0 == 1
+27 │     assert tup_b.item0 == 1
    │            ^^^^^^^^^^^    ^ u8
    │            │               
    │            mut u8
 
 note: 
-   ┌─ value_semantics.fe:30:12
+   ┌─ value_semantics.fe:27:12
    │
-30 │     assert tup_c.item0 == 1
+27 │     assert tup_b.item0 == 1
    │            ^^^^^^^^^^^^^^^^ bool
-31 │     tup_c.item0 = 10
+28 │ 
+29 │     let tup_imm: (u8, u8) = (1, 2)
+   │                              ^  ^ u8
+   │                              │   
+   │                              u8
+
+note: 
+   ┌─ value_semantics.fe:29:29
+   │
+29 │     let tup_imm: (u8, u8) = (1, 2)
+   │                             ^^^^^^ (u8, u8)
+30 │     let mut tup_c: (u8, u8) = tup_imm
+   │                               ^^^^^^^ (u8, u8) -Copy-> (u8, u8)
+31 │ 
+32 │     tup_c.item0 = 10
    │     ^^^^^ mut (u8, u8)
 
 note: 
-   ┌─ value_semantics.fe:31:5
+   ┌─ value_semantics.fe:32:5
    │
-31 │     tup_c.item0 = 10
+32 │     tup_c.item0 = 10
    │     ^^^^^^^^^^^   ^^ u8
    │     │              
    │     mut u8
-32 │     assert tup_c.item0 == 10
-   │            ^^^^^ mut (u8, u8)
-
-note: 
-   ┌─ value_semantics.fe:32:12
-   │
-32 │     assert tup_c.item0 == 10
-   │            ^^^^^^^^^^^    ^^ u8
-   │            │               
-   │            mut u8
-
-note: 
-   ┌─ value_semantics.fe:32:12
-   │
-32 │     assert tup_c.item0 == 10
-   │            ^^^^^^^^^^^^^^^^^ bool
 33 │     assert tup_imm.item0 == 1
    │            ^^^^^^^ (u8, u8)
 
@@ -235,390 +197,886 @@ note:
    │
 33 │     assert tup_imm.item0 == 1
    │            ^^^^^^^^^^^^^^^^^^ bool
+34 │ 
+35 │     tup_c = tup_imm
+   │     ^^^^^   ^^^^^^^ (u8, u8) -Copy-> (u8, u8)
+   │     │        
+   │     mut (u8, u8)
+36 │     assert tup_c.item0 == 1
+   │            ^^^^^ mut (u8, u8)
+
+note: 
+   ┌─ value_semantics.fe:36:12
+   │
+36 │     assert tup_c.item0 == 1
+   │            ^^^^^^^^^^^    ^ u8
+   │            │               
+   │            mut u8
+
+note: 
+   ┌─ value_semantics.fe:36:12
+   │
+36 │     assert tup_c.item0 == 1
+   │            ^^^^^^^^^^^^^^^^ bool
+37 │     tup_c.item0 = 10
+   │     ^^^^^ mut (u8, u8)
 
 note: 
    ┌─ value_semantics.fe:37:5
    │
-37 │     pub x: u64
-   │     ^^^^^^^^^^ u64
-38 │     pub y: u64
-   │     ^^^^^^^^^^ u64
+37 │     tup_c.item0 = 10
+   │     ^^^^^^^^^^^   ^^ u8
+   │     │              
+   │     mut u8
+38 │     assert tup_c.item0 == 10
+   │            ^^^^^ mut (u8, u8)
 
 note: 
-   ┌─ value_semantics.fe:41:5
+   ┌─ value_semantics.fe:38:12
    │
-41 │     pub a: Point
-   │     ^^^^^^^^^^^^ Point
-42 │     pub b: Point
-   │     ^^^^^^^^^^^^ Point
+38 │     assert tup_c.item0 == 10
+   │            ^^^^^^^^^^^    ^^ u8
+   │            │               
+   │            mut u8
 
 note: 
-   ┌─ value_semantics.fe:44:5
+   ┌─ value_semantics.fe:38:12
+   │
+38 │     assert tup_c.item0 == 10
+   │            ^^^^^^^^^^^^^^^^^ bool
+39 │     assert tup_imm.item0 == 1
+   │            ^^^^^^^ (u8, u8)
+
+note: 
+   ┌─ value_semantics.fe:39:12
+   │
+39 │     assert tup_imm.item0 == 1
+   │            ^^^^^^^^^^^^^    ^ u8
+   │            │                 
+   │            u8
+
+note: 
+   ┌─ value_semantics.fe:39:12
+   │
+39 │     assert tup_imm.item0 == 1
+   │            ^^^^^^^^^^^^^^^^^^ bool
+
+note: 
+   ┌─ value_semantics.fe:42:1
    │  
-44 │ ╭     pub fn from_origin_to(b: Point) -> Line {
-45 │ │         return Line(a: Point(x: 0, y: 0), b)
-46 │ │     }
-   │ ╰─────^ params: [{ label: None, name: b, typ: Point }] -> Line
-
-note: 
-   ┌─ value_semantics.fe:45:33
-   │
-45 │         return Line(a: Point(x: 0, y: 0), b)
-   │                                 ^     ^ u64
-   │                                 │      
-   │                                 u64
-
-note: 
-   ┌─ value_semantics.fe:45:24
-   │
-45 │         return Line(a: Point(x: 0, y: 0), b)
-   │                        ^^^^^^^^^^^^^^^^^  ^ Point -Copy-> Point
-   │                        │                   
-   │                        Point
-
-note: 
-   ┌─ value_semantics.fe:45:16
-   │
-45 │         return Line(a: Point(x: 0, y: 0), b)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line
-
-note: 
-   ┌─ value_semantics.fe:49:1
-   │  
-49 │ ╭ fn struct_constructor() {
-50 │ │     let mut a: Point = Point(x: 0, y: 0)
-51 │ │     let mut b: Point = Point(x: 10, y: 10)
-52 │ │ 
+42 │ ╭ fn tuple_of_structs() {
+43 │ │     let mut p: Point = Point(x: 0, y: 0)
+44 │ │     let q: Point = Point(x: 0, y: 0)
+45 │ │     let mut pair: (Point, Point) = (p, q)
    · │
-58 │ │     assert b.x == 10
-59 │ │ }
+49 │ │     assert q.x == 0
+50 │ │ }
    │ ╰─^ params: [] -> ()
 
 note: 
-   ┌─ value_semantics.fe:50:13
+   ┌─ value_semantics.fe:43:13
    │
-50 │     let mut a: Point = Point(x: 0, y: 0)
+43 │     let mut p: Point = Point(x: 0, y: 0)
    │             ^ mut Point
-51 │     let mut b: Point = Point(x: 10, y: 10)
-   │             ^ mut Point
-52 │ 
-53 │     let mut line: Line = Line(a, b)
-   │             ^^^^ mut Line
+44 │     let q: Point = Point(x: 0, y: 0)
+   │         ^ Point
+45 │     let mut pair: (Point, Point) = (p, q)
+   │             ^^^^ mut (Point, Point)
 
 note: 
-   ┌─ value_semantics.fe:50:33
+   ┌─ value_semantics.fe:43:33
    │
-50 │     let mut a: Point = Point(x: 0, y: 0)
+43 │     let mut p: Point = Point(x: 0, y: 0)
    │                                 ^     ^ u64
    │                                 │      
    │                                 u64
 
 note: 
-   ┌─ value_semantics.fe:50:24
+   ┌─ value_semantics.fe:43:24
    │
-50 │     let mut a: Point = Point(x: 0, y: 0)
+43 │     let mut p: Point = Point(x: 0, y: 0)
    │                        ^^^^^^^^^^^^^^^^^ Point
-51 │     let mut b: Point = Point(x: 10, y: 10)
-   │                                 ^^     ^^ u64
-   │                                 │       
-   │                                 u64
-
-note: 
-   ┌─ value_semantics.fe:51:24
-   │
-51 │     let mut b: Point = Point(x: 10, y: 10)
-   │                        ^^^^^^^^^^^^^^^^^^^ Point
-52 │ 
-53 │     let mut line: Line = Line(a, b)
-   │                               ^  ^ mut Point -Copy-> Point
-   │                               │   
-   │                               mut Point -Copy-> Point
-
-note: 
-   ┌─ value_semantics.fe:53:26
-   │
-53 │     let mut line: Line = Line(a, b)
-   │                          ^^^^^^^^^^ Line
-54 │     a.x = 1
-   │     ^ mut Point
-
-note: 
-   ┌─ value_semantics.fe:54:5
-   │
-54 │     a.x = 1
-   │     ^^^   ^ u64
-   │     │      
-   │     mut u64
-55 │     assert line.a.x == 0
-   │            ^^^^ mut Line
-
-note: 
-   ┌─ value_semantics.fe:55:12
-   │
-55 │     assert line.a.x == 0
-   │            ^^^^^^ mut Point
-
-note: 
-   ┌─ value_semantics.fe:55:12
-   │
-55 │     assert line.a.x == 0
-   │            ^^^^^^^^    ^ u64
-   │            │            
-   │            mut u64
-
-note: 
-   ┌─ value_semantics.fe:55:12
-   │
-55 │     assert line.a.x == 0
-   │            ^^^^^^^^^^^^^ bool
-56 │ 
-57 │     line.b.x = 100
-   │     ^^^^ mut Line
-
-note: 
-   ┌─ value_semantics.fe:57:5
-   │
-57 │     line.b.x = 100
-   │     ^^^^^^ mut Point
-
-note: 
-   ┌─ value_semantics.fe:57:5
-   │
-57 │     line.b.x = 100
-   │     ^^^^^^^^   ^^^ u64
-   │     │           
-   │     mut u64
-58 │     assert b.x == 10
-   │            ^ mut Point
-
-note: 
-   ┌─ value_semantics.fe:58:12
-   │
-58 │     assert b.x == 10
-   │            ^^^    ^^ u64
-   │            │       
-   │            mut u64
-
-note: 
-   ┌─ value_semantics.fe:58:12
-   │
-58 │     assert b.x == 10
-   │            ^^^^^^^^^ bool
-
-note: 
-   ┌─ value_semantics.fe:61:1
-   │  
-61 │ ╭ fn copies() {
-62 │ │     let p: Point = Point(x: 0, y: 0)
-63 │ │     let mut a: Point = p // copy
-64 │ │     a.x = 1
-   · │
-81 │ │     let mut n: Line = Line::from_origin_to(b) // copy
-82 │ │ }
-   │ ╰─^ params: [] -> ()
-
-note: 
-   ┌─ value_semantics.fe:62:9
-   │
-62 │     let p: Point = Point(x: 0, y: 0)
-   │         ^ Point
-63 │     let mut a: Point = p // copy
-   │             ^ mut Point
-   ·
-68 │     let b: Point = p     // no copy
-   │         ^ Point
-   ·
-75 │     let mut c: Point = a // copy
-   │             ^ mut Point
-   ·
-80 │     let m: Line = Line::from_origin_to(b)     // no copy
-   │         ^ Line
-81 │     let mut n: Line = Line::from_origin_to(b) // copy
-   │             ^ mut Line
-
-note: 
-   ┌─ value_semantics.fe:62:29
-   │
-62 │     let p: Point = Point(x: 0, y: 0)
+44 │     let q: Point = Point(x: 0, y: 0)
    │                             ^     ^ u64
    │                             │      
    │                             u64
 
 note: 
-   ┌─ value_semantics.fe:62:20
+   ┌─ value_semantics.fe:44:20
    │
-62 │     let p: Point = Point(x: 0, y: 0)
+44 │     let q: Point = Point(x: 0, y: 0)
    │                    ^^^^^^^^^^^^^^^^^ Point
-63 │     let mut a: Point = p // copy
-   │                        ^ Point -Copy-> Point
-64 │     a.x = 1
-   │     ^ mut Point
+45 │     let mut pair: (Point, Point) = (p, q)
+   │                                     ^  ^ Point
+   │                                     │   
+   │                                     mut Point
+
+note: 
+   ┌─ value_semantics.fe:45:36
+   │
+45 │     let mut pair: (Point, Point) = (p, q)
+   │                                    ^^^^^^ (Point, Point)
+46 │     pair.item0.x = 100
+   │     ^^^^ mut (Point, Point)
+
+note: 
+   ┌─ value_semantics.fe:46:5
+   │
+46 │     pair.item0.x = 100
+   │     ^^^^^^^^^^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:46:5
+   │
+46 │     pair.item0.x = 100
+   │     ^^^^^^^^^^^^   ^^^ u64
+   │     │               
+   │     mut u64
+47 │     pair.item1.x = 200
+   │     ^^^^ mut (Point, Point)
+
+note: 
+   ┌─ value_semantics.fe:47:5
+   │
+47 │     pair.item1.x = 200
+   │     ^^^^^^^^^^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:47:5
+   │
+47 │     pair.item1.x = 200
+   │     ^^^^^^^^^^^^   ^^^ u64
+   │     │               
+   │     mut u64
+48 │     assert p.x == 0
+   │            ^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:48:12
+   │
+48 │     assert p.x == 0
+   │            ^^^    ^ u64
+   │            │       
+   │            mut u64
+
+note: 
+   ┌─ value_semantics.fe:48:12
+   │
+48 │     assert p.x == 0
+   │            ^^^^^^^^ bool
+49 │     assert q.x == 0
+   │            ^ Point
+
+note: 
+   ┌─ value_semantics.fe:49:12
+   │
+49 │     assert q.x == 0
+   │            ^^^    ^ u64
+   │            │       
+   │            u64
+
+note: 
+   ┌─ value_semantics.fe:49:12
+   │
+49 │     assert q.x == 0
+   │            ^^^^^^^^ bool
+
+note: 
+   ┌─ value_semantics.fe:53:5
+   │
+53 │     pub x: u64
+   │     ^^^^^^^^^^ u64
+54 │     pub y: u64
+   │     ^^^^^^^^^^ u64
+
+note: 
+   ┌─ value_semantics.fe:57:5
+   │
+57 │     pub a: Point
+   │     ^^^^^^^^^^^^ Point
+58 │     pub b: Point
+   │     ^^^^^^^^^^^^ Point
+
+note: 
+   ┌─ value_semantics.fe:60:5
+   │  
+60 │ ╭     pub fn from_origin_to(_ b: Point) -> Line {
+61 │ │         return Line(a: Point(x: 0, y: 0), b)
+62 │ │     }
+   │ ╰─────^ params: [{ label: Some("_"), name: b, typ: Point }] -> Line
+
+note: 
+   ┌─ value_semantics.fe:61:33
+   │
+61 │         return Line(a: Point(x: 0, y: 0), b)
+   │                                 ^     ^ u64
+   │                                 │      
+   │                                 u64
+
+note: 
+   ┌─ value_semantics.fe:61:24
+   │
+61 │         return Line(a: Point(x: 0, y: 0), b)
+   │                        ^^^^^^^^^^^^^^^^^  ^ Point -Copy-> Point
+   │                        │                   
+   │                        Point
+
+note: 
+   ┌─ value_semantics.fe:61:16
+   │
+61 │         return Line(a: Point(x: 0, y: 0), b)
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line
 
 note: 
    ┌─ value_semantics.fe:64:5
+   │  
+64 │ ╭     pub fn get_a(self) -> Point {
+65 │ │         return self.a
+66 │ │     }
+   │ ╰─────^ params: [self] -> Point
+
+note: 
+   ┌─ value_semantics.fe:65:16
    │
-64 │     a.x = 1
+65 │         return self.a
+   │                ^^^^ Line
+
+note: 
+   ┌─ value_semantics.fe:65:16
+   │
+65 │         return self.a
+   │                ^^^^^^ Point -Copy-> Point
+
+note: 
+   ┌─ value_semantics.fe:69:1
+   │  
+69 │ ╭ fn struct_constructor() {
+70 │ │     let mut a: Point = Point(x: 0, y: 0)
+71 │ │     let mut b: Point = Point(x: 10, y: 10)
+72 │ │ 
+   · │
+78 │ │     assert b.x == 10
+79 │ │ }
+   │ ╰─^ params: [] -> ()
+
+note: 
+   ┌─ value_semantics.fe:70:13
+   │
+70 │     let mut a: Point = Point(x: 0, y: 0)
+   │             ^ mut Point
+71 │     let mut b: Point = Point(x: 10, y: 10)
+   │             ^ mut Point
+72 │ 
+73 │     let mut line: Line = Line(a, b)
+   │             ^^^^ mut Line
+
+note: 
+   ┌─ value_semantics.fe:70:33
+   │
+70 │     let mut a: Point = Point(x: 0, y: 0)
+   │                                 ^     ^ u64
+   │                                 │      
+   │                                 u64
+
+note: 
+   ┌─ value_semantics.fe:70:24
+   │
+70 │     let mut a: Point = Point(x: 0, y: 0)
+   │                        ^^^^^^^^^^^^^^^^^ Point
+71 │     let mut b: Point = Point(x: 10, y: 10)
+   │                                 ^^     ^^ u64
+   │                                 │       
+   │                                 u64
+
+note: 
+   ┌─ value_semantics.fe:71:24
+   │
+71 │     let mut b: Point = Point(x: 10, y: 10)
+   │                        ^^^^^^^^^^^^^^^^^^^ Point
+72 │ 
+73 │     let mut line: Line = Line(a, b)
+   │                               ^  ^ mut Point -Copy-> Point
+   │                               │   
+   │                               mut Point -Copy-> Point
+
+note: 
+   ┌─ value_semantics.fe:73:26
+   │
+73 │     let mut line: Line = Line(a, b)
+   │                          ^^^^^^^^^^ Line
+74 │     a.x = 1
+   │     ^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:74:5
+   │
+74 │     a.x = 1
    │     ^^^   ^ u64
    │     │      
    │     mut u64
-65 │     assert p.x == 0
+75 │     assert line.a.x == 0
+   │            ^^^^ mut Line
+
+note: 
+   ┌─ value_semantics.fe:75:12
+   │
+75 │     assert line.a.x == 0
+   │            ^^^^^^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:75:12
+   │
+75 │     assert line.a.x == 0
+   │            ^^^^^^^^    ^ u64
+   │            │            
+   │            mut u64
+
+note: 
+   ┌─ value_semantics.fe:75:12
+   │
+75 │     assert line.a.x == 0
+   │            ^^^^^^^^^^^^^ bool
+76 │ 
+77 │     line.b.x = 100
+   │     ^^^^ mut Line
+
+note: 
+   ┌─ value_semantics.fe:77:5
+   │
+77 │     line.b.x = 100
+   │     ^^^^^^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:77:5
+   │
+77 │     line.b.x = 100
+   │     ^^^^^^^^   ^^^ u64
+   │     │           
+   │     mut u64
+78 │     assert b.x == 10
+   │            ^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:78:12
+   │
+78 │     assert b.x == 10
+   │            ^^^    ^^ u64
+   │            │       
+   │            mut u64
+
+note: 
+   ┌─ value_semantics.fe:78:12
+   │
+78 │     assert b.x == 10
+   │            ^^^^^^^^^ bool
+
+note: 
+    ┌─ value_semantics.fe:81:1
+    │  
+ 81 │ ╭ fn copies() {
+ 82 │ │     let p: Point = Point(x: 0, y: 0)
+ 83 │ │     let mut a: Point = p // copy
+ 84 │ │     a.x = 1
+    · │
+101 │ │     let mut n: Line = Line::from_origin_to(b) // copy
+102 │ │ }
+    │ ╰─^ params: [] -> ()
+
+note: 
+    ┌─ value_semantics.fe:82:9
+    │
+ 82 │     let p: Point = Point(x: 0, y: 0)
+    │         ^ Point
+ 83 │     let mut a: Point = p // copy
+    │             ^ mut Point
+    ·
+ 88 │     let b: Point = p     // no copy
+    │         ^ Point
+    ·
+ 95 │     let mut c: Point = a // copy
+    │             ^ mut Point
+    ·
+100 │     let m: Line = Line::from_origin_to(b)     // no copy
+    │         ^ Line
+101 │     let mut n: Line = Line::from_origin_to(b) // copy
+    │             ^ mut Line
+
+note: 
+   ┌─ value_semantics.fe:82:29
+   │
+82 │     let p: Point = Point(x: 0, y: 0)
+   │                             ^     ^ u64
+   │                             │      
+   │                             u64
+
+note: 
+   ┌─ value_semantics.fe:82:20
+   │
+82 │     let p: Point = Point(x: 0, y: 0)
+   │                    ^^^^^^^^^^^^^^^^^ Point
+83 │     let mut a: Point = p // copy
+   │                        ^ Point -Copy-> Point
+84 │     a.x = 1
+   │     ^ mut Point
+
+note: 
+   ┌─ value_semantics.fe:84:5
+   │
+84 │     a.x = 1
+   │     ^^^   ^ u64
+   │     │      
+   │     mut u64
+85 │     assert p.x == 0
    │            ^ Point
 
 note: 
-   ┌─ value_semantics.fe:65:12
+   ┌─ value_semantics.fe:85:12
    │
-65 │     assert p.x == 0
+85 │     assert p.x == 0
    │            ^^^    ^ u64
    │            │       
    │            u64
 
 note: 
-   ┌─ value_semantics.fe:65:12
+   ┌─ value_semantics.fe:85:12
    │
-65 │     assert p.x == 0
+85 │     assert p.x == 0
    │            ^^^^^^^^ bool
-66 │     assert a.x == 1
+86 │     assert a.x == 1
    │            ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:66:12
+   ┌─ value_semantics.fe:86:12
    │
-66 │     assert a.x == 1
+86 │     assert a.x == 1
    │            ^^^    ^ u64
    │            │       
    │            mut u64
 
 note: 
-   ┌─ value_semantics.fe:66:12
+   ┌─ value_semantics.fe:86:12
    │
-66 │     assert a.x == 1
+86 │     assert a.x == 1
    │            ^^^^^^^^ bool
-67 │ 
-68 │     let b: Point = p     // no copy
+87 │ 
+88 │     let b: Point = p     // no copy
    │                    ^ Point
-69 │     a = b                // copy
+89 │     a = b                // copy
    │     ^   ^ Point -Copy-> Point
    │     │    
    │     mut Point
-70 │     assert a.x == 0
+90 │     assert a.x == 0
    │            ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:70:12
+   ┌─ value_semantics.fe:90:12
    │
-70 │     assert a.x == 0
+90 │     assert a.x == 0
    │            ^^^    ^ u64
    │            │       
    │            mut u64
 
 note: 
-   ┌─ value_semantics.fe:70:12
+   ┌─ value_semantics.fe:90:12
    │
-70 │     assert a.x == 0
+90 │     assert a.x == 0
    │            ^^^^^^^^ bool
-71 │     a.x = 2
+91 │     a.x = 2
    │     ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:71:5
+   ┌─ value_semantics.fe:91:5
    │
-71 │     a.x = 2
+91 │     a.x = 2
    │     ^^^   ^ u64
    │     │      
    │     mut u64
-72 │     assert b.x == 0
+92 │     assert b.x == 0
    │            ^ Point
 
 note: 
-   ┌─ value_semantics.fe:72:12
+   ┌─ value_semantics.fe:92:12
    │
-72 │     assert b.x == 0
+92 │     assert b.x == 0
    │            ^^^    ^ u64
    │            │       
    │            u64
 
 note: 
-   ┌─ value_semantics.fe:72:12
+   ┌─ value_semantics.fe:92:12
    │
-72 │     assert b.x == 0
+92 │     assert b.x == 0
    │            ^^^^^^^^ bool
-73 │     assert a.x == 2
+93 │     assert a.x == 2
    │            ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:73:12
+   ┌─ value_semantics.fe:93:12
    │
-73 │     assert a.x == 2
+93 │     assert a.x == 2
    │            ^^^    ^ u64
    │            │       
    │            mut u64
 
 note: 
-   ┌─ value_semantics.fe:73:12
+   ┌─ value_semantics.fe:93:12
    │
-73 │     assert a.x == 2
+93 │     assert a.x == 2
    │            ^^^^^^^^ bool
-74 │ 
-75 │     let mut c: Point = a // copy
+94 │ 
+95 │     let mut c: Point = a // copy
    │                        ^ mut Point -Copy-> Point
-76 │     a.x = 3
+96 │     a.x = 3
    │     ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:76:5
+   ┌─ value_semantics.fe:96:5
    │
-76 │     a.x = 3
+96 │     a.x = 3
    │     ^^^   ^ u64
    │     │      
    │     mut u64
-77 │     assert c.x == 2
+97 │     assert c.x == 2
    │            ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:77:12
+   ┌─ value_semantics.fe:97:12
    │
-77 │     assert c.x == 2
+97 │     assert c.x == 2
    │            ^^^    ^ u64
    │            │       
    │            mut u64
 
 note: 
-   ┌─ value_semantics.fe:77:12
+   ┌─ value_semantics.fe:97:12
    │
-77 │     assert c.x == 2
+97 │     assert c.x == 2
    │            ^^^^^^^^ bool
-78 │     assert a.x == 3
+98 │     assert a.x == 3
    │            ^ mut Point
 
 note: 
-   ┌─ value_semantics.fe:78:12
+   ┌─ value_semantics.fe:98:12
    │
-78 │     assert a.x == 3
+98 │     assert a.x == 3
    │            ^^^    ^ u64
    │            │       
    │            mut u64
 
 note: 
-   ┌─ value_semantics.fe:78:12
-   │
-78 │     assert a.x == 3
-   │            ^^^^^^^^ bool
-79 │ 
-80 │     let m: Line = Line::from_origin_to(b)     // no copy
-   │                                        ^ Point
+    ┌─ value_semantics.fe:98:12
+    │
+ 98 │     assert a.x == 3
+    │            ^^^^^^^^ bool
+ 99 │ 
+100 │     let m: Line = Line::from_origin_to(b)     // no copy
+    │                                        ^ Point
 
 note: 
-   ┌─ value_semantics.fe:80:19
-   │
-80 │     let m: Line = Line::from_origin_to(b)     // no copy
-   │                   ^^^^^^^^^^^^^^^^^^^^^^^ Line
-81 │     let mut n: Line = Line::from_origin_to(b) // copy
-   │                                            ^ Point
+    ┌─ value_semantics.fe:100:19
+    │
+100 │     let m: Line = Line::from_origin_to(b)     // no copy
+    │                   ^^^^^^^^^^^^^^^^^^^^^^^ Line
+101 │     let mut n: Line = Line::from_origin_to(b) // copy
+    │                                            ^ Point
 
 note: 
-   ┌─ value_semantics.fe:81:23
-   │
-81 │     let mut n: Line = Line::from_origin_to(b) // copy
-   │                       ^^^^^^^^^^^^^^^^^^^^^^^ Line -Copy-> Line
+    ┌─ value_semantics.fe:101:23
+    │
+101 │     let mut n: Line = Line::from_origin_to(b) // copy
+    │                       ^^^^^^^^^^^^^^^^^^^^^^^ Line -Copy-> Line
+
+note: 
+    ┌─ value_semantics.fe:104:1
+    │  
+104 │ ╭ fn struct_field_copies() {
+105 │ │     let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+106 │ │     let a1: Point = line.a       // copy
+107 │ │     let a2: Point = line.get_a() // copy
+    · │
+112 │ │     assert a2.x == 1
+113 │ │ }
+    │ ╰─^ params: [] -> ()
+
+note: 
+    ┌─ value_semantics.fe:105:13
+    │
+105 │     let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+    │             ^^^^ mut Line
+106 │     let a1: Point = line.a       // copy
+    │         ^^ Point
+107 │     let a2: Point = line.get_a() // copy
+    │         ^^ Point
+
+note: 
+    ┌─ value_semantics.fe:105:43
+    │
+105 │     let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+    │                                           ^     ^ u64
+    │                                           │      
+    │                                           u64
+
+note: 
+    ┌─ value_semantics.fe:105:34
+    │
+105 │     let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+    │                                  ^^^^^^^^^^^^^^^^^              ^     ^ u64
+    │                                  │                              │      
+    │                                  │                              u64
+    │                                  Point
+
+note: 
+    ┌─ value_semantics.fe:105:56
+    │
+105 │     let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+    │                                                        ^^^^^^^^^^^^^^^^^ Point
+
+note: 
+    ┌─ value_semantics.fe:105:26
+    │
+105 │     let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+    │                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Line
+106 │     let a1: Point = line.a       // copy
+    │                     ^^^^ mut Line
+
+note: 
+    ┌─ value_semantics.fe:106:21
+    │
+106 │     let a1: Point = line.a       // copy
+    │                     ^^^^^^ mut Point -Copy-> Point
+107 │     let a2: Point = line.get_a() // copy
+    │                     ^^^^ mut Line
+
+note: 
+    ┌─ value_semantics.fe:107:21
+    │
+107 │     let a2: Point = line.get_a() // copy
+    │                     ^^^^^^^^^^^^ Point
+108 │ 
+109 │     line.a.x = 100
+    │     ^^^^ mut Line
+
+note: 
+    ┌─ value_semantics.fe:109:5
+    │
+109 │     line.a.x = 100
+    │     ^^^^^^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:109:5
+    │
+109 │     line.a.x = 100
+    │     ^^^^^^^^   ^^^ u64
+    │     │           
+    │     mut u64
+110 │     assert line.a.x == 100
+    │            ^^^^ mut Line
+
+note: 
+    ┌─ value_semantics.fe:110:12
+    │
+110 │     assert line.a.x == 100
+    │            ^^^^^^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:110:12
+    │
+110 │     assert line.a.x == 100
+    │            ^^^^^^^^    ^^^ u64
+    │            │            
+    │            mut u64
+
+note: 
+    ┌─ value_semantics.fe:110:12
+    │
+110 │     assert line.a.x == 100
+    │            ^^^^^^^^^^^^^^^ bool
+111 │     assert a1.x == 1
+    │            ^^ Point
+
+note: 
+    ┌─ value_semantics.fe:111:12
+    │
+111 │     assert a1.x == 1
+    │            ^^^^    ^ u64
+    │            │        
+    │            u64
+
+note: 
+    ┌─ value_semantics.fe:111:12
+    │
+111 │     assert a1.x == 1
+    │            ^^^^^^^^^ bool
+112 │     assert a2.x == 1
+    │            ^^ Point
+
+note: 
+    ┌─ value_semantics.fe:112:12
+    │
+112 │     assert a2.x == 1
+    │            ^^^^    ^ u64
+    │            │        
+    │            u64
+
+note: 
+    ┌─ value_semantics.fe:112:12
+    │
+112 │     assert a2.x == 1
+    │            ^^^^^^^^^ bool
+
+note: 
+    ┌─ value_semantics.fe:115:1
+    │  
+115 │ ╭ fn ternary(_ b: bool) {
+116 │ │     let mut p: Point = Point(x: 10, y: 20)
+117 │ │     let mut q: Point = Point(x: 10, y: 20)
+118 │ │     move_rightward(p if b else q)
+    · │
+125 │ │     }
+126 │ │ }
+    │ ╰─^ params: [{ label: Some("_"), name: b, typ: bool }] -> ()
+
+note: 
+    ┌─ value_semantics.fe:116:13
+    │
+116 │     let mut p: Point = Point(x: 10, y: 20)
+    │             ^ mut Point
+117 │     let mut q: Point = Point(x: 10, y: 20)
+    │             ^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:116:33
+    │
+116 │     let mut p: Point = Point(x: 10, y: 20)
+    │                                 ^^     ^^ u64
+    │                                 │       
+    │                                 u64
+
+note: 
+    ┌─ value_semantics.fe:116:24
+    │
+116 │     let mut p: Point = Point(x: 10, y: 20)
+    │                        ^^^^^^^^^^^^^^^^^^^ Point
+117 │     let mut q: Point = Point(x: 10, y: 20)
+    │                                 ^^     ^^ u64
+    │                                 │       
+    │                                 u64
+
+note: 
+    ┌─ value_semantics.fe:117:24
+    │
+117 │     let mut q: Point = Point(x: 10, y: 20)
+    │                        ^^^^^^^^^^^^^^^^^^^ Point
+118 │     move_rightward(p if b else q)
+    │                         ^ bool
+
+note: 
+    ┌─ value_semantics.fe:118:20
+    │
+118 │     move_rightward(p if b else q)
+    │                    ^           ^ mut Point
+    │                    │            
+    │                    mut Point
+
+note: 
+    ┌─ value_semantics.fe:118:20
+    │
+118 │     move_rightward(p if b else q)
+    │                    ^^^^^^^^^^^^^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:118:5
+    │
+118 │     move_rightward(p if b else q)
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ()
+119 │     if b {
+    │        ^ bool
+120 │         assert p.x == 11
+    │                ^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:120:16
+    │
+120 │         assert p.x == 11
+    │                ^^^    ^^ u64
+    │                │       
+    │                mut u64
+
+note: 
+    ┌─ value_semantics.fe:120:16
+    │
+120 │         assert p.x == 11
+    │                ^^^^^^^^^ bool
+121 │         assert q.x == 10
+    │                ^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:121:16
+    │
+121 │         assert q.x == 10
+    │                ^^^    ^^ u64
+    │                │       
+    │                mut u64
+
+note: 
+    ┌─ value_semantics.fe:121:16
+    │
+121 │         assert q.x == 10
+    │                ^^^^^^^^^ bool
+122 │     } else {
+123 │         assert p.x == 10
+    │                ^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:123:16
+    │
+123 │         assert p.x == 10
+    │                ^^^    ^^ u64
+    │                │       
+    │                mut u64
+
+note: 
+    ┌─ value_semantics.fe:123:16
+    │
+123 │         assert p.x == 10
+    │                ^^^^^^^^^ bool
+124 │         assert q.x == 11
+    │                ^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:124:16
+    │
+124 │         assert q.x == 11
+    │                ^^^    ^^ u64
+    │                │       
+    │                mut u64
+
+note: 
+    ┌─ value_semantics.fe:124:16
+    │
+124 │         assert q.x == 11
+    │                ^^^^^^^^^ bool
+
+note: 
+    ┌─ value_semantics.fe:128:1
+    │  
+128 │ ╭ fn move_rightward(mut _ p: Point) {
+129 │ │     p.x += 1
+130 │ │ }
+    │ ╰─^ params: [{ label: Some("_"), name: p, typ: mut Point }] -> ()
+
+note: 
+    ┌─ value_semantics.fe:129:5
+    │
+129 │     p.x += 1
+    │     ^ mut Point
+
+note: 
+    ┌─ value_semantics.fe:129:5
+    │
+129 │     p.x += 1
+    │     ^^^    ^ u64
+    │     │       
+    │     mut u64
 
 

--- a/crates/analyzer/tests/snapshots/errors__mut_mistakes.snap
+++ b/crates/analyzer/tests/snapshots/errors__mut_mistakes.snap
@@ -82,10 +82,50 @@ error: cannot modify `self.x`, as it is not mutable
 47 │         self.x *= 2
    │         ^^^^^^ not mutable
 
-error: `move_stuff` argument `b` must be mutable
-   ┌─ compile_errors/mut_mistakes.fe:70:18
+error: borrow conflict in call to fn `move_stuff`
+   ┌─ compile_errors/mut_mistakes.fe:79:16
    │
-70 │    move_stuff(a, b) // ERROR
-   │                  ^ is not `mut`
+79 │     move_stuff(p, p) // ERROR
+   │                ^  - `p` is used again here
+   │                │   
+   │                `p` is used mutably here
+
+error: borrow conflict in call to fn `move_stuff`
+   ┌─ compile_errors/mut_mistakes.fe:80:31
+   │
+80 │     move_stuff(q if true else p, p) // ERROR
+   │                               ^  - `p` is used again here
+   │                               │   
+   │                               `p` is used mutably here
+
+error: borrow conflict in call to fn `mutate_self_and`
+   ┌─ compile_errors/mut_mistakes.fe:83:5
+   │
+83 │     p.mutate_self_and(p) // ERROR
+   │     ^                 - `p` is used again here
+   │     │                  
+   │     `p` is used mutably here
+
+error: borrow conflict in call to fn `set_ys`
+   ┌─ compile_errors/mut_mistakes.fe:90:5
+   │
+90 │     line.set_ys(a: line.b, b: line.a)           // ERROR
+   │     ^^^^           ---- `line` is used again here
+   │     │               
+   │     `line` is used mutably here
+
+error: borrow conflict in call to fn `set_ys`
+   ┌─ compile_errors/mut_mistakes.fe:91:5
+   │
+91 │     line.set_ys(a: p if true else line.b, b: q) // ERROR
+   │     ^^^^                          ---- `line` is used again here
+   │     │                              
+   │     `line` is used mutably here
+
+error: `move_stuff` argument at position 1 must be mutable
+   ┌─ compile_errors/mut_mistakes.fe:97:19
+   │
+97 │     move_stuff(a, b) // ERROR
+   │                   ^ is not `mut`
 
 

--- a/crates/test-files/fixtures/compile_errors/mut_mistakes.fe
+++ b/crates/test-files/fixtures/compile_errors/mut_mistakes.fe
@@ -47,8 +47,23 @@ struct Point {
         self.x *= 2
     }
 
-    pub fn set_x(mut self, _ x: u8) {
+    pub fn set_x(mut self, _ x: u64) {
         self.x = x
+    }
+
+    pub fn mutate_self_and(mut self, mut _ other: Point) {
+        self.x += 1
+        other.x += 1
+    }
+}
+
+struct Line {
+    pub a: Point
+    pub b: Point
+
+    pub fn set_ys(mut self, a: Point, b: Point) {
+        self.a.y = a.y
+        self.b.y = b.y
     }
 }
 
@@ -60,17 +75,43 @@ fn borrow_checker() {
 
     let r: Point = Point(x: 10, y: 20)
 
-    move_stuff(a: p, b: q) // OK
-    move_stuff(a: p, b: p) // TODO: should be ERROR
+    move_stuff(p, q) // OK
+    move_stuff(p, p) // ERROR
+    move_stuff(q if true else p, p) // ERROR
+
+    p.mutate_self_and(q) // OK
+    p.mutate_self_and(p) // ERROR
+
+    p.set_x(p.x)     // OK, p.x is primitive
+    set_x_to(p, p.x) // OK, p.x is primitive
+
+    let mut line: Line = Line(a: Point(x: 0, y: 0),
+                              b: Point(x: 1, y: 1))
+    line.set_ys(a: line.b, b: line.a)           // ERROR
+    line.set_ys(a: p if true else line.b, b: q) // ERROR
 }
 
 fn non_mut_arg() {
-   let mut a: Point = Point(x: 1, y: 2)
-   let b: Point = Point(x: 2, y: 3)
-   move_stuff(a, b) // ERROR
+    let mut a: Point = Point(x: 1, y: 2)
+    let b: Point = Point(x: 2, y: 3)
+    move_stuff(a, b) // ERROR
 }
 
-fn move_stuff(mut a: Point, mut b: Point) {
-   a.x *= 10
-   b.x *= 10
+fn move_stuff(mut _ a: Point, mut _ b: Point) {
+    a.x *= 10
+    b.x *= 10
+}
+
+fn move_rightward(mut _ p: Point) {
+    p.x += 1
+}
+
+fn set_x_to(mut _ p: Point, _ x: u64) {
+   p.x = x
+}
+
+fn ternary() {
+    let mut p: Point = Point(x: 1, y: 2)
+    let q: Point = Point(x: 1, y: 2)
+    move_rightward(p if false else q)
 }

--- a/crates/test-files/fixtures/features/bountiful_struct_copy_bug.fe
+++ b/crates/test-files/fixtures/features/bountiful_struct_copy_bug.fe
@@ -30,13 +30,11 @@ contract Foo {
         assert b.second.x == 1 and b.second.y == 2
 
         b.swap_y(p1: b.get_first(), p2: b.get_second())
-
-        // TODO: this should be prevented by a borrow checker.
-        // This causes the assertions below to fail:
-        // b.swap_y(p1: b.first, p2: b.second)
-
         assert b.first.y == 2
         assert b.second.y == 200
+
+        // This is a compiler error
+        // b.swap_y(p1: b.first, p2: b.second)
 
         return 0
     }

--- a/crates/test-files/fixtures/features/value_semantics.fe
+++ b/crates/test-files/fixtures/features/value_semantics.fe
@@ -4,6 +4,12 @@ contract Foo {
     pub fn bar(mut self) -> bool {
         self.set_array()
         tuple_of_primitive()
+        tuple_of_structs()
+        struct_constructor()
+        copies()
+        struct_field_copies()
+        ternary(true)
+        ternary(false)
 
         return true
     }
@@ -33,6 +39,16 @@ fn tuple_of_primitive() {
     assert tup_imm.item0 == 1
 }
 
+fn tuple_of_structs() {
+    let mut p: Point = Point(x: 0, y: 0)
+    let q: Point = Point(x: 0, y: 0)
+    let mut pair: (Point, Point) = (p, q)
+    pair.item0.x = 100
+    pair.item1.x = 200
+    assert p.x == 0
+    assert q.x == 0
+}
+
 struct Point {
     pub x: u64
     pub y: u64
@@ -41,8 +57,12 @@ struct Line {
     pub a: Point
     pub b: Point
 
-    pub fn from_origin_to(b: Point) -> Line {
+    pub fn from_origin_to(_ b: Point) -> Line {
         return Line(a: Point(x: 0, y: 0), b)
+    }
+
+    pub fn get_a(self) -> Point {
+        return self.a
     }
 }
 
@@ -79,4 +99,32 @@ fn copies() {
 
     let m: Line = Line::from_origin_to(b)     // no copy
     let mut n: Line = Line::from_origin_to(b) // copy
+}
+
+fn struct_field_copies() {
+    let mut line: Line = Line(a: Point(x: 1, y: 1), b: Point(x: 2, y: 2))
+    let a1: Point = line.a       // copy
+    let a2: Point = line.get_a() // copy
+
+    line.a.x = 100
+    assert line.a.x == 100
+    assert a1.x == 1
+    assert a2.x == 1
+}
+
+fn ternary(_ b: bool) {
+    let mut p: Point = Point(x: 10, y: 20)
+    let mut q: Point = Point(x: 10, y: 20)
+    move_rightward(p if b else q)
+    if b {
+        assert p.x == 11
+        assert q.x == 10
+    } else {
+        assert p.x == 10
+        assert q.x == 11
+    }
+}
+
+fn move_rightward(mut _ p: Point) {
+    p.x += 1
 }

--- a/crates/tests/src/snapshots/fe_compiler_tests__features__value_semantics.snap
+++ b/crates/tests/src/snapshots/fe_compiler_tests__features__value_semantics.snap
@@ -3,5 +3,5 @@ source: crates/tests/src/features.rs
 expression: "format!(\"{}\", harness.gas_reporter)"
 
 ---
-bar([]) used 23333 gas
+bar([]) used 29962 gas
 

--- a/newsfragments/777.feature.md
+++ b/newsfragments/777.feature.md
@@ -53,5 +53,3 @@ fn increment(mut x: u256) { // ERROR: primitive type parameters can't be mut
     x += 1
 }
 ```
-
-XXX see borrow check issue


### PR DESCRIPTION
### What was wrong?

fixes #810

### How was it fixed?

This is a temporary solution to the only borrowing bug that's possible in the current semantics of Fe, namely passing a mutable reference to a non-primitive object into a fn call, and another reference to that same object (mutable or otherwise).

This is an ugly brute force solution that will definitely not scale beyond this simple case, and doesn't do anything smart like allow disjoint partial borrows.

This should be replaced with a proper borrow checker (presumably operating on MIR) when Fe gains some kind of reference/projection type.