### PR TITLE
Bump salsa to latest (includes accumulator bugfix), and use salsa::tracked methods instead of separate _impl fns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -1774,12 +1781,13 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=e4d65a656fc68d0fb759b292ceae2aff2c785c5d#e4d65a656fc68d0fb759b292ceae2aff2c785c5d"
+source = "git+https://github.com/salsa-rs/salsa?rev=d32b3c1995b632d894250a667adb79c846b3da02#d32b3c1995b632d894250a667adb79c846b3da02"
 dependencies = [
  "append-only-vec",
  "arc-swap",
  "crossbeam",
  "dashmap",
+ "hashbrown 0.14.5",
  "hashlink",
  "indexmap",
  "parking_lot",
@@ -1794,12 +1802,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=e4d65a656fc68d0fb759b292ceae2aff2c785c5d#e4d65a656fc68d0fb759b292ceae2aff2c785c5d"
+source = "git+https://github.com/salsa-rs/salsa?rev=d32b3c1995b632d894250a667adb79c846b3da02#d32b3c1995b632d894250a667adb79c846b3da02"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=e4d65a656fc68d0fb759b292ceae2aff2c785c5d#e4d65a656fc68d0fb759b292ceae2aff2c785c5d"
+source = "git+https://github.com/salsa-rs/salsa?rev=d32b3c1995b632d894250a667adb79c846b3da02#d32b3c1995b632d894250a667adb79c846b3da02"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dir-test = "0.4"
 rustc-hash = "2.1.0"
 num-bigint = "0.4"
 paste = "1.0.15"
-salsa = { git = "https://github.com/salsa-rs/salsa", rev = "e4d65a656fc68d0fb759b292ceae2aff2c785c5d" }
+salsa = { git = "https://github.com/salsa-rs/salsa", rev = "d32b3c1995b632d894250a667adb79c846b3da02" }
 smallvec = { version = "1.13.2", features = ["union"] }
 wasm-bindgen-test = "0.3"
 glob = "0.3.2"

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -1,6 +1,6 @@
 use analysis_pass::ModuleAnalysisPass;
-use common::{InputDb, InputIngot};
-use hir_def::{module_tree_impl, IdentId, IngotId, TopLevelMod};
+use common::InputDb;
+use hir_def::TopLevelMod;
 pub use lower::parse::ParserError;
 use lower::parse::{parse_file_impl, ParseErrorAccumulator};
 use parser::GreenNode;
@@ -37,30 +37,6 @@ impl<'db> ModuleAnalysisPass<'db> for ParsingPass<'db> {
             .map(|d| Box::new(d.0) as _)
             .collect::<Vec<_>>()
     }
-}
-
-/// Returns the root modules and names of external ingots that the given `ingot`
-/// depends on.
-/// From the outside of the crate, this functionality can be accessed via
-/// [`TopLevelMod::external_ingots`](crate::TopLevelMod::external_ingots).
-// The reason why this function is not a public API is that we want to prohibit users of `HirDb` to
-// access `InputIngot` directly.
-#[salsa::tracked(return_ref)]
-#[allow(elided_named_lifetimes)]
-pub(crate) fn external_ingots_impl(
-    db: &dyn HirDb,
-    ingot: InputIngot,
-) -> Vec<(IdentId<'_>, IngotId<'_>)> {
-    let mut res = Vec::new();
-    for dep in ingot.external_ingots(db.as_input_db()) {
-        let name = IdentId::new(db, dep.name.to_string());
-        let ingot = module_tree_impl(db, dep.ingot)
-            .root_data()
-            .top_mod
-            .ingot(db);
-        res.push((name, ingot))
-    }
-    res
 }
 
 #[salsa::db]


### PR DESCRIPTION
Salsa 3 supports tracked methods, so I inlined the standalone tracked `_impl` functions. No functionality changes.