### PR TITLE
Improve error recovery in parsing fields definition

### DIFF
--- a/crates/parser2/src/parser/mod.rs
+++ b/crates/parser2/src/parser/mod.rs
@@ -446,6 +446,7 @@ impl<S: TokenStream> Parser<S> {
 
     /// Add the `msg` to the error list.
     fn error(&mut self, msg: &str) -> ErrorScope {
+        self.bump_trivias();
         self.is_err = true;
         let start = self.current_pos;
         let end = if let Some(current_token) = self.current_token() {

--- a/crates/parser2/src/parser/struct_.rs
+++ b/crates/parser2/src/parser/struct_.rs
@@ -3,6 +3,7 @@ use crate::SyntaxKind;
 use super::{
     attr::parse_attr_list,
     define_scope,
+    func::FuncScope,
     param::{parse_generic_params_opt, parse_where_clause_opt},
     token_stream::TokenStream,
     type_::parse_type,
@@ -90,6 +91,22 @@ impl super::Parse for RecordFieldDefScope {
         parse_attr_list(parser);
 
         parser.bump_if(SyntaxKind::PubKw);
+        // Since the Fe-V2 doesn't support method definition in a struct, we add an
+        // ad-hoc check for the method definition in a struct to avoid the confusing
+        // error message.
+        // The reason that justifies this ad-hoc check is
+        // 1. This error is difficult to recover properly with the current parser
+        //    design, and the emitted error message is confusing.
+        // 2. We anticipate that this error would happen often in the transition period
+        //    to Fe-V2.
+        if parser.current_kind() == Some(SyntaxKind::FnKw) {
+            let err_scope = parser.error("function definition in struct is not allowed");
+            let checkpoint = parser.enter(err_scope, None);
+            parser.parse(FuncScope::default(), None);
+            parser.leave(checkpoint);
+            return;
+        }
+
         parser.with_next_expected_tokens(
             |parser| {
                 if !parser.bump_if(SyntaxKind::Ident) {

--- a/crates/parser2/test_files/error_recovery/items/struct_.fe
+++ b/crates/parser2/test_files/error_recovery/items/struct_.fe
@@ -6,3 +6,11 @@ where T
     foo
     bar: i32::foo
 }
+
+pub struct Foo {
+    pub fn foo()  -> i32 {
+        return 1
+    }
+    
+    x: i32
+}

--- a/crates/parser2/test_files/error_recovery/items/struct_.snap
+++ b/crates/parser2/test_files/error_recovery/items/struct_.snap
@@ -3,9 +3,9 @@ source: crates/parser2/tests/error_recovery.rs
 expression: node
 input_file: crates/parser2/test_files/error_recovery/items/struct_.fe
 ---
-Root@0..74
-  ItemList@0..74
-    Item@0..74
+Root@0..160
+  ItemList@0..160
+    Item@0..76
       Struct@0..74
         ItemModifier@0..3
           PubKw@0..3 "pub"
@@ -73,4 +73,64 @@ Root@0..74
                   Ident@69..72 "foo"
           Newline@72..73 "\n"
           RBrace@73..74 "}"
+      Newline@74..76 "\n\n"
+    Item@76..160
+      Struct@76..160
+        ItemModifier@76..79
+          PubKw@76..79 "pub"
+        WhiteSpace@79..80 " "
+        StructKw@80..86 "struct"
+        WhiteSpace@86..87 " "
+        Ident@87..90 "Foo"
+        WhiteSpace@90..91 " "
+        RecordFieldDefList@91..160
+          LBrace@91..92 "{"
+          Newline@92..93 "\n"
+          WhiteSpace@93..97 "    "
+          RecordFieldDef@97..142
+            PubKw@97..100 "pub"
+            WhiteSpace@100..101 " "
+            Error@101..142
+              Func@101..142
+                FnKw@101..103 "fn"
+                WhiteSpace@103..104 " "
+                Ident@104..107 "foo"
+                FuncParamList@107..109
+                  LParen@107..108 "("
+                  RParen@108..109 ")"
+                WhiteSpace@109..111 "  "
+                Arrow@111..113 "->"
+                WhiteSpace@113..114 " "
+                PathType@114..117
+                  Path@114..117
+                    PathSegment@114..117
+                      Ident@114..117 "i32"
+                WhiteSpace@117..118 " "
+                BlockExpr@118..142
+                  LBrace@118..119 "{"
+                  Newline@119..120 "\n"
+                  WhiteSpace@120..128 "        "
+                  ReturnStmt@128..136
+                    ReturnKw@128..134 "return"
+                    WhiteSpace@134..135 " "
+                    LitExpr@135..136
+                      Lit@135..136
+                        Int@135..136 "1"
+                  Newline@136..137 "\n"
+                  WhiteSpace@137..141 "    "
+                  RBrace@141..142 "}"
+          Newline@142..143 "\n"
+          WhiteSpace@143..147 "    "
+          Newline@147..148 "\n"
+          WhiteSpace@148..152 "    "
+          RecordFieldDef@152..158
+            Ident@152..153 "x"
+            Colon@153..154 ":"
+            WhiteSpace@154..155 " "
+            PathType@155..158
+              Path@155..158
+                PathSegment@155..158
+                  Ident@155..158 "i32"
+          Newline@158..159 "\n"
+          RBrace@159..160 "}"
 


### PR DESCRIPTION
NOTE: Please start reviewing this PR after the name resolution PR is merged.

This PR adds the ad-hoc check to the parser to improve error messages when a function is defined inside a `struct/contract` definition.

The reason for this ad-hoc check is
1. This error is difficult to recover properly with the current parser design, and the emitted error message is confusing.
2. We anticipate that this error would often happen in the transition period to Fe-V2.