### PR TITLE
Ensure termination in trait solving

### DIFF
--- a/crates/common2/src/diagnostics.rs
+++ b/crates/common2/src/diagnostics.rs
@@ -166,7 +166,7 @@ impl DiagnosticPass {
             Self::MethodDefinition => 7,
             Self::TyCheck => 8,
 
-            Self::ExternalAnalysis(_) => std::u16::MAX,
+            Self::ExternalAnalysis(_) => u16::MAX,
         }
     }
 }

--- a/crates/fe/src/task/test.rs
+++ b/crates/fe/src/task/test.rs
@@ -1,10 +1,11 @@
-#![cfg(feature = "solc-backend")]
 use std::path::Path;
 
 use clap::Args;
 use colored::Colorize;
-use fe_common::diagnostics::print_diagnostics;
-use fe_common::utils::files::{get_project_root, BuildFiles};
+use fe_common::{
+    diagnostics::print_diagnostics,
+    utils::files::{get_project_root, BuildFiles},
+};
 use fe_driver::CompiledTest;
 use fe_test_runner::TestSink;
 

--- a/crates/hir-analysis/src/lib.rs
+++ b/crates/hir-analysis/src/lib.rs
@@ -69,6 +69,7 @@ pub struct Jar(
     ty::trait_resolution::is_goal_satisfiable,
     ty::trait_resolution::check_ty_wf,
     ty::trait_resolution::check_trait_inst_wf,
+    ty::trait_resolution::ty_depth_impl,
     // Type checking.
     ty::ty_check::check_func_body,
     // Diagnostic accumulators.

--- a/crates/hir-analysis/src/ty/canonical.rs
+++ b/crates/hir-analysis/src/ty/canonical.rs
@@ -43,7 +43,7 @@ where
     {
         assert!(table.is_empty());
 
-        for var in collect_variables(table.db(), &self.value).iter() {
+        for var in collect_variables(table.db, &self.value).iter() {
             table.new_var(var.sort, &var.kind);
         }
 

--- a/crates/hir-analysis/src/ty/trait_resolution/mod.rs
+++ b/crates/hir-analysis/src/ty/trait_resolution/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use hir::hir_def::IngotId;
+pub(crate) use proof_forest::ty_depth_impl;
 
 use super::{
     canonical::{Canonical, Canonicalized, Solution},
@@ -116,7 +117,8 @@ pub(crate) fn check_trait_inst_wf(
 pub enum GoalSatisfiability {
     /// Goal is satisfied with the unique solution.
     Satisfied(Solution<TraitInstId>),
-    /// Goal is satisfied, but with multiple solutions.
+    /// Goal might be satisfied, but needs more type information to determine
+    /// satisfiability and uniqueness.
     NeedsConfirmation(BTreeSet<Solution<TraitInstId>>),
 
     /// Goal contains invalid.

--- a/crates/uitest/fixtures/ty/trait_bound/coinductive.fe
+++ b/crates/uitest/fixtures/ty/trait_bound/coinductive.fe
@@ -1,0 +1,37 @@
+struct Vec<T> {
+    data: T
+}
+
+impl<T> Vec<T> {
+    fn new() -> Vec<T> {
+        todo()
+    }
+}
+
+trait Clone {
+    fn clone(self) -> Self
+}
+
+extern {
+    fn todo() -> !
+}
+
+impl Clone for i32 {
+    fn clone(self) -> i32 {
+        self
+    }
+}
+
+impl<T> Clone for Vec<T>
+where T: Clone {
+    fn clone(self) -> Vec<T> {
+        Self {
+            data: self.data.clone()
+        }
+    }
+}
+
+fn foo() {
+    let v = Vec::new()
+    let _ = v.clone()
+}

--- a/crates/uitest/fixtures/ty/trait_bound/coinductive.snap
+++ b/crates/uitest/fixtures/ty/trait_bound/coinductive.snap
@@ -1,0 +1,15 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: crates/uitest/fixtures/ty/trait_bound/coinductive.fe
+---
+error[8-0031]: type annotation is needed
+   ┌─ coinductive.fe:35:9
+   │
+35 │     let v = Vec::new()
+   │         ^
+   │         │
+   │         type annotation is needed
+   │         consider giving `: Vec<_>` here
+
+

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -12,7 +12,15 @@ additional-css = ["theme/reference.css"]
 [output.linkcheck]
 follow-web-links = true
 warning-policy = "error"
-exclude = [ 'github\.com', 'etherscan\.io', 'goerlifaucet\.com', 'alchemy\.com', 'infura\.io', 'marketplace.visualstudio\.com']
+exclude = [
+    'github\.com',
+    'etherscan\.io',
+    'goerlifaucet\.com',
+    'alchemy\.com',
+    'infura\.io',
+    'marketplace.visualstudio\.com',
+    'certik\.com',
+]
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
This PR ensures the termination in trait solving by adding a bound on type depth.
As the comments in the code describe, we'd need to revisit the trait solver when v2 is deployed.
This limitation doesn't break the soundness of the trait solver itself, but in some cases, users might need to add extra type annotations in their code.