### PR TITLE
Fix error in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ Run `fe --help` to explore further options.
 
 The following is a simple contract implemented in Fe.
 
-```rust
+```fe
 struct Signed {
-    book_msg: String<100>
+    pub book_msg: String<100>
 }
 
 contract GuestBook {
     messages: Map<address, String<100>>
 
-    pub fn sign(self, ctx: Context, book_msg: String<100>) {
+    pub fn sign(mut self, mut ctx: Context, book_msg: String<100>) {
         self.messages[ctx.msg_sender()] = book_msg
         ctx.emit(Signed(book_msg: book_msg))
     }

--- a/docs/validate_doc_examples.py
+++ b/docs/validate_doc_examples.py
@@ -6,6 +6,7 @@ from typing import Iterable, NamedTuple
 import subprocess
 
 THIS_DIR = pathlib.Path(__file__).parent
+ROOT_DIR = THIS_DIR.parent
 BOOK_SRC_DIR = THIS_DIR / 'src'
 TMP_SNIPPET_DIR = THIS_DIR / 'tmp_snippets'
 NEWS_DIR = THIS_DIR.parent / 'newsfragments'
@@ -33,6 +34,7 @@ def get_all_doc_files() -> Iterable[pathlib.Path]:
         yield path
     for path in NEWS_DIR.rglob('*.md'):
         yield path
+    yield ROOT_DIR / 'README.md'
 
 def get_all_snippets_in_file(path: pathlib.Path) -> Iterable[CodeSnippet]:
     with open(path) as f:


### PR DESCRIPTION

### What was wrong?

Example in Readme doesn't work anymore

### How was it fixed?

- Example needed some `mut`
- Added `README.md` in snippet validation

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
