### PR TITLE
solc 0.8.19; move solc-rust and yultsur repos to fe-lang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "solc"
 version = "0.1.0"
-source = "git+https://github.com/Y-Nak/solc-rust?rev=a647450#a647450aba4950a32d48fdd81d797a83894f731e"
+source = "git+https://github.com/fe-lang/solc-rust?rev=bde551e#bde551ef2ec13e7f88c93e42f76216d803b39bec"
 dependencies = [
  "cmake",
  "lazy_static",
@@ -2567,7 +2567,7 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 [[package]]
 name = "yultsur"
 version = "0.1.0"
-source = "git+https://github.com/g-r-a-n-t/yultsur?rev=ae85470#ae854702e90b2c70e5c19961167f2b6f2aff32d2"
+source = "git+https://github.com/fe-lang/yultsur?rev=ae85470#ae854702e90b2c70e5c19961167f2b6f2aff32d2"
 dependencies = [
  "indenter",
 ]

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -14,4 +14,4 @@ num-bigint = "0.4.3"
 fxhash = "0.2.1"
 indexmap = "1.6.2"
 smol_str = "0.1.21"
-yultsur = { git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470" }
+yultsur = { git = "https://github.com/fe-lang/yultsur", rev = "ae85470" }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -18,8 +18,8 @@ test-files = {path = "../test-files", package = "fe-test-files" }
 hex = "0.4"
 primitive-types = {version = "0.12", default-features = false, features = ["rlp"]}
 serde_json = "1.0.64"
-solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "a647450", optional = true}
-yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
+solc = { git = "https://github.com/fe-lang/solc-rust", rev = "bde551e", optional = true}
+yultsur = {git = "https://github.com/fe-lang/yultsur", rev = "ae85470"}
 indexmap = "1.6.2"
 insta = { default-features = false, version = "1.26" }
 

--- a/crates/tests-legacy/Cargo.toml
+++ b/crates/tests-legacy/Cargo.toml
@@ -24,7 +24,7 @@ primitive-types = {version = "0.12", default-features = false, features = ["rlp"
 rand = "0.8.5"
 rstest = "0.6.4"
 # This fork contains the shorthand macros and some other necessary updates.
-yultsur = {git = "https://github.com/g-r-a-n-t/yultsur", rev = "ae85470"}
+yultsur = {git = "https://github.com/fe-lang/yultsur", rev = "ae85470"}
 insta = { default-features = false, version = "1.26" }
 pretty_assertions = "1.0.0"
 wasm-bindgen-test = "0.3.24"

--- a/crates/yulc/Cargo.toml
+++ b/crates/yulc/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/ethereum/fe"
 
 [dependencies]
 # This fork supports concurrent compilation, which is required for Rust tests.
-solc = { git = "https://github.com/Y-Nak/solc-rust", rev = "a647450", optional = true}
+solc = { git = "https://github.com/fe-lang/solc-rust", rev = "bde551e", optional = true}
 serde_json = "1.0"
 indexmap = "1.6.2"
 

--- a/docs/src/development/build.md
+++ b/docs/src/development/build.md
@@ -11,7 +11,7 @@ The following commands only build the Fe -> Yul compiler components.
 
 **Full**
 
-The Fe compiler depends on the Solidity compiler for transforming Yul IR to EVM bytecode. We currently use [solc-rust](https://github.com/cburgdorf/solc-rust) to perform this. In order to compile solc-rust, the following must be installed on your system:
+The Fe compiler depends on the Solidity compiler for transforming Yul IR to EVM bytecode. We currently use [solc-rust](https://github.com/fe-lang/solc-rust) to perform this. In order to compile solc-rust, the following must be installed on your system:
 
 - cmake
 - boost(1.65+)


### PR DESCRIPTION
solc version bump. The build was failing on my machine due to a new warning introduced into a recent clang version, so I disabled the PEDANTIC option in the solc build config.

I also made forks of solc-rust and yultsur in the fe-lang org. Let's use these instead of bouncing between personal forks. Update these at will, of course.