### PR TITLE
v2: enum record variant support; one-liner record def

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,7 @@ dependencies = [
  "dir-test",
  "fe-compiler-test-utils",
  "fe-driver2",
+ "fe-hir",
  "wasm-bindgen-test",
 ]
 

--- a/crates/analyzer/src/db.rs
+++ b/crates/analyzer/src/db.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::arc_with_non_send_sync)]
 use crate::{
     context::{Analysis, Constant, FunctionBody},
     errors::{ConstEvalError, TypeError},

--- a/crates/analyzer/src/db/queries/module.rs
+++ b/crates/analyzer/src/db/queries/module.rs
@@ -564,7 +564,7 @@ pub fn module_used_item_map(
         )
         .value;
 
-        items.extend(Rc::try_unwrap(prelude_items).unwrap().into_iter());
+        items.extend(Rc::try_unwrap(prelude_items).unwrap());
     }
 
     Analysis::new(Rc::new(items), diagnostics.into())

--- a/crates/codegen/src/db.rs
+++ b/crates/codegen/src/db.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::arc_with_non_send_sync)]
 use std::rc::Rc;
 
 use fe_abi::{contract::AbiContract, event::AbiEvent, function::AbiFunction, types::AbiType};

--- a/crates/codegen/src/yul/runtime/mod.rs
+++ b/crates/codegen/src/yul/runtime/mod.rs
@@ -383,7 +383,7 @@ impl RuntimeProvider for DefaultRuntimeProvider {
         }
 
         let deref_ty = ptr_ty.deref(db.upcast());
-        let args = std::iter::once(ptr).chain(args.into_iter()).collect();
+        let args = std::iter::once(ptr).chain(args).collect();
         let legalized_ty = db.codegen_legalized_type(ptr_ty);
         if deref_ty.is_enum(db.upcast()) {
             let mut name = format!("enum_init_{}", ptr_ty.0);

--- a/crates/common/src/db.rs
+++ b/crates/common/src/db.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::arc_with_non_send_sync)]
 use crate::files::{File, SourceFileId, Utf8Path};
 use codespan_reporting as cs;
 use salsa;

--- a/crates/hir/src/hir_def/item.rs
+++ b/crates/hir/src/hir_def/item.rs
@@ -23,8 +23,8 @@ use crate::{
 
 use super::{
     scope_graph::{ScopeGraph, ScopeId},
-    AttrListId, Body, FuncParamListId, GenericParamListId, IdentId, IngotId, Partial, TypeId,
-    UseAlias, WhereClauseId,
+    AttrListId, Body, FuncParamListId, GenericParamListId, IdentId, IngotId, Partial, TupleTypeId,
+    TypeId, UseAlias, WhereClauseId,
 };
 
 #[derive(
@@ -687,7 +687,14 @@ pub struct VariantDefListId {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VariantDef {
     pub name: Partial<IdentId>,
-    pub ty: Option<TypeId>,
+    pub kind: VariantKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VariantKind {
+    Unit,
+    Tuple(TupleTypeId),
+    Record(FieldDefListId),
 }
 
 #[salsa::interned]

--- a/crates/hir/src/hir_def/types.rs
+++ b/crates/hir/src/hir_def/types.rs
@@ -13,7 +13,7 @@ pub enum TypeKind {
     Path(Partial<PathId>, GenericArgListId),
     SelfType,
     /// The `Vec` contains the types of the tuple elements.
-    Tuple(Vec<Partial<TypeId>>),
+    Tuple(TupleTypeId),
     /// The first `TypeId` is the element type, the second `Body` is the length.
     Array(Partial<TypeId>, Partial<Body>),
 }
@@ -22,4 +22,10 @@ pub enum TypeKind {
 pub struct TraitRef {
     pub path: Partial<PathId>,
     pub generic_args: GenericArgListId,
+}
+
+#[salsa::interned]
+pub struct TupleTypeId {
+    #[return_ref]
+    pub data: Vec<Partial<TypeId>>,
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -47,6 +47,7 @@ pub struct Jar(
     hir_def::VariantDefListId,
     hir_def::ImplItemListId,
     hir_def::TypeId,
+    hir_def::TupleTypeId,
     hir_def::UsePathId,
     /// Accumulated diagnostics.
     ParseErrorAccumulator,

--- a/crates/hir/src/lower/item.rs
+++ b/crates/hir/src/lower/item.rs
@@ -2,8 +2,8 @@ use parser::ast::{self, prelude::*};
 
 use crate::{
     hir_def::{
-        item::*, AttrListId, Body, FuncParamListId, GenericParamListId, IdentId, TraitRef, TypeId,
-        WhereClauseId,
+        item::*, AttrListId, Body, FuncParamListId, GenericParamListId, IdentId, TraitRef,
+        TupleTypeId, TypeId, WhereClauseId,
     },
     span::HirOrigin,
 };
@@ -412,8 +412,11 @@ impl VariantDefListId {
 impl VariantDef {
     fn lower_ast(ctxt: &mut FileLowerCtxt<'_>, ast: ast::VariantDef) -> Self {
         let name = IdentId::lower_token_partial(ctxt, ast.name());
-        let ty = ast.ty().map(|ty| TypeId::lower_ast(ctxt, ty));
-
-        Self { name, ty }
+        let kind = match ast.kind() {
+            ast::VariantKind::Unit => VariantKind::Unit,
+            ast::VariantKind::Tuple(t) => VariantKind::Tuple(TupleTypeId::lower_ast(ctxt, t)),
+            ast::VariantKind::Record(r) => VariantKind::Record(FieldDefListId::lower_ast(ctxt, r)),
+        };
+        Self { name, kind }
     }
 }

--- a/crates/hir/src/lower/scope_builder.rs
+++ b/crates/hir/src/lower/scope_builder.rs
@@ -3,9 +3,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     hir_def::{
-        scope_graph::{EdgeKind, Scope, ScopeEdge, ScopeGraph, ScopeId},
+        scope_graph::{EdgeKind, FieldParent, Scope, ScopeEdge, ScopeGraph, ScopeId},
         Body, ExprId, FieldDefListId, FuncParamListId, FuncParamName, GenericParamListId, ItemKind,
-        TopLevelMod, TrackedItemId, Use, VariantDefListId, Visibility,
+        TopLevelMod, TrackedItemId, Use, VariantDefListId, VariantKind, Visibility,
     },
     HirDb,
 };
@@ -141,7 +141,11 @@ impl<'db> ScopeGraphBuilder<'db> {
 
             Struct(inner) => {
                 self.graph.add_lex_edge(item_node, parent_node);
-                self.add_field_scope(item_node, inner.into(), inner.fields(self.db));
+                self.add_field_scope(
+                    item_node,
+                    FieldParent::Item(inner.into()),
+                    inner.fields(self.db),
+                );
                 self.add_generic_param_scope(
                     item_node,
                     inner.into(),
@@ -156,7 +160,11 @@ impl<'db> ScopeGraphBuilder<'db> {
 
             Contract(inner) => {
                 self.graph.add_lex_edge(item_node, parent_node);
-                self.add_field_scope(item_node, inner.into(), inner.fields(self.db));
+                self.add_field_scope(
+                    item_node,
+                    FieldParent::Item(inner.into()),
+                    inner.fields(self.db),
+                );
                 inner
                     .name(self.db)
                     .to_opt()
@@ -310,11 +318,11 @@ impl<'db> ScopeGraphBuilder<'db> {
     fn add_field_scope(
         &mut self,
         parent_node: NodeId,
-        parent_item: ItemKind,
+        parent: FieldParent,
         fields: FieldDefListId,
     ) {
         for (i, field) in fields.data(self.db).iter().enumerate() {
-            let scope_id = ScopeId::Field(parent_item, i);
+            let scope_id = ScopeId::Field(parent, i);
             let scope_data = Scope::new(scope_id, field.vis);
 
             let field_node = self.graph.push(scope_id, scope_data);
@@ -336,17 +344,22 @@ impl<'db> ScopeGraphBuilder<'db> {
     ) {
         let parent_vis = parent_item.vis(self.db);
 
-        for (i, field) in variants.data(self.db).iter().enumerate() {
+        for (i, variant) in variants.data(self.db).iter().enumerate() {
             let scope_id = ScopeId::Variant(parent_item, i);
             let scope_data = Scope::new(scope_id, parent_vis);
 
             let variant_node = self.graph.push(scope_id, scope_data);
             self.graph.add_lex_edge(variant_node, parent_node);
-            let kind = field
+            let kind = variant
                 .name
                 .to_opt()
                 .map(EdgeKind::variant)
                 .unwrap_or_else(EdgeKind::anon);
+
+            if let VariantKind::Record(fields) = variant.kind {
+                self.add_field_scope(variant_node, FieldParent::Variant(parent_item, i), fields)
+            }
+
             self.graph.add_edge(parent_node, variant_node, kind)
         }
     }

--- a/crates/hir/src/lower/types.rs
+++ b/crates/hir/src/lower/types.rs
@@ -1,6 +1,8 @@
 use parser::ast::{self, prelude::*};
 
-use crate::hir_def::{Body, GenericArgListId, Partial, PathId, TraitRef, TypeId, TypeKind};
+use crate::hir_def::{
+    Body, GenericArgListId, Partial, PathId, TraitRef, TupleTypeId, TypeId, TypeKind,
+};
 
 use super::FileLowerCtxt;
 
@@ -20,13 +22,7 @@ impl TypeId {
 
             ast::TypeKind::SelfType(_) => TypeKind::SelfType,
 
-            ast::TypeKind::Tuple(ty) => {
-                let mut elem_tys = Vec::new();
-                for elem in ty {
-                    elem_tys.push(Some(TypeId::lower_ast(ctxt, elem)).into());
-                }
-                TypeKind::Tuple(elem_tys)
-            }
+            ast::TypeKind::Tuple(ty) => TypeKind::Tuple(TupleTypeId::lower_ast(ctxt, ty)),
 
             ast::TypeKind::Array(ty) => {
                 let elem_ty = Self::lower_ast_partial(ctxt, ty.elem_ty());
@@ -46,6 +42,16 @@ impl TypeId {
         ast: Option<ast::Type>,
     ) -> Partial<Self> {
         ast.map(|ast| Self::lower_ast(ctxt, ast)).into()
+    }
+}
+
+impl TupleTypeId {
+    pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'_>, ast: ast::TupleType) -> Self {
+        let mut elem_tys = Vec::new();
+        for elem in ast {
+            elem_tys.push(Some(TypeId::lower_ast(ctxt, elem)).into());
+        }
+        TupleTypeId::new(ctxt.db(), elem_tys)
     }
 }
 

--- a/crates/hir/src/visitor.rs
+++ b/crates/hir/src/visitor.rs
@@ -1575,9 +1575,11 @@ pub fn walk_variant_def<V>(
             |span| span.tuple_type_moved(),
             |ctxt| visitor.visit_tuple_type(ctxt, t),
         ),
-        VariantKind::Record(_) => {
-            todo!()
-        }
+
+        VariantKind::Record(fields) => ctxt.with_new_ctxt(
+            |span| span.fields_moved(),
+            |ctxt| visitor.visit_field_def_list(ctxt, fields),
+        ),
     }
 }
 

--- a/crates/mir/src/db.rs
+++ b/crates/mir/src/db.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::arc_with_non_send_sync)]
 use std::{collections::BTreeMap, rc::Rc};
 
 use fe_analyzer::{

--- a/crates/mir/src/lower/function.rs
+++ b/crates/mir/src/lower/function.rs
@@ -1082,7 +1082,7 @@ impl<'db, 'a> BodyLowerHelper<'db, 'a> {
                 let enum_args = if data_ty.is_unit(self.db) {
                     vec![tag, self.make_unit()]
                 } else {
-                    std::iter::once(tag).chain(args.into_iter()).collect()
+                    std::iter::once(tag).chain(args).collect()
                 };
                 self.builder.aggregate_construct(ty, enum_args, source)
             }

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -83,6 +83,7 @@ pub fn parse_struct_def(
     ))
 }
 
+#[allow(clippy::unnecessary_literal_unwrap)]
 /// Parse a [`ModuleStmt::Enum`].
 /// # Panics
 /// Panics if the next token isn't [`TokenKind::Enum`].

--- a/crates/parser2/src/ast/item.rs
+++ b/crates/parser2/src/ast/item.rs
@@ -462,7 +462,11 @@ mod tests {
         let mut parser = Parser::new(lexer);
 
         parser.parse(ItemListScope::default(), None);
-        let item_list = ItemList::cast(parser.finish_to_node().0).unwrap();
+        let (node, errs) = parser.finish_to_node();
+        for e in errs {
+            eprintln!("{:?}", e);
+        }
+        let item_list = ItemList::cast(node).unwrap();
         let mut items = item_list.into_iter().collect::<Vec<_>>();
         assert_eq!(items.len(), 1);
         items.pop().unwrap().kind().unwrap().try_into().unwrap()
@@ -531,6 +535,7 @@ mod tests {
                 }
             "#;
         let s: Struct = parse_item(source);
+        dbg!(&s);
         assert_eq!(s.name().unwrap().text(), "Foo");
         let mut count = 0;
         for field in s.fields().unwrap() {

--- a/crates/parser2/src/parser/expr.rs
+++ b/crates/parser2/src/parser/expr.rs
@@ -35,7 +35,7 @@ fn parse_expr_with_min_bp<S: TokenStream>(
 
     loop {
         let Some(kind) = parser.current_kind() else {
-            break
+            break;
         };
 
         // Parse postfix operators.

--- a/crates/parser2/src/parser/item.rs
+++ b/crates/parser2/src/parser/item.rs
@@ -300,6 +300,8 @@ impl super::Parse for VariantDefScope {
 
         if parser.current_kind() == Some(SyntaxKind::LParen) {
             parser.parse(TupleTypeScope::default(), None);
+        } else if parser.current_kind() == Some(SyntaxKind::LBrace) {
+            parser.parse(RecordFieldDefListScope::default(), None);
         }
     }
 }

--- a/crates/parser2/src/parser/mod.rs
+++ b/crates/parser2/src/parser/mod.rs
@@ -463,6 +463,16 @@ impl<S: TokenStream> Parser<S> {
         ErrorScope::default()
     }
 
+    fn error_at_current_pos(&mut self, msg: &str) -> ErrorScope {
+        let pos = self.current_pos;
+        let range = TextRange::new(pos, pos);
+        self.errors.push(ParseError {
+            range,
+            msg: msg.to_string(),
+        });
+        ErrorScope::default()
+    }
+
     /// Returns `true` if the parser is in the dry run mode.
     fn is_dry_run(&self) -> bool {
         !self.dry_run_states.is_empty()

--- a/crates/parser2/src/parser/struct_.rs
+++ b/crates/parser2/src/parser/struct_.rs
@@ -54,19 +54,20 @@ define_scope! {
 impl super::Parse for RecordFieldDefListScope {
     fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) {
         parser.bump_expected(SyntaxKind::LBrace);
+        parser.set_newline_as_trivia(true);
 
         loop {
-            parser.set_newline_as_trivia(true);
             if parser.current_kind() == Some(SyntaxKind::RBrace) || parser.current_kind().is_none()
             {
                 break;
             }
+
             parser.parse(RecordFieldDefScope::default(), None);
-            parser.set_newline_as_trivia(false);
-            if !parser.bump_if(SyntaxKind::Newline)
+
+            if !parser.bump_if(SyntaxKind::Comma)
                 && parser.current_kind() != Some(SyntaxKind::RBrace)
             {
-                parser.error_and_recover("expected newline after field definition", None);
+                parser.error_at_current_pos("expected comma after field definition");
             }
         }
 
@@ -118,7 +119,7 @@ impl super::Parse for RecordFieldDefScope {
         if parser.bump_if(SyntaxKind::Colon) {
             parser.with_next_expected_tokens(
                 |parser| parse_type(parser, None),
-                &[SyntaxKind::Newline, SyntaxKind::RBrace],
+                &[SyntaxKind::Comma, SyntaxKind::Newline, SyntaxKind::RBrace],
             );
         } else {
             parser.error_and_recover("expected `name: type` for the field definition", None);

--- a/crates/parser2/test_files/syntax_node/items/contract.fe
+++ b/crates/parser2/test_files/syntax_node/items/contract.fe
@@ -1,7 +1,7 @@
 contract Empty {}
 
 pub contract C {
-    x: i32
-    y: u256
-    z: MyStruct::Encodable
+    x: i32,
+    y: u256,
+    z: MyStruct::Encodable,
 }

--- a/crates/parser2/test_files/syntax_node/items/contract.snap
+++ b/crates/parser2/test_files/syntax_node/items/contract.snap
@@ -3,8 +3,8 @@ source: crates/parser2/tests/syntax_node.rs
 expression: node
 input_file: crates/parser2/test_files/syntax_node/items/contract.fe
 ---
-Root@0..87
-  ItemList@0..87
+Root@0..90
+  ItemList@0..90
     Item@0..19
       Contract@0..17
         ContractKw@0..8 "contract"
@@ -15,8 +15,8 @@ Root@0..87
           LBrace@15..16 "{"
           RBrace@16..17 "}"
       Newline@17..19 "\n\n"
-    Item@19..87
-      Contract@19..87
+    Item@19..90
+      Contract@19..90
         ItemModifier@19..22
           PubKw@19..22 "pub"
         WhiteSpace@22..23 " "
@@ -24,7 +24,7 @@ Root@0..87
         WhiteSpace@31..32 " "
         Ident@32..33 "C"
         WhiteSpace@33..34 " "
-        RecordFieldDefList@34..87
+        RecordFieldDefList@34..90
           LBrace@34..35 "{"
           Newline@35..36 "\n"
           WhiteSpace@36..40 "    "
@@ -36,29 +36,32 @@ Root@0..87
               Path@43..46
                 PathSegment@43..46
                   Ident@43..46 "i32"
-          Newline@46..47 "\n"
-          WhiteSpace@47..51 "    "
-          RecordFieldDef@51..58
-            Ident@51..52 "y"
-            Colon@52..53 ":"
-            WhiteSpace@53..54 " "
-            PathType@54..58
-              Path@54..58
-                PathSegment@54..58
-                  Ident@54..58 "u256"
-          Newline@58..59 "\n"
-          WhiteSpace@59..63 "    "
-          RecordFieldDef@63..85
-            Ident@63..64 "z"
-            Colon@64..65 ":"
-            WhiteSpace@65..66 " "
-            PathType@66..85
-              Path@66..85
-                PathSegment@66..74
-                  Ident@66..74 "MyStruct"
-                Colon2@74..76 "::"
-                PathSegment@76..85
-                  Ident@76..85 "Encodable"
-          Newline@85..86 "\n"
-          RBrace@86..87 "}"
+          Comma@46..47 ","
+          Newline@47..48 "\n"
+          WhiteSpace@48..52 "    "
+          RecordFieldDef@52..59
+            Ident@52..53 "y"
+            Colon@53..54 ":"
+            WhiteSpace@54..55 " "
+            PathType@55..59
+              Path@55..59
+                PathSegment@55..59
+                  Ident@55..59 "u256"
+          Comma@59..60 ","
+          Newline@60..61 "\n"
+          WhiteSpace@61..65 "    "
+          RecordFieldDef@65..87
+            Ident@65..66 "z"
+            Colon@66..67 ":"
+            WhiteSpace@67..68 " "
+            PathType@68..87
+              Path@68..87
+                PathSegment@68..76
+                  Ident@68..76 "MyStruct"
+                Colon2@76..78 "::"
+                PathSegment@78..87
+                  Ident@78..87 "Encodable"
+          Comma@87..88 ","
+          Newline@88..89 "\n"
+          RBrace@89..90 "}"
 

--- a/crates/parser2/test_files/syntax_node/items/enums.fe
+++ b/crates/parser2/test_files/syntax_node/items/enums.fe
@@ -5,14 +5,22 @@ enum Basic {
     Tup(i32, u32)
 }
 
-enum Option<T> 
+enum RecordVariants {
+     Rectangle {
+         w: u32
+         h: u32
+     }
+     Circle { r: u32 }
+}
+
+enum Option<T>
     where T: Clone
 {
     Some(T)
     None
 }
 
-enum BoundEnum<T: Add + Mul , U: Sub + Div> 
+enum BoundEnum<T: Add + Mul , U: Sub + Div>
 where Foo::Bar<T>: Trait
 {
     AddMul(T)

--- a/crates/parser2/test_files/syntax_node/items/enums.fe
+++ b/crates/parser2/test_files/syntax_node/items/enums.fe
@@ -6,10 +6,7 @@ enum Basic {
 }
 
 enum RecordVariants {
-     Rectangle {
-         w: u32
-         h: u32
-     }
+     Rectangle { w: u32, h: u32 }
      Circle { r: u32 }
 }
 

--- a/crates/parser2/test_files/syntax_node/items/enums.snap
+++ b/crates/parser2/test_files/syntax_node/items/enums.snap
@@ -3,8 +3,8 @@ source: crates/parser2/tests/syntax_node.rs
 expression: node
 input_file: crates/parser2/test_files/syntax_node/items/enums.fe
 ---
-Root@0..220
-  ItemList@0..220
+Root@0..322
+  ItemList@0..322
     Item@0..15
       Enum@0..13
         EnumKw@0..4 "enum"
@@ -47,151 +47,208 @@ Root@0..220
           Newline@54..55 "\n"
           RBrace@55..56 "}"
       Newline@56..58 "\n\n"
-    Item@58..119
-      Enum@58..117
+    Item@58..162
+      Enum@58..160
         EnumKw@58..62 "enum"
         WhiteSpace@62..63 " "
-        Ident@63..69 "Option"
-        GenericParamList@69..72
-          Lt@69..70 "<"
-          TypeGenericParam@70..71
-            Ident@70..71 "T"
-          Gt@71..72 ">"
-        WhiteSpace@72..73 " "
-        Newline@73..74 "\n"
-        WhiteSpace@74..78 "    "
-        WhereClause@78..93
-          WhereKw@78..83 "where"
-          WhiteSpace@83..84 " "
-          WherePredicate@84..93
-            PathType@84..85
-              Path@84..85
-                PathSegment@84..85
-                  Ident@84..85 "T"
-            TypeBoundList@85..92
-              Colon@85..86 ":"
-              WhiteSpace@86..87 " "
-              TypeBound@87..92
-                Path@87..92
-                  PathSegment@87..92
-                    Ident@87..92 "Clone"
-            Newline@92..93 "\n"
-        VariantDefList@93..117
-          LBrace@93..94 "{"
-          Newline@94..95 "\n"
-          WhiteSpace@95..99 "    "
-          VariantDef@99..106
-            Ident@99..103 "Some"
-            TupleType@103..106
-              LParen@103..104 "("
-              PathType@104..105
-                Path@104..105
-                  PathSegment@104..105
-                    Ident@104..105 "T"
-              RParen@105..106 ")"
-          Newline@106..107 "\n"
-          WhiteSpace@107..111 "    "
-          VariantDef@111..115
-            Ident@111..115 "None"
-          Newline@115..116 "\n"
-          RBrace@116..117 "}"
-      Newline@117..119 "\n\n"
-    Item@119..220
-      Enum@119..220
-        EnumKw@119..123 "enum"
-        WhiteSpace@123..124 " "
-        Ident@124..133 "BoundEnum"
-        GenericParamList@133..162
-          Lt@133..134 "<"
-          TypeGenericParam@134..146
-            Ident@134..135 "T"
-            TypeBoundList@135..146
-              Colon@135..136 ":"
-              WhiteSpace@136..137 " "
-              TypeBound@137..140
-                Path@137..140
-                  PathSegment@137..140
-                    Ident@137..140 "Add"
-              WhiteSpace@140..141 " "
-              Plus@141..142 "+"
-              WhiteSpace@142..143 " "
-              TypeBound@143..146
-                Path@143..146
-                  PathSegment@143..146
-                    Ident@143..146 "Mul"
-          WhiteSpace@146..147 " "
-          Comma@147..148 ","
-          WhiteSpace@148..149 " "
-          TypeGenericParam@149..161
-            Ident@149..150 "U"
-            TypeBoundList@150..161
-              Colon@150..151 ":"
-              WhiteSpace@151..152 " "
-              TypeBound@152..155
-                Path@152..155
-                  PathSegment@152..155
-                    Ident@152..155 "Sub"
-              WhiteSpace@155..156 " "
-              Plus@156..157 "+"
-              WhiteSpace@157..158 " "
-              TypeBound@158..161
-                Path@158..161
-                  PathSegment@158..161
-                    Ident@158..161 "Div"
-          Gt@161..162 ">"
-        WhiteSpace@162..163 " "
-        Newline@163..164 "\n"
-        WhereClause@164..189
-          WhereKw@164..169 "where"
-          WhiteSpace@169..170 " "
-          WherePredicate@170..189
-            PathType@170..181
-              Path@170..178
-                PathSegment@170..173
-                  Ident@170..173 "Foo"
-                Colon2@173..175 "::"
-                PathSegment@175..178
-                  Ident@175..178 "Bar"
-              GenericArgList@178..181
-                Lt@178..179 "<"
-                TypeGenericArg@179..180
-                  PathType@179..180
-                    Path@179..180
-                      PathSegment@179..180
-                        Ident@179..180 "T"
-                Gt@180..181 ">"
-            TypeBoundList@181..188
-              Colon@181..182 ":"
-              WhiteSpace@182..183 " "
-              TypeBound@183..188
-                Path@183..188
-                  PathSegment@183..188
-                    Ident@183..188 "Trait"
-            Newline@188..189 "\n"
-        VariantDefList@189..220
-          LBrace@189..190 "{"
-          Newline@190..191 "\n"
-          WhiteSpace@191..195 "    "
-          VariantDef@195..204
-            Ident@195..201 "AddMul"
-            TupleType@201..204
-              LParen@201..202 "("
-              PathType@202..203
-                Path@202..203
-                  PathSegment@202..203
-                    Ident@202..203 "T"
-              RParen@203..204 ")"
-          Newline@204..205 "\n"
-          WhiteSpace@205..209 "    "
-          VariantDef@209..218
-            Ident@209..215 "SubDiv"
-            TupleType@215..218
-              LParen@215..216 "("
-              PathType@216..217
-                Path@216..217
-                  PathSegment@216..217
-                    Ident@216..217 "U"
-              RParen@217..218 ")"
+        Ident@63..77 "RecordVariants"
+        WhiteSpace@77..78 " "
+        VariantDefList@78..160
+          LBrace@78..79 "{"
+          Newline@79..80 "\n"
+          WhiteSpace@80..85 "     "
+          VariantDef@85..135
+            Ident@85..94 "Rectangle"
+            WhiteSpace@94..95 " "
+            RecordFieldDefList@95..135
+              LBrace@95..96 "{"
+              Newline@96..97 "\n"
+              WhiteSpace@97..106 "         "
+              RecordFieldDef@106..112
+                Ident@106..107 "w"
+                Colon@107..108 ":"
+                WhiteSpace@108..109 " "
+                PathType@109..112
+                  Path@109..112
+                    PathSegment@109..112
+                      Ident@109..112 "u32"
+              Newline@112..113 "\n"
+              WhiteSpace@113..122 "         "
+              RecordFieldDef@122..128
+                Ident@122..123 "h"
+                Colon@123..124 ":"
+                WhiteSpace@124..125 " "
+                PathType@125..128
+                  Path@125..128
+                    PathSegment@125..128
+                      Ident@125..128 "u32"
+              Newline@128..129 "\n"
+              WhiteSpace@129..134 "     "
+              RBrace@134..135 "}"
+          Newline@135..136 "\n"
+          WhiteSpace@136..141 "     "
+          VariantDef@141..158
+            Ident@141..147 "Circle"
+            WhiteSpace@147..148 " "
+            RecordFieldDefList@148..158
+              LBrace@148..149 "{"
+              WhiteSpace@149..150 " "
+              RecordFieldDef@150..156
+                Ident@150..151 "r"
+                Colon@151..152 ":"
+                WhiteSpace@152..153 " "
+                PathType@153..156
+                  Path@153..156
+                    PathSegment@153..156
+                      Ident@153..156 "u32"
+              WhiteSpace@156..157 " "
+              RBrace@157..158 "}"
+          Newline@158..159 "\n"
+          RBrace@159..160 "}"
+      Newline@160..162 "\n\n"
+    Item@162..222
+      Enum@162..220
+        EnumKw@162..166 "enum"
+        WhiteSpace@166..167 " "
+        Ident@167..173 "Option"
+        GenericParamList@173..176
+          Lt@173..174 "<"
+          TypeGenericParam@174..175
+            Ident@174..175 "T"
+          Gt@175..176 ">"
+        Newline@176..177 "\n"
+        WhiteSpace@177..181 "    "
+        WhereClause@181..196
+          WhereKw@181..186 "where"
+          WhiteSpace@186..187 " "
+          WherePredicate@187..196
+            PathType@187..188
+              Path@187..188
+                PathSegment@187..188
+                  Ident@187..188 "T"
+            TypeBoundList@188..195
+              Colon@188..189 ":"
+              WhiteSpace@189..190 " "
+              TypeBound@190..195
+                Path@190..195
+                  PathSegment@190..195
+                    Ident@190..195 "Clone"
+            Newline@195..196 "\n"
+        VariantDefList@196..220
+          LBrace@196..197 "{"
+          Newline@197..198 "\n"
+          WhiteSpace@198..202 "    "
+          VariantDef@202..209
+            Ident@202..206 "Some"
+            TupleType@206..209
+              LParen@206..207 "("
+              PathType@207..208
+                Path@207..208
+                  PathSegment@207..208
+                    Ident@207..208 "T"
+              RParen@208..209 ")"
+          Newline@209..210 "\n"
+          WhiteSpace@210..214 "    "
+          VariantDef@214..218
+            Ident@214..218 "None"
           Newline@218..219 "\n"
           RBrace@219..220 "}"
+      Newline@220..222 "\n\n"
+    Item@222..322
+      Enum@222..322
+        EnumKw@222..226 "enum"
+        WhiteSpace@226..227 " "
+        Ident@227..236 "BoundEnum"
+        GenericParamList@236..265
+          Lt@236..237 "<"
+          TypeGenericParam@237..249
+            Ident@237..238 "T"
+            TypeBoundList@238..249
+              Colon@238..239 ":"
+              WhiteSpace@239..240 " "
+              TypeBound@240..243
+                Path@240..243
+                  PathSegment@240..243
+                    Ident@240..243 "Add"
+              WhiteSpace@243..244 " "
+              Plus@244..245 "+"
+              WhiteSpace@245..246 " "
+              TypeBound@246..249
+                Path@246..249
+                  PathSegment@246..249
+                    Ident@246..249 "Mul"
+          WhiteSpace@249..250 " "
+          Comma@250..251 ","
+          WhiteSpace@251..252 " "
+          TypeGenericParam@252..264
+            Ident@252..253 "U"
+            TypeBoundList@253..264
+              Colon@253..254 ":"
+              WhiteSpace@254..255 " "
+              TypeBound@255..258
+                Path@255..258
+                  PathSegment@255..258
+                    Ident@255..258 "Sub"
+              WhiteSpace@258..259 " "
+              Plus@259..260 "+"
+              WhiteSpace@260..261 " "
+              TypeBound@261..264
+                Path@261..264
+                  PathSegment@261..264
+                    Ident@261..264 "Div"
+          Gt@264..265 ">"
+        Newline@265..266 "\n"
+        WhereClause@266..291
+          WhereKw@266..271 "where"
+          WhiteSpace@271..272 " "
+          WherePredicate@272..291
+            PathType@272..283
+              Path@272..280
+                PathSegment@272..275
+                  Ident@272..275 "Foo"
+                Colon2@275..277 "::"
+                PathSegment@277..280
+                  Ident@277..280 "Bar"
+              GenericArgList@280..283
+                Lt@280..281 "<"
+                TypeGenericArg@281..282
+                  PathType@281..282
+                    Path@281..282
+                      PathSegment@281..282
+                        Ident@281..282 "T"
+                Gt@282..283 ">"
+            TypeBoundList@283..290
+              Colon@283..284 ":"
+              WhiteSpace@284..285 " "
+              TypeBound@285..290
+                Path@285..290
+                  PathSegment@285..290
+                    Ident@285..290 "Trait"
+            Newline@290..291 "\n"
+        VariantDefList@291..322
+          LBrace@291..292 "{"
+          Newline@292..293 "\n"
+          WhiteSpace@293..297 "    "
+          VariantDef@297..306
+            Ident@297..303 "AddMul"
+            TupleType@303..306
+              LParen@303..304 "("
+              PathType@304..305
+                Path@304..305
+                  PathSegment@304..305
+                    Ident@304..305 "T"
+              RParen@305..306 ")"
+          Newline@306..307 "\n"
+          WhiteSpace@307..311 "    "
+          VariantDef@311..320
+            Ident@311..317 "SubDiv"
+            TupleType@317..320
+              LParen@317..318 "("
+              PathType@318..319
+                Path@318..319
+                  PathSegment@318..319
+                    Ident@318..319 "U"
+              RParen@319..320 ")"
+          Newline@320..321 "\n"
+          RBrace@321..322 "}"
 

--- a/crates/parser2/test_files/syntax_node/items/enums.snap
+++ b/crates/parser2/test_files/syntax_node/items/enums.snap
@@ -3,8 +3,8 @@ source: crates/parser2/tests/syntax_node.rs
 expression: node
 input_file: crates/parser2/test_files/syntax_node/items/enums.fe
 ---
-Root@0..322
-  ItemList@0..322
+Root@0..300
+  ItemList@0..300
     Item@0..15
       Enum@0..13
         EnumKw@0..4 "enum"
@@ -47,208 +47,206 @@ Root@0..322
           Newline@54..55 "\n"
           RBrace@55..56 "}"
       Newline@56..58 "\n\n"
-    Item@58..162
-      Enum@58..160
+    Item@58..140
+      Enum@58..138
         EnumKw@58..62 "enum"
         WhiteSpace@62..63 " "
         Ident@63..77 "RecordVariants"
         WhiteSpace@77..78 " "
-        VariantDefList@78..160
+        VariantDefList@78..138
           LBrace@78..79 "{"
           Newline@79..80 "\n"
           WhiteSpace@80..85 "     "
-          VariantDef@85..135
+          VariantDef@85..113
             Ident@85..94 "Rectangle"
             WhiteSpace@94..95 " "
-            RecordFieldDefList@95..135
+            RecordFieldDefList@95..113
               LBrace@95..96 "{"
-              Newline@96..97 "\n"
-              WhiteSpace@97..106 "         "
-              RecordFieldDef@106..112
-                Ident@106..107 "w"
-                Colon@107..108 ":"
-                WhiteSpace@108..109 " "
-                PathType@109..112
-                  Path@109..112
-                    PathSegment@109..112
-                      Ident@109..112 "u32"
-              Newline@112..113 "\n"
-              WhiteSpace@113..122 "         "
-              RecordFieldDef@122..128
-                Ident@122..123 "h"
-                Colon@123..124 ":"
-                WhiteSpace@124..125 " "
-                PathType@125..128
-                  Path@125..128
-                    PathSegment@125..128
-                      Ident@125..128 "u32"
-              Newline@128..129 "\n"
-              WhiteSpace@129..134 "     "
-              RBrace@134..135 "}"
-          Newline@135..136 "\n"
-          WhiteSpace@136..141 "     "
-          VariantDef@141..158
-            Ident@141..147 "Circle"
-            WhiteSpace@147..148 " "
-            RecordFieldDefList@148..158
-              LBrace@148..149 "{"
-              WhiteSpace@149..150 " "
-              RecordFieldDef@150..156
-                Ident@150..151 "r"
-                Colon@151..152 ":"
-                WhiteSpace@152..153 " "
-                PathType@153..156
-                  Path@153..156
-                    PathSegment@153..156
-                      Ident@153..156 "u32"
-              WhiteSpace@156..157 " "
-              RBrace@157..158 "}"
-          Newline@158..159 "\n"
-          RBrace@159..160 "}"
-      Newline@160..162 "\n\n"
-    Item@162..222
-      Enum@162..220
-        EnumKw@162..166 "enum"
-        WhiteSpace@166..167 " "
-        Ident@167..173 "Option"
-        GenericParamList@173..176
-          Lt@173..174 "<"
-          TypeGenericParam@174..175
-            Ident@174..175 "T"
-          Gt@175..176 ">"
-        Newline@176..177 "\n"
-        WhiteSpace@177..181 "    "
-        WhereClause@181..196
-          WhereKw@181..186 "where"
-          WhiteSpace@186..187 " "
-          WherePredicate@187..196
-            PathType@187..188
-              Path@187..188
-                PathSegment@187..188
-                  Ident@187..188 "T"
-            TypeBoundList@188..195
-              Colon@188..189 ":"
-              WhiteSpace@189..190 " "
-              TypeBound@190..195
-                Path@190..195
-                  PathSegment@190..195
-                    Ident@190..195 "Clone"
-            Newline@195..196 "\n"
-        VariantDefList@196..220
-          LBrace@196..197 "{"
-          Newline@197..198 "\n"
-          WhiteSpace@198..202 "    "
-          VariantDef@202..209
-            Ident@202..206 "Some"
-            TupleType@206..209
-              LParen@206..207 "("
-              PathType@207..208
-                Path@207..208
-                  PathSegment@207..208
-                    Ident@207..208 "T"
-              RParen@208..209 ")"
-          Newline@209..210 "\n"
-          WhiteSpace@210..214 "    "
-          VariantDef@214..218
-            Ident@214..218 "None"
-          Newline@218..219 "\n"
-          RBrace@219..220 "}"
-      Newline@220..222 "\n\n"
-    Item@222..322
-      Enum@222..322
-        EnumKw@222..226 "enum"
-        WhiteSpace@226..227 " "
-        Ident@227..236 "BoundEnum"
-        GenericParamList@236..265
-          Lt@236..237 "<"
-          TypeGenericParam@237..249
-            Ident@237..238 "T"
-            TypeBoundList@238..249
-              Colon@238..239 ":"
-              WhiteSpace@239..240 " "
-              TypeBound@240..243
-                Path@240..243
-                  PathSegment@240..243
-                    Ident@240..243 "Add"
-              WhiteSpace@243..244 " "
-              Plus@244..245 "+"
-              WhiteSpace@245..246 " "
-              TypeBound@246..249
-                Path@246..249
-                  PathSegment@246..249
-                    Ident@246..249 "Mul"
+              WhiteSpace@96..97 " "
+              RecordFieldDef@97..103
+                Ident@97..98 "w"
+                Colon@98..99 ":"
+                WhiteSpace@99..100 " "
+                PathType@100..103
+                  Path@100..103
+                    PathSegment@100..103
+                      Ident@100..103 "u32"
+              Comma@103..104 ","
+              WhiteSpace@104..105 " "
+              RecordFieldDef@105..111
+                Ident@105..106 "h"
+                Colon@106..107 ":"
+                WhiteSpace@107..108 " "
+                PathType@108..111
+                  Path@108..111
+                    PathSegment@108..111
+                      Ident@108..111 "u32"
+              WhiteSpace@111..112 " "
+              RBrace@112..113 "}"
+          Newline@113..114 "\n"
+          WhiteSpace@114..119 "     "
+          VariantDef@119..136
+            Ident@119..125 "Circle"
+            WhiteSpace@125..126 " "
+            RecordFieldDefList@126..136
+              LBrace@126..127 "{"
+              WhiteSpace@127..128 " "
+              RecordFieldDef@128..134
+                Ident@128..129 "r"
+                Colon@129..130 ":"
+                WhiteSpace@130..131 " "
+                PathType@131..134
+                  Path@131..134
+                    PathSegment@131..134
+                      Ident@131..134 "u32"
+              WhiteSpace@134..135 " "
+              RBrace@135..136 "}"
+          Newline@136..137 "\n"
+          RBrace@137..138 "}"
+      Newline@138..140 "\n\n"
+    Item@140..200
+      Enum@140..198
+        EnumKw@140..144 "enum"
+        WhiteSpace@144..145 " "
+        Ident@145..151 "Option"
+        GenericParamList@151..154
+          Lt@151..152 "<"
+          TypeGenericParam@152..153
+            Ident@152..153 "T"
+          Gt@153..154 ">"
+        Newline@154..155 "\n"
+        WhiteSpace@155..159 "    "
+        WhereClause@159..174
+          WhereKw@159..164 "where"
+          WhiteSpace@164..165 " "
+          WherePredicate@165..174
+            PathType@165..166
+              Path@165..166
+                PathSegment@165..166
+                  Ident@165..166 "T"
+            TypeBoundList@166..173
+              Colon@166..167 ":"
+              WhiteSpace@167..168 " "
+              TypeBound@168..173
+                Path@168..173
+                  PathSegment@168..173
+                    Ident@168..173 "Clone"
+            Newline@173..174 "\n"
+        VariantDefList@174..198
+          LBrace@174..175 "{"
+          Newline@175..176 "\n"
+          WhiteSpace@176..180 "    "
+          VariantDef@180..187
+            Ident@180..184 "Some"
+            TupleType@184..187
+              LParen@184..185 "("
+              PathType@185..186
+                Path@185..186
+                  PathSegment@185..186
+                    Ident@185..186 "T"
+              RParen@186..187 ")"
+          Newline@187..188 "\n"
+          WhiteSpace@188..192 "    "
+          VariantDef@192..196
+            Ident@192..196 "None"
+          Newline@196..197 "\n"
+          RBrace@197..198 "}"
+      Newline@198..200 "\n\n"
+    Item@200..300
+      Enum@200..300
+        EnumKw@200..204 "enum"
+        WhiteSpace@204..205 " "
+        Ident@205..214 "BoundEnum"
+        GenericParamList@214..243
+          Lt@214..215 "<"
+          TypeGenericParam@215..227
+            Ident@215..216 "T"
+            TypeBoundList@216..227
+              Colon@216..217 ":"
+              WhiteSpace@217..218 " "
+              TypeBound@218..221
+                Path@218..221
+                  PathSegment@218..221
+                    Ident@218..221 "Add"
+              WhiteSpace@221..222 " "
+              Plus@222..223 "+"
+              WhiteSpace@223..224 " "
+              TypeBound@224..227
+                Path@224..227
+                  PathSegment@224..227
+                    Ident@224..227 "Mul"
+          WhiteSpace@227..228 " "
+          Comma@228..229 ","
+          WhiteSpace@229..230 " "
+          TypeGenericParam@230..242
+            Ident@230..231 "U"
+            TypeBoundList@231..242
+              Colon@231..232 ":"
+              WhiteSpace@232..233 " "
+              TypeBound@233..236
+                Path@233..236
+                  PathSegment@233..236
+                    Ident@233..236 "Sub"
+              WhiteSpace@236..237 " "
+              Plus@237..238 "+"
+              WhiteSpace@238..239 " "
+              TypeBound@239..242
+                Path@239..242
+                  PathSegment@239..242
+                    Ident@239..242 "Div"
+          Gt@242..243 ">"
+        Newline@243..244 "\n"
+        WhereClause@244..269
+          WhereKw@244..249 "where"
           WhiteSpace@249..250 " "
-          Comma@250..251 ","
-          WhiteSpace@251..252 " "
-          TypeGenericParam@252..264
-            Ident@252..253 "U"
-            TypeBoundList@253..264
-              Colon@253..254 ":"
-              WhiteSpace@254..255 " "
-              TypeBound@255..258
-                Path@255..258
-                  PathSegment@255..258
-                    Ident@255..258 "Sub"
-              WhiteSpace@258..259 " "
-              Plus@259..260 "+"
-              WhiteSpace@260..261 " "
-              TypeBound@261..264
-                Path@261..264
-                  PathSegment@261..264
-                    Ident@261..264 "Div"
-          Gt@264..265 ">"
-        Newline@265..266 "\n"
-        WhereClause@266..291
-          WhereKw@266..271 "where"
-          WhiteSpace@271..272 " "
-          WherePredicate@272..291
-            PathType@272..283
-              Path@272..280
-                PathSegment@272..275
-                  Ident@272..275 "Foo"
-                Colon2@275..277 "::"
-                PathSegment@277..280
-                  Ident@277..280 "Bar"
-              GenericArgList@280..283
-                Lt@280..281 "<"
-                TypeGenericArg@281..282
-                  PathType@281..282
-                    Path@281..282
-                      PathSegment@281..282
-                        Ident@281..282 "T"
-                Gt@282..283 ">"
-            TypeBoundList@283..290
-              Colon@283..284 ":"
-              WhiteSpace@284..285 " "
-              TypeBound@285..290
-                Path@285..290
-                  PathSegment@285..290
-                    Ident@285..290 "Trait"
-            Newline@290..291 "\n"
-        VariantDefList@291..322
-          LBrace@291..292 "{"
-          Newline@292..293 "\n"
-          WhiteSpace@293..297 "    "
-          VariantDef@297..306
-            Ident@297..303 "AddMul"
-            TupleType@303..306
-              LParen@303..304 "("
-              PathType@304..305
-                Path@304..305
-                  PathSegment@304..305
-                    Ident@304..305 "T"
-              RParen@305..306 ")"
-          Newline@306..307 "\n"
-          WhiteSpace@307..311 "    "
-          VariantDef@311..320
-            Ident@311..317 "SubDiv"
-            TupleType@317..320
-              LParen@317..318 "("
-              PathType@318..319
-                Path@318..319
-                  PathSegment@318..319
-                    Ident@318..319 "U"
-              RParen@319..320 ")"
-          Newline@320..321 "\n"
-          RBrace@321..322 "}"
+          WherePredicate@250..269
+            PathType@250..261
+              Path@250..258
+                PathSegment@250..253
+                  Ident@250..253 "Foo"
+                Colon2@253..255 "::"
+                PathSegment@255..258
+                  Ident@255..258 "Bar"
+              GenericArgList@258..261
+                Lt@258..259 "<"
+                TypeGenericArg@259..260
+                  PathType@259..260
+                    Path@259..260
+                      PathSegment@259..260
+                        Ident@259..260 "T"
+                Gt@260..261 ">"
+            TypeBoundList@261..268
+              Colon@261..262 ":"
+              WhiteSpace@262..263 " "
+              TypeBound@263..268
+                Path@263..268
+                  PathSegment@263..268
+                    Ident@263..268 "Trait"
+            Newline@268..269 "\n"
+        VariantDefList@269..300
+          LBrace@269..270 "{"
+          Newline@270..271 "\n"
+          WhiteSpace@271..275 "    "
+          VariantDef@275..284
+            Ident@275..281 "AddMul"
+            TupleType@281..284
+              LParen@281..282 "("
+              PathType@282..283
+                Path@282..283
+                  PathSegment@282..283
+                    Ident@282..283 "T"
+              RParen@283..284 ")"
+          Newline@284..285 "\n"
+          WhiteSpace@285..289 "    "
+          VariantDef@289..298
+            Ident@289..295 "SubDiv"
+            TupleType@295..298
+              LParen@295..296 "("
+              PathType@296..297
+                Path@296..297
+                  PathSegment@296..297
+                    Ident@296..297 "U"
+              RParen@297..298 ")"
+          Newline@298..299 "\n"
+          RBrace@299..300 "}"
 

--- a/crates/parser2/test_files/syntax_node/structs/attr.fe
+++ b/crates/parser2/test_files/syntax_node/structs/attr.fe
@@ -4,7 +4,7 @@
 /// DocComment2
 pub struct StructAttr {
     /// This is `x`
-    x: foo::Bar
+    x: foo::Bar,
     /// This is `y`
     #cfg(target: evm)
     y: i32

--- a/crates/parser2/test_files/syntax_node/structs/attr.snap
+++ b/crates/parser2/test_files/syntax_node/structs/attr.snap
@@ -3,10 +3,10 @@ source: crates/parser2/tests/syntax_node.rs
 expression: node
 input_file: crates/parser2/test_files/syntax_node/structs/attr.fe
 ---
-Root@0..170
-  ItemList@0..170
-    Item@0..170
-      Struct@0..170
+Root@0..171
+  ItemList@0..171
+    Item@0..171
+      Struct@0..171
         AttrList@0..56
           DocCommentAttr@0..15
             DocComment@0..15 "/// DocComment1"
@@ -27,7 +27,7 @@ Root@0..170
         WhiteSpace@66..67 " "
         Ident@67..77 "StructAttr"
         WhiteSpace@77..78 " "
-        RecordFieldDefList@78..170
+        RecordFieldDefList@78..171
           LBrace@78..79 "{"
           Newline@79..80 "\n"
           WhiteSpace@80..84 "    "
@@ -47,34 +47,35 @@ Root@0..170
                 Colon2@110..112 "::"
                 PathSegment@112..115
                   Ident@112..115 "Bar"
-          Newline@115..116 "\n"
-          WhiteSpace@116..120 "    "
-          RecordFieldDef@120..168
-            AttrList@120..158
-              DocCommentAttr@120..135
-                DocComment@120..135 "/// This is `y`"
-              Newline@135..136 "\n"
-              WhiteSpace@136..140 "    "
-              Attr@140..157
-                Pound@140..141 "#"
-                Ident@141..144 "cfg"
-                AttrArgList@144..157
-                  LParen@144..145 "("
-                  AttrArg@145..156
-                    Ident@145..151 "target"
-                    Colon@151..152 ":"
-                    WhiteSpace@152..153 " "
-                    Ident@153..156 "evm"
-                  RParen@156..157 ")"
-              Newline@157..158 "\n"
-            WhiteSpace@158..162 "    "
-            Ident@162..163 "y"
-            Colon@163..164 ":"
-            WhiteSpace@164..165 " "
-            PathType@165..168
-              Path@165..168
-                PathSegment@165..168
-                  Ident@165..168 "i32"
-          Newline@168..169 "\n"
-          RBrace@169..170 "}"
+          Comma@115..116 ","
+          Newline@116..117 "\n"
+          WhiteSpace@117..121 "    "
+          RecordFieldDef@121..169
+            AttrList@121..159
+              DocCommentAttr@121..136
+                DocComment@121..136 "/// This is `y`"
+              Newline@136..137 "\n"
+              WhiteSpace@137..141 "    "
+              Attr@141..158
+                Pound@141..142 "#"
+                Ident@142..145 "cfg"
+                AttrArgList@145..158
+                  LParen@145..146 "("
+                  AttrArg@146..157
+                    Ident@146..152 "target"
+                    Colon@152..153 ":"
+                    WhiteSpace@153..154 " "
+                    Ident@154..157 "evm"
+                  RParen@157..158 ")"
+              Newline@158..159 "\n"
+            WhiteSpace@159..163 "    "
+            Ident@163..164 "y"
+            Colon@164..165 ":"
+            WhiteSpace@165..166 " "
+            PathType@166..169
+              Path@166..169
+                PathSegment@166..169
+                  Ident@166..169 "i32"
+          Newline@169..170 "\n"
+          RBrace@170..171 "}"
 

--- a/crates/parser2/test_files/syntax_node/structs/generics.fe
+++ b/crates/parser2/test_files/syntax_node/structs/generics.fe
@@ -1,18 +1,18 @@
-pub struct StructWithGenericParam<S, T, U> 
+pub struct StructWithGenericParam<S, T, U>
 {
-    x: S
-    y: T
-    z: U
+    x: S,
+    y: T,
+    z: U,
 }
- 
+
 pub struct StructWithGenericParam2<
     S,
     T: foo::Trait,
     U
 > {
-    x: *(S, *i32)
-    y: T
-    z: U
+    x: *(S, *i32),
+    y: T,
+    z: U,
 }
 
 pub struct StructWithGenericParam3<
@@ -24,15 +24,15 @@ pub struct StructWithGenericParam3<
     Option<T>: Trait1 + Trait2
     Result<U>: Trait2 + Trait3
 {
-    x: S
-    y: T
-    z: U
+    x: S,
+    y: T,
+    z: U,
 }
 
-pub struct MyArr<T: std::ops::Add, U, const N: usize> 
+pub struct MyArr<T: std::ops::Add, U, const N: usize>
     where
         (T, U): Trait + Trait<i32, Y>
 {
-    __inner: [T; N]
+    __inner: [T; N],
     __inner2: (T, U)
 }

--- a/crates/parser2/test_files/syntax_node/structs/generics.snap
+++ b/crates/parser2/test_files/syntax_node/structs/generics.snap
@@ -3,10 +3,10 @@ source: crates/parser2/tests/syntax_node.rs
 expression: node
 input_file: crates/parser2/test_files/syntax_node/structs/generics.fe
 ---
-Root@0..553
-  ItemList@0..553
-    Item@0..75
-      Struct@0..74
+Root@0..560
+  ItemList@0..560
+    Item@0..78
+      Struct@0..76
         ItemModifier@0..3
           PubKw@0..3 "pub"
         WhiteSpace@3..4 " "
@@ -26,20 +26,20 @@ Root@0..553
           TypeGenericParam@40..41
             Ident@40..41 "U"
           Gt@41..42 ">"
-        WhiteSpace@42..43 " "
-        Newline@43..44 "\n"
-        RecordFieldDefList@44..74
-          LBrace@44..45 "{"
-          Newline@45..46 "\n"
-          WhiteSpace@46..50 "    "
-          RecordFieldDef@50..54
-            Ident@50..51 "x"
-            Colon@51..52 ":"
-            WhiteSpace@52..53 " "
-            PathType@53..54
-              Path@53..54
-                PathSegment@53..54
-                  Ident@53..54 "S"
+        Newline@42..43 "\n"
+        RecordFieldDefList@43..76
+          LBrace@43..44 "{"
+          Newline@44..45 "\n"
+          WhiteSpace@45..49 "    "
+          RecordFieldDef@49..53
+            Ident@49..50 "x"
+            Colon@50..51 ":"
+            WhiteSpace@51..52 " "
+            PathType@52..53
+              Path@52..53
+                PathSegment@52..53
+                  Ident@52..53 "S"
+          Comma@53..54 ","
           Newline@54..55 "\n"
           WhiteSpace@55..59 "    "
           RecordFieldDef@59..63
@@ -50,413 +50,419 @@ Root@0..553
               Path@62..63
                 PathSegment@62..63
                   Ident@62..63 "T"
-          Newline@63..64 "\n"
-          WhiteSpace@64..68 "    "
-          RecordFieldDef@68..72
-            Ident@68..69 "z"
-            Colon@69..70 ":"
-            WhiteSpace@70..71 " "
-            PathType@71..72
-              Path@71..72
-                PathSegment@71..72
-                  Ident@71..72 "U"
-          Newline@72..73 "\n"
-          RBrace@73..74 "}"
-      Newline@74..75 "\n"
-    WhiteSpace@75..76 " "
-    Newline@76..77 "\n"
-    Item@77..188
-      Struct@77..186
-        ItemModifier@77..80
-          PubKw@77..80 "pub"
-        WhiteSpace@80..81 " "
-        StructKw@81..87 "struct"
-        WhiteSpace@87..88 " "
-        Ident@88..111 "StructWithGenericParam2"
-        GenericParamList@111..146
-          Lt@111..112 "<"
-          Newline@112..113 "\n"
-          WhiteSpace@113..117 "    "
-          TypeGenericParam@117..118
-            Ident@117..118 "S"
-          Comma@118..119 ","
-          Newline@119..120 "\n"
-          WhiteSpace@120..124 "    "
-          TypeGenericParam@124..137
-            Ident@124..125 "T"
-            TypeBoundList@125..137
-              Colon@125..126 ":"
-              WhiteSpace@126..127 " "
-              TypeBound@127..137
-                Path@127..137
-                  PathSegment@127..130
-                    Ident@127..130 "foo"
-                  Colon2@130..132 "::"
-                  PathSegment@132..137
-                    Ident@132..137 "Trait"
-          Comma@137..138 ","
-          Newline@138..139 "\n"
-          WhiteSpace@139..143 "    "
-          TypeGenericParam@143..144
-            Ident@143..144 "U"
-          Newline@144..145 "\n"
-          Gt@145..146 ">"
-        WhiteSpace@146..147 " "
-        RecordFieldDefList@147..186
-          LBrace@147..148 "{"
-          Newline@148..149 "\n"
-          WhiteSpace@149..153 "    "
-          RecordFieldDef@153..166
-            Ident@153..154 "x"
-            Colon@154..155 ":"
-            WhiteSpace@155..156 " "
-            PtrType@156..166
-              Star@156..157 "*"
-              TupleType@157..166
-                LParen@157..158 "("
-                PathType@158..159
-                  Path@158..159
-                    PathSegment@158..159
-                      Ident@158..159 "S"
-                Comma@159..160 ","
-                WhiteSpace@160..161 " "
-                PtrType@161..165
-                  Star@161..162 "*"
-                  PathType@162..165
-                    Path@162..165
-                      PathSegment@162..165
-                        Ident@162..165 "i32"
-                RParen@165..166 ")"
-          Newline@166..167 "\n"
-          WhiteSpace@167..171 "    "
-          RecordFieldDef@171..175
-            Ident@171..172 "y"
-            Colon@172..173 ":"
-            WhiteSpace@173..174 " "
-            PathType@174..175
-              Path@174..175
-                PathSegment@174..175
-                  Ident@174..175 "T"
-          Newline@175..176 "\n"
-          WhiteSpace@176..180 "    "
-          RecordFieldDef@180..184
-            Ident@180..181 "z"
-            Colon@181..182 ":"
-            WhiteSpace@182..183 " "
-            PathType@183..184
-              Path@183..184
-                PathSegment@183..184
-                  Ident@183..184 "U"
-          Newline@184..185 "\n"
-          RBrace@185..186 "}"
-      Newline@186..188 "\n\n"
-    Item@188..406
-      Struct@188..404
-        ItemModifier@188..191
-          PubKw@188..191 "pub"
-        WhiteSpace@191..192 " "
-        StructKw@192..198 "struct"
-        WhiteSpace@198..199 " "
-        Ident@199..222 "StructWithGenericParam3"
-        GenericParamList@222..282
-          Lt@222..223 "<"
-          Newline@223..224 "\n"
-          WhiteSpace@224..228 "    "
-          TypeGenericParam@228..254
-            Ident@228..229 "S"
-            TypeBoundList@229..254
-              Colon@229..230 ":"
-              WhiteSpace@230..231 " "
-              TypeBound@231..241
-                Path@231..241
-                  PathSegment@231..234
-                    Ident@231..234 "foo"
-                  Colon2@234..236 "::"
-                  PathSegment@236..241
-                    Ident@236..241 "Trait"
-              WhiteSpace@241..242 " "
-              Plus@242..243 "+"
-              WhiteSpace@243..244 " "
-              TypeBound@244..254
-                Path@244..254
-                  PathSegment@244..247
-                    Ident@244..247 "bar"
-                  Colon2@247..249 "::"
-                  PathSegment@249..254
-                    Ident@249..254 "Trait"
-          Comma@254..255 ","
-          Newline@255..256 "\n"
-          WhiteSpace@256..260 "    "
-          TypeGenericParam@260..261
-            Ident@260..261 "T"
-          Comma@261..262 ","
-          Newline@262..263 "\n"
-          WhiteSpace@263..267 "    "
-          TypeGenericParam@267..280
-            Ident@267..268 "U"
-            TypeBoundList@268..280
-              Colon@268..269 ":"
-              WhiteSpace@269..270 " "
-              TypeBound@270..280
-                Path@270..280
-                  PathSegment@270..273
-                    Ident@270..273 "bar"
-                  Colon2@273..275 "::"
-                  PathSegment@275..280
-                    Ident@275..280 "Trait"
-          Newline@280..281 "\n"
-          Gt@281..282 ">"
-        WhiteSpace@282..283 " "
-        WhereClause@283..374
-          WhereKw@283..288 "where"
-          Newline@288..289 "\n"
-          WhiteSpace@289..293 "    "
-          WherePredicate@293..312
-            PathType@293..294
-              Path@293..294
-                PathSegment@293..294
-                  Ident@293..294 "T"
-            TypeBoundList@294..311
-              Colon@294..295 ":"
-              WhiteSpace@295..296 " "
-              TypeBound@296..302
-                Path@296..302
-                  PathSegment@296..302
-                    Ident@296..302 "Trait1"
-              WhiteSpace@302..303 " "
-              Plus@303..304 "+"
-              WhiteSpace@304..305 " "
-              TypeBound@305..311
-                Path@305..311
-                  PathSegment@305..311
-                    Ident@305..311 "Trait2"
-            Newline@311..312 "\n"
-          WhiteSpace@312..316 "    "
-          WherePredicate@316..343
-            PathType@316..325
-              Path@316..322
-                PathSegment@316..322
-                  Ident@316..322 "Option"
-              GenericArgList@322..325
-                Lt@322..323 "<"
-                TypeGenericArg@323..324
-                  PathType@323..324
-                    Path@323..324
-                      PathSegment@323..324
-                        Ident@323..324 "T"
-                Gt@324..325 ">"
-            TypeBoundList@325..342
-              Colon@325..326 ":"
-              WhiteSpace@326..327 " "
-              TypeBound@327..333
-                Path@327..333
-                  PathSegment@327..333
-                    Ident@327..333 "Trait1"
-              WhiteSpace@333..334 " "
-              Plus@334..335 "+"
-              WhiteSpace@335..336 " "
-              TypeBound@336..342
-                Path@336..342
-                  PathSegment@336..342
-                    Ident@336..342 "Trait2"
-            Newline@342..343 "\n"
-          WhiteSpace@343..347 "    "
-          WherePredicate@347..374
-            PathType@347..356
-              Path@347..353
-                PathSegment@347..353
-                  Ident@347..353 "Result"
-              GenericArgList@353..356
-                Lt@353..354 "<"
-                TypeGenericArg@354..355
-                  PathType@354..355
-                    Path@354..355
-                      PathSegment@354..355
-                        Ident@354..355 "U"
-                Gt@355..356 ">"
-            TypeBoundList@356..373
-              Colon@356..357 ":"
-              WhiteSpace@357..358 " "
-              TypeBound@358..364
-                Path@358..364
-                  PathSegment@358..364
-                    Ident@358..364 "Trait2"
-              WhiteSpace@364..365 " "
-              Plus@365..366 "+"
-              WhiteSpace@366..367 " "
-              TypeBound@367..373
-                Path@367..373
-                  PathSegment@367..373
-                    Ident@367..373 "Trait3"
-            Newline@373..374 "\n"
-        RecordFieldDefList@374..404
-          LBrace@374..375 "{"
-          Newline@375..376 "\n"
-          WhiteSpace@376..380 "    "
-          RecordFieldDef@380..384
-            Ident@380..381 "x"
-            Colon@381..382 ":"
-            WhiteSpace@382..383 " "
-            PathType@383..384
-              Path@383..384
-                PathSegment@383..384
-                  Ident@383..384 "S"
-          Newline@384..385 "\n"
-          WhiteSpace@385..389 "    "
-          RecordFieldDef@389..393
-            Ident@389..390 "y"
-            Colon@390..391 ":"
-            WhiteSpace@391..392 " "
-            PathType@392..393
-              Path@392..393
-                PathSegment@392..393
-                  Ident@392..393 "T"
-          Newline@393..394 "\n"
-          WhiteSpace@394..398 "    "
-          RecordFieldDef@398..402
-            Ident@398..399 "z"
-            Colon@399..400 ":"
-            WhiteSpace@400..401 " "
-            PathType@401..402
-              Path@401..402
-                PathSegment@401..402
-                  Ident@401..402 "U"
-          Newline@402..403 "\n"
-          RBrace@403..404 "}"
-      Newline@404..406 "\n\n"
-    Item@406..553
-      Struct@406..553
-        ItemModifier@406..409
-          PubKw@406..409 "pub"
-        WhiteSpace@409..410 " "
-        StructKw@410..416 "struct"
+          Comma@63..64 ","
+          Newline@64..65 "\n"
+          WhiteSpace@65..69 "    "
+          RecordFieldDef@69..73
+            Ident@69..70 "z"
+            Colon@70..71 ":"
+            WhiteSpace@71..72 " "
+            PathType@72..73
+              Path@72..73
+                PathSegment@72..73
+                  Ident@72..73 "U"
+          Comma@73..74 ","
+          Newline@74..75 "\n"
+          RBrace@75..76 "}"
+      Newline@76..78 "\n\n"
+    Item@78..192
+      Struct@78..190
+        ItemModifier@78..81
+          PubKw@78..81 "pub"
+        WhiteSpace@81..82 " "
+        StructKw@82..88 "struct"
+        WhiteSpace@88..89 " "
+        Ident@89..112 "StructWithGenericParam2"
+        GenericParamList@112..147
+          Lt@112..113 "<"
+          Newline@113..114 "\n"
+          WhiteSpace@114..118 "    "
+          TypeGenericParam@118..119
+            Ident@118..119 "S"
+          Comma@119..120 ","
+          Newline@120..121 "\n"
+          WhiteSpace@121..125 "    "
+          TypeGenericParam@125..138
+            Ident@125..126 "T"
+            TypeBoundList@126..138
+              Colon@126..127 ":"
+              WhiteSpace@127..128 " "
+              TypeBound@128..138
+                Path@128..138
+                  PathSegment@128..131
+                    Ident@128..131 "foo"
+                  Colon2@131..133 "::"
+                  PathSegment@133..138
+                    Ident@133..138 "Trait"
+          Comma@138..139 ","
+          Newline@139..140 "\n"
+          WhiteSpace@140..144 "    "
+          TypeGenericParam@144..145
+            Ident@144..145 "U"
+          Newline@145..146 "\n"
+          Gt@146..147 ">"
+        WhiteSpace@147..148 " "
+        RecordFieldDefList@148..190
+          LBrace@148..149 "{"
+          Newline@149..150 "\n"
+          WhiteSpace@150..154 "    "
+          RecordFieldDef@154..167
+            Ident@154..155 "x"
+            Colon@155..156 ":"
+            WhiteSpace@156..157 " "
+            PtrType@157..167
+              Star@157..158 "*"
+              TupleType@158..167
+                LParen@158..159 "("
+                PathType@159..160
+                  Path@159..160
+                    PathSegment@159..160
+                      Ident@159..160 "S"
+                Comma@160..161 ","
+                WhiteSpace@161..162 " "
+                PtrType@162..166
+                  Star@162..163 "*"
+                  PathType@163..166
+                    Path@163..166
+                      PathSegment@163..166
+                        Ident@163..166 "i32"
+                RParen@166..167 ")"
+          Comma@167..168 ","
+          Newline@168..169 "\n"
+          WhiteSpace@169..173 "    "
+          RecordFieldDef@173..177
+            Ident@173..174 "y"
+            Colon@174..175 ":"
+            WhiteSpace@175..176 " "
+            PathType@176..177
+              Path@176..177
+                PathSegment@176..177
+                  Ident@176..177 "T"
+          Comma@177..178 ","
+          Newline@178..179 "\n"
+          WhiteSpace@179..183 "    "
+          RecordFieldDef@183..187
+            Ident@183..184 "z"
+            Colon@184..185 ":"
+            WhiteSpace@185..186 " "
+            PathType@186..187
+              Path@186..187
+                PathSegment@186..187
+                  Ident@186..187 "U"
+          Comma@187..188 ","
+          Newline@188..189 "\n"
+          RBrace@189..190 "}"
+      Newline@190..192 "\n\n"
+    Item@192..413
+      Struct@192..411
+        ItemModifier@192..195
+          PubKw@192..195 "pub"
+        WhiteSpace@195..196 " "
+        StructKw@196..202 "struct"
+        WhiteSpace@202..203 " "
+        Ident@203..226 "StructWithGenericParam3"
+        GenericParamList@226..286
+          Lt@226..227 "<"
+          Newline@227..228 "\n"
+          WhiteSpace@228..232 "    "
+          TypeGenericParam@232..258
+            Ident@232..233 "S"
+            TypeBoundList@233..258
+              Colon@233..234 ":"
+              WhiteSpace@234..235 " "
+              TypeBound@235..245
+                Path@235..245
+                  PathSegment@235..238
+                    Ident@235..238 "foo"
+                  Colon2@238..240 "::"
+                  PathSegment@240..245
+                    Ident@240..245 "Trait"
+              WhiteSpace@245..246 " "
+              Plus@246..247 "+"
+              WhiteSpace@247..248 " "
+              TypeBound@248..258
+                Path@248..258
+                  PathSegment@248..251
+                    Ident@248..251 "bar"
+                  Colon2@251..253 "::"
+                  PathSegment@253..258
+                    Ident@253..258 "Trait"
+          Comma@258..259 ","
+          Newline@259..260 "\n"
+          WhiteSpace@260..264 "    "
+          TypeGenericParam@264..265
+            Ident@264..265 "T"
+          Comma@265..266 ","
+          Newline@266..267 "\n"
+          WhiteSpace@267..271 "    "
+          TypeGenericParam@271..284
+            Ident@271..272 "U"
+            TypeBoundList@272..284
+              Colon@272..273 ":"
+              WhiteSpace@273..274 " "
+              TypeBound@274..284
+                Path@274..284
+                  PathSegment@274..277
+                    Ident@274..277 "bar"
+                  Colon2@277..279 "::"
+                  PathSegment@279..284
+                    Ident@279..284 "Trait"
+          Newline@284..285 "\n"
+          Gt@285..286 ">"
+        WhiteSpace@286..287 " "
+        WhereClause@287..378
+          WhereKw@287..292 "where"
+          Newline@292..293 "\n"
+          WhiteSpace@293..297 "    "
+          WherePredicate@297..316
+            PathType@297..298
+              Path@297..298
+                PathSegment@297..298
+                  Ident@297..298 "T"
+            TypeBoundList@298..315
+              Colon@298..299 ":"
+              WhiteSpace@299..300 " "
+              TypeBound@300..306
+                Path@300..306
+                  PathSegment@300..306
+                    Ident@300..306 "Trait1"
+              WhiteSpace@306..307 " "
+              Plus@307..308 "+"
+              WhiteSpace@308..309 " "
+              TypeBound@309..315
+                Path@309..315
+                  PathSegment@309..315
+                    Ident@309..315 "Trait2"
+            Newline@315..316 "\n"
+          WhiteSpace@316..320 "    "
+          WherePredicate@320..347
+            PathType@320..329
+              Path@320..326
+                PathSegment@320..326
+                  Ident@320..326 "Option"
+              GenericArgList@326..329
+                Lt@326..327 "<"
+                TypeGenericArg@327..328
+                  PathType@327..328
+                    Path@327..328
+                      PathSegment@327..328
+                        Ident@327..328 "T"
+                Gt@328..329 ">"
+            TypeBoundList@329..346
+              Colon@329..330 ":"
+              WhiteSpace@330..331 " "
+              TypeBound@331..337
+                Path@331..337
+                  PathSegment@331..337
+                    Ident@331..337 "Trait1"
+              WhiteSpace@337..338 " "
+              Plus@338..339 "+"
+              WhiteSpace@339..340 " "
+              TypeBound@340..346
+                Path@340..346
+                  PathSegment@340..346
+                    Ident@340..346 "Trait2"
+            Newline@346..347 "\n"
+          WhiteSpace@347..351 "    "
+          WherePredicate@351..378
+            PathType@351..360
+              Path@351..357
+                PathSegment@351..357
+                  Ident@351..357 "Result"
+              GenericArgList@357..360
+                Lt@357..358 "<"
+                TypeGenericArg@358..359
+                  PathType@358..359
+                    Path@358..359
+                      PathSegment@358..359
+                        Ident@358..359 "U"
+                Gt@359..360 ">"
+            TypeBoundList@360..377
+              Colon@360..361 ":"
+              WhiteSpace@361..362 " "
+              TypeBound@362..368
+                Path@362..368
+                  PathSegment@362..368
+                    Ident@362..368 "Trait2"
+              WhiteSpace@368..369 " "
+              Plus@369..370 "+"
+              WhiteSpace@370..371 " "
+              TypeBound@371..377
+                Path@371..377
+                  PathSegment@371..377
+                    Ident@371..377 "Trait3"
+            Newline@377..378 "\n"
+        RecordFieldDefList@378..411
+          LBrace@378..379 "{"
+          Newline@379..380 "\n"
+          WhiteSpace@380..384 "    "
+          RecordFieldDef@384..388
+            Ident@384..385 "x"
+            Colon@385..386 ":"
+            WhiteSpace@386..387 " "
+            PathType@387..388
+              Path@387..388
+                PathSegment@387..388
+                  Ident@387..388 "S"
+          Comma@388..389 ","
+          Newline@389..390 "\n"
+          WhiteSpace@390..394 "    "
+          RecordFieldDef@394..398
+            Ident@394..395 "y"
+            Colon@395..396 ":"
+            WhiteSpace@396..397 " "
+            PathType@397..398
+              Path@397..398
+                PathSegment@397..398
+                  Ident@397..398 "T"
+          Comma@398..399 ","
+          Newline@399..400 "\n"
+          WhiteSpace@400..404 "    "
+          RecordFieldDef@404..408
+            Ident@404..405 "z"
+            Colon@405..406 ":"
+            WhiteSpace@406..407 " "
+            PathType@407..408
+              Path@407..408
+                PathSegment@407..408
+                  Ident@407..408 "U"
+          Comma@408..409 ","
+          Newline@409..410 "\n"
+          RBrace@410..411 "}"
+      Newline@411..413 "\n\n"
+    Item@413..560
+      Struct@413..560
+        ItemModifier@413..416
+          PubKw@413..416 "pub"
         WhiteSpace@416..417 " "
-        Ident@417..422 "MyArr"
-        GenericParamList@422..459
-          Lt@422..423 "<"
-          TypeGenericParam@423..439
-            Ident@423..424 "T"
-            TypeBoundList@424..439
-              Colon@424..425 ":"
-              WhiteSpace@425..426 " "
-              TypeBound@426..439
-                Path@426..439
-                  PathSegment@426..429
-                    Ident@426..429 "std"
-                  Colon2@429..431 "::"
-                  PathSegment@431..434
-                    Ident@431..434 "ops"
-                  Colon2@434..436 "::"
-                  PathSegment@436..439
-                    Ident@436..439 "Add"
-          Comma@439..440 ","
-          WhiteSpace@440..441 " "
-          TypeGenericParam@441..442
-            Ident@441..442 "U"
-          Comma@442..443 ","
-          WhiteSpace@443..444 " "
-          ConstGenericParam@444..458
-            ConstKw@444..449 "const"
-            WhiteSpace@449..450 " "
-            Ident@450..451 "N"
-            Colon@451..452 ":"
-            WhiteSpace@452..453 " "
-            PathType@453..458
-              Path@453..458
-                PathSegment@453..458
-                  Ident@453..458 "usize"
-          Gt@458..459 ">"
-        WhiteSpace@459..460 " "
-        Newline@460..461 "\n"
-        WhiteSpace@461..465 "    "
-        WhereClause@465..509
-          WhereKw@465..470 "where"
-          Newline@470..471 "\n"
-          WhiteSpace@471..479 "        "
-          WherePredicate@479..509
-            TupleType@479..485
-              LParen@479..480 "("
-              PathType@480..481
-                Path@480..481
-                  PathSegment@480..481
-                    Ident@480..481 "T"
-              Comma@481..482 ","
-              WhiteSpace@482..483 " "
-              PathType@483..484
-                Path@483..484
-                  PathSegment@483..484
-                    Ident@483..484 "U"
-              RParen@484..485 ")"
-            TypeBoundList@485..508
-              Colon@485..486 ":"
-              WhiteSpace@486..487 " "
-              TypeBound@487..492
-                Path@487..492
-                  PathSegment@487..492
-                    Ident@487..492 "Trait"
+        StructKw@417..423 "struct"
+        WhiteSpace@423..424 " "
+        Ident@424..429 "MyArr"
+        GenericParamList@429..466
+          Lt@429..430 "<"
+          TypeGenericParam@430..446
+            Ident@430..431 "T"
+            TypeBoundList@431..446
+              Colon@431..432 ":"
+              WhiteSpace@432..433 " "
+              TypeBound@433..446
+                Path@433..446
+                  PathSegment@433..436
+                    Ident@433..436 "std"
+                  Colon2@436..438 "::"
+                  PathSegment@438..441
+                    Ident@438..441 "ops"
+                  Colon2@441..443 "::"
+                  PathSegment@443..446
+                    Ident@443..446 "Add"
+          Comma@446..447 ","
+          WhiteSpace@447..448 " "
+          TypeGenericParam@448..449
+            Ident@448..449 "U"
+          Comma@449..450 ","
+          WhiteSpace@450..451 " "
+          ConstGenericParam@451..465
+            ConstKw@451..456 "const"
+            WhiteSpace@456..457 " "
+            Ident@457..458 "N"
+            Colon@458..459 ":"
+            WhiteSpace@459..460 " "
+            PathType@460..465
+              Path@460..465
+                PathSegment@460..465
+                  Ident@460..465 "usize"
+          Gt@465..466 ">"
+        Newline@466..467 "\n"
+        WhiteSpace@467..471 "    "
+        WhereClause@471..515
+          WhereKw@471..476 "where"
+          Newline@476..477 "\n"
+          WhiteSpace@477..485 "        "
+          WherePredicate@485..515
+            TupleType@485..491
+              LParen@485..486 "("
+              PathType@486..487
+                Path@486..487
+                  PathSegment@486..487
+                    Ident@486..487 "T"
+              Comma@487..488 ","
+              WhiteSpace@488..489 " "
+              PathType@489..490
+                Path@489..490
+                  PathSegment@489..490
+                    Ident@489..490 "U"
+              RParen@490..491 ")"
+            TypeBoundList@491..514
+              Colon@491..492 ":"
               WhiteSpace@492..493 " "
-              Plus@493..494 "+"
-              WhiteSpace@494..495 " "
-              TypeBound@495..508
-                Path@495..500
-                  PathSegment@495..500
-                    Ident@495..500 "Trait"
-                GenericArgList@500..508
-                  Lt@500..501 "<"
-                  TypeGenericArg@501..504
-                    PathType@501..504
-                      Path@501..504
-                        PathSegment@501..504
-                          Ident@501..504 "i32"
-                  Comma@504..505 ","
-                  WhiteSpace@505..506 " "
-                  TypeGenericArg@506..507
-                    PathType@506..507
-                      Path@506..507
-                        PathSegment@506..507
-                          Ident@506..507 "Y"
-                  Gt@507..508 ">"
-            Newline@508..509 "\n"
-        RecordFieldDefList@509..553
-          LBrace@509..510 "{"
-          Newline@510..511 "\n"
-          WhiteSpace@511..515 "    "
-          RecordFieldDef@515..530
-            Ident@515..522 "__inner"
-            Colon@522..523 ":"
-            WhiteSpace@523..524 " "
-            ArrayType@524..530
-              LBracket@524..525 "["
-              PathType@525..526
-                Path@525..526
-                  PathSegment@525..526
-                    Ident@525..526 "T"
-              SemiColon@526..527 ";"
-              WhiteSpace@527..528 " "
-              PathExpr@528..529
-                Path@528..529
-                  PathSegment@528..529
-                    Ident@528..529 "N"
-              RBracket@529..530 "]"
-          Newline@530..531 "\n"
-          WhiteSpace@531..535 "    "
-          RecordFieldDef@535..551
-            Ident@535..543 "__inner2"
-            Colon@543..544 ":"
-            WhiteSpace@544..545 " "
-            TupleType@545..551
-              LParen@545..546 "("
-              PathType@546..547
-                Path@546..547
-                  PathSegment@546..547
-                    Ident@546..547 "T"
-              Comma@547..548 ","
-              WhiteSpace@548..549 " "
-              PathType@549..550
-                Path@549..550
-                  PathSegment@549..550
-                    Ident@549..550 "U"
-              RParen@550..551 ")"
-          Newline@551..552 "\n"
-          RBrace@552..553 "}"
+              TypeBound@493..498
+                Path@493..498
+                  PathSegment@493..498
+                    Ident@493..498 "Trait"
+              WhiteSpace@498..499 " "
+              Plus@499..500 "+"
+              WhiteSpace@500..501 " "
+              TypeBound@501..514
+                Path@501..506
+                  PathSegment@501..506
+                    Ident@501..506 "Trait"
+                GenericArgList@506..514
+                  Lt@506..507 "<"
+                  TypeGenericArg@507..510
+                    PathType@507..510
+                      Path@507..510
+                        PathSegment@507..510
+                          Ident@507..510 "i32"
+                  Comma@510..511 ","
+                  WhiteSpace@511..512 " "
+                  TypeGenericArg@512..513
+                    PathType@512..513
+                      Path@512..513
+                        PathSegment@512..513
+                          Ident@512..513 "Y"
+                  Gt@513..514 ">"
+            Newline@514..515 "\n"
+        RecordFieldDefList@515..560
+          LBrace@515..516 "{"
+          Newline@516..517 "\n"
+          WhiteSpace@517..521 "    "
+          RecordFieldDef@521..536
+            Ident@521..528 "__inner"
+            Colon@528..529 ":"
+            WhiteSpace@529..530 " "
+            ArrayType@530..536
+              LBracket@530..531 "["
+              PathType@531..532
+                Path@531..532
+                  PathSegment@531..532
+                    Ident@531..532 "T"
+              SemiColon@532..533 ";"
+              WhiteSpace@533..534 " "
+              PathExpr@534..535
+                Path@534..535
+                  PathSegment@534..535
+                    Ident@534..535 "N"
+              RBracket@535..536 "]"
+          Comma@536..537 ","
+          Newline@537..538 "\n"
+          WhiteSpace@538..542 "    "
+          RecordFieldDef@542..558
+            Ident@542..550 "__inner2"
+            Colon@550..551 ":"
+            WhiteSpace@551..552 " "
+            TupleType@552..558
+              LParen@552..553 "("
+              PathType@553..554
+                Path@553..554
+                  PathSegment@553..554
+                    Ident@553..554 "T"
+              Comma@554..555 ","
+              WhiteSpace@555..556 " "
+              PathType@556..557
+                Path@556..557
+                  PathSegment@556..557
+                    Ident@556..557 "U"
+              RParen@557..558 ")"
+          Newline@558..559 "\n"
+          RBrace@559..560 "}"
 

--- a/crates/parser2/test_files/syntax_node/structs/tupel_field.fe
+++ b/crates/parser2/test_files/syntax_node/structs/tupel_field.fe
@@ -1,9 +1,9 @@
 struct StructWithTupleField {
-    x: (i32, u32)
+    x: (i32, u32),
     y: (
         i32,
         foo::Bar,
         u32
-    )
+    ),
     z: ()
 }

--- a/crates/parser2/test_files/syntax_node/structs/tupel_field.snap
+++ b/crates/parser2/test_files/syntax_node/structs/tupel_field.snap
@@ -3,15 +3,15 @@ source: crates/parser2/tests/syntax_node.rs
 expression: node
 input_file: crates/parser2/test_files/syntax_node/structs/tupel_field.fe
 ---
-Root@0..117
-  ItemList@0..117
-    Item@0..117
-      Struct@0..117
+Root@0..119
+  ItemList@0..119
+    Item@0..119
+      Struct@0..119
         StructKw@0..6 "struct"
         WhiteSpace@6..7 " "
         Ident@7..27 "StructWithTupleField"
         WhiteSpace@27..28 " "
-        RecordFieldDefList@28..117
+        RecordFieldDefList@28..119
           LBrace@28..29 "{"
           Newline@29..30 "\n"
           WhiteSpace@30..34 "    "
@@ -32,49 +32,51 @@ Root@0..117
                   PathSegment@43..46
                     Ident@43..46 "u32"
               RParen@46..47 ")"
-          Newline@47..48 "\n"
-          WhiteSpace@48..52 "    "
-          RecordFieldDef@52..105
-            Ident@52..53 "y"
-            Colon@53..54 ":"
-            WhiteSpace@54..55 " "
-            TupleType@55..105
-              LParen@55..56 "("
-              Newline@56..57 "\n"
-              WhiteSpace@57..65 "        "
-              PathType@65..68
-                Path@65..68
-                  PathSegment@65..68
-                    Ident@65..68 "i32"
-              Comma@68..69 ","
-              Newline@69..70 "\n"
-              WhiteSpace@70..78 "        "
-              PathType@78..86
-                Path@78..86
-                  PathSegment@78..81
-                    Ident@78..81 "foo"
-                  Colon2@81..83 "::"
-                  PathSegment@83..86
-                    Ident@83..86 "Bar"
-              Comma@86..87 ","
-              Newline@87..88 "\n"
-              WhiteSpace@88..96 "        "
-              PathType@96..99
-                Path@96..99
-                  PathSegment@96..99
-                    Ident@96..99 "u32"
-              Newline@99..100 "\n"
-              WhiteSpace@100..104 "    "
-              RParen@104..105 ")"
-          Newline@105..106 "\n"
-          WhiteSpace@106..110 "    "
-          RecordFieldDef@110..115
-            Ident@110..111 "z"
-            Colon@111..112 ":"
-            WhiteSpace@112..113 " "
-            TupleType@113..115
-              LParen@113..114 "("
-              RParen@114..115 ")"
-          Newline@115..116 "\n"
-          RBrace@116..117 "}"
+          Comma@47..48 ","
+          Newline@48..49 "\n"
+          WhiteSpace@49..53 "    "
+          RecordFieldDef@53..106
+            Ident@53..54 "y"
+            Colon@54..55 ":"
+            WhiteSpace@55..56 " "
+            TupleType@56..106
+              LParen@56..57 "("
+              Newline@57..58 "\n"
+              WhiteSpace@58..66 "        "
+              PathType@66..69
+                Path@66..69
+                  PathSegment@66..69
+                    Ident@66..69 "i32"
+              Comma@69..70 ","
+              Newline@70..71 "\n"
+              WhiteSpace@71..79 "        "
+              PathType@79..87
+                Path@79..87
+                  PathSegment@79..82
+                    Ident@79..82 "foo"
+                  Colon2@82..84 "::"
+                  PathSegment@84..87
+                    Ident@84..87 "Bar"
+              Comma@87..88 ","
+              Newline@88..89 "\n"
+              WhiteSpace@89..97 "        "
+              PathType@97..100
+                Path@97..100
+                  PathSegment@97..100
+                    Ident@97..100 "u32"
+              Newline@100..101 "\n"
+              WhiteSpace@101..105 "    "
+              RParen@105..106 ")"
+          Comma@106..107 ","
+          Newline@107..108 "\n"
+          WhiteSpace@108..112 "    "
+          RecordFieldDef@112..117
+            Ident@112..113 "z"
+            Colon@113..114 ":"
+            WhiteSpace@114..115 " "
+            TupleType@115..117
+              LParen@115..116 "("
+              RParen@116..117 ")"
+          Newline@117..118 "\n"
+          RBrace@118..119 "}"
 

--- a/crates/uitest/Cargo.toml
+++ b/crates/uitest/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 driver = { path = "../driver2", package = "fe-driver2" }
+hir = { path = "../hir", package = "fe-hir" }
 fe-compiler-test-utils = { path = "../test-utils" }
 dir-test = "0.1"
 wasm-bindgen-test = "0.3"

--- a/crates/uitest/fixtures/name_resolution/conflict_field.fe
+++ b/crates/uitest/fixtures/name_resolution/conflict_field.fe
@@ -1,4 +1,4 @@
 pub struct MyS {
-    x: i32
-    x: u32
+    x: i32,
+    x: u32,
 }

--- a/crates/uitest/fixtures/name_resolution/conflict_field.snap
+++ b/crates/uitest/fixtures/name_resolution/conflict_field.snap
@@ -1,14 +1,14 @@
 ---
-source: crates/uitest/src/lib.rs
+source: crates/uitest/tests/name_resolution.rs
 expression: diags
 input_file: crates/uitest/fixtures/name_resolution/conflict_field.fe
 ---
 error[2-0001]: `x` conflicts with other definitions
   ┌─ conflict_field.fe:2:5
   │
-2 │     x: i32
+2 │     x: i32,
   │     ^ `x` is defined here
-3 │     x: u32
+3 │     x: u32,
   │     - `x` is redefined here
 
 

--- a/crates/uitest/fixtures/name_resolution/conflict_generics.fe
+++ b/crates/uitest/fixtures/name_resolution/conflict_generics.fe
@@ -1,4 +1,4 @@
 pub struct MyS<T, U, T> {
-    x: T
+    x: T,
     y: U
 }

--- a/crates/uitest/fixtures/name_resolution/conflict_generics.snap
+++ b/crates/uitest/fixtures/name_resolution/conflict_generics.snap
@@ -18,7 +18,7 @@ error[2-0004]: `T` is ambiguous
   │                -     - candidate `#1`
   │                │      
   │                candidate `#0`
-2 │     x: T
+2 │     x: T,
   │        ^ `T` is ambiguous
 
 

--- a/crates/uitest/fixtures/name_resolution/path_missing_generics.fe
+++ b/crates/uitest/fixtures/name_resolution/path_missing_generics.fe
@@ -1,12 +1,12 @@
 pub trait Trait {}
 
-pub struct MyS<T, U> 
+pub struct MyS<T, U>
     where T: Trait
           U: Trait
           Z: Trait
-{ 
-    t: T
-    u: U
+{
+    t: T,
+    u: U,
     z: Z
 }
 

--- a/crates/uitest/fixtures/name_resolution/path_shadow.fe
+++ b/crates/uitest/fixtures/name_resolution/path_shadow.fe
@@ -2,6 +2,6 @@ pub trait T {}
 pub struct MyS<T, U>
     where U: T
 {
-    t: T
+    t: T,
     u: U
 }

--- a/crates/uitest/fixtures/parser/struct_field_missing_comma.fe
+++ b/crates/uitest/fixtures/parser/struct_field_missing_comma.fe
@@ -1,0 +1,5 @@
+struct S {
+    x: u8
+    y: i8
+    ,z: i8,
+}

--- a/crates/uitest/fixtures/parser/struct_field_missing_comma.snap
+++ b/crates/uitest/fixtures/parser/struct_field_missing_comma.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uitest/tests/parser.rs
+expression: diags
+input_file: crates/uitest/fixtures/parser/struct_field_missing_comma.fe
+---
+error[1-0001]: expected comma after field definition
+  ┌─ struct_field_missing_comma.fe:2:10
+  │
+2 │     x: u8
+  │          ^ expected comma after field definition
+
+

--- a/crates/uitest/tests/parser.rs
+++ b/crates/uitest/tests/parser.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+
+use dir_test::{dir_test, Fixture};
+use driver::DriverDataBase;
+use fe_compiler_test_utils::snap_test;
+use hir::{analysis_pass::AnalysisPassManager, ParsingPass};
+
+#[dir_test(
+    dir: "$CARGO_MANIFEST_DIR/fixtures/parser",
+    glob: "*.fe"
+)]
+fn run_parser(fixture: Fixture<&str>) {
+    let mut driver = DriverDataBase::default();
+    let path = Path::new(fixture.path());
+    let top_mod = driver.top_mod_from_file(path, fixture.content());
+    driver.run_on_file_with_pass_manager(top_mod, init_parser_pass);
+    let diags = driver.format_diags();
+    snap_test!(diags, fixture.path());
+}
+
+fn init_parser_pass(db: &DriverDataBase) -> AnalysisPassManager<'_> {
+    let mut pass_manager = AnalysisPassManager::new();
+    pass_manager.add_module_pass(Box::new(ParsingPass::new(db)));
+    pass_manager
+}
+
+#[cfg(target_family = "wasm")]
+mod wasm {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[dir_test(
+        dir: "$CARGO_MANIFEST_DIR/fixtures/name_resolution",
+        glob: "*.fe",
+        postfix: "wasm"
+    )]
+    #[dir_test_attr(
+        #[wasm_bindgen_test]
+    )]
+    fn run_parser(fixture: Fixture<&str>) {
+        let mut driver = DriverDataBase::default();
+        let path = Path::new(fixture.path());
+        let top_mod = driver.top_mod_from_file(path, fixture.content());
+        driver.run_on_file_with_pass_manager(top_mod, init_parser_pass);
+    }
+}


### PR DESCRIPTION
v2 parser and HIR now allow record-type enum variants.

Struct (and record enum variant) fields must now be separated by a comma (newlines are allowed but not required). This allows a struct with multiple fields to be defined on a single line, eg `struct S { x: u8, y: u8 }`.

Nit-picky feedback welcome.