### PR TITLE
Fix ICE

### DIFF
--- a/crates/codegen/src/db/queries/abi.rs
+++ b/crates/codegen/src/db/queries/abi.rs
@@ -125,6 +125,7 @@ pub fn abi_type_maximum_size(db: &dyn CodegenDb, ty: TypeId) -> usize {
                 }
                 maximum + 32
             }
+            ir::TypeKind::MPtr(ty) => abi_type_maximum_size(db, ty.deref(db.upcast())),
 
             _ => unreachable!(),
         }
@@ -155,7 +156,7 @@ pub fn abi_type_minimum_size(db: &dyn CodegenDb, ty: TypeId) -> usize {
                 }
                 minimum + 32
             }
-
+            ir::TypeKind::MPtr(ty) => abi_type_minimum_size(db, ty.deref(db.upcast())),
             _ => unreachable!(),
         }
     }

--- a/crates/test-files/fixtures/crashes/mptr_field_abi.fe
+++ b/crates/test-files/fixtures/crashes/mptr_field_abi.fe
@@ -1,0 +1,7 @@
+struct Tx {
+  pub data: Array<u8, 320>
+}
+
+contract Foo {
+  pub fn bar(mut tx: Tx) {}
+}

--- a/crates/tests-legacy/src/crashes.rs
+++ b/crates/tests-legacy/src/crashes.rs
@@ -18,3 +18,4 @@ test_file! { agroce550 }
 test_file! { agroce551 }
 test_file! { agroce623 }
 test_file! { revert_const }
+test_file! { mptr_field_abi }

--- a/newsfragments/867.bugfix.md
+++ b/newsfragments/867.bugfix.md
@@ -1,0 +1,13 @@
+Fixed an ICE when using aggregate types with aggregate type fields in public functions
+
+This code would previously cause an ICE:
+
+```fe
+struct Tx {
+  pub data: Array<u8, 320>
+}
+
+contract Foo {
+  pub fn bar(mut tx: Tx) {}
+}
+```


### PR DESCRIPTION
### What was wrong?

This code currently crashes the compiler

```fe
struct Tx {
  pub data: Array<u8, 320>
}

contract Foo {
  pub fn bar(mut tx: Tx) {}
}
```

### How was it fixed?

Deref mptrs in `abi_type_minimum_size` and `abi_type_maximum_size`
