### PR TITLE
gh ci: set RUST_BACKTRACE=full

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-D warnings"
+  RUST_BACKTRACE: full
 
 jobs:
   lint:


### PR DESCRIPTION
Debugging the ci test panic (caused by some crate we depend on, in the the legacy compiler tests)