### PR TITLE
Test assertion string bugfix

### DIFF
--- a/crates/codegen/src/yul/isel/test.rs
+++ b/crates/codegen/src/yul/isel/test.rs
@@ -8,12 +8,12 @@ pub fn lower_test(db: &dyn CodegenDb, test: FunctionId) -> yul::Object {
     let test = db.mir_lowered_func_signature(test);
     context.function_dependency.insert(test);
 
-    let dep_constants = context.resolve_constant_dependency(db);
     let dep_functions: Vec<_> = context
         .resolve_function_dependency(db)
         .into_iter()
         .map(yul::Statement::FunctionDefinition)
         .collect();
+    let dep_constants = context.resolve_constant_dependency(db);
     let dep_contracts = context.resolve_contract_dependency(db);
     let runtime_funcs: Vec<_> = context
         .runtime

--- a/crates/tests/fixtures/files/assert_with_string.fe
+++ b/crates/tests/fixtures/files/assert_with_string.fe
@@ -1,0 +1,4 @@
+#test 
+fn foo() {
+    assert true, "oops"
+}

--- a/newsfragments/926.bugfix.md
+++ b/newsfragments/926.bugfix.md
@@ -1,0 +1,12 @@
+Yul codegen was failing to include string literals used in test assertions. This resulted in a compiler error.
+
+Example:
+
+```
+#test
+fn foo() {
+    assert false, "oops"
+}
+```
+
+The example code above was failing to compile, but now it compiles and executes as expected.


### PR DESCRIPTION
### What was wrong?

Yul codegen was failing to include string literals used in test assertions. This resulted in a compiler error.

Example:

```
#test
fn foo() {
    assert false, "oops"
}
```

### How was it fixed?

I had to reorder some statements dealing with the analyzer context in the Yul test lowering function.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [x] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)
- [x] Clean up commit history
