### PR TITLE
Add analysis benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo test --workspace --all-features --no-run --locked
+        run: cargo test --workspace --all-features --no-run --locked --exclude fe-language-server --exclude fe-bench
       - name: Run tests
-        run: cargo test --workspace --all-features --verbose
+        run: cargo test --workspace --all-features --verbose --exclude fe-language-server --exclude fe-bench
 
   wasm-test:
     runs-on: ubuntu-latest
@@ -75,7 +75,7 @@ jobs:
         # wasm-pack needs a Cargo.toml with a 'package' field.
         # (see https://github.com/rustwasm/wasm-pack/issues/642)
         # This will still run all tests in the workspace.
-        run: wasm-pack test --node crates/driver --workspace --exclude fe-language-server
+        run: wasm-pack test --node crates/driver --workspace --exclude fe-language-server --exclude fe-bench
 
   release:
     # Only run this when we push a tag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,10 +41,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -413,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +453,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -529,6 +577,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +667,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -756,6 +846,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fe-bench"
+version = "0.1.0"
+dependencies = [
+ "camino",
+ "criterion",
+ "fe-driver",
+ "fe-hir-analysis",
+ "fe-parser",
+ "walkdir",
+]
+
+[[package]]
 name = "fe-common"
 version = "0.26.0"
 dependencies = [
@@ -818,7 +920,7 @@ dependencies = [
  "fe-hir",
  "fe-test-utils",
  "if_chain",
- "itertools",
+ "itertools 0.14.0",
  "num-bigint",
  "rustc-hash 2.1.0",
  "salsa",
@@ -1081,6 +1183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,10 +1415,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1537,6 +1669,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1754,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polling"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,6 +1841,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.8.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2087,6 +2276,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fe-bench"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+criterion = "0.5"
+walkdir = "2.4"
+
+[dependencies]
+hir-analysis.workspace = true
+driver.workspace = true
+parser.workspace = true
+camino.workspace = true
+
+[[bench]]
+name = "analysis"
+harness = false

--- a/crates/bench/benches/analysis.rs
+++ b/crates/bench/benches/analysis.rs
@@ -1,0 +1,66 @@
+use camino::{Utf8Path, Utf8PathBuf};
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
+use driver::DriverDataBase;
+use walkdir::WalkDir;
+
+use parser::parse_source_file;
+
+fn diagnostics(c: &mut Criterion) {
+    let mut g = c.benchmark_group("analysis");
+    g.sampling_mode(SamplingMode::Flat);
+
+    g.bench_function("analyze corelib", |b| {
+        b.iter_with_large_drop(|| {
+            let mut db = DriverDataBase::default();
+            let (core, _) = db.static_core_ingot();
+            db.run_on_ingot(core);
+            db
+        });
+    });
+
+    let files = test_files("../uitest/fixtures/".into());
+
+    g.bench_function("uitest parsing", |b| {
+        b.iter(|| {
+            for (_, content) in &files {
+                parse_source_file(content);
+            }
+        })
+    });
+
+    g.bench_function("uitest diagnostics", |b| {
+        b.iter_with_large_drop(|| {
+            let mut db = DriverDataBase::default();
+            let (core, _) = db.static_core_ingot();
+            for (path, content) in &files {
+                let (ingot, file) = db.standalone(path, content, core);
+                let top_mod = db.top_mod(ingot, file);
+
+                db.run_on_top_mod(top_mod);
+            }
+            db
+        });
+    });
+
+    g.finish();
+}
+
+fn test_files(path: &Utf8Path) -> Vec<(Utf8PathBuf, String)> {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+
+    let test_dir = Utf8Path::new(manifest_dir).join(path);
+
+    WalkDir::new(test_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "fe"))
+        .map(|e| {
+            let path = Utf8PathBuf::from_path_buf(e.into_path()).unwrap();
+            let content = std::fs::read_to_string(&path).unwrap();
+            (path, content)
+        })
+        .collect()
+}
+
+criterion_group!(benches, diagnostics);
+criterion_main!(benches);

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    eprintln!("run `cargo bench`");
+}


### PR DESCRIPTION
Three simple benchmarks so far:
- analyze `library/core` (which is quite small right now; this will be more useful as the core lib grows)
- parse all fe files in uitest/fixtures/
- parse and analyze all fe files in uitest/fixtures

```
cd crates/bench
cargo bench
```

```
analysis/analyze corelib
                        time:   [1.2870 ms 1.2906 ms 1.2946 ms]
                        change: [-0.3730% +0.0087% +0.4142%] (p = 0.97 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe
analysis/uitest parsing time:   [1.6903 ms 1.6949 ms 1.6996 ms]
                        change: [-0.2576% +0.0639% +0.3805%] (p = 0.71 > 0.05)
                        No change in performance detected.
analysis/uitest diagnostics
                        time:   [28.317 ms 28.406 ms 28.502 ms]
                        change: [-0.5731% -0.0404% +0.4849%] (p = 0.88 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```