### PR TITLE
Exclude `alchemy.com` from linkcheck

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -12,7 +12,7 @@ additional-css = ["theme/reference.css"]
 [output.linkcheck]
 follow-web-links = true
 warning-policy = "error"
-exclude = [ 'github\.com', 'goerli\.etherscan\.io', 'goerlifaucet\.com' ]
+exclude = [ 'github\.com', 'goerli\.etherscan\.io', 'goerlifaucet\.com', 'alchemy\.com' ]
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
### What was wrong?
CI failed because the request to `alchemy.com` returns 403. 


### How was it fixed?
I excluded `alchemy.com` from `linkcheck`. It would be better to set `follow-web-links = false` when more links start returning error status codes. But I think it's not the time yet.

### To-Do

