### PR TITLE
Buf write simplification

### DIFF
--- a/crates/library/std/src/buf.fe
+++ b/crates/library/std/src/buf.fe
@@ -47,7 +47,7 @@ pub struct MemoryBuffer {
 
     pub fn new(len: u256) -> Self {
         unsafe {
-            return MemoryBuffer(offset: alloc(len), len)
+            return MemoryBuffer(offset: alloc(len: len + 30), len)
         }
     }
 
@@ -103,7 +103,8 @@ pub struct MemoryBufferWriter {
 
     pub fn write_n(mut self, value: u256, len: u256) {
         let offset: u256 = self.write_offset(len)
-        unsafe { rewrite_slot(offset, value, len) }
+        let shifted_value: u256 = evm::shl(bits: 256 - len * 8, value)
+        unsafe { evm::mstore(offset, value: shifted_value) }
     }
 
     pub fn write_buf(mut self, buf: MemoryBuffer) {
@@ -172,27 +173,6 @@ impl MemoryBufferWrite for u8 {
 // This is needed to prevent the `mir_lower_std_lib` to crash the compiler
 impl MemoryBufferWrite for () {
     fn write_buf(self, mut writer: MemoryBufferWriter) {}
-}
-
-/// Rewrites the left-most `len` bytes in slot with the right-most `len` bytes of `value`.
-unsafe fn rewrite_slot(offset: u256, value: u256, len: u256) {
-    // bit mask for right side of 256 bit slot
-    let mask: u256 = evm::shr(
-        bits: len * 8, 
-        value: 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff 
-    )
-    // new value shifted to left
-    let shifted_value: u256 = evm::shl(
-        bits: 256 - len * 8, 
-        value
-    )
-
-    let old_value: u256 = evm::mload(offset)
-    let new_value: u256 = evm::bitwise_or(
-        evm::bitwise_and(mask, old_value),
-        shifted_value
-    )
-    evm::mstore(offset, value: new_value)
 }
 
 /// Memory buffer reader abstraction.

--- a/newsfragments/898.performance.md
+++ b/newsfragments/898.performance.md
@@ -1,0 +1,1 @@
+`MemoryBuffer` now allocates an extra 31 bytes. This removes the need for runtime checks and bitshifting needed to ensure safe writing to a `MemoryBuffer`'s region.


### PR DESCRIPTION
### What was wrong?

The buf write implementation seems unnecessarily complicated.

Currently we allocate the exact `len` in memory for the buffer and ensure via `rewrite_slot` that we do not modify data outside of the buf's allocated region.

This PR changes the buf implementation so that an extra 31 bytes is allocated for bufs. This eliminates the need for a function like `rewrite_slot`.

### How was it fixed?

:keyboard: 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
