### PR TITLE
Correct install instructions for compiling from source

### DIFF
--- a/docs/src/user-guide/installation.md
+++ b/docs/src/user-guide/installation.md
@@ -64,10 +64,16 @@ sudo apt-get update &&\
  apt-get install cmake
 ```
 
+Navigate to the folder containing the Fe source code.
+
+```sh
+cd fe
+```
+
 Now, use Rust to build the Fe binary. To run Fe, you need to build using `solc-backend`.
 
 ```sh
-cargo build --feature solc-backend
+cargo build -r --feature solc-backend
 ```
 
 You will now find your Fe binary in `/target/release`. Check the build with:


### PR DESCRIPTION
### What was wrong?
Currently a debug build is produced and the following command attempts to run a release version of the code that has never been built.

### How was it fixed?
Adds the `-r` flag to the cargo build command to ensure the following step that checks for a successful build runs correctly.

Also adds instructions to change directories into the Fe repository directory before attempting to build (following current instructions step-by-step would lead to failures).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history