### PR TITLE
Use project root as default path for `fe test`

### DIFF
--- a/crates/common/src/utils/files.rs
+++ b/crates/common/src/utils/files.rs
@@ -7,6 +7,8 @@ use path_clean::PathClean;
 use smol_str::SmolStr;
 use walkdir::WalkDir;
 
+const FE_TOML: &str = "fe.toml";
+
 enum FileLoader {
     Static(Vec<(&'static str, &'static str)>),
     Fs,
@@ -141,7 +143,7 @@ pub struct ProjectFiles {
 impl ProjectFiles {
     fn load(loader: &FileLoader, path: &str) -> Result<Self, String> {
         let manifest_path = Path::new(path)
-            .join("fe.toml")
+            .join(FE_TOML)
             .to_str()
             .expect("unable to convert path to &str")
             .to_owned();
@@ -291,4 +293,25 @@ impl Manifest {
 
         Ok(manifest)
     }
+}
+
+/// Returns the root path of the current Fe project
+pub fn get_project_root() -> Option<String> {
+    let current_dir = std::env::current_dir().expect("Unable to get current directory");
+
+    let mut current_path = current_dir.clone();
+    loop {
+        let fe_toml_path = current_path.join(FE_TOML);
+        if fe_toml_path.is_file() {
+            return fe_toml_path
+                .parent()
+                .map(|val| val.to_string_lossy().to_string());
+        }
+
+        if !current_path.pop() {
+            break;
+        }
+    }
+
+    None
 }

--- a/crates/fe/src/task/test.rs
+++ b/crates/fe/src/task/test.rs
@@ -4,13 +4,14 @@ use std::path::Path;
 use clap::Args;
 use colored::Colorize;
 use fe_common::diagnostics::print_diagnostics;
-use fe_common::utils::files::BuildFiles;
+use fe_common::utils::files::{get_project_root, BuildFiles};
 use fe_driver::CompiledTest;
 use fe_test_runner::TestSink;
 
 #[derive(Args)]
 #[clap(about = "Execute tests in the current project")]
 pub struct TestArgs {
+    #[clap(default_value_t = get_project_root().unwrap_or(".".to_string()))]
     input_path: String,
     #[clap(long, takes_value(true))]
     optimize: Option<bool>,

--- a/newsfragments/913.feature.md
+++ b/newsfragments/913.feature.md
@@ -1,0 +1,3 @@
+Use the project root as default path for `fe test`
+
+Just run `fe test` from any directory of the project.


### PR DESCRIPTION

### What was wrong?

As described in #913, `fe test` should always fallback to assume the root project directory if no path is specified.

### How was it fixed?

JUST DID IT! LIKE A PSYCHOPATH.