### PR TITLE
Fix incorrect instantiation in constraint solving

### DIFF
--- a/crates/analyzer/src/traversal/expressions.rs
+++ b/crates/analyzer/src/traversal/expressions.rs
@@ -1,3 +1,11 @@
+use std::{ops::RangeInclusive, str::FromStr};
+
+use fe_common::{diagnostics::Label, numeric, Span};
+use fe_parser::{ast as fe, ast::GenericArg, node::Node};
+use num_bigint::BigInt;
+use num_traits::{ToPrimitive, Zero};
+use smol_str::SmolStr;
+
 use super::borrowck;
 use crate::{
     builtins::{ContractTypeMethod, GlobalFunction, Intrinsic, ValueMethod},
@@ -22,13 +30,6 @@ use crate::{
         utils::add_bin_operations_errors,
     },
 };
-
-use fe_common::{diagnostics::Label, numeric, Span};
-use fe_parser::{ast as fe, ast::GenericArg, node::Node};
-use num_bigint::BigInt;
-use num_traits::{ToPrimitive, Zero};
-use smol_str::SmolStr;
-use std::{ops::RangeInclusive, str::FromStr};
 
 // TODO: don't fail fatally if expected type is provided
 

--- a/crates/hir-analysis/src/ty/constraint_solver.rs
+++ b/crates/hir-analysis/src/ty/constraint_solver.rs
@@ -160,13 +160,14 @@ impl<'db> ConstraintSolver<'db> {
                 let res = if table.unify(gen_impl.ty(self.db), goal_ty).is_ok()
                     && table.unify(gen_impl.trait_(self.db), goal_trait).is_ok()
                 {
-                    let constraints = impl_.instantiate_identity().constraints(self.db);
+                    let constraints = gen_impl.fold_with(&mut table).constraints(self.db);
                     Some(constraints.fold_with(&mut table))
                 } else {
                     None
                 };
 
                 table.rollback_to(snapshot);
+
                 res
             })
         else {
@@ -178,7 +179,7 @@ impl<'db> ConstraintSolver<'db> {
             match is_goal_satisfiable(self.db, sub_goal, self.assumptions) {
                 GoalSatisfiability::Satisfied => {}
                 GoalSatisfiability::NotSatisfied(_) => {
-                    return GoalSatisfiability::NotSatisfied(self.goal)
+                    return GoalSatisfiability::NotSatisfied(self.goal);
                 }
                 GoalSatisfiability::InfiniteRecursion(_) => {
                     return GoalSatisfiability::InfiniteRecursion(self.goal)

--- a/crates/hir-analysis/src/ty/def_analysis.rs
+++ b/crates/hir-analysis/src/ty/def_analysis.rs
@@ -473,7 +473,7 @@ impl<'db> Visitor for DefAnalyzer<'db> {
         let span = ctxt.span().unwrap();
         if let Some(diag) = ty.emit_diag(self.db, span.clone().into()) {
             self.diags.push(diag)
-        } else if let Some(diag) = ty.emit_sat_diag(self.db, self.assumptions, span.into()) {
+        } else if let Some(diag) = ty.emit_wf_diag(self.db, self.assumptions, span.into()) {
             self.diags.push(diag)
         }
     }

--- a/crates/hir-analysis/src/ty/ty_check/expr.rs
+++ b/crates/hir-analysis/src/ty/ty_check/expr.rs
@@ -274,6 +274,7 @@ impl<'db> TyChecker<'db> {
         callable.check_args(self, args, call_span.args_moved(), None);
 
         let ret_ty = callable.ret_ty(self.db);
+        self.register_callable(expr, callable);
         ExprProp::new(ret_ty, true)
     }
 
@@ -344,6 +345,7 @@ impl<'db> TyChecker<'db> {
             Some((*receiver, receiver_ty)),
         );
         let ret_ty = callable.ret_ty(self.db);
+        self.register_callable(expr, callable);
         ExprProp::new(ret_ty, true)
     }
 

--- a/crates/hir-analysis/src/ty/ty_def.rs
+++ b/crates/hir-analysis/src/ty/ty_def.rs
@@ -342,7 +342,7 @@ impl TyId {
         visitor.diag
     }
 
-    pub(super) fn emit_sat_diag(
+    pub(super) fn emit_wf_diag(
         self,
         db: &dyn HirAnalysisDb,
         assumptions: AssumptionListId,

--- a/crates/hir-analysis/test_files/constraints/specialized.fe
+++ b/crates/hir-analysis/test_files/constraints/specialized.fe
@@ -1,0 +1,31 @@
+trait Trait {
+    fn f(self) -> i32
+}
+
+struct S<T> {
+    t: T
+}
+
+struct S2<T> {
+    s: S<T>
+}
+
+impl Trait for S<i32> {
+    fn f(self) -> i32 {
+        self.t
+    }
+}
+
+impl<T> Trait for S2<T>
+where S<T>: Trait {
+    fn f(self) -> i32 {
+        self.s.f()
+    }
+}
+
+fn bar() {
+    let t: i32 = 1
+    let s = S { t }
+    let s2 = S2 { s }
+    let _ = s2.f()
+}

--- a/crates/hir-analysis/tests/constraints.rs
+++ b/crates/hir-analysis/tests/constraints.rs
@@ -1,0 +1,17 @@
+mod test_db;
+use std::path::Path;
+
+use dir_test::{dir_test, Fixture};
+use test_db::HirAnalysisTestDb;
+
+#[dir_test(
+    dir: "$CARGO_MANIFEST_DIR/test_files/constraints",
+    glob: "*.fe"
+)]
+fn test_standalone(fixture: Fixture<&str>) {
+    let mut db = HirAnalysisTestDb::default();
+    let path = Path::new(fixture.path());
+    let file_name = path.file_name().and_then(|file| file.to_str()).unwrap();
+    let (top_mod, _) = db.new_stand_alone(file_name, fixture.content());
+    db.assert_no_diags(top_mod);
+}

--- a/crates/uitest/fixtures/ty_check/method_bound/specialized.fe
+++ b/crates/uitest/fixtures/ty_check/method_bound/specialized.fe
@@ -1,0 +1,30 @@
+trait Trait {
+    fn f(self) -> i32
+}
+
+struct S<T> {
+    t: T
+}
+
+struct S2<T> {
+    s: S<T>
+}
+
+impl Trait for S<i32> {
+    fn f(self) -> i32 {
+        self.t
+    }
+}
+
+impl<T> Trait for S2<T>
+where S<T>: Trait {
+    fn f(self) -> i32 {
+        self.s.f()
+    }
+}
+
+fn bar() {
+    let s = S { t: false }
+    let s2 = S2 { s }
+    let _ = s2.f()
+}

--- a/crates/uitest/fixtures/ty_check/method_bound/specialized.snap
+++ b/crates/uitest/fixtures/ty_check/method_bound/specialized.snap
@@ -1,0 +1,12 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: crates/uitest/fixtures/ty_check/method_bound/specialized.fe
+---
+error[6-0003]: trait bound is not satisfied
+   ┌─ specialized.fe:29:16
+   │
+29 │     let _ = s2.f()
+   │                ^ `S2<bool>` doesn't implement `Trait`
+
+


### PR DESCRIPTION
I broke the constraint solver when I introduced `Binder`.
This PR also adds the `Callable` information in the type checker, which will be necessary for MIR-lowering and the WF check for types that are implicitly introduced in method resolution.