### PR TITLE
Consolidated tracing / log cleanup

### DIFF
--- a/crates/analyzer/src/namespace/scopes.rs
+++ b/crates/analyzer/src/namespace/scopes.rs
@@ -551,7 +551,7 @@ impl AnalyzerContext for BlockScope<'_, '_> {
     }
 
     fn inherits_type(&self, typ: BlockScopeType) -> bool {
-        self.typ == typ || self.parent.map_or(false, |scope| scope.inherits_type(typ))
+        self.typ == typ || self.parent.is_some_and(|scope| scope.inherits_type(typ))
     }
 
     fn resolve_path(&self, path: &ast::Path, span: Span) -> Result<NamedThing, FatalError> {

--- a/crates/analyzer/src/traversal/types.rs
+++ b/crates/analyzer/src/traversal/types.rs
@@ -264,10 +264,9 @@ fn coerce(
                     && elts
                         .iter()
                         .zip(ftup.items.iter().zip(itup.items.iter()))
-                        .map(|(elt, (from, into))| {
+                        .all(|(elt, (from, into))| {
                             try_coerce_type(context, Some(elt), *from, *into, should_copy).is_ok()
                         })
-                        .all(|x| x)
                 {
                     // Update the type of the rhs tuple, because its elements
                     // have been coerced into the lhs element types.

--- a/crates/hir/src/hir_def/item.rs
+++ b/crates/hir/src/hir_def/item.rs
@@ -674,7 +674,7 @@ impl<'db> Func<'db> {
             .name
             .to_opt()
             .and_then(|name| name.ident())
-            .map_or(false, |ident| ident.is_self(db))
+            .is_some_and(|ident| ident.is_self(db))
     }
 
     /// Returns `true` if the function is method or associated functions.
@@ -1020,9 +1020,7 @@ impl<'db> Use<'db> {
     }
 
     pub fn is_glob(&self, db: &dyn HirDb) -> bool {
-        self.path(db)
-            .to_opt()
-            .map_or(false, |path| path.is_glob(db))
+        self.path(db).to_opt().is_some_and(|path| path.is_glob(db))
     }
 
     pub fn is_unnamed(&self, db: &dyn HirDb) -> bool {

--- a/crates/hir/src/hir_def/mod.rs
+++ b/crates/hir/src/hir_def/mod.rs
@@ -105,7 +105,7 @@ impl<'db> StringId<'db> {
     }
 
     pub fn len_bytes(&self, db: &dyn HirDb) -> usize {
-        self.data(db).as_bytes().len()
+        self.data(db).len()
     }
 }
 

--- a/crates/hir/src/hir_def/params.rs
+++ b/crates/hir/src/hir_def/params.rs
@@ -120,7 +120,7 @@ impl<'db> FuncParam<'db> {
     }
 
     pub fn is_self_param(&self, db: &dyn HirDb) -> bool {
-        self.name.to_opt().map_or(false, |name| name.is_self(db))
+        self.name.to_opt().is_some_and(|name| name.is_self(db))
     }
 }
 
@@ -145,7 +145,7 @@ impl<'db> FuncParamName<'db> {
     }
 
     pub fn is_self(&self, db: &dyn HirDb) -> bool {
-        self.ident().map_or(false, |id| id.is_self(db))
+        self.ident().is_some_and(|id| id.is_self(db))
     }
 
     pub fn pretty_print(&self, db: &dyn HirDb) -> String {

--- a/crates/hir/src/hir_def/use_tree.rs
+++ b/crates/hir/src/hir_def/use_tree.rs
@@ -12,7 +12,7 @@ impl<'db> UsePathId<'db> {
         self.data(db)
             .last()
             .and_then(|seg| seg.to_opt())
-            .map_or(false, |seg| seg.is_glob())
+            .is_some_and(|seg| seg.is_glob())
     }
 
     pub fn last_ident(&self, db: &'db dyn HirDb) -> Option<IdentId<'db>> {

--- a/crates/hir/src/lower/params.rs
+++ b/crates/hir/src/lower/params.rs
@@ -143,7 +143,7 @@ impl<'db> FuncParam<'db> {
         let name = ast.name().map(|ast| FuncParamName::lower_ast(ctxt, ast));
 
         let self_ty_fallback =
-            name.map_or(false, |name| name.is_self(ctxt.db())) && ast.ty().is_none();
+            name.is_some_and(|name| name.is_self(ctxt.db())) && ast.ty().is_none();
 
         let ty = if self_ty_fallback {
             Partial::Present(TypeId::fallback_self_ty(ctxt.db()))

--- a/crates/parser2/src/ast/item.rs
+++ b/crates/parser2/src/ast/item.rs
@@ -307,7 +307,7 @@ impl Use {
     }
 
     pub fn has_sub_tree(&self) -> bool {
-        self.use_tree().map_or(false, |it| it.has_subtree())
+        self.use_tree().is_some_and(|it| it.has_subtree())
     }
 }
 


### PR DESCRIPTION
These changes fix basic language server functionality on the [`salsa-update` branch](https://github.com/sbillig/fe/tree/salsa-update).

### Changes
- Ensure that debug / tracing level logs aren't spamming the LSP client.  I tried with nvim and at one point it was accumulating at least 20MB/sec of log statements.  The language server pegged at 100% CPU usage, this was seemingly related to the old tracing configuration.
  - Gnome even crashed a few times when I did `:LspLog` in nvim in zed.
- The language server was logging some things to stderr and others to the LSP client... instead this directs all tracing output to the LSP client and filters out debug and trace levels by default.
