### PR TITLE
Calldata reader

### DIFF
--- a/crates/library/std/src/context.fe
+++ b/crates/library/std/src/context.fe
@@ -19,6 +19,28 @@ pub trait Emittable {
   fn emit(self, _ val: OutOfReachMarker);
 }
 
+pub struct CalldataReader {
+    cur_offset: u256
+    len: u256
+
+    pub unsafe fn new(len: u256) -> CalldataReader {
+        return CalldataReader(cur_offset: 0, len)
+    }
+
+    pub fn remainder(self) -> u256 {
+        return self.len - self.cur_offset
+    }
+
+    pub fn read_u256(mut self) -> u256 {
+        unsafe {
+            let value: u256 = evm::call_data_load(offset: self.cur_offset)
+            self.cur_offset += 32
+            assert self.cur_offset <= self.len
+            return value
+        }
+    }
+}
+
 pub struct Context {
     pub fn base_fee(self) -> u256 {
         unsafe { return evm::base_fee() }
@@ -108,6 +130,13 @@ pub struct Context {
                 output_offset: buf.offset(), 
                 output_len: buf.output_len()
             ) == 1
+        }
+    }
+
+    pub fn calldata_reader(self) -> CalldataReader {
+        unsafe {
+            let len: u256 = evm::call_data_size()
+            return CalldataReader::new(len)
         }
     }
 

--- a/crates/tests/fixtures/files/calldata_reader.fe
+++ b/crates/tests/fixtures/files/calldata_reader.fe
@@ -1,0 +1,35 @@
+use std::context::CalldataReader
+use std::buf::{RawCallBuffer, MemoryBufferReader, MemoryBufferWriter}
+use std::evm
+
+contract SumMyNums {
+    pub fn __call__(ctx: Context) {
+        let mut reader: CalldataReader = ctx.calldata_reader()
+        let mut sum: u256 = 0
+
+        while reader.remainder() != 0 {
+            sum += reader.read_u256()
+        }
+
+        unsafe {
+            evm::mstore(offset: 0, value: sum)
+            evm::return_mem(offset: 0, len: 32) 
+        }
+    }
+}
+
+#test
+fn sum_my_nums(mut ctx: Context) {
+    let addr: address = address(SumMyNums.create(ctx, 0))
+
+    let mut buf: RawCallBuffer = RawCallBuffer::new(input_len: 96, output_len: 32)
+    let mut reader: MemoryBufferReader = buf.reader()
+    let mut writer: MemoryBufferWriter = buf.writer()
+
+    writer.write(value: 1)
+    writer.write(value: 2)
+    writer.write(value: 3)
+
+    assert ctx.raw_call(addr, value: 0, buf)
+    assert reader.read_u256() == 6
+}


### PR DESCRIPTION
Implementation of `CalldataReader`. An instance of `CalldataReader` can be created using `ctx.calldata_reader()`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [ ] Clean up commit history
