### PR TITLE
new discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The most advanced example that we can provide at this point is an implementation
 ## Community
 
 - Twitter: [@official_fe](https://twitter.com/official_fe)
-- Chat: [Discord](https://discord.gg/ywpkAXFjZH)
+- Chat: [Discord](https://discord.gg/hPePGYSw)
 
 
 ## License

--- a/website/index.html
+++ b/website/index.html
@@ -47,7 +47,7 @@
       <nav id="menu" class="hidden px-2 pt-2 pb-4 text-center sm:flex sm:p-0 sm:text-left">
         <a href="docs/quickstart/index.html" class="transition duration-100 ease-in-out block text-lg px-2 py-2 hover:bg-gray-700 hover:text-white rounded-sm sm:mt-0 sm:ml-2 sm:px-4" title="Get started" >Get started</a>
         <a href="docs/index.html" class="transition duration-100 ease-in-out mt-1 text-lg block px-2 py-2 hover:bg-gray-700 hover:text-white rounded-sm sm:mt-0 sm:ml-2 sm:px-4" title="Learn">Learn</a>
-        <a href="https://discord.gg/ywpkAXFjZH" class="transition duration-100 ease-in-out mt-1 text-lg block px-2 py-2 hover:bg-gray-700 hover:text-white rounded-sm sm:mt-0 sm:ml-2 sm:px-4"title="Community">Community</a>
+        <a href="https://discord.gg/hPePGYSw" class="transition duration-100 ease-in-out mt-1 text-lg block px-2 py-2 hover:bg-gray-700 hover:text-white rounded-sm sm:mt-0 sm:ml-2 sm:px-4"title="Community">Community</a>
         <a href="https://blog.fe-lang.org" class="transition duration-100 ease-in-out mt-1 text-lg block px-2 py-2 hover:bg-gray-700 hover:text-white rounded-sm sm:mt-0 sm:ml-2 sm:px-4" title="Blog">Blog</a>
       </nav>
     </div>
@@ -252,7 +252,7 @@ contract GuestBook {
             <h5 class="text-2xl tracking-tight mb-2">Contribute &rarr;</h5>
             <p class="text-gray-700 leading-5">Help improve Fe</p>
           </a>
-          <a href="https://discord.gg/ywpkAXFjZH" title="Discuss" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
+          <a href="https://discord.gg/hPePGYSw" title="Discuss" class="p-6 bg-gray-100 text-gray-900 shadow-lg rounded-sm hover:shadow-xl">
             <h5 class="text-2xl tracking-tight mb-2">Discuss &rarr;</h5>
             <p class="text-gray-700 leading-5">Discuss and explore with the community</p>
           </a>
@@ -280,7 +280,7 @@ contract GuestBook {
           <h4 class="font-semibold mb-4">Community</h4>
           <ul>
             <li><a class="block py-1 hover:text-white" href="https://twitter.com/official_fe" title="Fe on Twitter">Twitter</a></li>
-            <li><a class="block py-1 hover:text-white" href="https://discord.gg/ywpkAXFjZH" title="Fe on Discord">Discord</a></li>
+            <li><a class="block py-1 hover:text-white" href="https://discord.gg/hPePGYSw" title="Fe on Discord">Discord</a></li>
             <li><a class="block py-1 hover:text-white" href="https://github.com/ethereum/fe" title="Fe on GitHub">GitHub</a></li>
           </ul>
         </div>


### PR DESCRIPTION
### What was wrong?

People on Twitter reported that our discord invite link is dead

### How was it fixed?

Replaced with fresh link

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
