### PR TITLE
Update workflows dependencies

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,19 +16,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: install cargo-tarpaulin
         run: |
           cargo install cargo-tarpaulin

--- a/.github/workflows/expensive.yml
+++ b/.github/workflows/expensive.yml
@@ -13,20 +13,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
 
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
         run: cargo test --workspace --all-features --no-run --locked -- --ignored

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,45 +17,35 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Validate release notes entry
         run: ./newsfragments/validate_files.py
       - name: Lint with rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
       - name: Lint with clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D clippy::all
 
   book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: install mdbook & mdbook-linkcheck
         run: |
           cargo install mdbook
@@ -75,7 +65,7 @@ jobs:
           - os: ubuntu-latest
           - os: macOS-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Mac System dependencies
         if: startsWith(matrix.os,'macOS')
         run: |
@@ -86,13 +76,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libboost-all-dev
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo test --workspace --all-features --no-run --locked
       - name: Run tests
@@ -100,17 +88,16 @@ jobs:
 
   wasm-test:
       runs-on: ubuntu-latest
-      container: davesque/rust-wasm
       steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
       - name: Build WASM tests
         run: wasm-pack test --node crates/fe -- --workspace --no-run
       - name: Run WASM tests
@@ -134,7 +121,7 @@ jobs:
             BIN_FILE: fe_mac
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Linux dependencies
         if: startsWith(matrix.os,'ubuntu')
         run: |
@@ -145,11 +132,9 @@ jobs:
         run: |
           brew install boost
       - name: Install rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           toolchain: stable
-          override: true
       - name: Build
         run: cargo build --all-features --release && strip target/release/fe && mv target/release/fe target/release/${{ matrix.BIN_FILE }}
       - name: Release


### PR DESCRIPTION
Updated/removed some workflow dependencies to fix deprecate warnings.

* Remove deprecated docker container for wasm test.
* Replace `actions-rs/toolchain` with `dtolnay/rust-toolchain` Ref: https://github.com/actions-rs/toolchain/issues/216.
* Update `actions/checkout`.
*  Remove `actions-rs/cargo`.