### PR TITLE
Fix clippy for rust 1.68; ignore etherscan urls in book linkcheck

### DIFF
--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -330,13 +330,7 @@ pub fn module_structs(db: &dyn AnalyzerDb, module: ModuleId) -> Rc<[StructId]> {
     module
         .all_items(db)
         .iter()
-        .chain(
-            module
-                .used_items(db)
-                .values()
-                .into_iter()
-                .map(|(_, item)| item),
-        )
+        .chain(module.used_items(db).values().map(|(_, item)| item))
         .filter_map(|item| match item {
             Item::Type(TypeDef::Struct(id)) => Some(*id),
             _ => None,

--- a/crates/codegen/src/yul/runtime/data.rs
+++ b/crates/codegen/src/yul/runtime/data.rs
@@ -238,11 +238,7 @@ pub(super) fn make_aggregate_init(
     let ptr = YulVariable::new("ptr");
     let field_num = inner_ty.aggregate_field_num(db.upcast());
 
-    let iter_field_args = || {
-        (0..field_num)
-            .into_iter()
-            .map(|i| YulVariable::new(format! {"arg{i}"}))
-    };
+    let iter_field_args = || (0..field_num).map(|i| YulVariable::new(format! {"arg{i}"}));
 
     let mut body = vec![];
     for (idx, field_arg) in iter_field_args().enumerate() {
@@ -303,11 +299,7 @@ pub(super) fn make_enum_init(
     let ptr = YulVariable::new("ptr");
     let disc = YulVariable::new("disc");
     let disc_ty = arg_tys[0];
-    let enum_data = || {
-        (0..arg_tys.len() - 1)
-            .into_iter()
-            .map(|i| YulVariable::new(format! {"arg{i}"}))
-    };
+    let enum_data = || (0..arg_tys.len() - 1).map(|i| YulVariable::new(format! {"arg{i}"}));
 
     let tuple_def = TupleDef {
         items: arg_tys

--- a/crates/mir/src/lower/pattern_match/decision_tree.rs
+++ b/crates/mir/src/lower/pattern_match/decision_tree.rs
@@ -177,7 +177,6 @@ impl Occurrence {
     fn phi_specialize(&self, db: &dyn AnalyzerDb, ctor: ConstructorKind) -> Vec<Self> {
         let arity = ctor.arity(db);
         (0..arity)
-            .into_iter()
             .map(|i| {
                 let mut inner = self.0.clone();
                 inner.push(i);

--- a/crates/tests-legacy/src/features.rs
+++ b/crates/tests-legacy/src/features.rs
@@ -1075,7 +1075,7 @@ fn sized_vals_in_sto() {
         let harness = deploy_contract(&mut executor, "sized_vals_in_sto.fe", "Foo", &[]);
 
         let num = uint_token(68);
-        let nums = uint_array_token(&(0..42).into_iter().collect::<Vec<_>>());
+        let nums = uint_array_token(&(0..42).collect::<Vec<_>>());
         let string = string_token("there are 26 protons in fe");
 
         harness.test_function(&mut executor, "write_num", &[num.clone()], None);

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -12,7 +12,7 @@ additional-css = ["theme/reference.css"]
 [output.linkcheck]
 follow-web-links = true
 warning-policy = "error"
-exclude = [ 'github\.com', 'goerli\.etherscan\.io', 'goerlifaucet\.com', 'alchemy\.com' ]
+exclude = [ 'github\.com', 'etherscan\.io', 'goerlifaucet\.com', 'alchemy\.com' ]
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
### What was wrong?

New clippy = new failing lints
Also the mdbook linkcheck config needed to be adjusted for the tutorial update.

### How was it fixed?

:open_hands: