### PR TITLE
Add new section for external links

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
     * [Open auction](user-guide/tutorials/auction.md)
   * [Example Contracts](user-guide/example_contracts/index.md)
     * [Open auction](user-guide/example_contracts/auction_contract.md)
+    * [Useful external links](user-guide/external_links.md)
 * [Development](development/index.md)
     * [Build & Test](development/build.md)
     * [Release](development/release.md)

--- a/docs/src/user-guide/external_links.md
+++ b/docs/src/user-guide/external_links.md
@@ -1,0 +1,51 @@
+# Useful external links
+
+There are not many resources for Fe outside of the official documentation at this time. This section lists useful links to external resources.
+
+
+## Tools
+
+- [VS Code extension](https://marketplace.visualstudio.com/items?itemName=fe-lang.code-ve)
+- [Foundry Fe Support](https://github.com/fe-lang/Foundry-Fe)
+
+## Projects
+
+- [Bountiful](https://github.com/fe-lang/bountiful/tree/master) - Bug bounty platform written in Fe, live on Mainnet
+- [Simple DAO](https://github.com/cburgdorf/simple_dao) - A Simple DAO written in Fe - live on Mainnet and Optimism
+
+
+### Hackathon projects
+
+These are community projects written in Fe at various hackathons.
+
+- [Fixed-Point Numerical Library](https://github.com/bilgin-kocak/felang-fixedpoint) - A fixed-point number representation and mathematical operations tailored for Fe. It can be used in financial computations, scientific simulations, and data analysis.
+
+- [p256verifier](https://github.com/0xnonso/p256-verifier-fe) - Secp256r1 (a.k.a p256) curve signature verifier which allows for verification of a P256 signature in fe.
+
+- [Account Storage with Efficient Sparse Merkle Trees](https://github.com/kevincharm/account_kv_storage_fe) - Efficient Sparse Merkle Trees in Fe! SMTs enable inclusion and exclusion proofs for the entire set of Ethereum addresses.
+
+- [Tic Tac Toe](https://github.com/grey220022/Fehackathon) - An implementation of the classic tic tac toe game in Fe with a Python frontend.
+
+- [Fecret Santa](https://github.com/clemlak/fe-hackathon) - Fecret Santa is an onchain Secret Santa event based on a "chain": gift a collectible (ERC721 or ERC1155) to the last Santa and you'll be the next to receive a gift!
+
+- [Go do it](https://github.com/gin/go-do-it) - A commitment device to help you achieve your goals.
+
+- [Powerbald](https://github.com/kevincharm/powerbald-fe) - On chain lottery written in Fe
+
+- [sspc-flutter-fe](https://github.com/dknopik/sspc-flutter-fe) - Stupid Simple Payment Channel written in Fe
+
+### Others
+
+- [Fe standard library](https://github.com/ethereum/fe/tree/master/crates/library/std/src) - The Fe standard library comes bundled with the compiler but it is also a useful example for real world Fe code.
+
+- [Implementing an UniswapV3 trade in Fe](https://github.com/cburgdorf/fe-real-world-examples/blob/master/fe_contracts/defi/src/main.fe)
+
+## Blog posts
+
+- [Fe or Solidity, which is better?](https://dev.to/filosofiacodigoen/fe-or-solidity-which-is-better-1fdj) by Ahmed Castro
+
+## Videos
+
+- [Fe or Solidity, which is better?](https://www.youtube.com/watch?v=zKxmtbVNscg) by Ahmed Castro
+
+- [Fe o Solidity, ¿cuál es es mejor?](https://www.youtube.com/watch?v=_ODiAW8mq3o) by Ahmed Castro

--- a/newsfragments/971.doc.md
+++ b/newsfragments/971.doc.md
@@ -1,0 +1,3 @@
+A new doc section lists useful external links
+
+This section features links to tools, projects, blog posts, videos and more.


### PR DESCRIPTION
### What was wrong?

There are some useful Fe examples (or even tooling) that are currently hard to find. We should have a place in our docs that just acts as a link reference to external sites. We have a good collection of links here that I want to compile for this: https://notes.ethereum.org/rNqHGm1zRk671RO_ijDDmg

### How was it fixed?

Added a new Section "Useful external links" that is now home for links to projects, blog posts, videos etc.
