### PR TITLE
parser: Allow `mut` occurrence only in path pattern

### DIFF
--- a/crates/hir/src/hir_def/path.rs
+++ b/crates/hir/src/hir_def/path.rs
@@ -1,6 +1,5 @@
-use crate::{hir_def::Partial, HirDb};
-
 use super::{kw, IdentId};
+use crate::{hir_def::Partial, HirDb};
 
 #[salsa::interned]
 pub struct PathId {
@@ -15,6 +14,10 @@ impl PathId {
 
     pub fn len(self, db: &dyn HirDb) -> usize {
         self.segments(db).len()
+    }
+
+    pub fn is_ident(self, db: &dyn HirDb) -> bool {
+        self.len(db) == 1
     }
 
     pub fn self_ty(db: &dyn HirDb) -> Self {

--- a/crates/hir/src/lower/pat.rs
+++ b/crates/hir/src/lower/pat.rs
@@ -1,11 +1,10 @@
 use parser::ast;
 
+use super::body::BodyCtxt;
 use crate::{
     hir_def::{pat::*, IdentId, LitKind, PathId},
     span::HirOrigin,
 };
-
-use super::body::BodyCtxt;
 
 impl Pat {
     pub(super) fn lower_ast(ctxt: &mut BodyCtxt<'_, '_>, ast: ast::Pat) -> PatId {
@@ -30,9 +29,9 @@ impl Pat {
                 Pat::Tuple(elems)
             }
 
-            ast::PatKind::Path(path) => {
-                let path = PathId::lower_ast_partial(ctxt.f_ctxt, path.path());
-                Pat::Path(path)
+            ast::PatKind::Path(path_ast) => {
+                let path = PathId::lower_ast_partial(ctxt.f_ctxt, path_ast.path());
+                Pat::Path(path, path_ast.mut_token().is_some())
             }
 
             ast::PatKind::PathTuple(path_tup) => {

--- a/crates/hir/src/span/pat.rs
+++ b/crates/hir/src/span/pat.rs
@@ -46,6 +46,10 @@ define_lazy_span_node!(
 define_lazy_span_node!(
     LazyPathPatSpan,
     ast::PathPat,
+    @token {
+        (mut_token, mut_token),
+    }
+
     @node {
         (path, path, LazyPathSpan),
     }

--- a/crates/hir/src/visitor.rs
+++ b/crates/hir/src/visitor.rs
@@ -1133,7 +1133,7 @@ where
             }
         }
 
-        Pat::Path(path) => {
+        Pat::Path(path, _) => {
             if let Some(path) = path.to_opt() {
                 ctxt.with_new_ctxt(
                     |span| span.into_path_pat().path_moved(),

--- a/crates/parser2/src/ast/pat.rs
+++ b/crates/parser2/src/ast/pat.rs
@@ -33,11 +33,6 @@ impl Pat {
             _ => unreachable!(),
         }
     }
-
-    /// Returns the `mut` keyword if the patter is mutable.
-    pub fn mut_token(&self) -> Option<SyntaxToken> {
-        support::token(self.syntax(), SK::MutKw)
-    }
 }
 
 ast_node! {
@@ -90,6 +85,11 @@ ast_node! {
 impl PathPat {
     pub fn path(&self) -> Option<super::Path> {
         support::child(self.syntax())
+    }
+
+    /// Returns the `mut` keyword if the patter is mutable.
+    pub fn mut_token(&self) -> Option<SyntaxToken> {
+        support::token(self.syntax(), SK::MutKw)
     }
 }
 
@@ -175,11 +175,10 @@ pub enum PatKind {
 
 #[cfg(test)]
 mod tests {
-    use crate::{lexer::Lexer, parser::Parser};
-
     use wasm_bindgen_test::wasm_bindgen_test;
 
     use super::*;
+    use crate::{lexer::Lexer, parser::Parser};
 
     fn parse_pat<T>(source: &str) -> T
     where
@@ -282,9 +281,13 @@ mod tests {
                     assert!(matches!(field.pat().unwrap().kind(), PatKind::Path(_)));
                 }
                 2 => {
+                    let PatKind::Path(pat) = field.pat().unwrap().kind() else {
+                        panic!("unexpected record pat");
+                    };
+
                     assert!(field.name().is_none());
                     assert!(matches!(field.pat().unwrap().kind(), PatKind::Path(_)));
-                    assert!(field.pat().unwrap().mut_token().is_some());
+                    assert!(pat.mut_token().is_some());
                 }
                 _ => panic!("unexpected record pat"),
             }


### PR DESCRIPTION
This PR restricts 
1. the `mut` keyword occurrence in a pattern only before `Path`,
2. Add a field to `Hir::Pat::Path` to indicate the mutability of the path.

The main reason for the change was that I hesitated to make all HIR pattern kinds include mutability flags.