### PR TITLE
Calldata reader 

### DIFF
--- a/crates/library/std/src/context.fe
+++ b/crates/library/std/src/context.fe
@@ -32,7 +32,7 @@ pub struct CalldataReader {
     }
 
     pub fn advance(mut self, len: u256) -> u256 {
-        self.cur_offset += 32
+        self.cur_offset += len
         assert self.cur_offset <= self.len
         return self.cur_offset
     }
@@ -41,10 +41,7 @@ pub struct CalldataReader {
         unsafe {
             let value: u256 = evm::call_data_load(offset: self.cur_offset)
             self.advance(len)
-            if len < 32 {
-                return evm::shr(bits: 256 - len * 8, value)}
-            else {
-                return value }
+            return evm::shr(bits: 256 - len * 8, value)
         }
     }
 
@@ -67,9 +64,12 @@ pub struct CalldataReader {
     pub fn read_u128(mut self) -> u128 {
         return u128(self.read_n(len: 16))
     }
-    
     pub fn read_u256(mut self) -> u256 {
-        return self.read_n(len: 32)
+        unsafe {
+            let value: u256 = evm::call_data_load(offset: self.cur_offset)
+            self.advance(len: 32)
+            return value
+        }
     }
 }
 

--- a/crates/library/std/src/context.fe
+++ b/crates/library/std/src/context.fe
@@ -19,6 +19,60 @@ pub trait Emittable {
   fn emit(self, _ val: OutOfReachMarker);
 }
 
+pub struct CalldataReader {
+    cur_offset: u256
+    len: u256
+
+    pub unsafe fn new(len: u256) -> CalldataReader {
+        return CalldataReader(cur_offset: 0, len)
+    }
+
+    pub fn remainder(self) -> u256 {
+        return self.len - self.cur_offset
+    }
+
+    pub fn advance(mut self, len: u256) -> u256 {
+        self.cur_offset += 32
+        assert self.cur_offset <= self.len
+        return self.cur_offset
+    }
+
+    fn read_n(mut self, len: u256) -> u256 {
+        unsafe {
+            let value: u256 = evm::call_data_load(offset: self.cur_offset)
+            self.advance(len)
+            if len < 32 {
+                return evm::shr(bits: 256 - len * 8, value)}
+            else {
+                return value }
+        }
+    }
+
+    pub fn read_u8(mut self) -> u8 {
+        return u8(self.read_n(len: 1))
+    }
+
+    pub fn read_u16(mut self) -> u16 {
+        return u16(self.read_n(len: 2))
+    }
+
+    pub fn read_u32(mut self) -> u32 {
+        return u32(self.read_n(len: 4))
+    }
+
+    pub fn read_u64(mut self) -> u64 {
+        return u64(self.read_n(len: 8))
+    }
+
+    pub fn read_u128(mut self) -> u128 {
+        return u128(self.read_n(len: 16))
+    }
+    
+    pub fn read_u256(mut self) -> u256 {
+        return self.read_n(len: 32)
+    }
+}
+
 pub struct Context {
     pub fn base_fee(self) -> u256 {
         unsafe { return evm::base_fee() }
@@ -74,6 +128,13 @@ pub struct Context {
 
     pub fn self_address(self) -> address {
         unsafe { return address(__address()) }
+    }
+
+    pub fn calldata_reader(self) -> CalldataReader {
+        unsafe {
+            let len: u256 = evm::call_data_size()
+            return CalldataReader::new(len)
+        }
     }
 
     pub fn send_value(mut self, to: address, wei: u256) {

--- a/crates/tests/fixtures/files/call_fn.fe
+++ b/crates/tests/fixtures/files/call_fn.fe
@@ -5,14 +5,18 @@ use std::buf::{
     MemoryBufferReader,
     MemoryBuffer
 }
+use std::context::CalldataReader
+
 
 contract Foo {
     pub unsafe fn __call__(self, ctx: Context) {
         let mut buf: MemoryBuffer = MemoryBuffer::new(len: 32)
         let mut writer: MemoryBufferWriter = buf.writer()
-        if ctx.msg_sig() == 0x01 {
+        let mut reader: CalldataReader = ctx.calldata_reader()
+        let val: u256 = reader.read_u256()
+        if val == 0x01 {
             writer.write(value: 0x02)
-        } else if ctx.msg_sig() == 0x03 {
+        } else if val == 0x03 {
             writer.write(value: 0x04)
         } else {
             // unknown selector
@@ -26,11 +30,11 @@ contract Foo {
 #test
 unsafe fn test_foo(mut ctx: Context) {
     let foo: Foo = Foo.create(ctx, 0)
-    let mut buf: RawCallBuffer = RawCallBuffer::new(input_len: 4, output_len: 32)
+    let mut buf: RawCallBuffer = RawCallBuffer::new(input_len: 32, output_len: 32)
     let mut writer: MemoryBufferWriter = buf.writer()
     let mut reader: MemoryBufferReader = buf.reader()
     // 0x01 selector call
-    writer.write(value: u32(0x01))
+    writer.write(value: 0x01)
     assert evm::call(
         gas: evm::gas_remaining(), 
         addr: address(foo), 
@@ -39,12 +43,12 @@ unsafe fn test_foo(mut ctx: Context) {
     )
     assert reader.read_u256() == 0x02
 
-    buf = RawCallBuffer::new(input_len: 4, output_len: 32)
+    buf = RawCallBuffer::new(input_len: 32, output_len: 32)
     writer = buf.writer()
     reader = buf.reader()
 
     // 0x03 selector call
-    writer.write(value: u32(0x03))
+    writer.write(value: 0x03)
     assert evm::call(
          gas: evm::gas_remaining(), 
          addr: address(foo), 

--- a/crates/tests/fixtures/files/calldata_reader.fe
+++ b/crates/tests/fixtures/files/calldata_reader.fe
@@ -1,0 +1,38 @@
+
+use std::context::CalldataReader
+use std::buf::{RawCallBuffer, MemoryBufferReader, MemoryBufferWriter, MemoryBuffer}
+use std::evm
+
+contract SumMyNums {
+    pub fn __call__(ctx: Context) {
+        let mut reader: CalldataReader = ctx.calldata_reader()
+        let mut sum: u256 = 0
+
+        while reader.remainder() != 0 {
+            sum += reader.read_u256()
+        }
+
+        unsafe {
+            let mut buf: MemoryBuffer = MemoryBuffer::new(len: 32)
+            let mut writer: MemoryBufferWriter = buf.writer()
+            writer.write(value: sum)
+            evm::return_mem(buf) 
+        }
+    }
+}
+
+#test
+fn sum_my_nums(mut ctx: Context) {
+    let addr: address = address(SumMyNums.create(ctx, 0))
+
+    let mut buf: RawCallBuffer = RawCallBuffer::new(input_len: 96, output_len: 32)
+    let mut reader: MemoryBufferReader = buf.reader()
+    let mut writer: MemoryBufferWriter = buf.writer()
+
+    writer.write(value: 1)
+    writer.write(value: 2)
+    writer.write(value: 3)
+
+    assert ctx.raw_call(addr, value: 0, buf)
+    assert reader.read_u256() == 6
+}

--- a/crates/tests/fixtures/files/calldata_reader_extra.fe
+++ b/crates/tests/fixtures/files/calldata_reader_extra.fe
@@ -1,0 +1,39 @@
+
+use std::context::CalldataReader
+use std::buf::{RawCallBuffer, MemoryBufferReader, MemoryBufferWriter, MemoryBuffer}
+use std::evm
+
+contract SumMyNums {
+    pub fn __call__(ctx: Context) {
+        let mut reader: CalldataReader = ctx.calldata_reader()
+        let mut sum: u16 = 0
+
+        while reader.remainder() != 0 {
+            sum += reader.read_u16()
+        }
+
+        unsafe {
+            let mut buf: MemoryBuffer = MemoryBuffer::new(len: 2)
+            let mut writer: MemoryBufferWriter = buf.writer()
+            writer.write(value: sum)
+            evm::return_mem(buf)
+        }
+    }
+}
+
+#test
+fn sum_my_nums(mut ctx: Context) {
+    let addr: address = address(SumMyNums.create(ctx, 0))
+
+    let mut buf: RawCallBuffer = RawCallBuffer::new(input_len: 6, output_len: 2)
+    let mut reader: MemoryBufferReader = buf.reader()
+    let mut writer: MemoryBufferWriter = buf.writer()
+
+    writer.write(value: u16(1))
+    writer.write(value: u16(2))
+    writer.write(value: u16(3))
+
+    assert ctx.raw_call(addr, value: 0, buf)
+    assert reader.read_u16() == 6
+}
+


### PR DESCRIPTION
Implementation of CalldataReader. An instance of CalldataReader can be created using ctx.calldata_reader().
