### PR TITLE
Allow calls to type constructors on primitives to appear in constant expressions

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -577,6 +577,14 @@ impl CallType {
             self.function().map(|id| id.is_unsafe(db)).unwrap_or(false)
         }
     }
+
+    pub fn is_primitive_type_constructor(&self, db: &dyn AnalyzerDb) -> bool {
+        if let CallType::TypeConstructor(type_id) = self {
+            type_id.is_primitive(db)
+        } else {
+            false
+        }
+    }
 }
 
 impl fmt::Display for CallType {

--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -21,6 +21,7 @@ pub struct ItemScope<'a> {
     db: &'a dyn AnalyzerDb,
     module: ModuleId,
     expressions: RefCell<IndexMap<NodeId, ExpressionAttributes>>,
+    calls: RefCell<IndexMap<NodeId, CallType>>,
     pub diagnostics: RefCell<Vec<Diagnostic>>,
 }
 impl<'a> ItemScope<'a> {
@@ -29,6 +30,7 @@ impl<'a> ItemScope<'a> {
             db,
             module,
             expressions: RefCell::new(IndexMap::default()),
+            calls: RefCell::new(IndexMap::default()),
             diagnostics: RefCell::new(vec![]),
         }
     }
@@ -95,11 +97,11 @@ impl<'a> AnalyzerContext for ItemScope<'a> {
         panic!("ItemContext has no parent function")
     }
 
-    fn add_call(&self, _node: &Node<ast::Expr>, _call_type: CallType) {
-        unreachable!("Can't call function outside of function")
+    fn add_call(&self, _node: &Node<ast::Expr>, call_type: CallType) {
+        self.calls.borrow_mut().insert(_node.id, call_type);
     }
     fn get_call(&self, _node: &Node<ast::Expr>) -> Option<CallType> {
-        unreachable!("Can't call function outside of function")
+        self.calls.borrow().get(&_node.id).cloned()
     }
 
     fn is_in_function(&self) -> bool {

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1381,7 +1381,7 @@ fn expr_call_pure(
 
     if function.is_test(context.db()) {
         context.fancy_error(
-            &format!("`{}` is a test function", fn_name),
+            &format!("`{fn_name}` is a test function"),
             vec![Label::primary(call_span, "test functions are not callable")],
             vec![],
         );

--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -905,13 +905,13 @@ fn expr_call(
         );
     }
 
-    if context.is_in_function() {
+    if context.is_in_function() || call_type.is_primitive_type_constructor(context.db()) {
         context.add_call(func, call_type);
     } else {
         context.error(
             "calling function outside function",
             func.span,
-            "function can only be called inside function",
+            "ffunction can only be called inside function",
         );
     }
 

--- a/crates/analyzer/tests/snapshots/analysis__module_const.snap
+++ b/crates/analyzer/tests/snapshots/analysis__module_const.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
+assertion_line: 215
 expression: "build_snapshot(&db, module)"
 ---
 note: 

--- a/crates/fe/src/task/test.rs
+++ b/crates/fe/src/task/test.rs
@@ -26,7 +26,7 @@ pub fn test(args: TestArgs) {
         test_ingot(&args)
     };
 
-    println!("{}", test_sink);
+    println!("{test_sink}");
     if test_sink.failure_count() != 0 {
         std::process::exit(1)
     }
@@ -38,7 +38,7 @@ fn test_single_file(args: &TestArgs) -> TestSink {
     let mut db = fe_driver::Db::default();
     let content = match std::fs::read_to_string(input_path) {
         Err(err) => {
-            eprintln!("Failed to load file: `{}`. Error: {}", input_path, err);
+            eprintln!("Failed to load file: `{input_path}`. Error: {err}");
             std::process::exit(1)
         }
         Ok(content) => content,
@@ -51,7 +51,7 @@ fn test_single_file(args: &TestArgs) -> TestSink {
             sink
         }
         Err(error) => {
-            eprintln!("Unable to compile {}.", input_path);
+            eprintln!("Unable to compile {input_path}.");
             print_diagnostics(&db, &error.0);
             std::process::exit(1)
         }
@@ -60,7 +60,7 @@ fn test_single_file(args: &TestArgs) -> TestSink {
 
 pub fn execute_tests(module_name: &str, tests: &[CompiledTest], sink: &mut TestSink) {
     if tests.len() == 1 {
-        println!("executing 1 test in {}:", module_name);
+        println!("executing 1 test in {module_name}:");
     } else {
         println!("executing {} tests in {}:", tests.len(), module_name);
     }
@@ -83,18 +83,18 @@ fn test_ingot(args: &TestArgs) -> TestSink {
     let optimize = args.optimize.unwrap_or(true);
 
     if !Path::new(input_path).exists() {
-        eprintln!("Input directory does not exist: `{}`.", input_path);
+        eprintln!("Input directory does not exist: `{input_path}`.");
         std::process::exit(1)
     }
 
     let content = match load_files_from_dir(input_path) {
         Ok(files) if files.is_empty() => {
-            eprintln!("Input directory is not an ingot: `{}`", input_path);
+            eprintln!("Input directory is not an ingot: `{input_path}`");
             std::process::exit(1)
         }
         Ok(files) => files,
         Err(err) => {
-            eprintln!("Failed to load project files. Error: {}", err);
+            eprintln!("Failed to load project files. Error: {err}");
             std::process::exit(1)
         }
     };
@@ -110,7 +110,7 @@ fn test_ingot(args: &TestArgs) -> TestSink {
             sink
         }
         Err(error) => {
-            eprintln!("Unable to compile {}.", input_path);
+            eprintln!("Unable to compile {input_path}.");
             print_diagnostics(&db, &error.0);
             std::process::exit(1)
         }

--- a/crates/test-runner/src/lib.rs
+++ b/crates/test-runner/src/lib.rs
@@ -48,9 +48,9 @@ impl Display for TestSink {
 
         let test_description = |n: usize, status: &dyn Display| -> String {
             if n == 1 {
-                format!("1 test {}", status)
+                format!("1 test {status}")
             } else {
-                format!("{} tests {}", n, status)
+                format!("{n} tests {status}")
             }
         };
 
@@ -85,7 +85,7 @@ pub fn execute(name: &str, bytecode: &str, sink: &mut TestSink) -> bool {
     if reverted {
         sink.inc_success_count();
     } else {
-        sink.insert_failure(name, &format!("{:?}", result));
+        sink.insert_failure(name, &format!("{result:?}"));
     };
 
     reverted

--- a/crates/tests/fixtures/files/const_module.fe
+++ b/crates/tests/fixtures/files/const_module.fe
@@ -1,0 +1,11 @@
+contract ERC {}
+
+const DAI_ADDR: address = address(0x6b175474e89094c44da98b954eedeac495271d0f)
+const DAI_ERC: ERC = ERC(DAI_ADDR)
+
+#test
+fn test_bar() {
+    let actual: address = address(0x6b175474e89094c44da98b954eedeac495271d0f)
+    assert DAI_ADDR == actual
+    assert address(DAI_ERC) == actual
+}

--- a/newsfragments/809.feature.md
+++ b/newsfragments/809.feature.md
@@ -1,0 +1,10 @@
+Allow calls to type constructors for primitive types in constant expressions
+
+E.g. these are now allowed:
+
+```rust
+const DAI_ADDR: address = address(0x6b175474e89094c44da98b954eedeac495271d0f)
+const DAI_ERC: ERC = ERC(DAI_ADDR)
+```
+
+Note that contract type constructors are simply just addresses and thus treated as primitives.


### PR DESCRIPTION
### What was wrong?

As stated in #809 one very annoying thing that arises in pretty much every attempt to write real world Fe code is that it is currently not possible to use addresses as constants.

### How was it fixed?

Hacked until it worked.