### PR TITLE
fix typo

### DIFF
--- a/docs/src/user-guide/tutorials/auction.md
+++ b/docs/src/user-guide/tutorials/auction.md
@@ -25,7 +25,7 @@ You can see the entire contract [here](../example_contracts/auction_contract.md)
 
 ### Defining the `Contract` and initializing variables 
 
-A contract is Fe is defined using the `contract` keyword. A contract requires a constructor function to initialize any state variables used by the contract. If no constructor is defined, Fe will add a default with no state variables. The skeleton of the contract can look as follows:
+A contract in Fe is defined using the `contract` keyword. A contract requires a constructor function to initialize any state variables used by the contract. If no constructor is defined, Fe will add a default with no state variables. The skeleton of the contract can look as follows:
 
 ```rust
 contract Auction {


### PR DESCRIPTION
### What was wrong?

a small typo in the documentation

### How was it fixed?
changing "is" to "in"


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] OPTIONAL: Update [Spec](https://github.com/ethereum/fe/blob/master/docs/src/spec/index.md) if applicable
- [ ] Add entry to the [release notes](https://github.com/ethereum/fe/blob/master/newsfragments/README.md) (may forgo for trivial changes)

- [ ] Clean up commit history
