### PR TITLE
v2 parser: change assignment's lhs to expression

### DIFF
--- a/crates/hir/src/hir_def/stmt.rs
+++ b/crates/hir/src/hir_def/stmt.rs
@@ -10,7 +10,7 @@ pub enum Stmt {
     /// second `Option<TypeId>` is the type annotation, and the third
     /// `Option<ExprId>` is the expression for initialization.
     Let(PatId, Option<TypeId>, Option<ExprId>),
-    /// The `Assign` statement. The first `PatId` is the pattern for binding,
+    /// The `Assign` statement. The first `ExprId` is the destination of the assignment,
     /// and the second `ExprId` is the rhs value of the binding.
     Assign(ExprId, ExprId),
     /// The first `PatId` is the pattern for binding which can be used in the

--- a/crates/hir/src/hir_def/stmt.rs
+++ b/crates/hir/src/hir_def/stmt.rs
@@ -12,7 +12,7 @@ pub enum Stmt {
     Let(PatId, Option<TypeId>, Option<ExprId>),
     /// The `Assign` statement. The first `PatId` is the pattern for binding,
     /// and the second `ExprId` is the rhs value of the binding.
-    Assign(PatId, ExprId),
+    Assign(ExprId, ExprId),
     /// The first `PatId` is the pattern for binding which can be used in the
     /// for-loop body.
     ///

--- a/crates/hir/src/lower/stmt.rs
+++ b/crates/hir/src/lower/stmt.rs
@@ -20,9 +20,9 @@ impl Stmt {
             }
             ast::StmtKind::Assign(assign) => {
                 let lhs = assign
-                    .pat()
-                    .map(|pat| Pat::lower_ast(ctxt, pat))
-                    .unwrap_or_else(|| ctxt.push_missing_pat());
+                    .expr()
+                    .map(|expr| Expr::lower_ast(ctxt, expr))
+                    .unwrap_or_else(|| ctxt.push_missing_expr());
 
                 let rhs = assign
                     .expr()
@@ -88,13 +88,13 @@ fn desugar_aug_assign(
         .map(|ident| PathId::from_ident(ctxt.f_ctxt, ident));
 
     let lhs_origin: AugAssignDesugared = lhs_ident.unwrap().text_range().into();
-    let lhs_pat = if let Some(path) = path {
-        ctxt.push_pat(
-            Pat::Path(Some(path).into()),
+    let lhs_expr = if let Some(path) = path {
+        ctxt.push_expr(
+            Expr::Path(Some(path).into()),
             HirOrigin::desugared(lhs_origin.clone()),
         )
     } else {
-        ctxt.push_missing_pat()
+        ctxt.push_missing_expr()
     };
 
     let binop_lhs = if let Some(path) = path {
@@ -118,7 +118,7 @@ fn desugar_aug_assign(
     );
 
     (
-        Stmt::Assign(lhs_pat, expr),
+        Stmt::Assign(lhs_expr, expr),
         HirOrigin::desugared(AugAssignDesugared::stmt(ast)),
     )
 }

--- a/crates/hir/src/visitor.rs
+++ b/crates/hir/src/visitor.rs
@@ -859,9 +859,9 @@ where
             }
         }
 
-        Stmt::Assign(pat_id, expr_id) => {
-            visit_node_in_body!(visitor, ctxt, pat_id, pat);
-            visit_node_in_body!(visitor, ctxt, expr_id, expr);
+        Stmt::Assign(left_expr_id, right_expr_id) => {
+            visit_node_in_body!(visitor, ctxt, left_expr_id, expr);
+            visit_node_in_body!(visitor, ctxt, right_expr_id, expr);
         }
 
         Stmt::For(pat_id, cond_id, for_body_id) => {

--- a/crates/parser2/src/ast/stmt.rs
+++ b/crates/parser2/src/ast/stmt.rs
@@ -63,12 +63,7 @@ ast_node! {
     SK::AssignStmt,
 }
 impl AssignStmt {
-    /// Returns the pattern of the lhs of the assignment.
-    pub fn pat(&self) -> Option<super::Pat> {
-        support::child(self.syntax())
-    }
-
-    /// Returns the expression of the rhs of the assignment.
+    /// Returns the expression of the lhs and rhs of the assignment.
     pub fn expr(&self) -> Option<super::Expr> {
         support::child(self.syntax())
     }
@@ -202,7 +197,7 @@ pub enum StmtKind {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ast::{PatKind, TypeKind},
+        ast::{ExprKind, PatKind, TypeKind},
         lexer::Lexer,
         parser::Parser,
     };
@@ -248,8 +243,8 @@ mod tests {
     fn assign() {
         let assign_stmt: AssignStmt = parse_stmt(r#"Foo{x, y} = foo"#);
         assert!(matches!(
-            assign_stmt.pat().unwrap().kind(),
-            PatKind::Record(_)
+            assign_stmt.expr().unwrap().kind(),
+            ExprKind::RecordInit(_)
         ));
         assert!(assign_stmt.expr().is_some());
     }

--- a/crates/parser2/src/parser/stmt.rs
+++ b/crates/parser2/src/parser/stmt.rs
@@ -156,7 +156,7 @@ impl super::Parse for AssignStmtScope {
     fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) {
         parser.set_newline_as_trivia(false);
 
-        parser.with_recovery_tokens(parse_pat, &[SyntaxKind::Eq]);
+        parser.with_recovery_tokens(parse_expr, &[SyntaxKind::Eq]);
         if !parser.bump_if(SyntaxKind::Eq) {
             parser.error_and_recover("expected `=`", None);
             return;

--- a/crates/parser2/test_files/syntax_node/stmts/assign.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/assign.snap
@@ -5,7 +5,7 @@ input_file: crates/parser2/test_files/syntax_node/stmts/assign.fe
 ---
 Root@0..21
   AssignStmt@0..5
-    PathPat@0..1
+    PathExpr@0..1
       Path@0..1
         PathSegment@0..1
           Ident@0..1 "x"
@@ -17,24 +17,18 @@ Root@0..21
         Int@4..5 "1"
   Newline@5..6 "\n"
   AssignStmt@6..21
-    RecordPat@6..15
+    RecordInitExpr@6..15
       Path@6..9
         PathSegment@6..9
           Ident@6..9 "Foo"
-      RecordPatFieldList@9..15
+      RecordFieldList@9..15
         LBrace@9..10 "{"
-        RecordPatField@10..11
-          PathPat@10..11
-            Path@10..11
-              PathSegment@10..11
-                Ident@10..11 "x"
+        RecordField@10..11
+          Ident@10..11 "x"
         Comma@11..12 ","
         WhiteSpace@12..13 " "
-        RecordPatField@13..14
-          PathPat@13..14
-            Path@13..14
-              PathSegment@13..14
-                Ident@13..14 "y"
+        RecordField@13..14
+          Ident@13..14 "y"
         RBrace@14..15 "}"
     WhiteSpace@15..16 " "
     Eq@16..17 "="

--- a/crates/parser2/test_files/syntax_node/stmts/for.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/for.snap
@@ -24,7 +24,7 @@ Root@0..96
       Newline@14..15 "\n"
       WhiteSpace@15..19 "    "
       AssignStmt@19..32
-        PathPat@19..22
+        PathExpr@19..22
           Path@19..22
             PathSegment@19..22
               Ident@19..22 "sum"
@@ -88,7 +88,7 @@ Root@0..96
       Newline@72..73 "\n"
       WhiteSpace@73..77 "    "
       AssignStmt@77..94
-        PathPat@77..80
+        PathExpr@77..80
           Path@77..80
             PathSegment@77..80
               Ident@77..80 "sum"

--- a/crates/parser2/test_files/syntax_node/stmts/while.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/while.snap
@@ -24,7 +24,7 @@ Root@0..46
       Newline@14..15 "\n"
       WhiteSpace@15..19 "    "
       AssignStmt@19..30
-        PathPat@19..22
+        PathExpr@19..22
           Path@19..22
             PathSegment@19..22
               Ident@19..22 "sum"
@@ -44,7 +44,7 @@ Root@0..46
       Newline@30..31 "\n"
       WhiteSpace@31..35 "    "
       AssignStmt@35..44
-        PathPat@35..36
+        PathExpr@35..36
           Path@35..36
             PathSegment@35..36
               Ident@35..36 "i"


### PR DESCRIPTION
### What was wrong?
The new parser (v2 branch) wrongly supposes the assignment destination is a pattern, but it should be an expression.


### How was it fixed?
Parse lhs in assignment statements as an expression.

### To-Do
- Write tests for PR
