### PR TITLE
Update solc for apple silicon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,9 +58,8 @@ jobs:
         uses: Swatinem/rust-cache@v1
       - name: install mdbook & mdbook-linkcheck
         run: |
-          cargo install cargo-quickinstall
-          cargo quickinstall mdbook
-          cargo quickinstall mdbook-linkcheck
+          cargo install mdbook
+          cargo install mdbook-linkcheck
       - name: Validate links in book
         run: |
           mdbook build docs/
@@ -80,7 +79,8 @@ jobs:
       - name: Install Mac System dependencies
         if: startsWith(matrix.os,'macOS')
         run: |
-          brew install boost
+          brew tap Y-Nak/boost
+          brew install Y-nak/boost/boost
       - name: Install Linux dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
@@ -144,8 +144,8 @@ jobs:
       - name: Install Mac System dependencies
         if: startsWith(matrix.os,'macOS')
         run: |
-          brew update
-          brew install boost
+          brew tap Y-Nak/boost
+          brew install Y-nak/boost/boost
       - name: Install rust
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/Y-Nak/solc-rust?rev=f18b1ce#f18b1cec1996feb2a361c616f333507bcfc5be76"
+source = "git+https://github.com/Y-Nak/solc-rust?rev=20aeb7b#20aeb7b944be55b43c3fe5c5ea7f5677692b543f"
 dependencies = [
  "cmake",
  "lazy_static",

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Fe is an emerging smart contract language for the Ethereum blockchain.
 [![Coverage](https://codecov.io/gh/ethereum/fe/branch/master/graph/badge.svg)](https://codecov.io/gh/ethereum/fe)
 
 
+NOTE: **The larger part of the `master` branch will be replaced with the brand-new implementation, which is currently under development in the [fe-v2](https://github.com/ethereum/fe/tree/fe-v2) branch. Please refer to the branch if you kindly contribute to Fe**
+
 ## Overview
 
 Fe is a statically typed language for the Ethereum Virtual Machine (EVM). It is inspired by Python and Rust which makes it easy to learn -- especially for new developers entering the Ethereum ecosystem.

--- a/crates/abi/src/types.rs
+++ b/crates/abi/src/types.rs
@@ -16,8 +16,8 @@ pub enum AbiType {
 impl AbiType {
     pub fn selector_type_name(&self) -> String {
         match self {
-            Self::UInt(bits) => format!("uint{}", bits),
-            Self::Int(bits) => format!("int{}", bits),
+            Self::UInt(bits) => format!("uint{bits}"),
+            Self::Int(bits) => format!("int{bits}"),
             Self::Address => "address".to_string(),
             Self::Bool => "bool".to_string(),
             Self::Function => "function".to_string(),

--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -468,7 +468,7 @@ impl crate::display::DisplayWithDb for ExpressionAttributes {
         } = self;
         write!(f, "{}", typ.display(db))?;
         if let Some(val) = &const_value {
-            write!(f, " = {:?}", val)?;
+            write!(f, " = {val:?}")?;
         }
         for adj in type_adjustments {
             write!(f, " -{:?}-> {}", adj.kind, adj.into.display(db))?;
@@ -581,7 +581,7 @@ impl CallType {
 
 impl fmt::Display for CallType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/crates/analyzer/src/db/queries/contracts.rs
+++ b/crates/analyzer/src/db/queries/contracts.rs
@@ -232,7 +232,7 @@ pub fn contract_call_function(
                 diagnostics.push(errors::fancy_error(
                     "`pub` not allowed if `__call__` is defined",
                     vec![
-                        Label::primary(func.name_span(db), format!("`{}` can't be public", name)),
+                        Label::primary(func.name_span(db), format!("`{name}` can't be public")),
                         Label::secondary(init_span, "`__call__` defined here"),
                     ],
                     vec![
@@ -281,7 +281,7 @@ pub fn contract_field_map(
         match map.entry(node.name().into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
-                    &format!("duplicate field names in `contract {}`", contract_name,),
+                    &format!("duplicate field names in `contract {contract_name}`",),
                     entry.key(),
                     entry.get().data(db).ast.span,
                     node.span,

--- a/crates/analyzer/src/db/queries/enums.rs
+++ b/crates/analyzer/src/db/queries/enums.rs
@@ -140,12 +140,9 @@ pub fn enum_function_map(
 
         if builtins::ValueMethod::from_str(def_name).is_ok() {
             scope.error(
-                &format!(
-                    "function name `{}` conflicts with built-in function",
-                    def_name
-                ),
+                &format!("function name `{def_name}` conflicts with built-in function"),
                 func.name_span(db),
-                &format!("`{}` is a built-in function", def_name),
+                &format!("`{def_name}` is a built-in function"),
             );
             continue;
         }
@@ -163,7 +160,7 @@ pub fn enum_function_map(
             Entry::Vacant(entry) => {
                 if let Some(variant) = variant_map.get(def_name) {
                     scope.duplicate_name_error(
-                        &format!("function name `{}` conflicts with enum variant", def_name),
+                        &format!("function name `{def_name}` conflicts with enum variant"),
                         def_name,
                         variant.span(db),
                         func.name_span(db),
@@ -230,12 +227,9 @@ pub fn enum_cycle(
     let enum_name = enum_.name(db);
     let enum_span = enum_.span(db);
     scope.error(
-        &format!("recursive enum `{}`", enum_name),
+        &format!("recursive enum `{enum_name}`"),
         enum_span,
-        &format!(
-            "enum `{}` has infinite size due to recursive definition",
-            enum_name,
-        ),
+        &format!("enum `{enum_name}` has infinite size due to recursive definition",),
     );
 
     Analysis::new(

--- a/crates/analyzer/src/db/queries/functions.rs
+++ b/crates/analyzer/src/db/queries/functions.rs
@@ -216,11 +216,11 @@ pub fn function_signature(
                 // `__init__` and `__call__` must not return any type other than `()`.
                 if type_node.kind != ast::TypeDesc::Unit {
                     scope.fancy_error(
-                        &format!("`{}` function has incorrect return type", fn_name),
+                        &format!("`{fn_name}` function has incorrect return type"),
                         vec![Label::primary(type_node.span, "return type should be `()`")],
                         vec![
                             "Hint: Remove the return type specification.".to_string(),
-                            format!("Example: `pub fn {}():`", fn_name),
+                            format!("Example: `pub fn {fn_name}():`"),
                         ],
                     );
                 }

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -159,13 +159,10 @@ pub fn module_item_map(
             let kind = item.item_kind_display_name();
             let other_kind = global_item.item_kind_display_name();
             diagnostics.push(errors::error(
-                format!(
-                    "{} name conflicts with the {} named \"{}\"",
-                    kind, other_kind, item_name
-                ),
+                format!("{kind} name conflicts with the {other_kind} named \"{item_name}\""),
                 item.name_span(db)
                     .expect("user defined item is missing a name span"),
-                format!("`{}` is already defined", item_name),
+                format!("`{item_name}` is already defined"),
             ));
             continue;
         }
@@ -473,12 +470,9 @@ pub fn module_used_item_map(
                 let other_kind = global_item.item_kind_display_name();
 
                 diagnostics.push(errors::error(
-                    format!(
-                        "import name conflicts with the {} named \"{}\"",
-                        other_kind, name
-                    ),
+                    format!("import name conflicts with the {other_kind} named \"{name}\""),
                     name_span,
-                    format!("`{}` is already defined", name),
+                    format!("`{name}` is already defined"),
                 ));
 
                 None

--- a/crates/analyzer/src/db/queries/structs.rs
+++ b/crates/analyzer/src/db/queries/structs.rs
@@ -64,7 +64,7 @@ pub fn struct_field_map(
         match fields.entry(node.name().into()) {
             Entry::Occupied(entry) => {
                 scope.duplicate_name_error(
-                    &format!("duplicate field names in `struct {}`", struct_name,),
+                    &format!("duplicate field names in `struct {struct_name}`",),
                     entry.key(),
                     entry.get().data(db).ast.span,
                     node.span,
@@ -87,7 +87,7 @@ pub fn struct_field_map(
                     .then(|| Label::primary(field.span(db), String::new()))
             })
             .collect::<Vec<Label>>();
-        labels.last_mut().unwrap().message = format!("{} indexed fields", indexed_count);
+        labels.last_mut().unwrap().message = format!("{indexed_count} indexed fields");
 
         scope.fancy_error(
             &format!(
@@ -196,12 +196,9 @@ pub fn struct_function_map(
 
         if builtins::ValueMethod::from_str(def_name).is_ok() {
             scope.error(
-                &format!(
-                    "function name `{}` conflicts with built-in function",
-                    def_name
-                ),
+                &format!("function name `{def_name}` conflicts with built-in function"),
                 func.name_span(db),
-                &format!("`{}` is a built-in function", def_name),
+                &format!("`{def_name}` is a built-in function"),
             );
             continue;
         }

--- a/crates/analyzer/src/errors.rs
+++ b/crates/analyzer/src/errors.rs
@@ -204,13 +204,13 @@ pub fn type_error(
     error(
         message,
         span,
-        format!("this has type `{}`; expected type `{}`", actual, expected),
+        format!("this has type `{actual}`; expected type `{expected}`"),
     )
 }
 
 pub fn not_yet_implemented(feature: impl Display, span: Span) -> Diagnostic {
     error(
-        format!("feature not yet implemented: {}", feature),
+        format!("feature not yet implemented: {feature}"),
         span,
         "not yet implemented",
     )
@@ -225,8 +225,8 @@ pub fn duplicate_name_error(
     fancy_error(
         message,
         vec![
-            Label::primary(original, format!("`{}` first defined here", name)),
-            Label::secondary(duplicate, format!("`{}` redefined here", name)),
+            Label::primary(original, format!("`{name}` first defined here")),
+            Label::secondary(duplicate, format!("`{name}` redefined here")),
         ],
         vec![],
     )
@@ -248,8 +248,8 @@ pub fn name_conflict_error(
                 original.item_kind_display_name()
             ),
             vec![
-                Label::primary(original_span, format!("`{}` first defined here", name)),
-                Label::secondary(duplicate_span, format!("`{}` redefined here", name)),
+                Label::primary(original_span, format!("`{name}` first defined here")),
+                Label::secondary(duplicate_span, format!("`{name}` redefined here")),
             ],
             vec![],
         )
@@ -287,15 +287,11 @@ pub fn to_mem_error(span: Span) -> Diagnostic {
 }
 pub fn self_contract_type_error(span: Span, typ: &dyn Display) -> Diagnostic {
     fancy_error(
-        format!(
-            "`self` can't be used where a contract of type `{}` is expected",
-            typ,
-        ),
+        format!("`self` can't be used where a contract of type `{typ}` is expected",),
         vec![Label::primary(span, "cannot use `self` here")],
         vec![format!(
-            "Hint: Values of type `{t}` represent external contracts.\n\
-             To treat `self` as an external contract, use `{t}(ctx.self_address())`.",
-            t = typ
+            "Hint: Values of type `{typ}` represent external contracts.\n\
+             To treat `self` as an external contract, use `{typ}(ctx.self_address())`."
         )],
     )
 }

--- a/crates/analyzer/src/namespace/items.rs
+++ b/crates/analyzer/src/namespace/items.rs
@@ -1609,7 +1609,7 @@ impl DisplayWithDb for EnumVariantKind {
                 write!(f, "(")?;
                 let mut delim = "";
                 for ty in elts {
-                    write!(f, "{}", delim)?;
+                    write!(f, "{delim}")?;
                     ty.format(db, f)?;
                     delim = ", ";
                 }
@@ -1735,15 +1735,14 @@ impl ImplId {
             let trait_name = self.trait_id(db).name(db);
             sink.push(&errors::fancy_error(
                      format!(
-                         "the trait `{}` is private",
-                         trait_name,
+                         "the trait `{trait_name}` is private",
                      ),
                      vec![
                          Label::primary(self.trait_id(db).data(db).ast.kind.name.span, "this trait is not `pub`"),
                      ],
                      vec![
-                         format!("`{}` can only be used within `{}`", trait_name, trait_module_name),
-                         format!("Hint: use `pub trait {trait_}` to make `{trait_}` visible from outside of `{module}`", trait_=trait_name, module=trait_module_name),
+                         format!("`{trait_name}` can only be used within `{trait_module_name}`"),
+                         format!("Hint: use `pub trait {trait_name}` to make `{trait_name}` visible from outside of `{trait_module_name}`"),
                      ],
                  ));
         }
@@ -1827,11 +1826,11 @@ impl ImplId {
                         vec![
                             Label::primary(
                                 selfy_span,
-                                format!("`self` declared on the `{}`", selfy_thing),
+                                format!("`self` declared on the `{selfy_thing}`"),
                             ),
                             Label::primary(
                                 non_selfy_span,
-                                format!("no `self` declared on the `{}`", non_selfy_thing),
+                                format!("no `self` declared on the `{non_selfy_thing}`"),
                             ),
                         ],
                         vec![],

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -627,7 +627,7 @@ impl<'a, 'b> BlockScope<'a, 'b> {
                 } else {
                     // It's (currently) an error to shadow a variable in a nested scope
                     let err = self.duplicate_name_error(
-                        &format!("duplicate definition of variable `{}`", name),
+                        &format!("duplicate definition of variable `{name}`"),
                         name,
                         named_item
                             .name_span(self.db())
@@ -672,16 +672,15 @@ pub fn check_visibility(context: &dyn AnalyzerContext, named_thing: &NamedThing,
             let item_span = item.name_span(context.db()).unwrap_or(span);
             let item_kind_name = item.item_kind_display_name();
             context.fancy_error(
-                &format!("the {} `{}` is private", item_kind_name, item_name,),
+                &format!("the {item_kind_name} `{item_name}` is private",),
                 vec![
-                    Label::primary(span, format!("this {} is not `pub`", item_kind_name)),
-                    Label::secondary(item_span, format!("`{}` is defined here", item_name)),
+                    Label::primary(span, format!("this {item_kind_name} is not `pub`")),
+                    Label::secondary(item_span, format!("`{item_name}` is defined here")),
                 ],
                 vec![
-                    format!("`{}` can only be used within `{}`", item_name, module_name),
+                    format!("`{item_name}` can only be used within `{module_name}`"),
                     format!(
-                        "Hint: use `pub` to make `{}` visible from outside of `{}`",
-                        item_name, module_name,
+                        "Hint: use `pub` to make `{item_name}` visible from outside of `{module_name}`",
                     ),
                 ],
             );

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -742,7 +742,7 @@ impl fmt::Display for Base {
             Base::Address => "address",
             Base::Unit => "()",
         };
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }
 
@@ -762,7 +762,7 @@ impl fmt::Display for Integer {
             Integer::I16 => "i16",
             Integer::I8 => "i8",
         };
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }
 

--- a/crates/analyzer/src/traversal/assignments.rs
+++ b/crates/analyzer/src/traversal/assignments.rs
@@ -39,7 +39,7 @@ fn assignment_lhs_type(
             if let Some((name, span)) = name_def_span(scope, target) {
                 labels.push(Label::secondary(
                     span,
-                    format!("consider changing this to be mutable: `mut {}`", name),
+                    format!("consider changing this to be mutable: `mut {name}`"),
                 ));
             }
             scope.fancy_error(

--- a/crates/analyzer/src/traversal/borrowck.rs
+++ b/crates/analyzer/src/traversal/borrowck.rs
@@ -69,10 +69,10 @@ pub fn check_fn_call_arg_borrows(
                 if let Some((_, other_span)) = other_vars.iter().find(|(nt, _)| nt == var) {
                     let name = var.name(context.db());
                     context.fancy_error(
-                        &format!("borrow conflict in call to fn `{}`", fn_name),
+                        &format!("borrow conflict in call to fn `{fn_name}`"),
                         vec![
-                            Label::primary(*var_span, format!("`{}` is used mutably here", name)),
-                            Label::secondary(*other_span, format!("`{}` is used again here", name)),
+                            Label::primary(*var_span, format!("`{name}` is used mutably here")),
+                            Label::secondary(*other_span, format!("`{name}` is used again here")),
                         ],
                         vec![],
                     );

--- a/crates/analyzer/src/traversal/call_args.rs
+++ b/crates/analyzer/src/traversal/call_args.rs
@@ -130,7 +130,7 @@ pub fn validate_named_args(
                         "argument label mismatch",
                         vec![Label::primary(
                             actual_label.span,
-                            format!("expected `{}`", expected_label),
+                            format!("expected `{expected_label}`"),
                         )],
                         notes,
                     );
@@ -143,11 +143,10 @@ pub fn validate_named_args(
                             "missing argument label",
                             vec![Label::primary(
                                 Span::new(arg_val.span.file_id, arg_val.span.start, arg_val.span.start),
-                                format!("add `{}:` here", expected_label),
+                                format!("add `{expected_label}:` here"),
                             )],
                             vec![format!(
-                                "Note: this label is optional if the argument is a variable named `{}`.",
-                                expected_label
+                                "Note: this label is optional if the argument is a variable named `{expected_label}`."
                             )],
                         );
                 }
@@ -195,12 +194,9 @@ pub fn validate_named_args(
             ) {
                 Err(TypeCoercionError::Incompatible) => {
                     let msg = if let Some(label) = param.label() {
-                        format!("incorrect type for `{}` argument `{}`", name, label)
+                        format!("incorrect type for `{name}` argument `{label}`")
                     } else {
-                        format!(
-                            "incorrect type for `{}` argument at position {}",
-                            name, index
-                        )
+                        format!("incorrect type for `{name}` argument at position {index}")
                     };
                     context.type_error(&msg, arg.kind.value.span, param_type, arg_attr.typ);
                 }
@@ -220,9 +216,9 @@ pub fn validate_named_args(
 
         if param_type.is_mut(context.db()) && !arg_type.is_mut(context.db()) {
             let msg = if let Some(label) = param.label() {
-                format!("`{}` argument `{}` must be mutable", name, label)
+                format!("`{name}` argument `{label}` must be mutable")
             } else {
-                format!("`{}` argument at position {} must be mutable", name, index)
+                format!("`{name}` argument at position {index} must be mutable")
             };
             context.error(&msg, arg.kind.value.span, "is not `mut`");
         }

--- a/crates/analyzer/src/traversal/const_expr.rs
+++ b/crates/analyzer/src/traversal/const_expr.rs
@@ -294,7 +294,7 @@ impl Constant {
     fn extract_numeric(&self) -> &BigInt {
         match self {
             Constant::Int(val) => val,
-            _ => panic!("can't extract numeric value from {:?}", self),
+            _ => panic!("can't extract numeric value from {self:?}"),
         }
     }
 
@@ -305,7 +305,7 @@ impl Constant {
     fn extract_bool(&self) -> bool {
         match self {
             Constant::Bool(val) => *val,
-            _ => panic!("can't extract bool value from {:?}", self),
+            _ => panic!("can't extract bool value from {self:?}"),
         }
     }
 }

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -646,7 +646,7 @@ fn field_type(
         Type::SelfContract(id) => match id.field_type(context.db(), field_name) {
             Some(typ) => Ok(typ?.make_sptr(context.db())),
             None => Err(FatalError::new(context.fancy_error(
-                &format!("No field `{}` exists on this contract", field_name),
+                &format!("No field `{field_name}` exists on this contract"),
                 vec![Label::primary(field_span, "undefined field")],
                 vec![],
             ))),
@@ -682,7 +682,7 @@ fn field_type(
         Type::Tuple(tuple) => {
             let item_index = tuple_item_index(field_name).ok_or_else(||
                     FatalError::new(context.fancy_error(
-                        &format!("No field `{}` exists on this tuple", field_name),
+                        &format!("No field `{field_name}` exists on this tuple"),
                         vec![
                             Label::primary(
                                 field_span,
@@ -694,7 +694,7 @@ fn field_type(
 
             tuple.items.get(item_index).copied().ok_or_else(|| {
                 FatalError::new(context.fancy_error(
-                    &format!("No field `item{}` exists on this tuple", item_index),
+                    &format!("No field `item{item_index}` exists on this tuple"),
                     vec![Label::primary(field_span, "unknown field")],
                     vec![format!(
                         "Note: The highest possible field for this tuple is `item{}`",
@@ -818,8 +818,7 @@ fn expr_unary_operation(
                         "Can not apply unary operator",
                         op.span + operand.span,
                         &format!(
-                            "Expected unsigned type `{}`. Unary operator `-` can not be used here.",
-                            expected_int_type,
+                            "Expected unsigned type `{expected_int_type}`. Unary operator `-` can not be used here.",
                         ),
                     );
                 }
@@ -935,27 +934,26 @@ fn expr_call_name<T: std::fmt::Display>(
             {
                 // TODO: this doesn't have to be fatal
                 FatalError::new(context.fancy_error(
-                    &format!("`{}` must be called via `self`", name),
+                    &format!("`{name}` must be called via `self`"),
                     vec![
                         Label::primary(
                             function.name_span(context.db()),
-                            format!("`{}` is defined here as a function that takes `self`", name),
+                            format!("`{name}` is defined here as a function that takes `self`"),
                         ),
                         Label::primary(
                             func.span,
-                            format!("`{}` is called here as a standalone function", name),
+                            format!("`{name}` is called here as a standalone function"),
                         ),
                     ],
                     vec![format!(
-                        "Suggestion: use `self.{}(...)` instead of `{}(...)`",
-                        name, name
+                        "Suggestion: use `self.{name}(...)` instead of `{name}(...)`"
                     )],
                 ))
             } else {
                 FatalError::new(context.error(
-                    &format!("`{}` is not defined", name),
+                    &format!("`{name}` is not defined"),
                     func.span,
-                    &format!("`{}` has not been defined in this context", name),
+                    &format!("`{name}` has not been defined in this context"),
                 ))
             }
         } else {
@@ -1338,18 +1336,15 @@ fn validate_visibility_of_called_fn(
                 Label::primary(call_span, "this function is not `pub`"),
                 Label::secondary(
                     called_fn.name_span(context.db()),
-                    format!("`{}` is defined here", name),
+                    format!("`{name}` is defined here"),
                 ),
             ],
             vec![
                 format!(
-                    "`{}` can only be called from other functions within `{}`",
-                    name, parent_name
+                    "`{name}` can only be called from other functions within `{parent_name}`"
                 ),
                 format!(
-                    "Hint: use `pub fn {fun}(..)` to make `{fun}` callable from outside of `{parent}`",
-                    fun = name,
-                    parent = parent_name
+                    "Hint: use `pub fn {name}(..)` to make `{name}` callable from outside of `{parent_name}`"
                 ),
             ],
         );
@@ -1369,7 +1364,7 @@ fn expr_call_pure(
     let fn_name = function.name(context.db());
     if let Some(args) = generic_args {
         context.fancy_error(
-            &format!("`{}` function is not generic", fn_name),
+            &format!("`{fn_name}` function is not generic"),
             vec![Label::primary(
                 args.span,
                 "unexpected generic argument list",
@@ -1449,7 +1444,7 @@ fn expr_call_struct_constructor(
                 if !field.is_public(context.db()) {
                     Some(Label::primary(
                         field.span(context.db()),
-                        format!("Field `{}` is private", name),
+                        format!("Field `{name}` is private"),
                     ))
                 } else {
                     None
@@ -1459,13 +1454,11 @@ fn expr_call_struct_constructor(
 
         context.fancy_error(
             &format!(
-                "Can not call private constructor of struct `{}` ",
-                name
+                "Can not call private constructor of struct `{name}` "
             ),
             labels,
             vec![format!(
-                "Suggestion: implement a method `new(...)` on struct `{}` to call the constructor and return the struct",
-                name
+                "Suggestion: implement a method `new(...)` on struct `{name}` to call the constructor and return the struct"
             )],
         );
     }
@@ -1646,10 +1639,7 @@ fn expr_call_method(
                                     Label::primary(target.span, "this value is in storage"),
                                     Label::secondary(
                                         field.span,
-                                        format!(
-                                            "hint: copy the {} to memory with `.to_mem()`",
-                                            kind
-                                        ),
+                                        format!("hint: copy the {kind} to memory with `.to_mem()`"),
                                     ),
                                 ],
                                 vec![],
@@ -1724,8 +1714,8 @@ fn validate_trait_in_scope(
                 type_name
             ),
             vec![
-                Label::primary(name_span, format!("method not found in `{}`", type_name)),
-                Label::secondary(called_fn.name_span(context.db()), format!("the method is available for `{}` here", type_name))
+                Label::primary(name_span, format!("method not found in `{type_name}`")),
+                Label::secondary(called_fn.name_span(context.db()), format!("the method is available for `{type_name}` here"))
             ],
             vec![
                 "Hint: items from traits can only be used if the trait is in scope".into(),
@@ -2069,7 +2059,7 @@ fn check_for_call_to_special_fns(
             "Note: `__call__` is not part of the contract's interface, and can't be called."
         };
         Err(FatalError::new(context.fancy_error(
-            &format!("`{}()` is not directly callable", name),
+            &format!("`{name}()` is not directly callable"),
             vec![Label::primary(span, "")],
             vec![label.into()],
         )))
@@ -2086,9 +2076,9 @@ fn validate_numeric_literal_fits_type(
 ) {
     if !int_type.fits(num) {
         context.error(
-            &format!("literal out of range for `{}`", int_type),
+            &format!("literal out of range for `{int_type}`"),
             span,
-            &format!("does not fit into type `{}`", int_type),
+            &format!("does not fit into type `{int_type}`"),
         );
     }
 }

--- a/crates/analyzer/src/traversal/functions.rs
+++ b/crates/analyzer/src/traversal/functions.rs
@@ -91,12 +91,9 @@ fn loop_flow_statement(scope: &mut BlockScope, stmt: &Node<fe::FuncStmt>) {
             _ => unreachable!(),
         };
         scope.error(
-            &format!("`{}` outside of a loop", stmt_name),
+            &format!("`{stmt_name}` outside of a loop"),
             stmt.span,
-            &format!(
-                "`{}` can only be used inside of a `for` or `while` loop",
-                stmt_name
-            ),
+            &format!("`{stmt_name}` can only be used inside of a `for` or `while` loop"),
         );
     }
 }
@@ -379,10 +376,10 @@ fn match_pattern(
                 for (subpat, binds) in subpat_binds.iter() {
                     if !binds.contains_key(var) {
                         err = Some(scope.fancy_error(
-                            &format!("variable `{}` is not bound in all sub patterns", var),
+                            &format!("variable `{var}` is not bound in all sub patterns"),
                             vec![Label::primary(
                                 subpat.span,
-                                format!("variable `{}` is not bound here", var),
+                                format!("variable `{var}` is not bound here"),
                             )],
                             vec![],
                         ));
@@ -403,7 +400,7 @@ fn match_pattern(
                     if bind.ty != ty {
                         bind.spans.iter().for_each(|span| {
                             err = Some(scope.type_error(
-                                &format! {"mismatched type for `{}` between sub patterns", var},
+                                &format! {"mismatched type for `{var}` between sub patterns"},
                                 *span,
                                 ty,
                                 bind.ty,
@@ -478,9 +475,9 @@ fn struct_pattern(
         let pat = match pat_fields.remove(f_name) {
             Some((_, span)) if !field.is_public(scope.db()) => {
                 let err = scope.fancy_error(
-                    &format!("field `{}` is not public field", f_name),
+                    &format!("field `{f_name}` is not public field"),
                     vec![
-                        Label::primary(span, format!("`{}` is not public", f_name)),
+                        Label::primary(span, format!("`{f_name}` is not public")),
                         Label::secondary(field.span(scope.db()), "field is defined here"),
                     ],
                     vec![],
@@ -495,7 +492,7 @@ fn struct_pattern(
                     Node::new(Pattern::WildCard, dummy_span)
                 } else {
                     let err = scope.fancy_error(
-                        &format!("missing field `{}` in the pattern", f_name),
+                        &format!("missing field `{f_name}` in the pattern"),
                         vec![Label::primary(pat_span, "missing field")],
                         vec![],
                     );

--- a/crates/analyzer/src/traversal/pragma.rs
+++ b/crates/analyzer/src/traversal/pragma.rs
@@ -17,16 +17,14 @@ pub fn check_pragma_version(stmt: &Node<ast::Pragma>) -> Option<Diagnostic> {
     } else {
         Some(errors::fancy_error(
             format!(
-                "The current compiler version {} doesn't match the specified requirement",
-                actual_version
+                "The current compiler version {actual_version} doesn't match the specified requirement"
             ),
             vec![Label::primary(
                 version_requirement.span,
                 "The specified version requirement",
             )],
             vec![format!(
-                "Note: Use `pragma {}` to make the code compile",
-                actual_version
+                "Note: Use `pragma {actual_version}` to make the code compile"
             )],
         ))
     }

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -72,7 +72,7 @@ pub fn try_cast_type(
         (Type::Base(Base::Address), Type::Base(Base::Numeric(into))) => {
             if into != Integer::U256 {
                 context.error(
-                    &format!("can't cast `address` to `{}`", into),
+                    &format!("can't cast `address` to `{into}`"),
                     into_span,
                     "try `u256` here",
                 );

--- a/crates/analyzer/src/traversal/utils.rs
+++ b/crates/analyzer/src/traversal/utils.rs
@@ -27,15 +27,12 @@ pub fn add_bin_operations_errors(
 
     match error {
         BinaryOperationError::NotEqualAndUnsigned => context.fancy_error(
-            &format!("`{}` operand types must be equal and unsigned", op),
+            &format!("`{op}` operand types must be equal and unsigned"),
             vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![],
         ),
         BinaryOperationError::RightIsSigned => context.fancy_error(
-            &format!(
-                "The right hand side of the `{}` operation must be unsigned",
-                op
-            ),
+            &format!("The right hand side of the `{op}` operation must be unsigned"),
             vec![Label::primary(
                 rspan,
                 format!("this has signed type `{}`", rtype.display(db)),
@@ -43,7 +40,7 @@ pub fn add_bin_operations_errors(
             vec![],
         ),
         BinaryOperationError::RightTooLarge => context.fancy_error(
-            &format!("incompatible `{}` operand types", op),
+            &format!("incompatible `{op}` operand types"),
             vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![format!(
                 "The type of the right hand side cannot be larger than the left (`{}`)",
@@ -51,12 +48,12 @@ pub fn add_bin_operations_errors(
             )],
         ),
         BinaryOperationError::TypesNotCompatible => context.fancy_error(
-            &format!("`{}` operand types are not compatible", op),
+            &format!("`{op}` operand types are not compatible"),
             vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![],
         ),
         BinaryOperationError::TypesNotNumeric => context.fancy_error(
-            &format!("`{}` operands must be numeric", op),
+            &format!("`{op}` operands must be numeric"),
             vec![type_label(db, lspan, ltype), type_label(db, rspan, rtype)],
             vec![],
         ),

--- a/crates/analyzer/tests/analysis.rs
+++ b/crates/analyzer/tests/analysis.rs
@@ -476,7 +476,7 @@ fn lookup_spans<T: Clone>(
 }
 
 fn build_display_diagnostic<T: Display>(span: Span, attributes: &T) -> Diagnostic {
-    let label = Label::primary(span, format!("{}", attributes));
+    let label = Label::primary(span, format!("{attributes}"));
     Diagnostic {
         severity: Severity::Note,
         message: String::new(),

--- a/crates/codegen/src/db/queries/abi.rs
+++ b/crates/codegen/src/db/queries/abi.rs
@@ -208,7 +208,7 @@ pub fn abi_type(db: &dyn CodegenDb, ty: TypeId) -> AbiType {
                 .enumerate()
                 .map(|(i, item)| {
                     let field_ty = db.codegen_abi_type(*item);
-                    AbiTupleField::new(format!("{}", i), field_ty)
+                    AbiTupleField::new(format!("{i}"), field_ty)
                 })
                 .collect();
 

--- a/crates/codegen/src/db/queries/function.rs
+++ b/crates/codegen/src/db/queries/function.rs
@@ -43,16 +43,16 @@ pub fn symbol_name(db: &dyn CodegenDb, function: FunctionId) -> Rc<String> {
                 id.trait_id(db.upcast()).name(db.upcast()),
                 safe_name(db, id.receiver(db.upcast()))
             );
-            format!("{}${}", class_name, func_name)
+            format!("{class_name}${func_name}")
         }
         Some(class) => {
             let class_name = class.name(db.upcast());
-            format!("{}${}", class_name, func_name)
+            format!("{class_name}${func_name}")
         }
         _ => func_name,
     };
 
-    format!("{}${}", module_name, func_name).into()
+    format!("{module_name}${func_name}").into()
 }
 
 fn type_suffix(function: FunctionId, db: &dyn CodegenDb) -> SmolStr {

--- a/crates/codegen/src/yul/isel/function.rs
+++ b/crates/codegen/src/yul/isel/function.rs
@@ -431,7 +431,7 @@ impl<'db, 'a> FuncLowerHelper<'db, 'a> {
 
             InstKind::YulIntrinsic { op, args } => {
                 let args: Vec<_> = args.iter().map(|arg| self.value_expr(*arg)).collect();
-                let op_name = identifier! { (format!("{}", op).strip_prefix("__").unwrap()) };
+                let op_name = identifier! { (format!("{op}").strip_prefix("__").unwrap()) };
                 let result = expression! { [op_name]([args...]) };
                 // Intrinsic operation never returns ptr type, so we can use u256_ty as a dummy
                 // type for the result.

--- a/crates/codegen/src/yul/runtime/abi.rs
+++ b/crates/codegen/src/yul/runtime/abi.rs
@@ -305,7 +305,7 @@ pub(super) fn make_abi_encode_seq(
     let enc_size = YulVariable::new("enc_size");
     let data_ptr = YulVariable::new("data_ptr");
     let values: Vec<_> = (0..value_num)
-        .map(|idx| YulVariable::new(format!("value{}", idx)))
+        .map(|idx| YulVariable::new(format!("value{idx}")))
         .collect();
 
     let total_header_size =
@@ -369,7 +369,7 @@ pub(super) fn make_abi_decode(
     let data_offset = YulVariable::new("data_offset");
     let tmp_offset = YulVariable::new("tmp_offset");
     let returns: Vec<_> = (0..types.len())
-        .map(|i| YulVariable::new(format!("$ret{}", i)))
+        .map(|i| YulVariable::new(format!("$ret{i}")))
         .collect();
 
     let abi_enc_size = abi_enc_size(db, types);
@@ -502,7 +502,7 @@ impl DefaultRuntimeProvider {
                     _ => unreachable!(),
                 };
                 args.push(literal_expression! {(len)});
-                let name = format! {"$abi_decode_string_from_{}", func_name_postfix};
+                let name = format! {"$abi_decode_string_from_{func_name_postfix}"};
                 self.create_then_call(&name, args, |provider| {
                     make_abi_decode_string_type(provider, db, &name, abi_loc)
                 })
@@ -514,7 +514,7 @@ impl DefaultRuntimeProvider {
                     _ => unreachable!(),
                 };
                 args.push(literal_expression! {(len)});
-                let name = format! {"$abi_decode_bytes_from_{}", func_name_postfix};
+                let name = format! {"$abi_decode_bytes_from_{func_name_postfix}"};
                 self.create_then_call(&name, args, |provider| {
                     make_abi_decode_bytes_type(provider, db, &name, abi_loc)
                 })

--- a/crates/codegen/src/yul/runtime/data.rs
+++ b/crates/codegen/src/yul/runtime/data.rs
@@ -241,7 +241,7 @@ pub(super) fn make_aggregate_init(
     let iter_field_args = || {
         (0..field_num)
             .into_iter()
-            .map(|i| YulVariable::new(format! {"arg{}", i}))
+            .map(|i| YulVariable::new(format! {"arg{i}"}))
     };
 
     let mut body = vec![];
@@ -306,7 +306,7 @@ pub(super) fn make_enum_init(
     let enum_data = || {
         (0..arg_tys.len() - 1)
             .into_iter()
-            .map(|i| YulVariable::new(format! {"arg{}", i}))
+            .map(|i| YulVariable::new(format! {"arg{i}"}))
     };
 
     let tuple_def = TupleDef {

--- a/crates/codegen/src/yul/runtime/mod.rs
+++ b/crates/codegen/src/yul/runtime/mod.rs
@@ -412,9 +412,9 @@ impl RuntimeProvider for DefaultRuntimeProvider {
         let symbol_name = db.codegen_constant_string_symbol_name(data.to_string());
 
         let name = if is_dst_storage {
-            format!("$string_copy_{}_storage", symbol_name)
+            format!("$string_copy_{symbol_name}_storage")
         } else {
-            format!("$string_copy_{}_memory", symbol_name)
+            format!("$string_copy_{symbol_name}_memory")
         };
 
         self.create_then_call(&name, vec![dst], |provider| {
@@ -432,7 +432,7 @@ impl RuntimeProvider for DefaultRuntimeProvider {
         debug_assert!(string_len >= data.len());
         let symbol_name = db.codegen_constant_string_symbol_name(data.to_string());
 
-        let name = format!("$string_construct_{}", symbol_name);
+        let name = format!("$string_construct_{symbol_name}");
         let arg = literal_expression!((32 + string_len));
         self.create_then_call(&name, vec![arg], |provider| {
             data::make_string_construct(provider, db, &name, data)
@@ -612,13 +612,13 @@ impl RuntimeProvider for DefaultRuntimeProvider {
                     TypeKind::Array(ArrayDef { len, .. }) => *len,
                     _ => unreachable!(),
                 };
-                let name = format! {"$abi_encode_bytes{}_type_to_{}", len, func_name_postfix};
+                let name = format! {"$abi_encode_bytes{len}_type_to_{func_name_postfix}"};
                 self.create_then_call(&name, args, |provider| {
                     abi::make_abi_encode_bytes_type(provider, db, &name, len, is_dst_storage)
                 })
             }
             AbiType::String => {
-                let name = format! {"$abi_encode_string_type_to_{}", func_name_postfix};
+                let name = format! {"$abi_encode_string_type_to_{func_name_postfix}"};
                 self.create_then_call(&name, args, |provider| {
                     abi::make_abi_encode_string_type(provider, db, &name, is_dst_storage)
                 })

--- a/crates/codegen/src/yul/runtime/revert.rs
+++ b/crates/codegen/src/yul/runtime/revert.rs
@@ -86,5 +86,5 @@ fn type_signature_for_revert(db: &dyn CodegenDb, name: &str, ty: TypeId) -> yul:
     )
     .selector();
     let type_sig = selector.hex();
-    literal_expression! {(format!{"0x{}", type_sig })}
+    literal_expression! {(format!{"0x{type_sig}" })}
 }

--- a/crates/common/src/panic.rs
+++ b/crates/common/src/panic.rs
@@ -20,5 +20,5 @@ fn report_ice(info: &panic::PanicInfo) {
     eprintln!("Fe is still under heavy development, and isn't yet ready for production use.");
     eprintln!();
     eprintln!("If you would, please report this bug at the following URL:");
-    eprintln!("  {}", BUG_REPORT_URL);
+    eprintln!("  {BUG_REPORT_URL}");
 }

--- a/crates/common/src/utils/humanize.rs
+++ b/crates/common/src/utils/humanize.rs
@@ -10,7 +10,7 @@ impl Pluralizable for &str {
         if self.ends_with('s') {
             self.to_string()
         } else {
-            format!("{}s", self)
+            format!("{self}s")
         }
     }
 

--- a/crates/fe/src/task/build.rs
+++ b/crates/fe/src/task/build.rs
@@ -53,7 +53,7 @@ fn build_single_file(compile_arg: &BuildArgs) -> (String, CompiledModule) {
     let mut db = fe_driver::Db::default();
     let content = match std::fs::read_to_string(input_path) {
         Err(err) => {
-            eprintln!("Failed to load file: `{}`. Error: {}", input_path, err);
+            eprintln!("Failed to load file: `{input_path}`. Error: {err}");
             std::process::exit(1)
         }
         Ok(content) => content,
@@ -68,7 +68,7 @@ fn build_single_file(compile_arg: &BuildArgs) -> (String, CompiledModule) {
     ) {
         Ok(module) => module,
         Err(error) => {
-            eprintln!("Unable to compile {}.", input_path);
+            eprintln!("Unable to compile {input_path}.");
             print_diagnostics(&db, &error.0);
             std::process::exit(1)
         }
@@ -83,18 +83,18 @@ fn build_ingot(compile_arg: &BuildArgs) -> (String, CompiledModule) {
     let optimize = compile_arg.optimize.unwrap_or(true);
 
     if !Path::new(input_path).exists() {
-        eprintln!("Input directory does not exist: `{}`.", input_path);
+        eprintln!("Input directory does not exist: `{input_path}`.");
         std::process::exit(1)
     }
 
     let files = match load_files_from_dir(input_path) {
         Ok(files) if files.is_empty() => {
-            eprintln!("Input directory is not an ingot: `{}`", input_path);
+            eprintln!("Input directory is not an ingot: `{input_path}`");
             std::process::exit(1)
         }
         Ok(files) => files,
         Err(err) => {
-            eprintln!("Failed to load project files. Error: {}", err);
+            eprintln!("Failed to load project files. Error: {err}");
             std::process::exit(1)
         }
     };
@@ -109,7 +109,7 @@ fn build_ingot(compile_arg: &BuildArgs) -> (String, CompiledModule) {
     ) {
         Ok(module) => module,
         Err(error) => {
-            eprintln!("Unable to compile {}.", input_path);
+            eprintln!("Unable to compile {input_path}.");
             print_diagnostics(&db, &error.0);
             std::process::exit(1)
         }
@@ -143,12 +143,9 @@ pub fn build(compile_arg: BuildArgs) {
     let output_dir = &compile_arg.output_dir;
     let overwrite = compile_arg.overwrite;
     match write_compiled_module(compiled_module, &content, emit, output_dir, overwrite) {
-        Ok(_) => eprintln!("Compiled {}. Outputs in `{}`", input_path, output_dir),
+        Ok(_) => eprintln!("Compiled {input_path}. Outputs in `{output_dir}`"),
         Err(err) => {
-            eprintln!(
-                "Failed to write output to directory: `{}`. Error: {}",
-                output_dir, err
-            );
+            eprintln!("Failed to write output to directory: `{output_dir}`. Error: {err}");
             std::process::exit(1)
         }
     }
@@ -188,7 +185,7 @@ fn write_compiled_module(
             let lexer = fe_parser::lexer::Lexer::new(SourceFileId::dummy_file(), file_content);
             lexer.collect::<Vec<_>>()
         };
-        write_output(&output_dir.join("module.tokens"), &format!("{:#?}", tokens))?;
+        write_output(&output_dir.join("module.tokens"), &format!("{tokens:#?}"))?;
     }
 
     for (name, contract) in module.contracts.drain(0..) {
@@ -228,7 +225,7 @@ fn write_output(path: &Path, content: &str) -> Result<(), String> {
 }
 
 fn ioerr_to_string(error: Error) -> String {
-    format!("{}", error)
+    format!("{error}")
 }
 
 fn verify_nonexistent_or_empty(dir: &Path) -> Result<(), String> {
@@ -247,16 +244,16 @@ fn mir_dump(input_path: &str) {
     if Path::new(input_path).is_file() {
         let content = match std::fs::read_to_string(input_path) {
             Err(err) => {
-                eprintln!("Failed to load file: `{}`. Error: {}", input_path, err);
+                eprintln!("Failed to load file: `{input_path}`. Error: {err}");
                 std::process::exit(1)
             }
             Ok(content) => content,
         };
 
         match fe_driver::dump_mir_single_file(&mut db, input_path, &content) {
-            Ok(text) => println!("{}", text),
+            Ok(text) => println!("{text}"),
             Err(err) => {
-                eprintln!("Unable to dump mir `{}", input_path);
+                eprintln!("Unable to dump mir `{input_path}");
                 print_diagnostics(&db, &err.0);
                 std::process::exit(1)
             }

--- a/crates/fe/src/task/check.rs
+++ b/crates/fe/src/task/check.rs
@@ -28,18 +28,18 @@ fn check_single_file(db: &mut Db, input_path: &str) -> Vec<Diagnostic> {
 
 fn check_ingot(db: &mut Db, input_path: &str) -> Vec<Diagnostic> {
     if !Path::new(input_path).exists() {
-        eprintln!("Input directory does not exist: `{}`.", input_path);
+        eprintln!("Input directory does not exist: `{input_path}`.");
         std::process::exit(1)
     }
 
     let files = match load_files_from_dir(input_path) {
         Ok(files) if files.is_empty() => {
-            eprintln!("Input directory is not an ingot: `{}`", input_path);
+            eprintln!("Input directory is not an ingot: `{input_path}`");
             std::process::exit(1)
         }
         Ok(files) => files,
         Err(err) => {
-            eprintln!("Failed to load project files. Error: {}", err);
+            eprintln!("Failed to load project files. Error: {err}");
             std::process::exit(1)
         }
     };

--- a/crates/fe/src/task/new.rs
+++ b/crates/fe/src/task/new.rs
@@ -33,7 +33,7 @@ pub fn create_new_project(args: NewProjectArgs) {
     match fs::create_dir_all(source_path.as_path()) {
         Ok(_) => create_project(source_path.as_path()),
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{err}");
             std::process::exit(1);
         }
     }

--- a/crates/mir/src/db/queries/function.rs
+++ b/crates/mir/src/db/queries/function.rs
@@ -113,11 +113,11 @@ impl ir::FunctionId {
                     id.receiver(db.upcast()).display(db.upcast()),
                     id.trait_id(db.upcast()).name(db.upcast())
                 );
-                format!("{}::{}", class_name, func_name).into()
+                format!("{class_name}::{func_name}").into()
             }
             Some(class) => {
                 let class_name = class.name(db.upcast());
-                format!("{}::{}", class_name, func_name).into()
+                format!("{class_name}::{func_name}").into()
             }
             _ => func_name.into(),
         }

--- a/crates/mir/src/db/queries/types.rs
+++ b/crates/mir/src/db/queries/types.rs
@@ -392,11 +392,11 @@ impl TypeId {
             TypeKind::Bool => write!(w, "bool"),
             TypeKind::Address => write!(w, "address"),
             TypeKind::Unit => write!(w, "()"),
-            TypeKind::String(size) => write!(w, "Str<{}>", size),
+            TypeKind::String(size) => write!(w, "Str<{size}>"),
             TypeKind::Array(ArrayDef { elem_ty, len }) => {
                 write!(w, "[")?;
                 elem_ty.print(db, w)?;
-                write!(w, "; {}]", len)
+                write!(w, "; {len}]")
             }
             TypeKind::Tuple(TupleDef { items }) => {
                 write!(w, "(")?;

--- a/crates/mir/src/graphviz/function.rs
+++ b/crates/mir/src/graphviz/function.rs
@@ -59,7 +59,7 @@ impl FunctionNode {
         for (i, param) in params.iter().enumerate() {
             let name = &param.name;
             let ty = param.ty;
-            write!(&mut sig, "{}: ", name).unwrap();
+            write!(&mut sig, "{name}: ").unwrap();
             ty.pretty_print(db, &body.store, &mut sig).unwrap();
             if param_len - 1 != i {
                 write!(sig, ", ").unwrap();

--- a/crates/mir/src/ir/inst.rs
+++ b/crates/mir/src/ir/inst.rs
@@ -572,7 +572,7 @@ impl fmt::Display for YulIntrinsicOp {
             Self::Gaslimit => "__gaslimit",
         };
 
-        write!(w, "{}", op)
+        write!(w, "{op}")
     }
 }
 

--- a/crates/mir/src/lower/function.rs
+++ b/crates/mir/src/lower/function.rs
@@ -830,7 +830,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
         let lhs = self.lower_expr_to_value(lhs);
         let tmp = self
             .builder
-            .declare(Local::tmp_local(format!("${}_tmp", op).into(), ty));
+            .declare(Local::tmp_local(format!("${op}_tmp").into(), ty));
 
         match op {
             ast::BoolOperator::And => {

--- a/crates/mir/src/lower/pattern_match/mod.rs
+++ b/crates/mir/src/lower/pattern_match/mod.rs
@@ -20,8 +20,8 @@ use super::function::BodyLowerHelper;
 pub mod decision_tree;
 mod tree_vis;
 
-pub(super) fn lower_match<'db, 'a, 'b>(
-    helper: &'b mut BodyLowerHelper<'db, 'a>,
+pub(super) fn lower_match<'b>(
+    helper: &'b mut BodyLowerHelper<'_, '_>,
     mat: &PatternMatrix,
     scrutinee: &Node<Expr>,
     arms: &'b [Node<MatchArm>],

--- a/crates/mir/src/pretty_print/inst.rs
+++ b/crates/mir/src/pretty_print/inst.rs
@@ -32,13 +32,13 @@ impl PrettyPrint for InstId {
             }
 
             InstKind::Unary { op, value } => {
-                write!(w, "{}", op)?;
+                write!(w, "{op}")?;
                 value.pretty_print(db, store, w)
             }
 
             InstKind::Binary { op, lhs, rhs } => {
                 lhs.pretty_print(db, store, w)?;
-                write!(w, " {} ", op)?;
+                write!(w, " {op} ")?;
                 rhs.pretty_print(db, store, w)
             }
 
@@ -57,7 +57,7 @@ impl PrettyPrint for InstId {
 
                 let arg_len = args.len();
                 for (arg_idx, arg) in args.iter().enumerate().take(arg_len - 1) {
-                    write!(w, "<{}>: ", arg_idx)?;
+                    write!(w, "<{arg_idx}>: ")?;
                     arg.pretty_print(db, store, w)?;
                     write!(w, ", ")?;
                 }
@@ -105,7 +105,7 @@ impl PrettyPrint for InstId {
                 call_type,
             } => {
                 let name = func.debug_name(db);
-                write!(w, "{}@{}(", name, call_type)?;
+                write!(w, "{name}@{call_type}(")?;
                 args.as_slice().pretty_print(db, store, w)?;
                 write!(w, ")")
             }
@@ -179,7 +179,7 @@ impl PrettyPrint for InstId {
             InstKind::Create { value, contract } => {
                 write!(w, "create ")?;
                 let contract_name = contract.name(db.upcast());
-                write!(w, "{} ", contract_name)?;
+                write!(w, "{contract_name} ")?;
                 value.pretty_print(db, store, w)
             }
 
@@ -190,14 +190,14 @@ impl PrettyPrint for InstId {
             } => {
                 write!(w, "create2 ")?;
                 let contract_name = contract.name(db.upcast());
-                write!(w, "{} ", contract_name)?;
+                write!(w, "{contract_name} ")?;
                 value.pretty_print(db, store, w)?;
                 write!(w, " ")?;
                 salt.pretty_print(db, store, w)
             }
 
             InstKind::YulIntrinsic { op, args } => {
-                write!(w, "{}(", op)?;
+                write!(w, "{op}(")?;
                 args.as_slice().pretty_print(db, store, w)?;
                 write!(w, ")")
             }

--- a/crates/mir/src/pretty_print/value.rs
+++ b/crates/mir/src/pretty_print/value.rs
@@ -18,14 +18,14 @@ impl PrettyPrint for ValueId {
     ) -> fmt::Result {
         match store.value_data(*self) {
             Value::Temporary { .. } | Value::Local(_) => write!(w, "_{}", self.index()),
-            Value::Immediate { imm, .. } => write!(w, "{}", imm),
+            Value::Immediate { imm, .. } => write!(w, "{imm}"),
             Value::Constant { constant, .. } => {
                 let const_value = constant.data(db);
                 write!(w, "const ")?;
                 match &const_value.value {
-                    ConstantValue::Immediate(num) => write!(w, "{}", num),
-                    ConstantValue::Str(s) => write!(w, r#""{}""#, s),
-                    ConstantValue::Bool(b) => write!(w, "{}", b),
+                    ConstantValue::Immediate(num) => write!(w, "{num}"),
+                    ConstantValue::Str(s) => write!(w, r#""{s}""#),
+                    ConstantValue::Bool(b) => write!(w, "{b}"),
                 }
             }
             Value::Unit { .. } => write!(w, "()"),

--- a/crates/parser/src/ast.rs
+++ b/crates/parser/src/ast.rs
@@ -593,14 +593,14 @@ impl fmt::Display for Module {
             .iter()
             .partition(|&stmt| matches!(stmt, ModuleStmt::Use(_) | ModuleStmt::Pragma(_)));
         for stmt in &uses {
-            writeln!(f, "{}", stmt)?;
+            writeln!(f, "{stmt}")?;
         }
         if !uses.is_empty() && !rest.is_empty() {
             writeln!(f)?;
         }
         let mut delim = "";
         for stmt in rest {
-            writeln!(f, "{}{}", delim, stmt)?;
+            writeln!(f, "{delim}{stmt}")?;
             delim = "\n";
         }
         Ok(())
@@ -643,12 +643,12 @@ impl fmt::Display for Use {
 impl fmt::Display for UseTree {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            UseTree::Glob { prefix } => write!(f, "{}::*", prefix),
+            UseTree::Glob { prefix } => write!(f, "{prefix}::*"),
             UseTree::Simple { path, rename } => {
                 if let Some(rename) = rename {
                     write!(f, "{} as {}", path, rename.kind)
                 } else {
-                    write!(f, "{}", path)
+                    write!(f, "{path}")
                 }
             }
             UseTree::Nested { prefix, children } => {
@@ -666,7 +666,7 @@ impl fmt::Display for Path {
             .map(|name| name.kind.as_ref())
             .collect::<Vec<_>>()
             .join("::");
-        write!(f, "{}", joined_names)?;
+        write!(f, "{joined_names}")?;
 
         Ok(())
     }
@@ -805,8 +805,8 @@ impl fmt::Display for TypeDesc {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             TypeDesc::Unit => write!(f, "()"),
-            TypeDesc::Base { base } => write!(f, "{}", base),
-            TypeDesc::Path(path) => write!(f, "{}", path),
+            TypeDesc::Base { base } => write!(f, "{base}"),
+            TypeDesc::Path(path) => write!(f, "{path}"),
             TypeDesc::Tuple { items } => {
                 if items.len() == 1 {
                     write!(f, "({},)", items[0].kind)
@@ -1047,7 +1047,7 @@ impl fmt::Display for FuncStmt {
 impl fmt::Display for VarDeclTarget {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            VarDeclTarget::Name(name) => write!(f, "{}", name),
+            VarDeclTarget::Name(name) => write!(f, "{name}"),
             VarDeclTarget::Tuple(elts) => {
                 if elts.len() == 1 {
                     write!(f, "({},)", elts[0].kind)
@@ -1116,11 +1116,11 @@ impl fmt::Display for Expr {
                     write!(f, "({})", node_comma_joined(elts))
                 }
             }
-            Expr::Bool(bool) => write!(f, "{}", bool),
-            Expr::Name(name) => write!(f, "{}", name),
-            Expr::Path(path) => write!(f, "{}", path),
-            Expr::Num(num) => write!(f, "{}", num),
-            Expr::Str(str) => write!(f, "\"{}\"", str),
+            Expr::Bool(bool) => write!(f, "{bool}"),
+            Expr::Name(name) => write!(f, "{name}"),
+            Expr::Path(path) => write!(f, "{path}"),
+            Expr::Num(num) => write!(f, "{num}"),
+            Expr::Str(str) => write!(f, "\"{str}\""),
             Expr::Unit => write!(f, "()"),
         }
     }
@@ -1131,7 +1131,7 @@ impl fmt::Display for CallArg {
         if let Some(label) = &self.label {
             if let Expr::Name(var_name) = &self.value.kind {
                 if var_name == &label.kind {
-                    return write!(f, "{}", var_name);
+                    return write!(f, "{var_name}");
                 }
             }
             write!(f, "{}: {}", label.kind, self.value.kind)
@@ -1228,9 +1228,9 @@ impl fmt::Display for Pattern {
                     .map(|(name, pat)| format!("{}: {}", name.kind, pat.kind));
                 let fields = comma_joined(fields);
                 if *is_rest {
-                    write!(f, "{{{}, ..}}", fields)
+                    write!(f, "{{{fields}, ..}}")
                 } else {
-                    write!(f, "{{{}}}", fields)
+                    write!(f, "{{{fields}}}")
                 }
             }
             Self::Or(pats) => {
@@ -1268,7 +1268,7 @@ where
     T: fmt::Display,
 {
     items
-        .map(|item| format!("{}", item))
+        .map(|item| format!("{item}"))
         .collect::<Vec<_>>()
         .join(delim)
 }
@@ -1286,7 +1286,7 @@ fn write_nodes_line_wrapped(f: &mut impl Write, nodes: &[Node<impl fmt::Display>
 fn double_line_joined(items: &[impl fmt::Display]) -> String {
     items
         .iter()
-        .map(|item| format!("{}", item))
+        .map(|item| format!("{item}"))
         .collect::<Vec<_>>()
         .join("\n\n")
 }
@@ -1345,25 +1345,25 @@ impl PrefixBindingPower for UnaryOperator {
 
 fn maybe_fmt_left_with_parens(op: &impl InfixBindingPower, expr: &Expr) -> String {
     if expr_right_binding_power(expr) < op.infix_binding_power().0 {
-        format!("({})", expr)
+        format!("({expr})")
     } else {
-        format!("{}", expr)
+        format!("{expr}")
     }
 }
 
 fn maybe_fmt_right_with_parens(op: &impl InfixBindingPower, expr: &Expr) -> String {
     if op.infix_binding_power().1 > expr_left_binding_power(expr) {
-        format!("({})", expr)
+        format!("({expr})")
     } else {
-        format!("{}", expr)
+        format!("{expr}")
     }
 }
 
 fn maybe_fmt_operand_with_parens(op: &impl PrefixBindingPower, expr: &Expr) -> String {
     if op.prefix_binding_power() > expr_left_binding_power(expr) {
-        format!("({})", expr)
+        format!("({expr})")
     } else {
-        format!("{}", expr)
+        format!("{expr}")
     }
 }
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -138,7 +138,7 @@ pub fn parse_call_args(par: &mut Parser) -> ParseResult<Node<Vec<Node<CallArg>>>
                         vec![Label::primary(eq.span, "unexpected `=`".to_string())],
                         vec![
                             "Argument labels should be followed by `:`.".to_string(),
-                            format!("Hint: try `{}:`", name),
+                            format!("Hint: try `{name}:`"),
                             "If this is a variable assignment, it must be a standalone statement."
                                 .to_string(),
                         ],
@@ -249,7 +249,7 @@ fn prefix_binding_power(op: TokenKind) -> u8 {
     match op {
         Not => 65,
         Plus | Minus | Tilde => 135,
-        _ => panic!("Unexpected unary op token: {:?}", op),
+        _ => panic!("Unexpected unary op token: {op:?}"),
     }
 }
 
@@ -442,7 +442,7 @@ fn atom(par: &mut Parser, tok: &Token) -> Node<Expr> {
                 Expr::Str(tok.text.into())
             }
         }
-        _ => panic!("Unexpected atom token: {:?}", tok),
+        _ => panic!("Unexpected atom token: {tok:?}"),
     };
     Node::new(expr, tok.span)
 }
@@ -565,7 +565,7 @@ fn infix_op(
                 }
             }
         }
-        _ => panic!("Unexpected infix op token: {:?}", op),
+        _ => panic!("Unexpected infix op token: {op:?}"),
     };
     Ok(expr)
 }

--- a/crates/parser/src/grammar/module.rs
+++ b/crates/parser/src/grammar/module.rs
@@ -262,7 +262,7 @@ pub fn parse_pragma(par: &mut Parser) -> ParseResult<Node<Pragma>> {
         )),
         Err(err) => {
             par.fancy_error(
-                format!("failed to parse pragma statement: {}", err),
+                format!("failed to parse pragma statement: {err}"),
                 vec![Label::primary(
                     version_requirement_span,
                     "Invalid version requirement",

--- a/crates/parser/src/lexer.rs
+++ b/crates/parser/src/lexer.rs
@@ -57,9 +57,7 @@ mod tests {
 
         assert!(
             actual.iter().eq(expected.iter()),
-            "\nexpected: {:?}\n  actual: {:?}",
-            expected,
-            actual
+            "\nexpected: {expected:?}\n  actual: {actual:?}"
         );
     }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -266,7 +266,7 @@ impl<'a> Parser<'a> {
             Ok(())
         } else {
             self.fancy_error(
-                format!("{} must start with `{{`", context_name),
+                format!("{context_name} must start with `{{`"),
                 vec![Label::primary(
                     Span::new(self.file_id, context_span.end, context_span.end),
                     "expected `{` here",
@@ -294,7 +294,7 @@ impl<'a> Parser<'a> {
                 let tok = self.next()?;
                 self.unexpected_token_error(
                     &tok,
-                    format!("unexpected token while parsing {}", context_name),
+                    format!("unexpected token while parsing {context_name}"),
                     vec![format!(
                         "expected a newline; found {} instead",
                         tok.kind.describe()

--- a/crates/parser/tests/cases/print_ast.rs
+++ b/crates/parser/tests/cases/print_ast.rs
@@ -16,7 +16,7 @@ fn parse_and_print(path: &str, src: &str) -> String {
         print_diagnostics(&db, &diags);
         panic!("parse error");
     }
-    format!("{}", module)
+    format!("{module}")
 }
 
 macro_rules! test_print {

--- a/crates/test-files/src/lib.rs
+++ b/crates/test-files/src/lib.rs
@@ -5,7 +5,7 @@ const FIXTURES: Dir = include_dir!("$CARGO_MANIFEST_DIR/fixtures");
 pub fn fixture(path: &str) -> &'static str {
     FIXTURES
         .get_file(path)
-        .unwrap_or_else(|| panic!("bad fixture file path {}", path))
+        .unwrap_or_else(|| panic!("bad fixture file path {path}"))
         .contents_utf8()
         .expect("fixture file isn't utf8")
 }
@@ -13,21 +13,21 @@ pub fn fixture(path: &str) -> &'static str {
 pub fn fixture_bytes(path: &str) -> &'static [u8] {
     FIXTURES
         .get_file(path)
-        .unwrap_or_else(|| panic!("bad fixture file path {}", path))
+        .unwrap_or_else(|| panic!("bad fixture file path {path}"))
         .contents()
 }
 
 pub fn fixture_dir(path: &str) -> &Dir<'static> {
     FIXTURES
         .get_dir(path)
-        .unwrap_or_else(|| panic!("no fixture dir named \"{}\"", path))
+        .unwrap_or_else(|| panic!("no fixture dir named \"{path}\""))
 }
 
 /// Returns `(file_path, file_content)`
 pub fn fixture_dir_files(path: &str) -> Vec<(&'static str, &'static str)> {
     let dir = FIXTURES
         .get_dir(path)
-        .unwrap_or_else(|| panic!("no fixture dir named \"{}\"", path));
+        .unwrap_or_else(|| panic!("no fixture dir named \"{path}\""));
 
     fe_library::static_dir_files(dir)
 }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -18,7 +18,7 @@ test-files = {path = "../test-files", package = "fe-test-files" }
 hex = "0.4"
 primitive-types = {version = "0.11.1", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"
-solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "f18b1ce", optional = true}
+solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "20aeb7b", optional = true}
 yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
 indexmap = "1.6.2"
 insta = { default-features = false, version = "1.7.1" }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -30,7 +30,7 @@ impl GasReporter {
     }
 
     pub fn add_func_call_record(&self, function: &str, input: &[ethabi::Token], gas_used: u64) {
-        let description = format!("{}({:?})", function, input);
+        let description = format!("{function}({input:?})");
         self.add_record(&description, gas_used)
     }
 }
@@ -112,7 +112,7 @@ impl ContractHarness {
         let function = &self.abi.functions[name][0];
         function
             .encode_input(input)
-            .unwrap_or_else(|reason| panic!("Unable to encode input for {}: {:?}", name, reason))
+            .unwrap_or_else(|reason| panic!("Unable to encode input for {name}: {reason:?}"))
     }
 
     pub fn capture_call_raw_bytes(
@@ -141,8 +141,7 @@ impl ContractHarness {
         assert_eq!(
             output.map(ToOwned::to_owned),
             actual_output,
-            "unexpected output from `fn {}`",
-            name
+            "unexpected output from `fn {name}`"
         )
     }
 
@@ -164,7 +163,7 @@ impl ContractHarness {
                 .decode_output(&output)
                 .unwrap_or_else(|_| panic!("unable to decode output of {}: {:?}", name, &output))
                 .pop(),
-            evm::Capture::Exit((reason, _)) => panic!("failed to run \"{}\": {:?}", name, reason),
+            evm::Capture::Exit((reason, _)) => panic!("failed to run \"{name}\": {reason:?}"),
             evm::Capture::Trap(_) => panic!("trap"),
         }
     }
@@ -227,10 +226,9 @@ impl ContractHarness {
                 .collect::<Vec<_>>();
 
             if !outputs_for_event.iter().any(|v| v == expected_output) {
-                println!("raw logs dump: {:?}", raw_logs);
+                println!("raw logs dump: {raw_logs:?}");
                 panic!(
-                    "no \"{}\" logs matching: {:?}\nfound: {:?}",
-                    name, expected_output, outputs_for_event
+                    "no \"{name}\" logs matching: {expected_output:?}\nfound: {outputs_for_event:?}"
                 )
             }
         }
@@ -340,7 +338,7 @@ pub fn deploy_contract(
         Ok(module) => module,
         Err(error) => {
             fe_common::diagnostics::print_diagnostics(&db, &error.0);
-            panic!("failed to compile module: {}", fixture)
+            panic!("failed to compile module: {fixture}")
         }
     };
 
@@ -371,7 +369,7 @@ pub fn deploy_contract_from_ingot(
         Ok(module) => module,
         Err(error) => {
             fe_common::diagnostics::print_diagnostics(&db, &error.0);
-            panic!("failed to compile ingot: {}", path)
+            panic!("failed to compile ingot: {path}")
         }
     };
 
@@ -418,7 +416,7 @@ pub fn encode_revert(selector: &str, input: &[ethabi::Token]) -> Vec<u8> {
     for param in input {
         let encoded = match param {
             ethabi::Token::Uint(val) | ethabi::Token::Int(val) => {
-                format!("{:0>64}", format!("{:x}", val))
+                format!("{:0>64}", format!("{val:x}"))
             }
             ethabi::Token::Bool(val) => format!("{:0>64x}", *val as i32),
             ethabi::Token::String(val) => {
@@ -436,7 +434,7 @@ pub fn encode_revert(selector: &str, input: &[ethabi::Token]) -> Vec<u8> {
                 // bytes
                 let string_bytes = hex::encode(&string_bytes);
 
-                format!("{}{}{}", DATA_OFFSET, string_len, string_bytes)
+                format!("{DATA_OFFSET}{string_len}{string_bytes}")
             }
             _ => todo!("Other ABI types not supported yet"),
         };
@@ -582,7 +580,7 @@ pub fn load_contract(address: H160, fixture: &str, contract_name: &str) -> Contr
         driver::compile_single_file(&mut db, fixture, test_files::fixture(fixture), true, true)
             .unwrap_or_else(|err| {
                 print_diagnostics(&db, &err.0);
-                panic!("failed to compile fixture: {}", fixture);
+                panic!("failed to compile fixture: {fixture}");
             });
     let compiled_contract = compiled_module
         .contracts
@@ -744,13 +742,13 @@ pub fn string_token(s: &str) -> ethabi::Token {
 
 #[allow(dead_code)]
 pub fn address(s: &str) -> H160 {
-    H160::from_str(s).unwrap_or_else(|_| panic!("couldn't create address from: {}", s))
+    H160::from_str(s).unwrap_or_else(|_| panic!("couldn't create address from: {s}"))
 }
 
 #[allow(dead_code)]
 pub fn address_token(s: &str) -> ethabi::Token {
     // left pads to 40 characters
-    ethabi::Token::Address(address(&format!("{:0>40}", s)))
+    ethabi::Token::Address(address(&format!("{s:0>40}")))
 }
 
 #[allow(dead_code)]

--- a/crates/tests/src/differential.rs
+++ b/crates/tests/src/differential.rs
@@ -134,13 +134,13 @@ impl<'a> DualHarness {
     ) -> DualHarness {
         let fe_harness = test_utils::deploy_contract(
             executor,
-            &format!("differential/{}.fe", fixture),
+            &format!("differential/{fixture}.fe"),
             contract_name,
             init_params,
         );
         let solidity_harness = test_utils::deploy_solidity_contract(
             executor,
-            &format!("differential/{}.sol", fixture),
+            &format!("differential/{fixture}.sol"),
             contract_name,
             init_params,
             true,

--- a/crates/tests/src/features.rs
+++ b/crates/tests/src/features.rs
@@ -22,14 +22,14 @@ pub fn deploy_contract(
 ) -> ContractHarness {
     test_utils::deploy_contract(
         executor,
-        &format!("features/{}", fixture),
+        &format!("features/{fixture}"),
         contract_name,
         init_params,
     )
 }
 
 pub fn load_contract(address: H160, fixture: &str, contract_name: &str) -> ContractHarness {
-    test_utils::load_contract(address, &format!("features/{}", fixture), contract_name)
+    test_utils::load_contract(address, &format!("features/{fixture}"), contract_name)
 }
 
 #[test]

--- a/crates/tests/src/ingots.rs
+++ b/crates/tests/src/ingots.rs
@@ -10,7 +10,7 @@ pub fn deploy_ingot(
 ) -> ContractHarness {
     test_utils::deploy_contract_from_ingot(
         executor,
-        &format!("ingots/{}/src", fixture),
+        &format!("ingots/{fixture}/src"),
         contract_name,
         init_params,
     )

--- a/crates/tests/src/stress.rs
+++ b/crates/tests/src/stress.rs
@@ -12,7 +12,7 @@ pub fn deploy_contract(
 ) -> ContractHarness {
     fe_compiler_test_utils::deploy_contract(
         executor,
-        &format!("stress/{}", fixture),
+        &format!("stress/{fixture}"),
         contract_name,
         init_params,
     )

--- a/crates/yulc/Cargo.toml
+++ b/crates/yulc/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ethereum/fe"
 
 [dependencies]
 # This fork supports concurrent compilation, which is required for Rust tests.
-solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "f18b1ce", optional = true}
+solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "20aeb7b", optional = true}
 serde_json = "1.0"
 indexmap = "1.6.2"
 

--- a/docs/src/development/build.md
+++ b/docs/src/development/build.md
@@ -14,8 +14,14 @@ The following commands only build the Fe -> Yul compiler components.
 The Fe compiler depends on the Solidity compiler for transforming Yul IR to EVM bytecode. We currently use [solc-rust](https://github.com/cburgdorf/solc-rust) to perform this. In order to compile solc-rust, the following must be installed on your system:
 
 - cmake
-- libboost
+- libboost@1.79 (This is temporary and will be updated when solidity v0.8.18 is released)
 - libclang
+
+For macOS, you can install boost@1.79 dependency using the below command:
+```bash
+    brew tap Y-Nak/boost
+    brew install Y-nak/boost/boost
+```
 
 Once these have been installed, you may run the full build. This is enabled using the *solc-backend* feature.
 


### PR DESCRIPTION
### What was wrong?
* Resolve #771 (Thanks again! @0xalpharush)
* Update solc version to 0.8.17
* Make clippy happy
* Add note about the refactoring in `README.md`

I made temporal `brew tap` to install `boost@1.79` for Apple silicon users and noted the building process in `build.md`. 
This can be removed when solidity v0.8.18 is released; see https://github.com/ethereum/solidity/pull/13867 for more information.

