### PR TITLE
fix: Return exit code 1 when `fe-driver2` encounters errors

### DIFF
--- a/crates/driver2/src/lib.rs
+++ b/crates/driver2/src/lib.rs
@@ -130,6 +130,10 @@ impl<'db> DiagnosticsCollection<'db> {
         });
         diags
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 fn initialize_analysis_pass(db: &DriverDataBase) -> AnalysisPassManager<'_> {

--- a/crates/driver2/src/main.rs
+++ b/crates/driver2/src/main.rs
@@ -27,7 +27,11 @@ pub fn main() {
     let (ingot, file) = db.standalone(path, &source);
     let top_mod = db.top_mod(ingot, file);
     let diags = db.run_on_top_mod(top_mod);
-    diags.emit(&db);
+
+    if !diags.is_empty() {
+        diags.emit(&db);
+        std::process::exit(1);
+    }
 
     if args.dump_scope_graph {
         println!("{}", dump_scope_graph(&db, top_mod));


### PR DESCRIPTION
This PR ensures that `fe-driver2` commands exits with code `1` when errors are detected, preventing silent failures.

This changes can help building CI automations [like this one](https://github.com/Turupawn/fe-examples) that I'm building now.