### PR TITLE
Fix language server in stdio mode

### DIFF
--- a/crates/language-server/editors/vscode/src/extension.ts
+++ b/crates/language-server/editors/vscode/src/extension.ts
@@ -66,7 +66,7 @@ export async function activate(
   const customServerPath = config.get<string>("binaryPath", "");
   const serverPath = customServerPath || getServerPath();
 
-  let useTcp = true;
+  let useTcp = false;
 
   let connectionInfo = {
     port: 4242,

--- a/crates/language-server/src/lsp_actor/mod.rs
+++ b/crates/language-server/src/lsp_actor/mod.rs
@@ -7,6 +7,7 @@ use async_lsp::{
 };
 use service::LspActorKey;
 use std::collections::HashMap;
+use tracing::debug;
 
 use act_locally::{
     dispatcher::Dispatcher,
@@ -121,7 +122,7 @@ impl Dispatcher<LspActorKey> for LspDispatcher {
     ) -> Result<Box<dyn Response>, ActorError> {
         let MessageKey(key) = key;
         if let Some(unwrapper) = self.unwrappers.get(&key) {
-            println!("Found an unwrapper for key {}!", &key);
+            debug!("Found an unwrapper for key {}!", &key);
             unwrapper(message)
         } else {
             Err(ActorError::HandlerNotFound)


### PR DESCRIPTION
### What was wrong?
The language server was crashing in stdio mode.  It turned out there was a `println` statement somewhere clogging up stdio, which should be reserved for JSON-RPC messages when running the language server in stdio mode.

### How was it fixed?
I just changed the `println` to a `debug` statement.  The VSCode extension now uses stdio without problems.  This will make it easier to support other editors.
