### PR TITLE
prototype nvim plugin

### DIFF
--- a/crates/language-server/editors/nvim/README.md
+++ b/crates/language-server/editors/nvim/README.md
@@ -1,0 +1,118 @@
+# nvim-fe Plugin
+
+Neovim plugin for the **Fe programming language** with:
+- Syntax highlighting via Tree-sitter
+- Indentation support
+- LSP integration for go-to-definition and more
+
+## Installation
+
+### Prerequisites
+
+1. **Neovim 0.9.0 or later**
+   - Requires Tree-sitter and `vim.filetype.add` support
+
+2. **GCC or Clang**
+   - For compiling the Tree-sitter parser
+
+3. **`fe-language-server`**
+   - Install to your `PATH`
+
+---
+
+### Manual Installation
+
+1. Copy this directory to:
+   ```bash
+   cp -r ./ ~/.local/share/nvim/site/pack/plugins/start/nvim-fe
+   ```
+
+2. Install `nvim-treesitter`:
+   ```bash
+   git clone https://github.com/nvim-treesitter/nvim-treesitter ~/.local/share/nvim/site/pack/plugins/start/nvim-treesitter
+   ```
+
+3. Add to `init.lua`:
+   ```lua
+   require("nvim_fe").setup()
+   ```
+
+---
+
+### Install with `packer.nvim`
+
+Add to your packer config:
+
+```lua
+use({
+    "this/directory",
+    config = function()
+        require("nvim_fe").setup()
+    end,
+    requires = {
+        "nvim-treesitter/nvim-treesitter",
+    },
+})
+```
+
+### Install with `lazy.nvim`
+
+```lua
+{
+    "this/directory",
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    config = function()
+        require("nvim_fe").setup()
+    end,
+}
+```
+
+---
+
+## Features
+
+- **Syntax Highlighting**: Automatically highlights `.fe` files
+- **Indentation**: Tree-sitter-based indentation for `.fe` files
+- **LSP Support**: Dynamically starts the Fe language server when opening `.fe` files
+
+---
+
+## Troubleshooting
+
+### Missing Syntax Highlighting
+
+1. Ensure `nvim-treesitter` is installed:
+   ```bash
+   :TSInstallInfo
+   ```
+   Confirm `fe` is listed under "Parsers installed."
+
+2. Check queries:
+   ```bash
+   :lua print(vim.inspect(vim.api.nvim_get_runtime_file("queries/fe/*.scm", true)))
+   ```
+   Ensure `fe` queries are loaded.
+
+---
+
+### Missing LSP Features
+
+1. Ensure `fe-language-server` is installed and available in your `PATH`.
+
+2. Check the LSP client:
+   ```bash
+   :LspInfo
+   ```
+   Confirm the Fe LSP client is listed and attached.
+
+---
+
+### Reinstall the Plugin
+
+Delete the runtime directories to force reinstallation:
+```bash
+rm -rf ~/.local/share/nvim/tree-sitter-fe
+rm -rf ~/.local/share/nvim/nvim-fe-runtime
+```
+
+Restart Neovim and the plugin will reinitialize.

--- a/crates/language-server/editors/nvim/lua/nvim_fe/init.lua
+++ b/crates/language-server/editors/nvim/lua/nvim_fe/init.lua
@@ -1,0 +1,148 @@
+local M = {}
+
+local ts_repo_url = "https://github.com/fe-lang/tree-sitter-fe.git"
+local plugin_runtime_dir = vim.fn.stdpath("data") .. "/nvim-fe-runtime"
+local queries_dir = plugin_runtime_dir .. "/queries/fe"
+local repo_dir = vim.fn.stdpath("data") .. "/tree-sitter-fe"
+
+-- Ensure a directory exists
+local function ensure_dir(dir)
+    if vim.fn.isdirectory(dir) == 0 then
+        vim.fn.mkdir(dir, "p")
+    end
+end
+
+-- Prepend the plugin's runtime directory to Neovim's runtime path
+local function add_to_runtime()
+    if not vim.tbl_contains(vim.opt.runtimepath:get(), plugin_runtime_dir) then
+        vim.opt.runtimepath:prepend(plugin_runtime_dir)
+    end
+end
+
+-- Check if setup is needed
+local function needs_setup()
+    if vim.fn.isdirectory(repo_dir) == 0 then
+        return true
+    end
+    local query_files = vim.fn.glob(queries_dir .. "/*.scm", false, true)
+    return #query_files == 0 -- Check if queries are missing
+end
+
+-- Clone or update the tree-sitter-fe repository
+local function setup_repository()
+    if vim.fn.isdirectory(repo_dir) == 0 then
+        vim.fn.system({ "git", "clone", ts_repo_url, repo_dir })
+        vim.notify("Cloned tree-sitter-fe repository.", vim.log.levels.INFO)
+    else
+        vim.fn.system({ "git", "-C", repo_dir, "pull" })
+        vim.notify("Updated tree-sitter-fe repository.", vim.log.levels.INFO)
+    end
+end
+
+-- Set up Tree-sitter queries
+local function setup_queries()
+    ensure_dir(queries_dir)
+
+    local repo_queries_dir = repo_dir .. "/queries"
+    if vim.fn.isdirectory(repo_queries_dir) == 1 then
+        for _, query_file in ipairs(vim.fn.glob(repo_queries_dir .. "/*.scm", false, true)) do
+            local dest = queries_dir .. "/" .. vim.fn.fnamemodify(query_file, ":t")
+            vim.fn.system({ "cp", query_file, dest })
+        end
+        vim.notify("Fe queries copied to plugin runtime path.", vim.log.levels.INFO)
+    else
+        vim.notify("No queries directory found in tree-sitter-fe repository.", vim.log.levels.WARN)
+    end
+end
+
+-- Configure Tree-sitter for Fe
+local function setup_treesitter()
+    local ok, configs = pcall(require, "nvim-treesitter.configs")
+    if not ok then
+        vim.notify("nvim-treesitter is not installed. Please install it for Fe syntax highlighting.", vim.log.levels
+            .WARN)
+        return
+    end
+
+    local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+    parser_config.fe = {
+        install_info = {
+            url = ts_repo_url,
+            files = { "src/parser.c", "src/scanner.c" },
+            branch = "main",
+        },
+        filetype = "fe",
+    }
+
+    configs.setup({
+        ensure_installed = { "fe" },
+        highlight = { enable = true },
+        indent = { enable = true },
+    })
+end
+
+-- Set up filetype detection for `.fe` files
+local function setup_filetype()
+    vim.filetype.add({
+        extension = {
+            fe = "fe",
+        },
+    })
+end
+
+-- Set up LSP for Fe
+local function setup_lsp()
+    vim.api.nvim_create_autocmd("FileType", {
+        pattern = "fe",
+        callback = function()
+            local function find_root(patterns)
+                local cwd = vim.loop.cwd()
+                for _, pattern in ipairs(patterns) do
+                    local path = vim.fs.find(pattern, { upward = true, path = cwd })
+                    if #path > 0 then
+                        return vim.fs.dirname(path[1])
+                    end
+                end
+                return nil
+            end
+
+            local root_dir = find_root({ ".git", "fe.toml" })
+            if not root_dir then
+                vim.notify("Fe LSP: Could not determine root directory.", vim.log.levels.WARN)
+                return
+            end
+
+            local client_id = vim.lsp.start_client({
+                name = "fe",
+                cmd = { "fe-language-server" },
+                root_dir = root_dir,
+                filetypes = { "fe" },
+            })
+
+            if client_id then
+                vim.lsp.buf_attach_client(0, client_id)
+                vim.keymap.set("n", "gd", vim.lsp.buf.definition, { buffer = true })
+            end
+        end,
+    })
+end
+
+-- Plugin setup entry point
+function M.setup()
+    ensure_dir(plugin_runtime_dir)
+    add_to_runtime()
+    setup_filetype()
+
+    if needs_setup() then
+        setup_repository()
+        setup_queries()
+        setup_treesitter()
+        vim.notify("Fe plugin setup completed.", vim.log.levels.INFO)
+    else
+        setup_treesitter() -- Ensure Tree-sitter is configured
+    end
+
+    setup_lsp()
+end
+
+return M


### PR DESCRIPTION
This nvim plugin sets up treesitter and lsp support for fe language.  It requires that `fe-language-server` is in the path and that the user has the `treesitter-nvim` plugin installed.