### PR TITLE
Typo: Fix rpc arg in deploy_contract tutorial script

### DIFF
--- a/docs/src/quickstart/deploy_contract.md
+++ b/docs/src/quickstart/deploy_contract.md
@@ -137,7 +137,7 @@ cast to_ascii "0x000000000000000000000000000000000000000000000000000000000000002
 or simply pipe the output of the `cast call` to `to_ascii` to do the query and conversion in a single command:
 
 ```sh
-cast call --rpc-url https://rpc.sepolia.org <contract-address> "get_msg(address)" <your-account-address-that-signed-the-guestbook> | cast --to-ascii
+cast call --rpc-url http://localhost:8545 <contract-address> "get_msg(address)" <your-account-address-that-signed-the-guestbook> | cast --to-ascii
 ```
 
 Either way, the response will be the message you passed to the `sign(string)` function.


### PR DESCRIPTION
### What was wrong?



### How was it fixed?
Corrected from --rpc-url https://rpc.sepolia.org to --rpc-url http://localhost:8545 for local node example

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
