### PR TITLE
Fix resolving generics on associated fns

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1381,7 +1381,7 @@ fn expr_call_pure(
 
     if function.is_test(context.db()) {
         context.fancy_error(
-            &format!("`{}` is a test function", fn_name),
+            &format!("`{fn_name}` is a test function"),
             vec![Label::primary(call_span, "test functions are not callable")],
             vec![],
         );

--- a/crates/fe/src/task/test.rs
+++ b/crates/fe/src/task/test.rs
@@ -26,7 +26,7 @@ pub fn test(args: TestArgs) {
         test_ingot(&args)
     };
 
-    println!("{}", test_sink);
+    println!("{test_sink}");
     if test_sink.failure_count() != 0 {
         std::process::exit(1)
     }
@@ -38,7 +38,7 @@ fn test_single_file(args: &TestArgs) -> TestSink {
     let mut db = fe_driver::Db::default();
     let content = match std::fs::read_to_string(input_path) {
         Err(err) => {
-            eprintln!("Failed to load file: `{}`. Error: {}", input_path, err);
+            eprintln!("Failed to load file: `{input_path}`. Error: {err}");
             std::process::exit(1)
         }
         Ok(content) => content,
@@ -51,7 +51,7 @@ fn test_single_file(args: &TestArgs) -> TestSink {
             sink
         }
         Err(error) => {
-            eprintln!("Unable to compile {}.", input_path);
+            eprintln!("Unable to compile {input_path}.");
             print_diagnostics(&db, &error.0);
             std::process::exit(1)
         }
@@ -60,7 +60,7 @@ fn test_single_file(args: &TestArgs) -> TestSink {
 
 pub fn execute_tests(module_name: &str, tests: &[CompiledTest], sink: &mut TestSink) {
     if tests.len() == 1 {
-        println!("executing 1 test in {}:", module_name);
+        println!("executing 1 test in {module_name}:");
     } else {
         println!("executing {} tests in {}:", tests.len(), module_name);
     }
@@ -83,18 +83,18 @@ fn test_ingot(args: &TestArgs) -> TestSink {
     let optimize = args.optimize.unwrap_or(true);
 
     if !Path::new(input_path).exists() {
-        eprintln!("Input directory does not exist: `{}`.", input_path);
+        eprintln!("Input directory does not exist: `{input_path}`.");
         std::process::exit(1)
     }
 
     let content = match load_files_from_dir(input_path) {
         Ok(files) if files.is_empty() => {
-            eprintln!("Input directory is not an ingot: `{}`", input_path);
+            eprintln!("Input directory is not an ingot: `{input_path}`");
             std::process::exit(1)
         }
         Ok(files) => files,
         Err(err) => {
-            eprintln!("Failed to load project files. Error: {}", err);
+            eprintln!("Failed to load project files. Error: {err}");
             std::process::exit(1)
         }
     };
@@ -110,7 +110,7 @@ fn test_ingot(args: &TestArgs) -> TestSink {
             sink
         }
         Err(error) => {
-            eprintln!("Unable to compile {}.", input_path);
+            eprintln!("Unable to compile {input_path}.");
             print_diagnostics(&db, &error.0);
             std::process::exit(1)
         }

--- a/crates/mir/src/db/queries/function.rs
+++ b/crates/mir/src/db/queries/function.rs
@@ -40,7 +40,6 @@ pub fn mir_lowered_pseudo_monomorphized_func_signature(
         .iter()
         .map(|generic| (generic.name(), analyzer_types::TypeId::unit(db.upcast())))
         .collect::<BTreeMap<_, _>>();
-
     lower_monomorphized_func_signature(db, analyzer_func, resolved_generics)
 }
 

--- a/crates/test-files/fixtures/features/generic_functions.fe
+++ b/crates/test-files/fixtures/features/generic_functions.fe
@@ -36,6 +36,11 @@ struct Runner {
     return val.compute(val: 1000)
   }
 
+  pub fn run_static<T: Computable>(_ val: T) -> u256 {
+    return val.compute(val: 1000)
+  }
+
+
   pub fn dummy<T: Dummy>(self, _ val: T) {
 
   }
@@ -46,6 +51,8 @@ contract Example {
     let runner: Runner = Runner();
     assert runner.run(Mac()) == 1001
     assert runner.run(Linux(counter: 10)) == 1015
+
+    assert Runner::run_static(Mac()) == 1001
 
     // We are testing that we can satisfy a trait bound where the trait is defined in another module
     runner.dummy(Mac())

--- a/crates/test-runner/src/lib.rs
+++ b/crates/test-runner/src/lib.rs
@@ -48,9 +48,9 @@ impl Display for TestSink {
 
         let test_description = |n: usize, status: &dyn Display| -> String {
             if n == 1 {
-                format!("1 test {}", status)
+                format!("1 test {status}")
             } else {
-                format!("{} tests {}", n, status)
+                format!("{n} tests {status}")
             }
         };
 
@@ -85,7 +85,7 @@ pub fn execute(name: &str, bytecode: &str, sink: &mut TestSink) -> bool {
     if reverted {
         sink.inc_success_count();
     } else {
-        sink.insert_failure(name, &format!("{:?}", result));
+        sink.insert_failure(name, &format!("{result:?}"));
     };
 
     reverted

--- a/newsfragments/861.bugfix.md
+++ b/newsfragments/861.bugfix.md
@@ -1,0 +1,17 @@
+Fixed resolving of generic arguments to associated functions.
+
+For example, this code would previously crash the compiler:
+
+```rust
+...
+  // This function doesn't take self
+  pub fn run_static<T: Computable>(_ val: T) -> u256 {
+    return val.compute(val: 1000)
+  }
+...
+
+// Invoking it would previously crash the compiler
+Runner::run_static(Mac())
+...
+```
+


### PR DESCRIPTION
### What was wrong?

Invoking associated functions that take generics causes ICE.

e.g. given the following function `run`

```Rust
struct OperatingSystem {
  pub run<T: Task>(task: T) {
    task.run()
  }
}
```
It will currently cause an ICE when `OperatingSystem::run(some_task)` is invoked.

### How was it fixed?

Properly resolve generic parameters for associated functions
