### PR TITLE
 v2 parser: change assignment's lhs to expression

### DIFF
--- a/crates/analyzer/tests/errors.rs
+++ b/crates/analyzer/tests/errors.rs
@@ -104,7 +104,6 @@ test_stmt! { assert_reason_not_string, "assert true, 1" }
 test_stmt! { assign_int, "5 = 6" }
 test_stmt! { assign_call, "self.f() = 10" }
 test_stmt! { assign_type_mismatch, "let mut x: u256 = 10\nx = address(0)" }
-test_stmt! { aug_assign_non_numeric, "let mut a: u256 = 1\nlet b: bool = true\na += b" }
 test_stmt! { binary_op_add_sign_mismatch, "let a: u256 = 1\nlet b: i256 = 2\na + b" }
 test_stmt! { binary_op_lshift_bool, "let a: bool = true\nlet b: i256\na << b" }
 test_stmt! { binary_op_lshift_with_int, "let a: u256 = 1\nlet b: i256 = 2\na << b" }

--- a/crates/hir/src/hir_def/expr.rs
+++ b/crates/hir/src/hir_def/expr.rs
@@ -10,7 +10,6 @@ pub enum Expr {
     Block(Vec<StmtId>),
     /// The first `ExprId` is the lhs, the second is the rhs.
     ///
-    /// **NOTE:** The `AugAssign` statement is desugared to a `Assign` statement
     /// and a `BinOp`.
     Bin(ExprId, ExprId, Partial<BinOp>),
     Un(ExprId, Partial<UnOp>),
@@ -37,9 +36,16 @@ pub enum Expr {
     /// third is the else branch.
     /// In case `else if`, the third is the lowered into `If` expression.
     If(ExprId, ExprId, Option<ExprId>),
+    
 
     /// The first `ExprId` is the scrutinee, the second is the arms.
     Match(ExprId, Partial<Vec<MatchArm>>),
+
+    /// The `Assign` Expression. The first `ExprId` is the destination of the assignment,
+    /// and the second `ExprId` is the rhs value of the binding.
+    Assign(ExprId, ExprId),
+
+    AugAssign(ExprId, ExprId, ArithBinOp),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/hir/src/hir_def/expr.rs
+++ b/crates/hir/src/hir_def/expr.rs
@@ -36,7 +36,6 @@ pub enum Expr {
     /// third is the else branch.
     /// In case `else if`, the third is the lowered into `If` expression.
     If(ExprId, ExprId, Option<ExprId>),
-    
 
     /// The first `ExprId` is the scrutinee, the second is the arms.
     Match(ExprId, Partial<Vec<MatchArm>>),

--- a/crates/hir/src/hir_def/stmt.rs
+++ b/crates/hir/src/hir_def/stmt.rs
@@ -10,9 +10,6 @@ pub enum Stmt {
     /// second `Option<TypeId>` is the type annotation, and the third
     /// `Option<ExprId>` is the expression for initialization.
     Let(PatId, Option<TypeId>, Option<ExprId>),
-    /// The `Assign` statement. The first `PatId` is the pattern for binding,
-    /// and the second `ExprId` is the rhs value of the binding.
-    Assign(PatId, ExprId),
     /// The first `PatId` is the pattern for binding which can be used in the
     /// for-loop body.
     ///

--- a/crates/hir/src/lower/expr.rs
+++ b/crates/hir/src/lower/expr.rs
@@ -2,7 +2,7 @@ use parser::ast::{self, prelude::*};
 
 use crate::{
     hir_def::{
-        expr::*, Body, GenericArgListId, IdentId, IntegerId, ItemKind, LitKind, Pat, PathId, Stmt,
+        expr::*, kw::SELF, Body, GenericArgListId, IdentId, IntegerId, ItemKind, LitKind, Pat, PathId, Stmt
     },
     span::HirOrigin,
 };
@@ -174,6 +174,19 @@ impl Expr {
 
             ast::ExprKind::Paren(paren) => {
                 return Self::push_to_body_opt(ctxt, paren.expr());
+            }
+            ast::ExprKind::Assign(assign) => {
+                let lhs = Self::push_to_body_opt(ctxt, assign.lhs_expr());
+                let rhs = Self::push_to_body_opt(ctxt, assign.rhs_expr());
+                Self::Assign(lhs, rhs)
+            }
+
+            ast::ExprKind::AugAssign(aug_assign) => {
+                let lhs = Self::push_to_body_opt(ctxt, aug_assign.lhs_expr());
+                let rhs = Self::push_to_body_opt(ctxt, aug_assign.rhs_expr());
+                let binop = aug_assign.op().map(ArithBinOp::lower_ast).unwrap();
+
+                Self::AugAssign(lhs, rhs, binop)
             }
         };
 

--- a/crates/hir/src/lower/expr.rs
+++ b/crates/hir/src/lower/expr.rs
@@ -175,6 +175,7 @@ impl Expr {
             ast::ExprKind::Paren(paren) => {
                 return Self::push_to_body_opt(ctxt, paren.expr());
             }
+
             ast::ExprKind::Assign(assign) => {
                 let lhs = Self::push_to_body_opt(ctxt, assign.lhs_expr());
                 let rhs = Self::push_to_body_opt(ctxt, assign.rhs_expr());

--- a/crates/hir/src/lower/expr.rs
+++ b/crates/hir/src/lower/expr.rs
@@ -2,7 +2,7 @@ use parser::ast::{self, prelude::*};
 
 use crate::{
     hir_def::{
-        expr::*, kw::SELF, Body, GenericArgListId, IdentId, IntegerId, ItemKind, LitKind, Pat, PathId, Stmt
+        expr::*, Body, GenericArgListId, IdentId, IntegerId, ItemKind, LitKind, Pat, PathId, Stmt,
     },
     span::HirOrigin,
 };

--- a/crates/hir/src/lower/path.rs
+++ b/crates/hir/src/lower/path.rs
@@ -30,9 +30,5 @@ impl PathId {
         ast.map(|ast| Self::lower_ast(ctxt, ast)).into()
     }
 
-    pub(super) fn from_token(ctxt: &mut FileLowerCtxt<'_>, ast: SyntaxToken) -> Self {
-        let ident_id = IdentId::new(ctxt.db(), ast.text().to_string());
-        let seg = vec![Partial::Present(ident_id)];
-        Self::new(ctxt.db(), seg)
-    }
+   
 }

--- a/crates/hir/src/lower/path.rs
+++ b/crates/hir/src/lower/path.rs
@@ -1,4 +1,4 @@
-use parser::{ast, SyntaxToken};
+use parser::ast;
 
 use crate::hir_def::{kw, IdentId, Partial, PathId};
 
@@ -29,6 +29,4 @@ impl PathId {
     ) -> Partial<Self> {
         ast.map(|ast| Self::lower_ast(ctxt, ast)).into()
     }
-
-   
 }

--- a/crates/hir/src/lower/stmt.rs
+++ b/crates/hir/src/lower/stmt.rs
@@ -1,8 +1,8 @@
 use parser::ast::{self, prelude::*};
 
 use crate::{
-    hir_def::{stmt::*, ArithBinOp, Expr, Pat, PathId, TypeId},
-    span::{AugAssignDesugared, HirOrigin},
+    hir_def::{stmt::*, Expr, Pat, TypeId},
+    span::HirOrigin,
 };
 
 use super::body::BodyCtxt;
@@ -18,21 +18,6 @@ impl Stmt {
                 let init = let_.initializer().map(|init| Expr::lower_ast(ctxt, init));
                 (Stmt::Let(pat, ty, init), HirOrigin::raw(&ast))
             }
-            ast::StmtKind::Assign(assign) => {
-                let lhs = assign
-                    .pat()
-                    .map(|pat| Pat::lower_ast(ctxt, pat))
-                    .unwrap_or_else(|| ctxt.push_missing_pat());
-
-                let rhs = assign
-                    .expr()
-                    .map(|expr| Expr::lower_ast(ctxt, expr))
-                    .unwrap_or_else(|| ctxt.push_missing_expr());
-                (Stmt::Assign(lhs, rhs), HirOrigin::raw(&ast))
-            }
-
-            ast::StmtKind::AugAssign(aug_assign) => desugar_aug_assign(ctxt, &aug_assign),
-
             ast::StmtKind::For(for_) => {
                 let bind = Pat::lower_ast_opt(ctxt, for_.pat());
                 let iter = Expr::push_to_body_opt(ctxt, for_.iterable());
@@ -76,49 +61,4 @@ impl Stmt {
 
         ctxt.push_stmt(stmt, origin_kind)
     }
-}
-
-fn desugar_aug_assign(
-    ctxt: &mut BodyCtxt<'_, '_>,
-    ast: &ast::AugAssignStmt,
-) -> (Stmt, HirOrigin<ast::Stmt>) {
-    let lhs_ident = ast.ident();
-    let path = lhs_ident
-        .clone()
-        .map(|ident| PathId::from_token(ctxt.f_ctxt, ident));
-
-    let lhs_origin: AugAssignDesugared = lhs_ident.unwrap().text_range().into();
-    let lhs_pat = if let Some(path) = path {
-        ctxt.push_pat(
-            Pat::Path(Some(path).into()),
-            HirOrigin::desugared(lhs_origin.clone()),
-        )
-    } else {
-        ctxt.push_missing_pat()
-    };
-
-    let binop_lhs = if let Some(path) = path {
-        ctxt.push_expr(
-            Expr::Path(Some(path).into()),
-            HirOrigin::desugared(lhs_origin),
-        )
-    } else {
-        ctxt.push_missing_expr()
-    };
-
-    let binop_rhs = ast
-        .expr()
-        .map(|expr| Expr::lower_ast(ctxt, expr))
-        .unwrap_or_else(|| ctxt.push_missing_expr());
-
-    let binop = ast.op().map(|op| ArithBinOp::lower_ast(op).into()).into();
-    let expr = ctxt.push_expr(
-        Expr::Bin(binop_lhs, binop_rhs, binop),
-        HirOrigin::desugared(AugAssignDesugared::stmt(ast)),
-    );
-
-    (
-        Stmt::Assign(lhs_pat, expr),
-        HirOrigin::desugared(AugAssignDesugared::stmt(ast)),
-    )
 }

--- a/crates/hir/src/span/expr.rs
+++ b/crates/hir/src/span/expr.rs
@@ -53,9 +53,11 @@ impl LazyExprSpan {
     pub fn into_match_expr(self) -> LazyMatchExprSpan {
         LazyMatchExprSpan(self.0)
     }
+
     pub fn into_aug_assign_expr(self) -> LazyAugAssignExprSpan {
         LazyAugAssignExprSpan(self.0)
     }
+
     pub fn into_assign_expr(self) -> LazyAssignExprSpan {
         LazyAssignExprSpan(self.0)
     }
@@ -80,8 +82,8 @@ define_lazy_span_node!(
 define_lazy_span_node!(
     LazyAssignExprSpan,
     ast::AssignExpr,
-    @node {
-        (lhs_expr, lhs_expr, LazySpanAtom), //no eq function
+    @token {
+        (eq, eq),
     }
 );
 

--- a/crates/hir/src/span/expr.rs
+++ b/crates/hir/src/span/expr.rs
@@ -232,9 +232,9 @@ mod tests {
 
         let body: Body = db.expect_item::<Body>(text);
         let bin_expr = match body.exprs(db.as_hir_db()).values().nth(2).unwrap().unwrap() {
-              Expr::AugAssign(lhs, rhs, bin_op) => (*lhs, *rhs, *bin_op),
-              _ => unreachable!(),
-        };       
+            Expr::AugAssign(lhs, rhs, bin_op) => (*lhs, *rhs, *bin_op),
+            _ => unreachable!(),
+        };
         let top_mod = body.top_mod(db.as_hir_db());
         assert_eq!("x", db.text_at(top_mod, &bin_expr.0.lazy_span(body)));
         assert_eq!("1", db.text_at(top_mod, &bin_expr.1.lazy_span(body)));

--- a/crates/hir/src/span/expr.rs
+++ b/crates/hir/src/span/expr.rs
@@ -53,6 +53,12 @@ impl LazyExprSpan {
     pub fn into_match_expr(self) -> LazyMatchExprSpan {
         LazyMatchExprSpan(self.0)
     }
+    pub fn into_aug_assign_expr(self) -> LazyAugAssignExprSpan {
+        LazyAugAssignExprSpan(self.0)
+    }
+    pub fn into_assign_expr(self) -> LazyAssignExprSpan {
+        LazyAssignExprSpan(self.0)
+    }
 }
 
 define_lazy_span_node! {
@@ -66,6 +72,22 @@ define_lazy_span_node! {
 define_lazy_span_node!(
     LazyBinExprSpan,
     ast::BinExpr,
+    @node {
+        (op, op, LazySpanAtom),
+    }
+);
+
+define_lazy_span_node!(
+    LazyAssignExprSpan,
+    ast::AssignExpr,
+    @node {
+        (lhs_expr, lhs_expr, LazySpanAtom), //no eq function
+    }
+);
+
+define_lazy_span_node!(
+    LazyAugAssignExprSpan,
+    ast::AugAssignExpr,
     @node {
         (op, op, LazySpanAtom),
     }
@@ -193,7 +215,7 @@ impl ChainInitiator for ExprRoot {
 #[cfg(test)]
 mod tests {
     use crate::{
-        hir_def::{Body, Expr, Stmt},
+        hir_def::{ArithBinOp, Body, Expr},
         test_db::TestDb,
         HirDb,
     };
@@ -209,18 +231,13 @@ mod tests {
         }"#;
 
         let body: Body = db.expect_item::<Body>(text);
-        let bin_expr = match body.stmts(db.as_hir_db()).values().next().unwrap().unwrap() {
-            Stmt::Assign(_, rhs) => *rhs,
-            _ => unreachable!(),
-        };
-        let (lhs, rhs) = match body.exprs(db.as_hir_db())[bin_expr].unwrap() {
-            Expr::Bin(lhs, rhs, _) => (lhs, rhs),
-            _ => unreachable!(),
-        };
-
+        let bin_expr = match body.exprs(db.as_hir_db()).values().nth(2).unwrap().unwrap() {
+              Expr::AugAssign(lhs, rhs, bin_op) => (*lhs, *rhs, *bin_op),
+              _ => unreachable!(),
+        };       
         let top_mod = body.top_mod(db.as_hir_db());
-        assert_eq!("x += 1", db.text_at(top_mod, &bin_expr.lazy_span(body)));
-        assert_eq!("x", db.text_at(top_mod, &lhs.lazy_span(body)));
-        assert_eq!("1", db.text_at(top_mod, &rhs.lazy_span(body)));
+        assert_eq!("x", db.text_at(top_mod, &bin_expr.0.lazy_span(body)));
+        assert_eq!("1", db.text_at(top_mod, &bin_expr.1.lazy_span(body)));
+        assert_eq!(ArithBinOp::Add, bin_expr.2);
     }
 }

--- a/crates/hir/src/span/item.rs
+++ b/crates/hir/src/span/item.rs
@@ -213,7 +213,6 @@ impl LazyUseSpan {
                         use_.focus = DesugaredUseFocus::Path;
                         ResolvedOriginKind::Desugared(root, DesugaredOrigin::Use(use_))
                     }
-                    _ => ResolvedOriginKind::None,
                 })
         }
 
@@ -244,7 +243,6 @@ impl LazyUseSpan {
                         use_.focus = DesugaredUseFocus::Alias;
                         ResolvedOriginKind::Desugared(root, DesugaredOrigin::Use(use_))
                     }
-                    _ => ResolvedOriginKind::None,
                 })
         }
 

--- a/crates/hir/src/span/mod.rs
+++ b/crates/hir/src/span/mod.rs
@@ -1,7 +1,4 @@
-use parser::{
-    ast::{self, prelude::*, AstPtr, SyntaxNodePtr},
-    TextRange,
-};
+use parser::ast::{self, prelude::*, AstPtr, SyntaxNodePtr};
 
 use common::diagnostics::Span;
 
@@ -33,10 +30,10 @@ pub mod lazy_spans {
     };
 
     pub use super::expr::{
-        LazyBinExprSpan, LazyCallArgListSpan, LazyCallArgSpan, LazyCallExprSpan, LazyExprSpan,
-        LazyFieldExprSpan, LazyFieldListSpan, LazyFieldSpan, LazyLitExprSpan, LazyMatchArmListSpan,
-        LazyMatchArmSpan, LazyMatchExprSpan, LazyMethodCallExprSpan, LazyPathExprSpan,
-        LazyRecordInitExprSpan, LazyUnExprSpan, LazyAssignExprSpan, LazyAugAssignExprSpan,
+        LazyAssignExprSpan, LazyAugAssignExprSpan, LazyBinExprSpan, LazyCallArgListSpan,
+        LazyCallArgSpan, LazyCallExprSpan, LazyExprSpan, LazyFieldExprSpan, LazyFieldListSpan,
+        LazyFieldSpan, LazyLitExprSpan, LazyMatchArmListSpan, LazyMatchArmSpan, LazyMatchExprSpan,
+        LazyMethodCallExprSpan, LazyPathExprSpan, LazyRecordInitExprSpan, LazyUnExprSpan,
     };
 
     pub use super::item::{

--- a/crates/hir/src/span/mod.rs
+++ b/crates/hir/src/span/mod.rs
@@ -36,7 +36,7 @@ pub mod lazy_spans {
         LazyBinExprSpan, LazyCallArgListSpan, LazyCallArgSpan, LazyCallExprSpan, LazyExprSpan,
         LazyFieldExprSpan, LazyFieldListSpan, LazyFieldSpan, LazyLitExprSpan, LazyMatchArmListSpan,
         LazyMatchArmSpan, LazyMatchExprSpan, LazyMethodCallExprSpan, LazyPathExprSpan,
-        LazyRecordInitExprSpan, LazyUnExprSpan,
+        LazyRecordInitExprSpan, LazyUnExprSpan, LazyAssignExprSpan, LazyAugAssignExprSpan,
     };
 
     pub use super::item::{
@@ -220,28 +220,10 @@ where
 pub enum DesugaredOrigin {
     /// The HIR node is the result of desugaring an augmented assignment
     /// statement.
-    AugAssign(AugAssignDesugared),
 
     /// The HIR node is the result of desugaring a AST use.
     /// In HIR lowering, nested use tree is flattened into a single use path.
     Use(UseDesugared),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
-pub enum AugAssignDesugared {
-    /// The HIR node is the result of desugaring an augmented assignment
-    /// statement.
-    Stmt(AstPtr<ast::AugAssignStmt>),
-    /// The `TextRange` points to the LHS of the augmented assignment statement.
-    Lhs(TextRange),
-    /// The HIR node points to the RHS of the RHS of augmented assignment.
-    Rhs(AstPtr<ast::Expr>),
-}
-
-impl AugAssignDesugared {
-    pub(crate) fn stmt(ast: &ast::AugAssignStmt) -> Self {
-        Self::Stmt(AstPtr::new(ast))
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/hir/src/span/stmt.rs
+++ b/crates/hir/src/span/stmt.rs
@@ -48,34 +48,4 @@ impl ChainInitiator for StmtRoot {
 
 #[cfg(test)]
 mod tests {
-    use crate::{hir_def::Body, test_db::TestDb, HirDb};
-
-    #[test]
-    fn aug_assign() {
-        let mut db = TestDb::default();
-
-        let text = r#"
-            fn foo() {
-                let mut x = 0
-                x += 1
-            }
-        }"#;
-
-        let body: Body = db.expect_item::<Body>(text);
-        let top_mod = body.top_mod(db.as_hir_db());
-        assert!(body.stmts(db.as_hir_db()).len() == 2);
-        for (i, stmt) in body.stmts(db.as_hir_db()).keys().enumerate() {
-            match i {
-                0 => {
-                    let span = stmt.lazy_span(body);
-                    assert_eq!("let mut x = 0", db.text_at(top_mod, &span));
-                }
-                1 => {
-                    let span = stmt.lazy_span(body);
-                    assert_eq!("x += 1", db.text_at(top_mod, &span));
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
 }

--- a/crates/hir/src/span/stmt.rs
+++ b/crates/hir/src/span/stmt.rs
@@ -45,6 +45,3 @@ impl ChainInitiator for StmtRoot {
         ResolvedOrigin::resolve(db, top_mod, origin)
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/crates/hir/src/span/stmt.rs
+++ b/crates/hir/src/span/stmt.rs
@@ -47,5 +47,4 @@ impl ChainInitiator for StmtRoot {
 }
 
 #[cfg(test)]
-mod tests {
-}
+mod tests {}

--- a/crates/hir/src/span/transition.rs
+++ b/crates/hir/src/span/transition.rs
@@ -18,8 +18,7 @@ use crate::{
 use super::{
     body_ast, const_ast, contract_ast, enum_ast, expr::ExprRoot, func_ast, impl_ast,
     impl_trait_ast, mod_ast, pat::PatRoot, stmt::StmtRoot, struct_ast, trait_ast, type_alias_ast,
-    use_ast, DesugaredOrigin, DesugaredUseFocus, HirOrigin, LazySpan,
-    UseDesugared,
+    use_ast, DesugaredOrigin, DesugaredUseFocus, HirOrigin, LazySpan, UseDesugared,
 };
 
 /// This type represents function from the hir origin to another hir origin to
@@ -436,7 +435,6 @@ macro_rules! define_lazy_span_node {
 impl DesugaredOrigin {
     fn resolve(self, _db: &dyn SpannedHirDb, root: SyntaxNode, file: InputFile) -> Span {
         let range = match self {
-           
             Self::Use(UseDesugared {
                 root: use_root,
                 path,

--- a/crates/hir/src/span/transition.rs
+++ b/crates/hir/src/span/transition.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::{
     body_ast, const_ast, contract_ast, enum_ast, expr::ExprRoot, func_ast, impl_ast,
     impl_trait_ast, mod_ast, pat::PatRoot, stmt::StmtRoot, struct_ast, trait_ast, type_alias_ast,
-    use_ast, AugAssignDesugared, DesugaredOrigin, DesugaredUseFocus, HirOrigin, LazySpan,
+    use_ast, DesugaredOrigin, DesugaredUseFocus, HirOrigin, LazySpan,
     UseDesugared,
 };
 
@@ -436,14 +436,7 @@ macro_rules! define_lazy_span_node {
 impl DesugaredOrigin {
     fn resolve(self, _db: &dyn SpannedHirDb, root: SyntaxNode, file: InputFile) -> Span {
         let range = match self {
-            Self::AugAssign(AugAssignDesugared::Stmt(ptr)) => {
-                ptr.syntax_node_ptr().to_node(&root).text_range()
-            }
-            Self::AugAssign(AugAssignDesugared::Lhs(range)) => range,
-            Self::AugAssign(AugAssignDesugared::Rhs(ptr)) => {
-                ptr.syntax_node_ptr().to_node(&root).text_range()
-            }
-
+           
             Self::Use(UseDesugared {
                 root: use_root,
                 path,

--- a/crates/hir/src/span/transition.rs
+++ b/crates/hir/src/span/transition.rs
@@ -363,7 +363,7 @@ macro_rules! define_lazy_span_node {
                         fn f(origin: crate::span::transition::ResolvedOrigin, _: crate::span::transition::LazyArg) -> crate::span::transition::ResolvedOrigin {
                             origin.map(|node| <$sk_node as AstNode>::cast(node)
                                 .and_then(|n| n.$getter_node())
-                                .map(|n| n.syntax().clone().into()))
+                                .map(|n|  n.syntax().clone().into()))
                         }
 
                         let lazy_transition = crate::span::transition::LazyTransitionFn {

--- a/crates/hir/src/span/transition.rs
+++ b/crates/hir/src/span/transition.rs
@@ -363,7 +363,7 @@ macro_rules! define_lazy_span_node {
                         fn f(origin: crate::span::transition::ResolvedOrigin, _: crate::span::transition::LazyArg) -> crate::span::transition::ResolvedOrigin {
                             origin.map(|node| <$sk_node as AstNode>::cast(node)
                                 .and_then(|n| n.$getter_node())
-                                .map(|n|  n.syntax().clone().into()))
+                                .map(|n| n.syntax().clone().into()))
                         }
 
                         let lazy_transition = crate::span::transition::LazyTransitionFn {

--- a/crates/hir/src/span/use_tree.rs
+++ b/crates/hir/src/span/use_tree.rs
@@ -31,7 +31,6 @@ impl LazyUsePathSpan {
                         .get(idx)
                         .map(|ptr| ResolvedOriginKind::Node(ptr.syntax_node_ptr().to_node(&root)))
                         .unwrap_or_else(|| ResolvedOriginKind::None),
-                    _ => ResolvedOriginKind::None,
                 })
         }
 
@@ -72,7 +71,6 @@ impl LazyUseAliasSpan {
                         .alias
                         .and_then(|ptr| ptr.to_node(&root).alias().map(ResolvedOriginKind::Token))
                         .unwrap_or_else(|| ResolvedOriginKind::None),
-                    _ => ResolvedOriginKind::None,
                 })
         }
 

--- a/crates/hir/src/visitor.rs
+++ b/crates/hir/src/visitor.rs
@@ -874,11 +874,6 @@ where
             }
         }
 
-        Stmt::Assign(pat_id, expr_id) => {
-            visit_node_in_body!(visitor, ctxt, pat_id, pat);
-            visit_node_in_body!(visitor, ctxt, expr_id, expr);
-        }
-
         Stmt::For(pat_id, cond_id, for_body_id) => {
             visit_node_in_body!(visitor, ctxt, pat_id, pat);
             visit_node_in_body!(visitor, ctxt, cond_id, expr);
@@ -1071,7 +1066,7 @@ where
                 visit_node_in_body!(visitor, ctxt, else_, expr);
             }
         }
-
+        
         Expr::Match(scrutinee, arms) => {
             visit_node_in_body!(visitor, ctxt, scrutinee, expr);
 
@@ -1090,6 +1085,16 @@ where
                     },
                 );
             }
+        }
+        
+        Expr::Assign(left_expr_id, right_expr_id) => {
+            visit_node_in_body!(visitor, ctxt, left_expr_id, expr);
+            visit_node_in_body!(visitor, ctxt, right_expr_id, expr);
+        }
+
+        Expr::AugAssign(left_expr_id, right_expr_id, _) => {
+            visit_node_in_body!(visitor, ctxt, left_expr_id, expr);
+            visit_node_in_body!(visitor, ctxt, right_expr_id, expr);
         }
     }
 }

--- a/crates/hir/src/visitor.rs
+++ b/crates/hir/src/visitor.rs
@@ -1066,7 +1066,7 @@ where
                 visit_node_in_body!(visitor, ctxt, else_, expr);
             }
         }
-        
+
         Expr::Match(scrutinee, arms) => {
             visit_node_in_body!(visitor, ctxt, scrutinee, expr);
 
@@ -1086,7 +1086,7 @@ where
                 );
             }
         }
-        
+
         Expr::Assign(left_expr_id, right_expr_id) => {
             visit_node_in_body!(visitor, ctxt, left_expr_id, expr);
             visit_node_in_body!(visitor, ctxt, right_expr_id, expr);

--- a/crates/parser2/src/ast/expr.rs
+++ b/crates/parser2/src/ast/expr.rs
@@ -352,7 +352,7 @@ impl AssignExpr {
     pub fn rhs_expr(&self) -> Option<super::Expr> {
         support::children(self.syntax()).nth(1)
     }
-    
+
     pub fn eq(&self) -> Option<SyntaxToken> {
         support::token(self.syntax(), SK::Eq)
     }

--- a/crates/parser2/src/ast/expr.rs
+++ b/crates/parser2/src/ast/expr.rs
@@ -352,6 +352,9 @@ impl AssignExpr {
     pub fn rhs_expr(&self) -> Option<super::Expr> {
         support::children(self.syntax()).nth(1)
     }
+    pub fn eq(&self) -> Option<SyntaxToken> {
+        support::token(self.syntax(), SK::Eq)
+    }
 }
 
 ast_node! {
@@ -976,6 +979,7 @@ mod tests {
     #[wasm_bindgen_test]
     fn assign() {
         let assign_expr: AssignExpr = parse_expr(r#"Foo{x, y} = foo"#);
+
         assert!(matches!(
             assign_expr.lhs_expr().unwrap().kind(),
             ExprKind::RecordInit(_)

--- a/crates/parser2/src/ast/expr.rs
+++ b/crates/parser2/src/ast/expr.rs
@@ -54,7 +54,6 @@ impl Expr {
             SK::AssignExpr => ExprKind::Assign(AstNode::cast(self.syntax().clone()).unwrap()),
             SK::AugAssignExpr => ExprKind::AugAssign(AstNode::cast(self.syntax().clone()).unwrap()),
             _ => unreachable!(),
-
         }
     }
 }
@@ -339,7 +338,6 @@ impl ParenExpr {
     }
 }
 
-
 ast_node! {
     /// `x = 1`
     pub struct AssignExpr,
@@ -369,8 +367,8 @@ impl AugAssignExpr {
 
     pub fn op(&self) -> Option<super::ArithBinOp> {
         self.syntax()
-        .children_with_tokens()
-        .find_map(ArithBinOp::from_node_or_token)
+            .children_with_tokens()
+            .find_map(ArithBinOp::from_node_or_token)
     }
 
     /// Returns the expression of the rhs of the assignment.
@@ -398,7 +396,7 @@ pub enum ExprKind {
     Match(MatchExpr),
     Paren(ParenExpr),
     Assign(AssignExpr),
-    AugAssign(AugAssignExpr)
+    AugAssign(AugAssignExpr),
 }
 
 ast_node! {
@@ -987,11 +985,10 @@ mod tests {
             ExprKind::Path(_)
         ));
     }
-    
+
     #[test]
     #[wasm_bindgen_test]
     fn aug_assign() {
-
         let aug_assign_expr: AugAssignExpr = parse_expr("x += 1");
         assert!(matches!(
             aug_assign_expr.lhs_expr().unwrap().kind(),
@@ -1001,7 +998,7 @@ mod tests {
             aug_assign_expr.op().unwrap(),
             crate::ast::ArithBinOp::Add(_)
         ));
-    
+
         let aug_assign_expr: AugAssignExpr = parse_expr("x.y <<= 1");
         assert!(matches!(
             aug_assign_expr.lhs_expr().unwrap().kind(),
@@ -1012,5 +1009,4 @@ mod tests {
             crate::ast::ArithBinOp::LShift(_)
         ));
     }
-    
 }

--- a/crates/parser2/src/ast/expr.rs
+++ b/crates/parser2/src/ast/expr.rs
@@ -352,6 +352,7 @@ impl AssignExpr {
     pub fn rhs_expr(&self) -> Option<super::Expr> {
         support::children(self.syntax()).nth(1)
     }
+    
     pub fn eq(&self) -> Option<SyntaxToken> {
         support::token(self.syntax(), SK::Eq)
     }

--- a/crates/parser2/src/ast/stmt.rs
+++ b/crates/parser2/src/ast/stmt.rs
@@ -1,7 +1,7 @@
 use rowan::ast::{support, AstNode};
 
 use super::ast_node;
-use crate::{SyntaxKind as SK, SyntaxToken};
+use crate::SyntaxKind as SK;
 
 ast_node! {
     /// A statement.
@@ -52,7 +52,6 @@ impl LetStmt {
         support::child(self.syntax())
     }
 }
-
 
 ast_node! {
     /// `for pat in expr {..}`

--- a/crates/parser2/src/ast/stmt.rs
+++ b/crates/parser2/src/ast/stmt.rs
@@ -8,8 +8,6 @@ ast_node! {
     /// Use [`Self::kind`] to get the specific kind of the statement.
     pub struct Stmt,
     SK::LetStmt
-    | SK::AssignStmt
-    | SK::AugAssignStmt
     | SK::ForStmt
     | SK::WhileStmt
     | SK::ContinueStmt
@@ -22,8 +20,6 @@ impl Stmt {
     pub fn kind(&self) -> StmtKind {
         match self.syntax().kind() {
             SK::LetStmt => StmtKind::Let(AstNode::cast(self.syntax().clone()).unwrap()),
-            SK::AssignStmt => StmtKind::Assign(AstNode::cast(self.syntax().clone()).unwrap()),
-            SK::AugAssignStmt => StmtKind::AugAssign(AstNode::cast(self.syntax().clone()).unwrap()),
             SK::ForStmt => StmtKind::For(AstNode::cast(self.syntax().clone()).unwrap()),
             SK::WhileStmt => StmtKind::While(AstNode::cast(self.syntax().clone()).unwrap()),
             SK::ContinueStmt => StmtKind::Continue(AstNode::cast(self.syntax().clone()).unwrap()),
@@ -57,45 +53,6 @@ impl LetStmt {
     }
 }
 
-ast_node! {
-    /// `x = 1`
-    pub struct AssignStmt,
-    SK::AssignStmt,
-}
-impl AssignStmt {
-    /// Returns the pattern of the lhs of the assignment.
-    pub fn pat(&self) -> Option<super::Pat> {
-        support::child(self.syntax())
-    }
-
-    /// Returns the expression of the rhs of the assignment.
-    pub fn expr(&self) -> Option<super::Expr> {
-        support::child(self.syntax())
-    }
-}
-
-ast_node! {
-    /// `x += 1`
-    pub struct AugAssignStmt,
-    SK::AugAssignStmt,
-}
-impl AugAssignStmt {
-    /// Returns the identifier of the lhs of the aug assignment.
-    pub fn ident(&self) -> Option<SyntaxToken> {
-        support::token(self.syntax(), SK::Ident)
-    }
-
-    pub fn op(&self) -> Option<super::ArithBinOp> {
-        self.syntax()
-            .children_with_tokens()
-            .find_map(super::ArithBinOp::from_node_or_token)
-    }
-
-    /// Returns the expression of the rhs of the assignment.
-    pub fn expr(&self) -> Option<super::Expr> {
-        support::child(self.syntax())
-    }
-}
 
 ast_node! {
     /// `for pat in expr {..}`
@@ -189,8 +146,6 @@ impl ExprStmt {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::TryInto)]
 pub enum StmtKind {
     Let(LetStmt),
-    Assign(AssignStmt),
-    AugAssign(AugAssignStmt),
     For(ForStmt),
     While(WhileStmt),
     Continue(ContinueStmt),
@@ -241,36 +196,6 @@ mod tests {
         assert!(matches!(let_stmt.pat().unwrap().kind(), PatKind::Path(_)));
         assert!(let_stmt.type_annotation().is_none());
         assert!(let_stmt.initializer().is_none());
-    }
-
-    #[test]
-    #[wasm_bindgen_test]
-    fn assign() {
-        let assign_stmt: AssignStmt = parse_stmt(r#"Foo{x, y} = foo"#);
-        assert!(matches!(
-            assign_stmt.pat().unwrap().kind(),
-            PatKind::Record(_)
-        ));
-        assert!(assign_stmt.expr().is_some());
-    }
-
-    #[test]
-    #[wasm_bindgen_test]
-    fn aug_assign() {
-        let aug_assign_stmt: AugAssignStmt = parse_stmt("x += 1");
-        assert!(matches!(aug_assign_stmt.ident().unwrap().text(), "x",));
-        assert!(matches!(
-            aug_assign_stmt.op().unwrap(),
-            crate::ast::ArithBinOp::Add(_)
-        ));
-
-        let aug_assign_stmt: AugAssignStmt = parse_stmt("x <<= 1");
-
-        assert!(matches!(aug_assign_stmt.ident().unwrap().text(), "x",));
-        assert!(matches!(
-            aug_assign_stmt.op().unwrap(),
-            crate::ast::ArithBinOp::LShift(_)
-        ));
     }
 
     #[test]

--- a/crates/parser2/src/parser/expr.rs
+++ b/crates/parser2/src/parser/expr.rs
@@ -144,6 +144,10 @@ fn postfix_binding_power(kind: SyntaxKind) -> Option<u8> {
 fn infix_binding_power<S: TokenStream>(parser: &mut Parser<S>) -> Option<(u8, u8)> {
     use SyntaxKind::*;
 
+    if is_aug(parser) {
+        return Some((11, 10));
+    }
+
     let bp = match parser.current_kind()? {
         Pipe2 => (50, 51),
         Amp2 => (60, 61),
@@ -169,13 +173,7 @@ fn infix_binding_power<S: TokenStream>(parser: &mut Parser<S>) -> Option<(u8, u8
         Amp => (100, 101),
         LShift | RShift => (110, 111),
         Plus | Minus => (120, 121),
-        Star | Slash | Percent => {
-            if is_aug(parser) {
-                (11, 10)
-            } else {
-                (130, 131)
-            }
-        }
+        Star | Slash | Percent => (130, 131),
         Star2 => (141, 140),
         Dot => (151, 150),
         Eq => {
@@ -351,6 +349,7 @@ fn is_lt_eq<S: TokenStream>(parser: &mut Parser<S>) -> bool {
 fn is_gt_eq<S: TokenStream>(parser: &mut Parser<S>) -> bool {
     parser.dry_run(|parser| parser.parse(GtEqScope::default(), None).0)
 }
+
 fn is_aug<S: TokenStream>(parser: &mut Parser<S>) -> bool {
     parser.dry_run(|parser| {
         if !bump_aug_assign_op(parser) {
@@ -361,6 +360,7 @@ fn is_aug<S: TokenStream>(parser: &mut Parser<S>) -> bool {
         parser.current_kind() == Some(SyntaxKind::Eq)
     })
 }
+
 fn is_asn<S: TokenStream>(parser: &mut Parser<S>) -> bool {
     parser.dry_run(|parser| {
         parser.set_newline_as_trivia(false);

--- a/crates/parser2/src/parser/expr.rs
+++ b/crates/parser2/src/parser/expr.rs
@@ -87,11 +87,11 @@ fn parse_expr_with_min_bp<S: TokenStream>(
                 // Method call is already handled as the postfix operator.
                 SyntaxKind::Dot => parser.parse(FieldExprScope::default(), Some(checkpoint)).0,
                 _ => {
-                     // 1. Try to parse the expression as an augmented assignment expression.
+                    // 1. Try to parse the expression as an augmented assignment expression.
                     // 2. If 1. fails, try to parse the expression as an assignment expression.
                     // 3. If 2. fails, try to parse the expression as a binary expression.
                     parser.parse(BinExprScope::default(), Some(checkpoint)).0
-                },
+                }
             } {
                 return false;
             }
@@ -169,15 +169,18 @@ fn infix_binding_power<S: TokenStream>(parser: &mut Parser<S>) -> Option<(u8, u8
         Amp => (100, 101),
         LShift | RShift => (110, 111),
         Plus | Minus => (120, 121),
-        Star | Slash | Percent =>  if is_aug(parser) {
-            (11, 10)} else {
+        Star | Slash | Percent => {
+            if is_aug(parser) {
+                (11, 10)
+            } else {
                 (130, 131)
             }
+        }
         Star2 => (141, 140),
         Dot => (151, 150),
         Eq => {
-             // `Assign` and `AugAssign` have the same binding power
-             (11, 10)
+            // `Assign` and `AugAssign` have the same binding power
+            (11, 10)
         }
         _ => return None,
     };
@@ -204,7 +207,7 @@ impl super::Parse for BinExprScope {
         if is_aug(parser) {
             self.set_kind(SyntaxKind::AugAssignExpr);
             bump_aug_assign_op(parser);
-            parser.bump_expected(SyntaxKind::Eq);    
+            parser.bump_expected(SyntaxKind::Eq);
             parse_expr_with_min_bp(parser, rbp, true);
         } else if is_asn(parser) {
             self.set_kind(SyntaxKind::AssignExpr);
@@ -216,7 +219,7 @@ impl super::Parse for BinExprScope {
             bump_bin_op(parser);
             parse_expr_with_min_bp(parser, rbp, false);
         }
-       }
+    }
 }
 
 define_scope! { IndexExprScope, IndexExpr, Override(RBracket) }

--- a/crates/parser2/src/parser/stmt.rs
+++ b/crates/parser2/src/parser/stmt.rs
@@ -20,18 +20,7 @@ pub fn parse_stmt<S: TokenStream>(parser: &mut Parser<S>, checkpoint: Option<Che
         Some(ContinueKw) => parser.parse(ContinueStmtScope::default(), checkpoint),
         Some(BreakKw) => parser.parse(BreakStmtScope::default(), checkpoint),
         Some(ReturnKw) => parser.parse(ReturnStmtScope::default(), checkpoint),
-        _ => {
-            // 1. Try to parse the statement as an augmented assignment statement.
-            // 2. If 1. fails, try to parse the statement as an assignment statement.
-            // 3. If 2. fails, try to parse the statement as an expression statement.
-            if parser.dry_run(|parser| parser.parse(AugAssignStmtScope::default(), None).0) {
-                parser.parse(AugAssignStmtScope::default(), checkpoint)
-            } else if parser.dry_run(|parser| parser.parse(AssignStmtScope::default(), None).0) {
-                parser.parse(AssignStmtScope::default(), checkpoint)
-            } else {
-                parser.parse(ExprStmtScope::default(), checkpoint)
-            }
-        }
+        _ => parser.parse(ExprStmtScope::default(), checkpoint),
     }
     .0
 }
@@ -117,85 +106,9 @@ impl super::Parse for ReturnStmtScope {
     }
 }
 
-define_scope! { AugAssignStmtScope, AugAssignStmt, Inheritance }
-impl super::Parse for AugAssignStmtScope {
-    fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) {
-        parser.set_newline_as_trivia(false);
-
-        parser.with_recovery_tokens(
-            |parser| {
-                parser.bump_or_recover(
-                    SyntaxKind::Ident,
-                    "expeced identifier for the assignment",
-                    None,
-                )
-            },
-            &[SyntaxKind::Eq],
-        );
-
-        parser.with_next_expected_tokens(
-            |parser| {
-                if !bump_aug_assign_op(parser) {
-                    parser.error_and_recover("expected augmented assignment operator", None);
-                }
-            },
-            &[SyntaxKind::Eq],
-        );
-
-        if !parser.bump_if(SyntaxKind::Eq) {
-            parser.error_and_recover("expected `=`", None);
-            return;
-        }
-
-        parse_expr(parser);
-    }
-}
-
-define_scope! { AssignStmtScope, AssignStmt, Inheritance }
-impl super::Parse for AssignStmtScope {
-    fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) {
-        parser.set_newline_as_trivia(false);
-
-        parser.with_recovery_tokens(parse_pat, &[SyntaxKind::Eq]);
-        if !parser.bump_if(SyntaxKind::Eq) {
-            parser.error_and_recover("expected `=`", None);
-            return;
-        }
-
-        parse_expr(parser);
-    }
-}
-
 define_scope! { ExprStmtScope, ExprStmt, Inheritance }
 impl super::Parse for ExprStmtScope {
     fn parse<S: TokenStream>(&mut self, parser: &mut Parser<S>) {
         parse_expr(parser);
-    }
-}
-
-fn bump_aug_assign_op<S: TokenStream>(parser: &mut Parser<S>) -> bool {
-    use SyntaxKind::*;
-    match parser.current_kind() {
-        Some(Pipe | Hat | Amp | Plus | Minus | Star | Slash | Percent | Star2) => {
-            parser.bump();
-            true
-        }
-        Some(Lt) => {
-            if expr::is_lshift(parser) {
-                parser.parse(expr::LShiftScope::default(), None);
-                true
-            } else {
-                false
-            }
-        }
-        Some(Gt) => {
-            if expr::is_rshift(parser) {
-                parser.parse(expr::RShiftScope::default(), None);
-                true
-            } else {
-                false
-            }
-        }
-        _ => false,
     }
 }

--- a/crates/parser2/src/parser/stmt.rs
+++ b/crates/parser2/src/parser/stmt.rs
@@ -1,4 +1,4 @@
-use crate::{parser::expr, SyntaxKind};
+use crate::SyntaxKind;
 
 use super::{
     define_scope,

--- a/crates/parser2/src/syntax_kind.rs
+++ b/crates/parser2/src/syntax_kind.rs
@@ -290,7 +290,7 @@ pub enum SyntaxKind {
     AssignExpr,
     /// x += 1
     AugAssignExpr,
-    
+
     // Statements. These are non-leaf nodes.
     /// `let x = 1`
     LetStmt,

--- a/crates/parser2/src/syntax_kind.rs
+++ b/crates/parser2/src/syntax_kind.rs
@@ -290,6 +290,7 @@ pub enum SyntaxKind {
     AssignExpr,
     /// x += 1
     AugAssignExpr,
+    
     // Statements. These are non-leaf nodes.
     /// `let x = 1`
     LetStmt,

--- a/crates/parser2/src/syntax_kind.rs
+++ b/crates/parser2/src/syntax_kind.rs
@@ -286,14 +286,13 @@ pub enum SyntaxKind {
     MatchExpr,
     /// `(1 + 2)`
     ParenExpr,
-
+    /// x = 1
+    AssignExpr,
+    /// x += 1
+    AugAssignExpr,
     // Statements. These are non-leaf nodes.
     /// `let x = 1`
     LetStmt,
-    /// `x = 1`
-    AssignStmt,
-    /// `x += 1`
-    AugAssignStmt,
     /// `for x in y {..}`
     ForStmt,
     /// `while expr {..}`
@@ -461,6 +460,7 @@ pub enum SyntaxKind {
 
     /// Represents an error branch.
     Error,
+
 }
 
 impl SyntaxKind {

--- a/crates/parser2/src/syntax_kind.rs
+++ b/crates/parser2/src/syntax_kind.rs
@@ -460,7 +460,6 @@ pub enum SyntaxKind {
 
     /// Represents an error branch.
     Error,
-
 }
 
 impl SyntaxKind {

--- a/crates/parser2/test_files/syntax_node/stmts/assign.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/assign.snap
@@ -4,43 +4,39 @@ expression: node
 input_file: crates/parser2/test_files/syntax_node/stmts/assign.fe
 ---
 Root@0..21
-  AssignStmt@0..5
-    PathPat@0..1
-      Path@0..1
-        PathSegment@0..1
-          Ident@0..1 "x"
-    WhiteSpace@1..2 " "
-    Eq@2..3 "="
-    WhiteSpace@3..4 " "
-    LitExpr@4..5
-      Lit@4..5
-        Int@4..5 "1"
+  ExprStmt@0..5
+    AssignExpr@0..5
+      PathExpr@0..1
+        Path@0..1
+          PathSegment@0..1
+            Ident@0..1 "x"
+      WhiteSpace@1..2 " "
+      Eq@2..3 "="
+      WhiteSpace@3..4 " "
+      LitExpr@4..5
+        Lit@4..5
+          Int@4..5 "1"
   Newline@5..6 "\n"
-  AssignStmt@6..21
-    RecordPat@6..15
-      Path@6..9
-        PathSegment@6..9
-          Ident@6..9 "Foo"
-      RecordPatFieldList@9..15
-        LBrace@9..10 "{"
-        RecordPatField@10..11
-          PathPat@10..11
-            Path@10..11
-              PathSegment@10..11
-                Ident@10..11 "x"
-        Comma@11..12 ","
-        WhiteSpace@12..13 " "
-        RecordPatField@13..14
-          PathPat@13..14
-            Path@13..14
-              PathSegment@13..14
-                Ident@13..14 "y"
-        RBrace@14..15 "}"
-    WhiteSpace@15..16 " "
-    Eq@16..17 "="
-    WhiteSpace@17..18 " "
-    PathExpr@18..21
-      Path@18..21
-        PathSegment@18..21
-          Ident@18..21 "foo"
+  ExprStmt@6..21
+    AssignExpr@6..21
+      RecordInitExpr@6..15
+        Path@6..9
+          PathSegment@6..9
+            Ident@6..9 "Foo"
+        RecordFieldList@9..15
+          LBrace@9..10 "{"
+          RecordField@10..11
+            Ident@10..11 "x"
+          Comma@11..12 ","
+          WhiteSpace@12..13 " "
+          RecordField@13..14
+            Ident@13..14 "y"
+          RBrace@14..15 "}"
+      WhiteSpace@15..16 " "
+      Eq@16..17 "="
+      WhiteSpace@17..18 " "
+      PathExpr@18..21
+        Path@18..21
+          PathSegment@18..21
+            Ident@18..21 "foo"
 

--- a/crates/parser2/test_files/syntax_node/stmts/for.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/for.snap
@@ -23,26 +23,27 @@ Root@0..96
       LBrace@13..14 "{"
       Newline@14..15 "\n"
       WhiteSpace@15..19 "    "
-      AssignStmt@19..32
-        PathPat@19..22
-          Path@19..22
-            PathSegment@19..22
-              Ident@19..22 "sum"
-        WhiteSpace@22..23 " "
-        Eq@23..24 "="
-        WhiteSpace@24..25 " "
-        BinExpr@25..32
-          PathExpr@25..28
-            Path@25..28
-              PathSegment@25..28
-                Ident@25..28 "sum"
-          WhiteSpace@28..29 " "
-          Plus@29..30 "+"
-          WhiteSpace@30..31 " "
-          PathExpr@31..32
-            Path@31..32
-              PathSegment@31..32
-                Ident@31..32 "i"
+      ExprStmt@19..32
+        AssignExpr@19..32
+          PathExpr@19..22
+            Path@19..22
+              PathSegment@19..22
+                Ident@19..22 "sum"
+          WhiteSpace@22..23 " "
+          Eq@23..24 "="
+          WhiteSpace@24..25 " "
+          BinExpr@25..32
+            PathExpr@25..28
+              Path@25..28
+                PathSegment@25..28
+                  Ident@25..28 "sum"
+            WhiteSpace@28..29 " "
+            Plus@29..30 "+"
+            WhiteSpace@30..31 " "
+            PathExpr@31..32
+              Path@31..32
+                PathSegment@31..32
+                  Ident@31..32 "i"
       Newline@32..33 "\n"
       RBrace@33..34 "}"
   Newline@34..36 "\n\n"
@@ -87,34 +88,35 @@ Root@0..96
       LBrace@71..72 "{"
       Newline@72..73 "\n"
       WhiteSpace@73..77 "    "
-      AssignStmt@77..94
-        PathPat@77..80
-          Path@77..80
-            PathSegment@77..80
-              Ident@77..80 "sum"
-        WhiteSpace@80..81 " "
-        Eq@81..82 "="
-        WhiteSpace@82..83 " "
-        BinExpr@83..94
-          BinExpr@83..90
-            PathExpr@83..86
-              Path@83..86
-                PathSegment@83..86
-                  Ident@83..86 "sum"
-            WhiteSpace@86..87 " "
-            Plus@87..88 "+"
-            WhiteSpace@88..89 " "
-            PathExpr@89..90
-              Path@89..90
-                PathSegment@89..90
-                  Ident@89..90 "x"
-          WhiteSpace@90..91 " "
-          Plus@91..92 "+"
-          WhiteSpace@92..93 " "
-          PathExpr@93..94
-            Path@93..94
-              PathSegment@93..94
-                Ident@93..94 "y"
+      ExprStmt@77..94
+        AssignExpr@77..94
+          PathExpr@77..80
+            Path@77..80
+              PathSegment@77..80
+                Ident@77..80 "sum"
+          WhiteSpace@80..81 " "
+          Eq@81..82 "="
+          WhiteSpace@82..83 " "
+          BinExpr@83..94
+            BinExpr@83..90
+              PathExpr@83..86
+                Path@83..86
+                  PathSegment@83..86
+                    Ident@83..86 "sum"
+              WhiteSpace@86..87 " "
+              Plus@87..88 "+"
+              WhiteSpace@88..89 " "
+              PathExpr@89..90
+                Path@89..90
+                  PathSegment@89..90
+                    Ident@89..90 "x"
+            WhiteSpace@90..91 " "
+            Plus@91..92 "+"
+            WhiteSpace@92..93 " "
+            PathExpr@93..94
+              Path@93..94
+                PathSegment@93..94
+                  Ident@93..94 "y"
       Newline@94..95 "\n"
       RBrace@95..96 "}"
 

--- a/crates/parser2/test_files/syntax_node/stmts/let.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/let.snap
@@ -69,50 +69,50 @@ Root@0..231
         Int@49..50 "1"
   Newline@50..52 "\n\n"
   ExprStmt@52..62
-    BinExpr@52..62
-      AugAssignExpr@52..58
-        PathExpr@52..53
-          Path@52..53
-            PathSegment@52..53
-              Ident@52..53 "x"
-        WhiteSpace@53..54 " "
-        Plus@54..55 "+"
-        Eq@55..56 "="
-        WhiteSpace@56..57 " "
+    AugAssignExpr@52..62
+      PathExpr@52..53
+        Path@52..53
+          PathSegment@52..53
+            Ident@52..53 "x"
+      WhiteSpace@53..54 " "
+      Plus@54..55 "+"
+      Eq@55..56 "="
+      WhiteSpace@56..57 " "
+      BinExpr@57..62
         LitExpr@57..58
           Lit@57..58
             Int@57..58 "1"
-      WhiteSpace@58..59 " "
-      Plus@59..60 "+"
-      WhiteSpace@60..61 " "
-      LitExpr@61..62
-        Lit@61..62
-          Int@61..62 "1"
+        WhiteSpace@58..59 " "
+        Plus@59..60 "+"
+        WhiteSpace@60..61 " "
+        LitExpr@61..62
+          Lit@61..62
+            Int@61..62 "1"
   Newline@62..63 "\n"
   ExprStmt@63..75
-    BinExpr@63..75
-      AugAssignExpr@63..70
-        PathExpr@63..64
-          Path@63..64
-            PathSegment@63..64
-              Ident@63..64 "y"
-        WhiteSpace@64..65 " "
-        LShift@65..67
-          Lt@65..66 "<"
-          Lt@66..67 "<"
-        Eq@67..68 "="
-        WhiteSpace@68..69 " "
+    AugAssignExpr@63..75
+      PathExpr@63..64
+        Path@63..64
+          PathSegment@63..64
+            Ident@63..64 "y"
+      WhiteSpace@64..65 " "
+      LShift@65..67
+        Lt@65..66 "<"
+        Lt@66..67 "<"
+      Eq@67..68 "="
+      WhiteSpace@68..69 " "
+      BinExpr@69..75
         LitExpr@69..70
           Lit@69..70
             Int@69..70 "1"
-      WhiteSpace@70..71 " "
-      RShift@71..73
-        Gt@71..72 ">"
-        Gt@72..73 ">"
-      WhiteSpace@73..74 " "
-      LitExpr@74..75
-        Lit@74..75
-          Int@74..75 "2"
+        WhiteSpace@70..71 " "
+        RShift@71..73
+          Gt@71..72 ">"
+          Gt@72..73 ">"
+        WhiteSpace@73..74 " "
+        LitExpr@74..75
+          Lit@74..75
+            Int@74..75 "2"
   Newline@75..77 "\n\n"
   LetStmt@77..102
     LetKw@77..80 "let"

--- a/crates/parser2/test_files/syntax_node/stmts/let.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/let.snap
@@ -68,16 +68,20 @@ Root@0..231
       Lit@49..50
         Int@49..50 "1"
   Newline@50..52 "\n\n"
-  AugAssignStmt@52..62
-    Ident@52..53 "x"
-    WhiteSpace@53..54 " "
-    Plus@54..55 "+"
-    Eq@55..56 "="
-    WhiteSpace@56..57 " "
-    BinExpr@57..62
-      LitExpr@57..58
-        Lit@57..58
-          Int@57..58 "1"
+  ExprStmt@52..62
+    BinExpr@52..62
+      AugAssignExpr@52..58
+        PathExpr@52..53
+          Path@52..53
+            PathSegment@52..53
+              Ident@52..53 "x"
+        WhiteSpace@53..54 " "
+        Plus@54..55 "+"
+        Eq@55..56 "="
+        WhiteSpace@56..57 " "
+        LitExpr@57..58
+          Lit@57..58
+            Int@57..58 "1"
       WhiteSpace@58..59 " "
       Plus@59..60 "+"
       WhiteSpace@60..61 " "
@@ -85,18 +89,22 @@ Root@0..231
         Lit@61..62
           Int@61..62 "1"
   Newline@62..63 "\n"
-  AugAssignStmt@63..75
-    Ident@63..64 "y"
-    WhiteSpace@64..65 " "
-    LShift@65..67
-      Lt@65..66 "<"
-      Lt@66..67 "<"
-    Eq@67..68 "="
-    WhiteSpace@68..69 " "
-    BinExpr@69..75
-      LitExpr@69..70
-        Lit@69..70
-          Int@69..70 "1"
+  ExprStmt@63..75
+    BinExpr@63..75
+      AugAssignExpr@63..70
+        PathExpr@63..64
+          Path@63..64
+            PathSegment@63..64
+              Ident@63..64 "y"
+        WhiteSpace@64..65 " "
+        LShift@65..67
+          Lt@65..66 "<"
+          Lt@66..67 "<"
+        Eq@67..68 "="
+        WhiteSpace@68..69 " "
+        LitExpr@69..70
+          Lit@69..70
+            Int@69..70 "1"
       WhiteSpace@70..71 " "
       RShift@71..73
         Gt@71..72 ">"

--- a/crates/parser2/test_files/syntax_node/stmts/while.snap
+++ b/crates/parser2/test_files/syntax_node/stmts/while.snap
@@ -23,45 +23,47 @@ Root@0..46
       LBrace@13..14 "{"
       Newline@14..15 "\n"
       WhiteSpace@15..19 "    "
-      AssignStmt@19..30
-        PathPat@19..22
-          Path@19..22
-            PathSegment@19..22
-              Ident@19..22 "sum"
-        WhiteSpace@22..23 " "
-        Eq@23..24 "="
-        WhiteSpace@24..25 " "
-        BinExpr@25..30
-          LitExpr@25..26
-            Lit@25..26
-              Int@25..26 "1"
-          WhiteSpace@26..27 " "
-          Plus@27..28 "+"
-          WhiteSpace@28..29 " "
-          LitExpr@29..30
-            Lit@29..30
-              Int@29..30 "2"
+      ExprStmt@19..30
+        AssignExpr@19..30
+          PathExpr@19..22
+            Path@19..22
+              PathSegment@19..22
+                Ident@19..22 "sum"
+          WhiteSpace@22..23 " "
+          Eq@23..24 "="
+          WhiteSpace@24..25 " "
+          BinExpr@25..30
+            LitExpr@25..26
+              Lit@25..26
+                Int@25..26 "1"
+            WhiteSpace@26..27 " "
+            Plus@27..28 "+"
+            WhiteSpace@28..29 " "
+            LitExpr@29..30
+              Lit@29..30
+                Int@29..30 "2"
       Newline@30..31 "\n"
       WhiteSpace@31..35 "    "
-      AssignStmt@35..44
-        PathPat@35..36
-          Path@35..36
-            PathSegment@35..36
-              Ident@35..36 "i"
-        WhiteSpace@36..37 " "
-        Eq@37..38 "="
-        WhiteSpace@38..39 " "
-        BinExpr@39..44
-          PathExpr@39..40
-            Path@39..40
-              PathSegment@39..40
-                Ident@39..40 "i"
-          WhiteSpace@40..41 " "
-          Plus@41..42 "+"
-          WhiteSpace@42..43 " "
-          LitExpr@43..44
-            Lit@43..44
-              Int@43..44 "1"
+      ExprStmt@35..44
+        AssignExpr@35..44
+          PathExpr@35..36
+            Path@35..36
+              PathSegment@35..36
+                Ident@35..36 "i"
+          WhiteSpace@36..37 " "
+          Eq@37..38 "="
+          WhiteSpace@38..39 " "
+          BinExpr@39..44
+            PathExpr@39..40
+              Path@39..40
+                PathSegment@39..40
+                  Ident@39..40 "i"
+            WhiteSpace@40..41 " "
+            Plus@41..42 "+"
+            WhiteSpace@42..43 " "
+            LitExpr@43..44
+              Lit@43..44
+                Int@43..44 "1"
       Newline@44..45 "\n"
       RBrace@45..46 "}"
 


### PR DESCRIPTION
resolves #875 

What was wrong?

The new parser (v2 branch) wrongly supposes the assignment destination is a pattern, but it should be an expression.

How was it fixed?

change Assign and augassign to expressions