### PR TITLE
[website: docs] adds detail to installation pages

### DIFF
--- a/docs/src/quickstart/installation.md
+++ b/docs/src/quickstart/installation.md
@@ -1,19 +1,19 @@
-## Installation
+# Installation
 
 At this point Fe is only available for **Linux** and **MacOS**.
 
 > Note: If you happen to be a Windows developer, consider getting involved
 > and help us to support the Windows platform. [Here would be a good place to start.](https://github.com/ethereum/fe/issues/62)
 
-### Download the compiler
+## Download the compiler
 
-At this point Fe is only distributed via a single executable file linked from the [home page](https://fe-lang.org). In the future we will make sure it can be installed through popular package managers such as `apt` or `homebrew`.
+Fe is only distributed via a single executable file linked from the [home page](https://fe-lang.org). In the future we will make sure it can be installed through popular package managers such as `apt` or `homebrew`.
 
 Depending on your operating system, the file that you download is either named `fe_amd64` or `fe_mac`.
 
 > Note: We will rename the file to `fe` and assume that name for the rest of the guide. In the future when Fe can be installed via other mechanisms we can assume `fe` to become the canonical command name.
 
-### Add permission to execute
+## Add permission to execute
 
 In order to be able to execute the Fe compiler we will have to make the file *executable*. This can be done by navigating to the directory where the file is located and executing `chmod + x <filename>` (e.g. `chmod +x fe`).
 
@@ -38,7 +38,49 @@ SUBCOMMANDS:
     new      Create new fe project
 ```
 
-### Editor support & Syntax highlighting
+# Building from source
+
+You can also build Fe from the source code provided in our Github [repository](https://github.com/ethereum/fe). To do this you will need to have [Rust](https://www.rust-lang.org/tools/install) installed. Then, cloen the github repository using:
+
+```sh
+git clone https://github.com/ethereum/fe.git
+```
+
+Depending on your environment you may need to install some additional packages before building the Fe binary, specifically `libboost-all-dev`, `libclang` and `cmake`. For example, on a Linux system:
+
+```sh
+sudo apt-get update &&\
+ apt-get install libboost-all-dev &&\
+ apt-get install libclang-dev &&\
+ apt-get install cmake
+```
+
+Now, use Rust to build the Fe binary. To run Fe, you need to build using `solc-backend`.
+
+```sh
+cargo build --feature solc-backend
+```
+
+You will now find your Fe binary in `/target/release`. Check the build with:
+
+```sh
+./target/release/fe --version
+```
+
+If everything worked, you should see the Fe version printed to the terminal:
+
+```sh
+fe 0.24.0
+```
+
+You can run the built-in tests using:
+
+```sh
+cargo test --workspace --features solc-backend
+```
+
+
+## Editor support & Syntax highlighting
 
 Fe is a new language and editor support is still in its early days. However, basic syntax highlighting is available for Visual Studio Code via this [VS Code extension](https://marketplace.visualstudio.com/items?itemName=fe-lang.code-ve).
 

--- a/docs/theme/reference.css
+++ b/docs/theme/reference.css
@@ -51,3 +51,14 @@ main .warning p::before {
 .ayu main .warning p a {
   color: #80d0d0
 }
+
+/* add consistent whitespace around code blocks*/
+.pre code {
+  white-space: pre;
+}
+
+pre {
+  display: block;
+  margin-top: 4rem;
+  margin-bottom: 4rem;
+}


### PR DESCRIPTION
PR adds details on how to build from source to the installation guide in the docs. This is useful because:

a) the most recent binary release will not run on Ubuntu <23.X - this allows Ubuntu users to build for themselves between now and the next release.
b) some folks want to build from source to develop Fe and this wasn't previously documented on the site.

I also added a tiny piece of CSS that adds a narrow whitespace buffer around code blocks to make code-snippet heavy pages a bit easier to read.


### To-Do
- [x] Clean up commit history
