### PR TITLE
Include runtime_bytecode in artifacts

### DIFF
--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -341,6 +341,7 @@ pub fn deploy_contract(
         fixture,
         test_files::fixture(fixture),
         true,
+        false,
         true,
     ) {
         Ok(module) => module,
@@ -376,7 +377,7 @@ pub fn deploy_contract_from_ingot(
     let files = test_files::fixture_dir_files("ingots");
     let build_files = BuildFiles::load_static(files, path).expect("failed to load build files");
     let mut db = driver::Db::default();
-    let compiled_module = match driver::compile_ingot(&mut db, &build_files, true, true) {
+    let compiled_module = match driver::compile_ingot(&mut db, &build_files, true, false, true) {
         Ok(module) => module,
         Err(error) => {
             fe_common::diagnostics::print_diagnostics(&db, &error.0);
@@ -587,12 +588,18 @@ pub fn compile_solidity_contract(
 #[allow(dead_code)]
 pub fn load_contract(address: H160, fixture: &str, contract_name: &str) -> ContractHarness {
     let mut db = driver::Db::default();
-    let compiled_module =
-        driver::compile_single_file(&mut db, fixture, test_files::fixture(fixture), true, true)
-            .unwrap_or_else(|err| {
-                print_diagnostics(&db, &err.0);
-                panic!("failed to compile fixture: {fixture}");
-            });
+    let compiled_module = driver::compile_single_file(
+        &mut db,
+        fixture,
+        test_files::fixture(fixture),
+        true,
+        false,
+        true,
+    )
+    .unwrap_or_else(|err| {
+        print_diagnostics(&db, &err.0);
+        panic!("failed to compile fixture: {fixture}");
+    });
     let compiled_contract = compiled_module
         .contracts
         .get(contract_name)
@@ -712,9 +719,9 @@ impl ExecutionOutput {
 #[cfg(feature = "solc-backend")]
 fn execute_runtime_functions(executor: &mut Executor, runtime: &Runtime) -> (ExitReason, Vec<u8>) {
     let yul_code = runtime.to_yul().to_string().replace('"', "\\\"");
-    let bytecode = fe_yulc::compile_single_contract("Contract", &yul_code, false)
+    let contract_bytecode = fe_yulc::compile_single_contract("Contract", &yul_code, false, false)
         .expect("failed to compile Yul");
-    let bytecode = hex::decode(bytecode).expect("failed to decode bytecode");
+    let bytecode = hex::decode(contract_bytecode.bytecode).expect("failed to decode bytecode");
 
     if let evm::Capture::Exit((reason, _, output)) = executor.create(
         address(DEFAULT_CALLER),

--- a/crates/tests-legacy/src/crashes.rs
+++ b/crates/tests-legacy/src/crashes.rs
@@ -8,7 +8,7 @@ macro_rules! test_file {
             let mut db = fe_driver::Db::default();
             let path = concat!("crashes/", stringify!($name), ".fe");
             let src = test_files::fixture(path);
-            fe_driver::compile_single_file(&mut db, path, src, true, true).ok();
+            fe_driver::compile_single_file(&mut db, path, src, true, false, true).ok();
         }
     };
 }

--- a/newsfragments/947.feature.md
+++ b/newsfragments/947.feature.md
@@ -1,0 +1,16 @@
+Give option to produce runtime bytecode as compilation artifact
+
+Previously, the compiler could only produce the bytecode that is used
+for the deployment of the contract. Now it can also produce the runtime
+bytecode which is the bytecode that is saved to storage.
+
+Being able to obtain the runtime bytecode is useful for contract
+verification.
+
+To obtain the runtime bytecode use the `runtime-bytecode` option
+of the `--emit` flag (multiple options allowed).
+
+Example Output:
+
+- mycontract.bin (bytecode for deployment)
+- mycontract.runtime.bin (runtime bytecode)


### PR DESCRIPTION
### What was wrong?

Currently, the compiler would only outputs the bytecode that is used for contract deployment but not the runtime bytecode that is later saved to storage and can be read out from the blockchain.

Being able to obtain the runtime bytecode is useful for contract verification.

### How was it fixed?

Basically just expose the `deployedBytecode` that `solc` already gives us.
Note:

- I named the file `mycontract.runtime.bin` because I find the term *runtime bytecode* less ambigious than *deployed bytecode*
- Producing runtime bytecode is another variant of the `--emit` options. Note that the default did **NOT** change from `abi, bytecode` because there are certain contracts where we currently can not produce runtime bytecode for. These seem to be contracts that use `create`/`create2` in `__init__`.
- Related to the former point, getting the runtime bytecode is on demand e.g. `--emit abi,bytecode,runtime-bytecode` 