### PR TITLE
Fix Discord Links in contributing.md and index.md

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -45,7 +45,7 @@ To report an issue, please use the [Github issue board](https://github.com/ether
 - any error messages or relevant logs
 - the specific source code where the issue originates
 
-The appropriate place for technical discussions about the language itself is the Fe [Discord](https://discord.gg/yCT6NYBb).
+The appropriate place for technical discussions about the language itself is the Fe [Discord](https://discord.gg/ywpkAXFjZH).
 
 ### Rasing Pull Requests
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,4 +59,4 @@ The details of the EVM can also cause the higher level languages to be less intu
 
 You can read much more information about Fe in these docs. If you want to get building, you can begin with our [Quickstart guide](quickstart/index.md).
 
-You can also get involved in the Fe community by contributing code or documentation to the project Github or joining the conversation on [Discord](https://discord.gg/yCT6NYBb). Learn more on our [Contributing](contributing.md) page.
+You can also get involved in the Fe community by contributing code or documentation to the project Github or joining the conversation on [Discord](https://discord.gg/ywpkAXFjZH). Learn more on our [Contributing](contributing.md) page.


### PR DESCRIPTION
### What was wrong?

Broken Discord links, same issue with https://github.com/ethereum/fe/pull/849 but on different pages.

### How was it fixed?
Old: https://discord.com/invite/yCT6NYBb

New: https://discord.com/invite/ywpkAXFjZH

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
