### PR TITLE
Default to project root if no input path specified

### DIFF
--- a/crates/fe/src/task/build.rs
+++ b/crates/fe/src/task/build.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use clap::{ArgEnum, Args};
 use fe_common::diagnostics::print_diagnostics;
 use fe_common::files::SourceFileId;
-use fe_common::utils::files::{BuildFiles, ProjectMode};
+use fe_common::utils::files::{get_project_root, BuildFiles, ProjectMode};
 use fe_driver::CompiledModule;
 
 const DEFAULT_OUTPUT_DIR_NAME: &str = "output";
@@ -24,6 +24,7 @@ enum Emit {
 #[derive(Args)]
 #[clap(about = "Build the current project")]
 pub struct BuildArgs {
+    #[clap(default_value_t = get_project_root().unwrap_or(".".to_string()))]
     input_path: String,
     #[clap(short, long, default_value = DEFAULT_OUTPUT_DIR_NAME)]
     output_dir: String,

--- a/crates/fe/src/task/check.rs
+++ b/crates/fe/src/task/check.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use clap::Args;
 use fe_common::{
     diagnostics::{print_diagnostics, Diagnostic},
+    utils::files::get_project_root,
     utils::files::BuildFiles,
 };
 use fe_driver::Db;
@@ -10,6 +11,7 @@ use fe_driver::Db;
 #[derive(Args)]
 #[clap(about = "Analyze the current project and report errors, but don't build artifacts")]
 pub struct CheckArgs {
+    #[clap(default_value_t = get_project_root().unwrap_or(".".to_string()))]
     input_path: String,
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -563,12 +563,12 @@ pub fn compile_solidity_contract(
     let abi = if let serde_json::Value::Array(data) = &output["contracts"]["input.sol"][name]["abi"]
     {
         data.iter()
-            .cloned()
             .filter(|val| {
                 // ethabi doesn't yet support error types so we just filter them out for now
                 // https://github.com/rust-ethereum/ethabi/issues/225
                 val["type"] != "error"
             })
+            .cloned()
             .collect::<Vec<_>>()
     } else {
         vec![]

--- a/newsfragments/962.feature.md
+++ b/newsfragments/962.feature.md
@@ -1,0 +1,3 @@
+`fe build` and `fe check` now default to the project's root directory if no path is specified.
+
+


### PR DESCRIPTION
### What was wrong?

Currently `fe build` always needs to be supplied with an `<input-path>` which can be annoying when jumping between directories.

The `fe build` command should instead try to figure out the `<input-path>` itself if no input path is given. This is already the behavior of the `fe test` command.

The same is true for `fe check`.

### How was it fixed?

When `fe build` is given no `<input-path>`, it now defaults to the project's root directory (based on where a `fe.toml` is found) or falls back to the current directory if no `fe.toml` is found. 

The same is true for `fe check`
