### PR TITLE
Allow filtering tests when running fe test

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -28,6 +28,7 @@ pub struct CompiledContract {
 }
 
 #[cfg(feature = "solc-backend")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompiledTest {
     pub name: SmolStr,
     bytecode: String,

--- a/newsfragments/919.feature.md
+++ b/newsfragments/919.feature.md
@@ -1,0 +1,3 @@
+Allow filtering tests to run via `fe test --filter <some-filter`
+
+E.g. Running `fe test --filter foo` will run all tests that contain `foo` in their name.


### PR DESCRIPTION
### What was wrong?

There's currently no way to restrict `fe test` to only run a subset of tests

### How was it fixed?

Added a `--filter <some-filter>` option to allow filtering the tests.
I initially had it as a separate optional input (e.g. fe filter . <some-filter>) but that means people have to specify the directory manually which can be annoying when hopping between different directories.
