### PR TITLE
Supply Content-Type header to JSON-RPC call

### DIFF
--- a/crates/fe/src/task/verify.rs
+++ b/crates/fe/src/task/verify.rs
@@ -70,6 +70,7 @@ fn request_bytecode(rpc_url: &str, contract_address: &str) -> Result<String, Str
     let client = reqwest::blocking::Client::new();
     let res = client
         .post(rpc_url)
+        .header("Content-Type", "application/json")
         .body(format!(
             "{{
             \"jsonrpc\": \"2.0\",

--- a/newsfragments/951.bugfix.md
+++ b/newsfragments/951.bugfix.md
@@ -1,0 +1,5 @@
+Fixed issue with `verify` not working with certain JSON-RPC providers.
+
+Previously, the `verify` command would not work if a JSON-RPC provider
+expected the request to be made with a `Content-Type` header. Now, the
+`Content-Type` header is set as `application/json`.


### PR DESCRIPTION
### What was wrong?

Some JSON-RPC APIs are picky about the `Content-Type` header for requests. We should provide it. See #951 

### How was it fixed?

Provided
