### PR TITLE
Dummy file path conversions to fix CI + WASM build

### DIFF
--- a/crates/language-server/src/handlers/notifications.rs
+++ b/crates/language-server/src/handlers/notifications.rs
@@ -9,6 +9,9 @@ use crate::{
     workspace::{IngotFileContext, SyncableIngotFileContext, SyncableInputFile},
 };
 
+#[cfg(target_arch = "wasm32")]
+use crate::util::DummyFilePathConversion;
+
 fn run_diagnostics(
     state: &mut ServerState,
     path: &str,

--- a/crates/language-server/src/server.rs
+++ b/crates/language-server/src/server.rs
@@ -3,6 +3,9 @@ use anyhow::Result;
 use lsp_server::{Connection, Notification};
 use lsp_types::{HoverProviderCapability, InitializeParams, ServerCapabilities};
 
+#[cfg(target_arch = "wasm32")]
+use crate::util::DummyFilePathConversion;
+
 fn server_capabilities() -> ServerCapabilities {
     ServerCapabilities {
         hover_provider: Some(HoverProviderCapability::Simple(true)),

--- a/crates/language-server/src/util.rs
+++ b/crates/language-server/src/util.rs
@@ -110,3 +110,24 @@ pub fn diag_to_lsp(
     });
     result
 }
+
+#[cfg(target_arch = "wasm32")]
+use std::path::Path;
+
+#[cfg(target_arch = "wasm32")]
+pub trait DummyFilePathConversion {
+    fn to_file_path(&self) -> Result<std::path::PathBuf, ()>;
+    fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()>;
+}
+
+#[cfg(target_arch = "wasm32")]
+impl DummyFilePathConversion for lsp_types::Url {
+    fn to_file_path(&self) -> Result<std::path::PathBuf, ()> {
+        // for now we don't support file paths on wasm
+        Err(())
+    }
+    fn from_file_path<P: AsRef<Path>>(_path: P) -> Result<Url, ()> {
+        // for now we don't support file paths on wasm
+        Err(())
+    }
+}


### PR DESCRIPTION
### What was wrong?
The WASM build was failing due to `Uri::to_file_path` and `Uri::from_file_path` not being implemented for WASM targets.


### How was it fixed?
I made a trait defined only for WASM targets which implements dummy functions