### PR TITLE
Christoph/fix/ctx abi

### DIFF
--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -130,7 +130,7 @@ pub fn function_signature(
                 });
 
                 if let Some(context_type) = scope.get_context_type() {
-                    if typ == Ok(context_type) {
+                    if typ.as_ref().map(|val| val.deref(db)) == Ok(context_type) {
                         if arg.name() != "ctx" {
                             scope.error(
                                 "invalid `Context` instance name",

--- a/crates/codegen/src/db/queries/abi.rs
+++ b/crates/codegen/src/db/queries/abi.rs
@@ -78,13 +78,13 @@ pub fn abi_function(db: &dyn CodegenDb, function: FunctionId) -> AbiFunction {
         Some(CtxDecl { mut_: Some(_), .. }) => CtxParam::Mut,
     };
 
-    AbiFunction::new(
-        func_type,
-        name.to_string(),
-        args,
-        ret_ty,
-        StateMutability::from_self_and_ctx_params(self_param, ctx_param),
-    )
+    let state_mutability = if name == "__init__" {
+        StateMutability::Payable
+    } else {
+        StateMutability::from_self_and_ctx_params(self_param, ctx_param)
+    };
+
+    AbiFunction::new(func_type, name.to_string(), args, ret_ty, state_mutability)
 }
 
 pub fn abi_function_argument_maximum_size(db: &dyn CodegenDb, function: FunctionId) -> usize {


### PR DESCRIPTION
### What was wrong?

1. The `__init__` function of a contract should always be categorized as `payable` even if it looks pure from its signature. 

2. the `CtxDecl` wasn't correctly inferred in case the context was taken with `mut`

### How was it fixed?

Trivial changes