### PR TITLE
Cover __init__ function in contracts

### DIFF
--- a/docs/src/spec/items/contracts.md
+++ b/docs/src/spec/items/contracts.md
@@ -46,6 +46,23 @@ contract GuestBook {
 }
 ```
 
+## The `__init__` function
+
+The `__init__` function is a special contract function that can only be called at *contract deployment time*. It is mostly used to set initial values to storage variables upon deployment.
+
+```fe
+pub contract Example {
+
+    admin: address
+
+    pub fn __init__(mut self, admin: address)  {
+        self.admin = admin
+    }
+}
+```
+
+It is **not possible** to call `__init__` at runtime.
+
 [NEWLINE]: ../lexical_structure/tokens.md#newline
 [IDENTIFIER]: ../lexical_structure/identifiers.md
 [_Visibility_]: ./visibility_and_privacy.md


### PR DESCRIPTION


### What was wrong?

As stated in #792 we don't cover the `__init__` function yet

### How was it fixed?

:writing_hand: 

