### PR TITLE
address literals

### DIFF
--- a/crates/analyzer/src/context.rs
+++ b/crates/analyzer/src/context.rs
@@ -589,6 +589,7 @@ impl fmt::Display for CallType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Constant {
     Int(BigInt),
+    Address(BigInt),
     Bool(bool),
     Str(SmolStr),
 }

--- a/crates/analyzer/src/namespace/types.rs
+++ b/crates/analyzer/src/namespace/types.rs
@@ -33,6 +33,10 @@ pub fn i256_min() -> BigInt {
     BigInt::from(-2).pow(255)
 }
 
+pub fn address_max() -> BigInt {
+    BigInt::from(2).pow(160) - 1
+}
+
 /// Names that can be used to build identifiers without collision.
 pub trait SafeNames {
     /// Name in the lower snake format (e.g. lower_snake_case).

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -393,9 +393,12 @@ pub fn apply_generic_type_args(
                 // TODO: Fix me when `GenericArg` can represent literals not only `Int`.
                 match const_value {
                     Constant::Int(val) => Ok(GenericArg::Int(val.try_into().unwrap())),
-                    Constant::Bool(_) | Constant::Str(_) => Err(TypeError::new(
-                        context.not_yet_implemented("non numeric type const generics", expr.span),
-                    )),
+                    Constant::Address(_) | Constant::Bool(_) | Constant::Str(_) => {
+                        Err(TypeError::new(context.not_yet_implemented(
+                            "non numeric type const generics",
+                            expr.span,
+                        )))
+                    }
                 }
             }
 

--- a/crates/analyzer/tests/snapshots/analysis__const_local.snap
+++ b/crates/analyzer/tests/snapshots/analysis__const_local.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
+assertion_line: 302
 expression: "build_snapshot(&db, module)"
 ---
 note: 
@@ -10,8 +11,8 @@ note:
  4 │ │         const C2: i64 = 2
  5 │ │         const C3: i64 = 10
    · │
-15 │ │         return C10
-16 │ │     }
+16 │ │         return C10
+17 │ │     }
    │ ╰─────^ params: [] -> u256
 
 note: 
@@ -39,7 +40,9 @@ note:
    │               ^^ bool
 13 │         const C10: u256 = 42 if C9 else 0 // 42
    │               ^^^ u256
-14 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
+14 │         const C11: address = 0xfefe
+   │               ^^^ address
+15 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
    │             ^^^^ Array<bool, 42>
 
 note: 
@@ -144,18 +147,20 @@ note:
    │
 13 │         const C10: u256 = 42 if C9 else 0 // 42
    │                           ^^^^^^^^^^^^^^^ u256 = Int(42)
-14 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
+14 │         const C11: address = 0xfefe
+   │                              ^^^^^^ address = Address(65278)
+15 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
    │                                 ^^^       ^^^^    ^^^ u256
    │                                 │         │        
    │                                 │         bool
    │                                 u256
 
 note: 
-   ┌─ const_local.fe:14:42
+   ┌─ const_local.fe:15:42
    │
-14 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
+15 │         let _arr: Array<bool, { C10 }> = [true; { C10 }]
    │                                          ^^^^^^^^^^^^^^^ Array<bool, 42>
-15 │         return C10
+16 │         return C10
    │                ^^^ u256
 
 

--- a/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
+++ b/crates/analyzer/tests/snapshots/analysis__erc20_token.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/analyzer/tests/analysis.rs
+assertion_line: 183
 expression: "build_snapshot(&db, module)"
 ---
 note: 
@@ -536,8 +537,8 @@ note:
    ┌─ erc20_token.fe:83:5
    │  
 83 │ ╭     fn _transfer(mut self, mut ctx: Context, sender: address, recipient: address, value: u256) {
-84 │ │         assert sender != address(0)
-85 │ │         assert recipient != address(0)
+84 │ │         assert sender != 0
+85 │ │         assert recipient != 0
 86 │ │         _before_token_transfer(from: sender, to: recipient, value)
    · │
 89 │ │         ctx.emit(Transfer(from: sender, to: recipient, value))
@@ -547,38 +548,26 @@ note:
 note: 
    ┌─ erc20_token.fe:84:16
    │
-84 │         assert sender != address(0)
-   │                ^^^^^^            ^ u256
-   │                │                  
+84 │         assert sender != 0
+   │                ^^^^^^    ^ address
+   │                │          
    │                address
-
-note: 
-   ┌─ erc20_token.fe:84:26
-   │
-84 │         assert sender != address(0)
-   │                          ^^^^^^^^^^ address
 
 note: 
    ┌─ erc20_token.fe:84:16
    │
-84 │         assert sender != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^ bool
-85 │         assert recipient != address(0)
-   │                ^^^^^^^^^            ^ u256
-   │                │                     
+84 │         assert sender != 0
+   │                ^^^^^^^^^^^ bool
+85 │         assert recipient != 0
+   │                ^^^^^^^^^    ^ address
+   │                │             
    │                address
-
-note: 
-   ┌─ erc20_token.fe:85:29
-   │
-85 │         assert recipient != address(0)
-   │                             ^^^^^^^^^^ address
 
 note: 
    ┌─ erc20_token.fe:85:16
    │
-85 │         assert recipient != address(0)
-   │                ^^^^^^^^^^^^^^^^^^^^^^^ bool
+85 │         assert recipient != 0
+   │                ^^^^^^^^^^^^^^ bool
 86 │         _before_token_transfer(from: sender, to: recipient, value)
    │                                      ^^^^^^      ^^^^^^^^^  ^^^^^ u256
    │                                      │           │           

--- a/crates/analyzer/tests/snapshots/errors__mismatch_return_type.snap
+++ b/crates/analyzer/tests/snapshots/errors__mismatch_return_type.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/analyzer/tests/errors.rs
+assertion_line: 281
 expression: "error_string(&path, test_files::fixture(path))"
 ---
 error: expected function to return `address` but was `u256`
   ┌─ compile_errors/mismatch_return_type.fe:3:9
   │
-3 │         return 1
-  │         ^^^^^^^^
+3 │         return u256(1)
+  │         ^^^^^^^^^^^^^^
 
 

--- a/crates/analyzer/tests/snapshots/errors__return_call_to_fn_with_param_type_mismatch.snap
+++ b/crates/analyzer/tests/snapshots/errors__return_call_to_fn_with_param_type_mismatch.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/analyzer/tests/errors.rs
+assertion_line: 295
 expression: "error_string(&path, test_files::fixture(path))"
 ---
 error: incorrect type for `foo` argument at position 0
   ┌─ compile_errors/return_call_to_fn_with_param_type_mismatch.fe:7:20
   │
 7 │         return foo(100)
-  │                    ^^^ this has type `u256`; expected type `address`
+  │                    ^^^ this has type `u256`; expected type `bool`
 
 

--- a/crates/mir/src/ir/constant.rs
+++ b/crates/mir/src/ir/constant.rs
@@ -39,7 +39,7 @@ pub enum ConstantValue {
 impl From<context::Constant> for ConstantValue {
     fn from(value: context::Constant) -> Self {
         match value {
-            context::Constant::Int(num) => Self::Immediate(num),
+            context::Constant::Int(num) | context::Constant::Address(num) => Self::Immediate(num),
             context::Constant::Str(s) => Self::Str(s),
             context::Constant::Bool(b) => Self::Bool(b),
         }

--- a/crates/parser/tests/cases/snapshots/cases__print_ast__erc20.snap
+++ b/crates/parser/tests/cases/snapshots/cases__print_ast__erc20.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/parser/tests/cases/print_ast.rs
+assertion_line: 45
 expression: "parse_and_print(\"demos/erc20_token.fe\", src)"
-
 ---
 struct Approval {
     pub owner: address
@@ -82,8 +82,8 @@ contract ERC20 {
     }
 
     fn _transfer(mut self, mut ctx: Context, sender: address, recipient: address, value: u256) {
-        assert sender != address(0)
-        assert recipient != address(0)
+        assert sender != 0
+        assert recipient != 0
         _before_token_transfer(from: sender, to: recipient, value)
         self._balances[sender] = self._balances[sender] - value
         self._balances[recipient] = self._balances[recipient] + value

--- a/crates/test-files/fixtures/compile_errors/mismatch_return_type.fe
+++ b/crates/test-files/fixtures/compile_errors/mismatch_return_type.fe
@@ -1,5 +1,5 @@
 contract Foo {
     pub fn bar() -> address {
-        return 1
+        return u256(1)
     }
 }

--- a/crates/test-files/fixtures/compile_errors/return_call_to_fn_with_param_type_mismatch.fe
+++ b/crates/test-files/fixtures/compile_errors/return_call_to_fn_with_param_type_mismatch.fe
@@ -1,5 +1,5 @@
 contract Foo {
-    pub fn foo(_ val: address) -> u256 {
+    pub fn foo(_ val: bool) -> u256 {
         return 42
     }
 

--- a/crates/test-files/fixtures/demos/erc20_token.fe
+++ b/crates/test-files/fixtures/demos/erc20_token.fe
@@ -81,8 +81,8 @@ contract ERC20 {
     }
 
     fn _transfer(mut self, mut ctx: Context, sender: address, recipient: address, value: u256) {
-        assert sender != address(0)
-        assert recipient != address(0)
+        assert sender != 0
+        assert recipient != 0
         _before_token_transfer(from: sender, to: recipient, value)
         self._balances[sender] = self._balances[sender] - value
         self._balances[recipient] = self._balances[recipient] + value

--- a/crates/test-files/fixtures/features/const_local.fe
+++ b/crates/test-files/fixtures/features/const_local.fe
@@ -11,6 +11,7 @@ contract Foo {
         const C8: bool = false
         const C9: bool = C8 < C7 // true
         const C10: u256 = 42 if C9 else 0 // 42
+        const C11: address = 0xfefe
         let _arr: Array<bool, { C10 }> = [true; { C10 }]
         return C10
     }

--- a/crates/tests/fixtures/files/const_local.fe
+++ b/crates/tests/fixtures/files/const_local.fe
@@ -10,6 +10,7 @@ fn bar() -> u256 {
     const C8: bool = false
     const C9: bool = C8 < C7 // true
     const C10: u256 = 42 if C9 else 0 // 42
+    const C11: address = 0xfefe
     let _arr: Array<bool, { C10 }> = [true; { C10 }]
     return C10
 }

--- a/docs/src/spec/expressions/call.md
+++ b/docs/src/spec/expressions/call.md
@@ -26,8 +26,8 @@ Example:
 contract Foo {
 
     pub fn demo(self) {
-        let ann: address = address(0xaa)
-        let bob: address = address(0xbb)
+        let ann: address = 0xaa
+        let bob: address = 0xbb
         self.transfer(from: ann, to: bob, 25)
     }
 

--- a/docs/src/spec/items/functions.md
+++ b/docs/src/spec/items/functions.md
@@ -82,8 +82,8 @@ contract CoolCoin {
         return true
     }
     pub fn demo(mut self) {
-        let ann: address = address(0xaa)
-        let bob: address = address(0xbb)
+        let ann: address = 0xaa
+        let bob: address = 0xbb
         self.balance[ann] = 100
 
         let bonus: u256 = 2

--- a/docs/src/spec/items/visibility_and_privacy.md
+++ b/docs/src/spec/items/visibility_and_privacy.md
@@ -47,7 +47,7 @@ use ding::dong::Dang
 contract Foo {
     pub fn hot_dang() -> Dang {
         return Dang(
-            my_address: address(8),
+            my_address: 8,
             my_u256: 42,
             my_i8: -1
         )

--- a/docs/src/spec/type_system/types/address.md
+++ b/docs/src/spec/type_system/types/address.md
@@ -11,7 +11,7 @@ contract Example {
 
   fn do_something() {
     // A plain address (not part of a tuple, struct etc) remains on the stack
-    let dai_contract: address = address(0x6b175474e89094c44da98b954eedeac495271d0f)
+    let dai_contract: address = 0x6b175474e89094c44da98b954eedeac495271d0f
   }
 }
 ```

--- a/newsfragments/864.feature.md
+++ b/newsfragments/864.feature.md
@@ -1,0 +1,4 @@
+`address` values can now be specified with a number literal, with no explicit
+cast. So instead of `let t: address = address(0xfe)`, one can now write
+`let t: address = 0xfe`. This also means that it's possible to define `const`
+addresses: `const SOME_KNOWN_CONTRACT: address = 0xfefefefe`


### PR DESCRIPTION
### What was wrong?

'twas impossible to define a `const` address, due to address values needing an explicit `address(...)` cast, which is treated as a function call internally, and thus not allowed in a `const` context yet.

Closes #809 (not exactly as stated, but with this change it's possible to define all primitive types in a const context so we don't need the type constructors/casts). This is an alternative to #862.

### How was it fixed?

Allow number literals to be interpreted as an addresses. Anywhere an `address` type is expected, a number literal is allowed (as long as it fits in a u160).
```rust
const FOO: address = 0xfe // OK!
fn foo(a: address) { .. }
foo(100) // OK! 
// ^ note that this is decimal 100! Perhaps we should only allow hex literals?
```

This might feel a bit loosey-goosey, but I think it'll be fine in real code, which likely won't often use address literals for anything other than 0 and `const` definitions.