### PR TITLE
chore: update website copyright notice date

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -265,7 +265,7 @@ contract GuestBook {
       <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-y-10">
         <div>
           <img class="h-24" src="fe-logo.svg" alt="Fe Programming language">
-          <p class="mt-4 text-gray-400 text-sm">Fe Programming Language<br>&copy; 2021 Ethereum Foundation</p>
+          <p class="mt-4 text-gray-400 text-sm">Fe Programming Language<br>&copy; 2021-2023 Ethereum Foundation</p>
         </div>
         <div>
           <h4 class="font-semibold mb-4">Get Started</h4>


### PR DESCRIPTION
### What was wrong?
I was browsing the Fe language [website](https://fe-lang.org/) and noticed the copyright notice was out of date. This is not a huge concern, but considering the website has been updated in 2022 and 2023 updating the date to a range to reflect that seems like a good idea.

### How was it fixed?
Updated the copyright notice in the footer of the website to be a range from 2021 (website first published) to 2023 (current year)
