### PR TITLE
Add support for development in both Docker and Github Codespace.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"name": "fe-lang-v2",
+	"image": "mcr.microsoft.com/devcontainers/rust:latest",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+	},
+	"extensions": [
+		"GitHub.vscode-github-actions",
+		"ms-vsliveshare.vsliveshare",
+		"vadimcn.vscode-lldb",
+		"matklad.rust-analyzer",
+		"serayuzgur.crates",
+		"tamasfe.even-better-toml",
+		"usernamehw.errorlens",
+		"aaron-bond.better-comments",
+		"yzhang.markdown-all-in-one"
+	],
+	"settings": {
+		"explorer.compactFolders": false,
+		"editor.rulers": [
+			80
+		],
+		"workbench.colorTheme": "Default Dark+",
+		"workbench.preferredDarkColorTheme": "Monokai",
+		"workbench.colorCustomizations": {
+			"editorRuler.foreground": "#5f5f62"
+		},
+		"workbench.activityBar.location": "top"
+	}
+}


### PR DESCRIPTION
### What was wrong?

There is no support for Devcontainer


### How was it fixed?

Added `.devcontainer/devcontainer.json` file.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [X] Clean up commit history
