### PR TITLE
Fix rpc-url in Quickstart::Deploy your contract

### DIFF
--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -117,7 +117,7 @@ Since reading the messages doesn't change any state within the blockchain, you d
 To do that run:
 
 ```sh
-$ cast call --rpc-url https://rpc.sepolia.org <contract-address> "get_msg(address)" <your-account-address-that-signed-the-guestbook>
+$ cast call --rpc-url http://localhost:8545 <contract-address> "get_msg(address)" <your-account-address-that-signed-the-guestbook>
 ```
 
 Notice that the command doesn't need to provide a private key simply because we are not sending an actual transaction.


### PR DESCRIPTION
In the example where the contract is deployed on the anvil the sepolia rpc-url is used. Corrected to anvil rpc-url.