### PR TITLE
fix: Return exit code 1 when `fe check` encounters errors (continuation)

### DIFF
--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -105,8 +105,12 @@ pub fn run(opts: &Options) {
 
             let core_diags = db.run_on_ingot(core_ingot);
             let local_diags = db.run_on_ingot(local_ingot);
-            core_diags.emit(&db);
-            local_diags.emit(&db);
+
+            if !core_diags.is_empty() || !local_diags.is_empty() {
+                core_diags.emit(&db);
+                local_diags.emit(&db);
+                std::process::exit(1);
+            }
         }
         Command::New => eprintln!("`fe new` doesn't work at the moment"),
     }


### PR DESCRIPTION
replaces #1059

This PR ensures that `fe check` command exits with code 1 when errors are detected, preventing silent failures.

This changes can help building CI automations [like this one](https://github.com/Turupawn/fe-examples) that I'm building now.