### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,19 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "terminal_size",
- "winapi",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,18 +428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "environmental"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
-
-[[package]]
 name = "ethabi"
 version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,11 +469,8 @@ dependencies = [
  "ethereum-types",
  "hash-db",
  "hash256-std-hasher",
- "parity-scale-codec",
  "rlp",
  "rlp-derive",
- "scale-info",
- "serde",
  "sha3",
  "triehash",
 ]
@@ -526,17 +498,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8ff320c1e25e7f6d676858f16ffd9b0493d2cc67c3d900c6f2ed027b747f43"
 dependencies = [
  "auto_impl",
- "environmental",
  "ethereum",
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
  "log",
- "parity-scale-codec",
  "primitive-types",
  "rlp",
- "scale-info",
- "serde",
  "sha3",
 ]
 
@@ -546,10 +514,7 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4537041d3a3438d59b2d01bd950ce89fb1ccb3cf21d9331193c10be12e849f"
 dependencies = [
- "parity-scale-codec",
  "primitive-types",
- "scale-info",
- "serde",
 ]
 
 [[package]]
@@ -558,7 +523,6 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6181da8734c86873ac9b3f9886d4e00105361039dcfb9f621be9a0ddb8f43961"
 dependencies = [
- "environmental",
  "evm-core",
  "evm-runtime",
  "primitive-types",
@@ -571,7 +535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6157af91ca70fcf3581afaea1fa25974a71b9ef63d454c08dfba93ab0c7715d"
 dependencies = [
  "auto_impl",
- "environmental",
  "evm-core",
  "primitive-types",
  "sha3",
@@ -1020,7 +983,6 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15226a375927344c78d39dc6b49e2d5562a5b0705e26a589093c6792e52eed8e"
 dependencies = [
- "console",
  "lazy_static",
  "serde",
  "serde_json",
@@ -1684,7 +1646,6 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8980cafbe98a7ee7a9cc16b32ebce542c77883f512d83fbf2ddc8f6a85ea74c9"
 dependencies = [
- "bitvec",
  "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
@@ -1896,16 +1857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/crates/analyzer/Cargo.toml
+++ b/crates/analyzer/Cargo.toml
@@ -25,7 +25,7 @@ petgraph = "0.6.0"
 smol_str = "0.1.21"
 
 [dev-dependencies]
-insta = "1.7.1"
+insta = { default-features = false, version = "1.7.1" }
 rstest = "0.6.4"
 test-files = {path = "../test-files", package = "fe-test-files" }
 fe-library = {path = "../library"}

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 
 [dev-dependencies]
 fe-test-files = {path = "../test-files", version = "^0.20.0-alpha"}
-insta = "1.7.1"
+insta = { default-features = false, version = "1.7.1" }
 wasm-bindgen-test = "0.3"
 pretty_assertions = "1.0.0"
 criterion = "0.3.5"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -7,9 +7,9 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/ethereum/fe"
 
 [dependencies]
-ethabi = "17.0"
-evm = "0.35.0"
-evm-runtime = "0.35.0"
+ethabi = { default-features = false, features = ["full-serde"], version = "17.0" }
+evm = { default-features = false, version = "0.35.0" }
+evm-runtime = { default-features = false, version = "0.35.0" }
 fe-common = {path = "../common", version = "^0.20.0-alpha"}
 fe-driver = {path = "../driver", version = "^0.20.0-alpha"}
 fe-yulc = {path = "../yulc", version = "^0.20.0-alpha", optional = true, features = ["solc-backend"]}
@@ -21,7 +21,7 @@ serde_json = "1.0.64"
 solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "f18b1ce", optional = true}
 yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 indexmap = "1.6.2"
-insta = "1.7.1"
+insta = { default-features = false, version = "1.7.1" }
 
 # used by ethabi, we need to force the js feature for wasm support
 getrandom = { version = "0.2.3", features = ["js"] }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -9,9 +9,9 @@ repository = "https://github.com/ethereum/fe"
 [dependencies]
 
 [dev-dependencies]
-ethabi = "17.0"
-evm = "0.35.0"
-evm-runtime = "0.35.0"
+ethabi = { default-features = false, version = "17.0" }
+evm = { default-features = false, version = "0.35.0" }
+evm-runtime = { default-features = false, version = "0.35.0" }
 fe-analyzer = {path = "../analyzer", version = "^0.20.0-alpha"}
 fe-common = {path = "../common", version = "^0.20.0-alpha"}
 fe-compiler-test-utils = {path = "../test-utils" }
@@ -25,7 +25,7 @@ rand = "0.7.3"
 rstest = "0.6.4"
 # This fork contains the shorthand macros and some other necessary updates.
 yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
-insta = "1.7.1"
+insta = { default-features = false, version = "1.7.1" }
 pretty_assertions = "1.0.0"
 wasm-bindgen-test = "0.3.24"
 


### PR DESCRIPTION
Cuts development and CI times.

#### Before

Build: 211 crates
Check: 215 crates
Test: 312 crates

#### After

Build: 208 crates
Check: 212 crates
Test: 309 crates