### PR TITLE
Salsa 3, part 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,18 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,12 +104,6 @@ name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-
-[[package]]
-name = "append-only-vec"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7992085ec035cfe96992dd31bfd495a2ebd31969bb95f624471cb6c0b349e571"
 
 [[package]]
 name = "arc-swap"
@@ -410,6 +392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225450ee9328e1e828319b48a89726cffc1b0ad26fd9211ad435de9fa376acae"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,28 +601,6 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1021,6 +990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1124,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,24 +1185,25 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1543,7 +1532,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rustc_version",
  "syn",
 ]
@@ -1558,6 +1547,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.95.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1570,15 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1860,8 +1871,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1872,8 +1892,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1982,13 +2008,13 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=ca9fba4e83b38ad7c2002b394edd792fa75f924a#ca9fba4e83b38ad7c2002b394edd792fa75f924a"
+source = "git+https://github.com/salsa-rs/salsa?rev=325d9aca9eae52db8a3f15056bcfc11e5a39d084#325d9aca9eae52db8a3f15056bcfc11e5a39d084"
 dependencies = [
- "append-only-vec",
  "arc-swap",
- "crossbeam",
+ "boxcar",
+ "crossbeam-queue",
  "dashmap",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "hashlink",
  "indexmap",
  "parking_lot",
@@ -2003,12 +2029,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=ca9fba4e83b38ad7c2002b394edd792fa75f924a#ca9fba4e83b38ad7c2002b394edd792fa75f924a"
+source = "git+https://github.com/salsa-rs/salsa?rev=325d9aca9eae52db8a3f15056bcfc11e5a39d084#325d9aca9eae52db8a3f15056bcfc11e5a39d084"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=ca9fba4e83b38ad7c2002b394edd792fa75f924a#ca9fba4e83b38ad7c2002b394edd792fa75f924a"
+source = "git+https://github.com/salsa-rs/salsa?rev=325d9aca9eae52db8a3f15056bcfc11e5a39d084#325d9aca9eae52db8a3f15056bcfc11e5a39d084"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2025,6 +2051,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2432,10 +2464,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term 0.46.0",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec 1.13.2",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2687,6 +2723,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,26 +2911,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,12 +106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,9 +2002,8 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=325d9aca9eae52db8a3f15056bcfc11e5a39d084#325d9aca9eae52db8a3f15056bcfc11e5a39d084"
+source = "git+https://github.com/salsa-rs/salsa?rev=99be5d9917c3dd88e19735a82ef6bf39ba84bd7e#99be5d9917c3dd88e19735a82ef6bf39ba84bd7e"
 dependencies = [
- "arc-swap",
  "boxcar",
  "crossbeam-queue",
  "dashmap",
@@ -2029,12 +2022,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=325d9aca9eae52db8a3f15056bcfc11e5a39d084#325d9aca9eae52db8a3f15056bcfc11e5a39d084"
+source = "git+https://github.com/salsa-rs/salsa?rev=99be5d9917c3dd88e19735a82ef6bf39ba84bd7e#99be5d9917c3dd88e19735a82ef6bf39ba84bd7e"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=325d9aca9eae52db8a3f15056bcfc11e5a39d084#325d9aca9eae52db8a3f15056bcfc11e5a39d084"
+source = "git+https://github.com/salsa-rs/salsa?rev=99be5d9917c3dd88e19735a82ef6bf39ba84bd7e#99be5d9917c3dd88e19735a82ef6bf39ba84bd7e"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,8 +863,9 @@ version = "0.26.0"
 dependencies = [
  "camino",
  "fe-parser",
- "indexmap",
+ "ordermap",
  "paste",
+ "rustc-hash 2.1.0",
  "salsa",
  "semver",
  "smol_str 0.3.2",
@@ -1394,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1672,6 +1673,15 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
+name = "ordermap"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55fdf45a2b1e929e3656d404395767e05c98b6ebd8157eb31e370077d545160"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "overload"
@@ -1972,7 +1982,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 [[package]]
 name = "salsa"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=d32b3c1995b632d894250a667adb79c846b3da02#d32b3c1995b632d894250a667adb79c846b3da02"
+source = "git+https://github.com/salsa-rs/salsa?rev=ca9fba4e83b38ad7c2002b394edd792fa75f924a#ca9fba4e83b38ad7c2002b394edd792fa75f924a"
 dependencies = [
  "append-only-vec",
  "arc-swap",
@@ -1993,12 +2003,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.1.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=d32b3c1995b632d894250a667adb79c846b3da02#d32b3c1995b632d894250a667adb79c846b3da02"
+source = "git+https://github.com/salsa-rs/salsa?rev=ca9fba4e83b38ad7c2002b394edd792fa75f924a#ca9fba4e83b38ad7c2002b394edd792fa75f924a"
 
 [[package]]
 name = "salsa-macros"
 version = "0.18.0"
-source = "git+https://github.com/salsa-rs/salsa?rev=d32b3c1995b632d894250a667adb79c846b3da02#d32b3c1995b632d894250a667adb79c846b3da02"
+source = "git+https://github.com/salsa-rs/salsa?rev=ca9fba4e83b38ad7c2002b394edd792fa75f924a#ca9fba4e83b38ad7c2002b394edd792fa75f924a"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,7 +900,7 @@ dependencies = [
  "paste",
  "rustc-hash 2.1.0",
  "salsa",
- "smallvec 1.13.2",
+ "smallvec 2.0.0-alpha.10",
 ]
 
 [[package]]
@@ -924,7 +924,6 @@ dependencies = [
  "num-bigint",
  "rustc-hash 2.1.0",
  "salsa",
- "smallvec 1.13.2",
  "smallvec 2.0.0-alpha.10",
 ]
 
@@ -975,7 +974,7 @@ dependencies = [
  "logos",
  "rowan",
  "rustc-hash 2.1.0",
- "smallvec 1.13.2",
+ "smallvec 2.0.0-alpha.10",
  "unwrap-infallible",
  "wasm-bindgen",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dir-test = "0.4"
 rustc-hash = "2.1.0"
 num-bigint = "0.4"
 paste = "1.0.15"
-salsa = { git = "https://github.com/salsa-rs/salsa", rev = "ca9fba4e83b38ad7c2002b394edd792fa75f924a" }
+salsa = { git = "https://github.com/salsa-rs/salsa", rev = "325d9aca9eae52db8a3f15056bcfc11e5a39d084" }
 smallvec = { version = "2.0.0-alpha.10" }
 wasm-bindgen-test = "0.3"
 glob = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dir-test = "0.4"
 rustc-hash = "2.1.0"
 num-bigint = "0.4"
 paste = "1.0.15"
-salsa = { git = "https://github.com/salsa-rs/salsa", rev = "325d9aca9eae52db8a3f15056bcfc11e5a39d084" }
+salsa = { git = "https://github.com/salsa-rs/salsa", rev = "99be5d9917c3dd88e19735a82ef6bf39ba84bd7e" }
 smallvec = { version = "2.0.0-alpha.10" }
 wasm-bindgen-test = "0.3"
 glob = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dir-test = "0.4"
 rustc-hash = "2.1.0"
 num-bigint = "0.4"
 paste = "1.0.15"
-salsa = { git = "https://github.com/salsa-rs/salsa", rev = "d32b3c1995b632d894250a667adb79c846b3da02" }
+salsa = { git = "https://github.com/salsa-rs/salsa", rev = "ca9fba4e83b38ad7c2002b394edd792fa75f924a" }
 smallvec = { version = "2.0.0-alpha.10" }
 wasm-bindgen-test = "0.3"
 glob = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rustc-hash = "2.1.0"
 num-bigint = "0.4"
 paste = "1.0.15"
 salsa = { git = "https://github.com/salsa-rs/salsa", rev = "d32b3c1995b632d894250a667adb79c846b3da02" }
-smallvec = { version = "1.13.2", features = ["union"] }
+smallvec = { version = "2.0.0-alpha.10" }
 wasm-bindgen-test = "0.3"
 glob = "0.3.2"
 semver = "1.0.24"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -10,10 +10,11 @@ description = "Provides HIR definition and lowering for Fe lang."
 
 [dependencies]
 camino.workspace = true
-indexmap = "2.7"
 paste.workspace = true
 salsa.workspace = true
 semver.workspace = true
 smol_str = "0.3.2"
 
 parser.workspace = true
+ordermap = "0.5.5"
+rustc-hash.workspace = true

--- a/crates/hir-analysis/Cargo.toml
+++ b/crates/hir-analysis/Cargo.toml
@@ -18,7 +18,6 @@ num-bigint.workspace = true
 rustc-hash.workspace = true
 salsa.workspace = true
 smallvec.workspace = true
-smallvec2 = { package = "smallvec", version = "2.0.0-alpha.10" }
 
 common.workspace = true
 test-utils.workspace = true

--- a/crates/hir-analysis/src/name_resolution/diagnostics.rs
+++ b/crates/hir-analysis/src/name_resolution/diagnostics.rs
@@ -2,11 +2,12 @@ use hir::{
     hir_def::{IdentId, TopLevelMod},
     span::DynLazySpan,
 };
+use salsa::Update;
 
 use super::NameRes;
 use crate::HirAnalysisDb;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub enum NameResDiag<'db> {
     /// The definition conflicts with other definitions.
     Conflict(IdentId<'db>, Vec<DynLazySpan<'db>>),

--- a/crates/hir-analysis/src/name_resolution/import_resolver.rs
+++ b/crates/hir-analysis/src/name_resolution/import_resolver.rs
@@ -10,6 +10,7 @@ use hir::{
 };
 use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::Update;
 
 use super::{
     diagnostics::NameResDiag,
@@ -679,7 +680,7 @@ impl<'db> ImportResolver<'db> {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Update)]
 pub struct ResolvedImports<'db> {
     pub named_resolved: FxHashMap<ScopeId<'db>, NamedImportSet<'db>>,
     pub glob_resolved: FxHashMap<ScopeId<'db>, GlobImportSet<'db>>,
@@ -727,7 +728,7 @@ impl<'db> Importer<'db> for DefaultImporter {
 
 pub type NamedImportSet<'db> = FxHashMap<IdentId<'db>, NameResBucket<'db>>;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Update)]
 pub struct GlobImportSet<'db> {
     imported: FxHashMap<Use<'db>, FxHashMap<IdentId<'db>, Vec<NameRes<'db>>>>,
 }

--- a/crates/hir-analysis/src/name_resolution/import_resolver.rs
+++ b/crates/hir-analysis/src/name_resolution/import_resolver.rs
@@ -4,6 +4,7 @@ use std::{
     mem,
 };
 
+use common::indexmap::IndexMap;
 use hir::{
     hir_def::{prim_ty::PrimTy, scope_graph::ScopeId, IdentId, IngotId, Use},
     span::DynLazySpan,
@@ -682,9 +683,9 @@ impl<'db> ImportResolver<'db> {
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Update)]
 pub struct ResolvedImports<'db> {
-    pub named_resolved: FxHashMap<ScopeId<'db>, NamedImportSet<'db>>,
-    pub glob_resolved: FxHashMap<ScopeId<'db>, GlobImportSet<'db>>,
-    pub unnamed_resolved: FxHashMap<ScopeId<'db>, Vec<NameResBucket<'db>>>,
+    pub named_resolved: IndexMap<ScopeId<'db>, NamedImportSet<'db>>,
+    pub glob_resolved: IndexMap<ScopeId<'db>, GlobImportSet<'db>>,
+    pub unnamed_resolved: IndexMap<ScopeId<'db>, Vec<NameResBucket<'db>>>,
 }
 
 pub(super) trait Importer<'db> {

--- a/crates/hir-analysis/src/name_resolution/name_resolver.rs
+++ b/crates/hir-analysis/src/name_resolution/name_resolver.rs
@@ -17,6 +17,7 @@ use hir::{
     span::DynLazySpan,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::Update;
 
 use super::{
     import_resolver::Importer,
@@ -88,7 +89,7 @@ impl Default for QueryDirective {
 /// The struct contains the lookup result of a name query.
 /// The results can contain more than one name resolutions which belong to
 /// different name domains.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Update)]
 pub struct NameResBucket<'db> {
     pub(super) bucket: FxHashMap<NameDomain, NameResolutionResult<'db, NameRes<'db>>>,
 }
@@ -240,7 +241,7 @@ impl<'db> From<NameRes<'db>> for NameResBucket<'db> {
 }
 
 /// The struct contains the lookup result of a name query.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub struct NameRes<'db> {
     /// The kind of the resolution.
     pub kind: NameResKind<'db>,
@@ -400,7 +401,7 @@ impl<'db> NameRes<'db> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, derive_more::From)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, derive_more::From, Update)]
 pub enum NameResKind<'db> {
     /// The name is resolved to a scope.
     Scope(ScopeId<'db>),
@@ -427,7 +428,7 @@ impl<'db> NameResKind<'db> {
 /// The name derivation indicates where a name resolution comes from.
 /// Name derivation is used to track the origin of a resolution, and to
 /// determine the shadowing rules.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Update)]
 pub enum NameDerivation<'db> {
     /// Derived from a definition in the current scope.
     Def,
@@ -732,7 +733,7 @@ impl<'db, 'a> NameResolver<'db, 'a> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub enum NameResolutionError<'db> {
     /// The name is not found.
     NotFound,
@@ -775,7 +776,7 @@ impl fmt::Display for NameResolutionError<'_> {
 impl std::error::Error for NameResolutionError<'_> {}
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Update)]
     /// Each resolved name is associated with a domain that indicates which domain
     /// the name belongs to.
     /// The multiple same names can be introduced in a same scope as long as they

--- a/crates/hir-analysis/src/name_resolution/traits_in_scope.rs
+++ b/crates/hir-analysis/src/name_resolution/traits_in_scope.rs
@@ -1,5 +1,5 @@
+use common::indexmap::IndexSet;
 use hir::hir_def::{scope_graph::ScopeId, Body, ExprId, ItemKind, Mod, TopLevelMod, Trait};
-use rustc_hash::FxHashSet;
 
 use crate::{name_resolution::resolve_imports, HirAnalysisDb};
 
@@ -7,7 +7,7 @@ use crate::{name_resolution::resolve_imports, HirAnalysisDb};
 pub fn available_traits_in_scope<'db>(
     db: &'db dyn HirAnalysisDb,
     scope: ScopeId<'db>,
-) -> &'db FxHashSet<Trait<'db>> {
+) -> &'db IndexSet<Trait<'db>> {
     let scope_kind = TraitScopeKind::from_scope(db, scope);
     let trait_scope = TraitScope::new(db, scope_kind);
     available_traits_in_scope_impl(db, trait_scope)
@@ -17,8 +17,8 @@ pub fn available_traits_in_scope<'db>(
 pub(crate) fn available_traits_in_scope_impl<'db>(
     db: &'db dyn HirAnalysisDb,
     t_scope: TraitScope<'db>,
-) -> FxHashSet<Trait<'db>> {
-    let mut traits = FxHashSet::default();
+) -> IndexSet<Trait<'db>> {
+    let mut traits = IndexSet::default();
     let scope = t_scope.inner(db).to_scope();
 
     let imports = &resolve_imports(db, scope.ingot(db.as_hir_db())).1;

--- a/crates/hir-analysis/src/ty/adt_def.rs
+++ b/crates/hir-analysis/src/ty/adt_def.rs
@@ -1,28 +1,29 @@
 use hir::{
     hir_def::{
-        scope_graph::ScopeId, Contract, Enum, FieldDefListId, IdentId, IngotId, ItemKind, Partial,
-        Struct, TypeId as HirTyId, VariantDefListId, VariantKind,
+        scope_graph::ScopeId, Contract, Enum, FieldDefListId, GenericParamOwner, IdentId, IngotId,
+        ItemKind, Partial, Struct, TypeId as HirTyId, VariantDefListId, VariantKind,
     },
     span::DynLazySpan,
 };
+use salsa::Update;
 
 use super::{
     binder::Binder,
     ty_def::{InvalidCause, TyId},
-    ty_lower::{collect_generic_params, lower_hir_ty, GenericParamOwnerId, GenericParamTypeSet},
+    ty_lower::{collect_generic_params, lower_hir_ty, GenericParamTypeSet},
 };
 use crate::HirAnalysisDb;
 
 /// Lower HIR ADT definition(`struct/enum/contract`) to [`AdtDef`].
 #[salsa::tracked]
-pub fn lower_adt<'db>(db: &'db dyn HirAnalysisDb, adt: AdtRefId<'db>) -> AdtDef<'db> {
+pub fn lower_adt<'db>(db: &'db dyn HirAnalysisDb, adt: AdtRef<'db>) -> AdtDef<'db> {
     AdtTyBuilder::new(db, adt).build()
 }
 
 /// Represents a ADT type definition.
 #[salsa::tracked]
 pub struct AdtDef<'db> {
-    pub adt_ref: AdtRefId<'db>,
+    pub adt_ref: AdtRef<'db>,
 
     /// Type parameters of the ADT.
     #[return_ref]
@@ -52,20 +53,21 @@ impl<'db> AdtDef<'db> {
     }
 
     pub(crate) fn is_struct(self, db: &dyn HirAnalysisDb) -> bool {
-        matches!(self.adt_ref(db).data(db), AdtRef::Struct(_))
+        matches!(self.adt_ref(db), AdtRef::Struct(_))
     }
 
     pub fn scope(self, db: &'db dyn HirAnalysisDb) -> ScopeId<'db> {
-        self.adt_ref(db).scope(db)
+        self.adt_ref(db).scope()
     }
 
+    #[allow(dead_code)] // xxx
     pub(crate) fn variant_ty_span(
         self,
         db: &'db dyn HirAnalysisDb,
         field_idx: usize,
         ty_idx: usize,
     ) -> DynLazySpan<'db> {
-        match self.adt_ref(db).data(db) {
+        match self.adt_ref(db) {
             AdtRef::Enum(e) => {
                 let span = e.lazy_span().variants_moved().variant_moved(field_idx);
                 match e.variants(db.as_hir_db()).data(db.as_hir_db())[field_idx].kind {
@@ -95,7 +97,7 @@ impl<'db> AdtDef<'db> {
 
     pub(crate) fn ingot(self, db: &'db dyn HirAnalysisDb) -> IngotId<'db> {
         let hir_db = db.as_hir_db();
-        match self.adt_ref(db).data(db) {
+        match self.adt_ref(db) {
             AdtRef::Enum(e) => e.top_mod(hir_db).ingot(hir_db),
             AdtRef::Struct(s) => s.top_mod(hir_db).ingot(hir_db),
             AdtRef::Contract(c) => c.top_mod(hir_db).ingot(hir_db),
@@ -105,8 +107,8 @@ impl<'db> AdtDef<'db> {
     pub(crate) fn as_generic_param_owner(
         self,
         db: &'db dyn HirAnalysisDb,
-    ) -> Option<GenericParamOwnerId<'db>> {
-        self.adt_ref(db).generic_owner_id(db)
+    ) -> Option<GenericParamOwner<'db>> {
+        self.adt_ref(db).generic_owner()
     }
 }
 
@@ -152,18 +154,33 @@ impl<'db> AdtField<'db> {
     }
 }
 
-#[salsa::interned]
-pub struct AdtRefId<'db> {
-    pub data: AdtRef<'db>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, derive_more::From, salsa::Supertype, Update)]
+pub enum AdtRef<'db> {
+    Enum(Enum<'db>),
+    Struct(Struct<'db>),
+    Contract(Contract<'db>),
 }
 
-impl<'db> AdtRefId<'db> {
-    pub fn scope(self, db: &'db dyn HirAnalysisDb) -> ScopeId<'db> {
-        self.data(db).scope()
+impl<'db> AdtRef<'db> {
+    pub fn try_from_item(item: ItemKind<'db>) -> Option<Self> {
+        match item {
+            ItemKind::Enum(x) => Some(x.into()),
+            ItemKind::Struct(x) => Some(x.into()),
+            ItemKind::Contract(x) => Some(x.into()),
+            _ => None,
+        }
     }
 
-    pub fn as_item(self, db: &'db dyn HirAnalysisDb) -> ItemKind<'db> {
-        match self.data(db) {
+    pub fn scope(self) -> ScopeId<'db> {
+        match self {
+            Self::Enum(e) => e.scope(),
+            Self::Struct(s) => s.scope(),
+            Self::Contract(c) => c.scope(),
+        }
+    }
+
+    pub fn as_item(self) -> ItemKind<'db> {
+        match self {
             AdtRef::Enum(e) => e.into(),
             AdtRef::Struct(s) => s.into(),
             AdtRef::Contract(c) => c.into(),
@@ -172,7 +189,7 @@ impl<'db> AdtRefId<'db> {
 
     pub fn name(self, db: &'db dyn HirAnalysisDb) -> IdentId<'db> {
         let hir_db = db.as_hir_db();
-        match self.data(db) {
+        match self {
             AdtRef::Enum(e) => e.name(hir_db),
             AdtRef::Struct(s) => s.name(hir_db),
             AdtRef::Contract(c) => c.name(hir_db),
@@ -181,79 +198,38 @@ impl<'db> AdtRefId<'db> {
         .unwrap_or_else(|| IdentId::new(hir_db, "<unknown>".to_string()))
     }
 
-    pub fn kind_name(self, db: &dyn HirAnalysisDb) -> &'static str {
-        self.as_item(db).kind_name()
+    pub fn kind_name(self) -> &'static str {
+        self.as_item().kind_name()
     }
 
     pub fn name_span(self, db: &'db dyn HirAnalysisDb) -> DynLazySpan<'db> {
-        self.scope(db)
+        self.scope()
             .name_span(db.as_hir_db())
             .unwrap_or_else(DynLazySpan::invalid)
     }
 
-    pub fn from_enum(db: &'db dyn HirAnalysisDb, enum_: Enum<'db>) -> Self {
-        Self::new(db, AdtRef::Enum(enum_))
-    }
-
-    pub fn from_struct(db: &'db dyn HirAnalysisDb, struct_: Struct<'db>) -> Self {
-        Self::new(db, AdtRef::Struct(struct_))
-    }
-
-    pub fn from_contract(db: &'db dyn HirAnalysisDb, contract: Contract<'db>) -> Self {
-        Self::new(db, AdtRef::Contract(contract))
-    }
-
-    pub fn try_from_item(db: &'db dyn HirAnalysisDb, item: ItemKind<'db>) -> Option<Self> {
-        match item {
-            ItemKind::Enum(e) => Some(Self::from_enum(db, e)),
-            ItemKind::Struct(s) => Some(Self::from_struct(db, s)),
-            ItemKind::Contract(c) => Some(Self::from_contract(db, c)),
-            _ => None,
-        }
-    }
-
-    pub(crate) fn generic_owner_id(
-        self,
-        db: &'db dyn HirAnalysisDb,
-    ) -> Option<GenericParamOwnerId<'db>> {
-        match self.data(db) {
-            AdtRef::Enum(e) => Some(GenericParamOwnerId::new(db, e.into())),
-            AdtRef::Struct(s) => Some(GenericParamOwnerId::new(db, s.into())),
-            AdtRef::Contract(_) => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]
-pub enum AdtRef<'db> {
-    Enum(Enum<'db>),
-    Struct(Struct<'db>),
-    Contract(Contract<'db>),
-}
-
-impl<'db> AdtRef<'db> {
-    pub fn scope(self) -> ScopeId<'db> {
+    pub(crate) fn generic_owner(self) -> Option<GenericParamOwner<'db>> {
         match self {
-            Self::Enum(e) => e.scope(),
-            Self::Struct(s) => s.scope(),
-            Self::Contract(c) => c.scope(),
+            AdtRef::Enum(e) => Some(e.into()),
+            AdtRef::Struct(s) => Some(s.into()),
+            AdtRef::Contract(_) => None,
         }
     }
 }
 
 struct AdtTyBuilder<'db> {
     db: &'db dyn HirAnalysisDb,
-    adt: AdtRefId<'db>,
+    adt: AdtRef<'db>,
     params: GenericParamTypeSet<'db>,
     variants: Vec<AdtField<'db>>,
 }
 
 impl<'db> AdtTyBuilder<'db> {
-    fn new(db: &'db dyn HirAnalysisDb, adt: AdtRefId<'db>) -> Self {
+    fn new(db: &'db dyn HirAnalysisDb, adt: AdtRef<'db>) -> Self {
         Self {
             db,
             adt,
-            params: GenericParamTypeSet::empty(db, adt.scope(db)),
+            params: GenericParamTypeSet::empty(db, adt.scope()),
             variants: Vec::new(),
         }
     }
@@ -265,18 +241,16 @@ impl<'db> AdtTyBuilder<'db> {
     }
 
     fn collect_generic_params(&mut self) {
-        let owner = match self.adt.data(self.db) {
+        let owner = match self.adt {
             AdtRef::Contract(_) => return,
             AdtRef::Enum(enum_) => enum_.into(),
             AdtRef::Struct(struct_) => struct_.into(),
         };
-        let owner_id = GenericParamOwnerId::new(self.db, owner);
-
-        self.params = collect_generic_params(self.db, owner_id);
+        self.params = collect_generic_params(self.db, owner);
     }
 
     fn collect_variants(&mut self) {
-        match self.adt.data(self.db) {
+        match self.adt {
             AdtRef::Struct(struct_) => {
                 self.collect_field_types(struct_.fields(self.db.as_hir_db()));
             }
@@ -292,7 +266,7 @@ impl<'db> AdtTyBuilder<'db> {
     }
 
     fn collect_field_types(&mut self, fields: FieldDefListId<'db>) {
-        let scope = self.adt.scope(self.db);
+        let scope = self.adt.scope();
 
         let fields = fields
             .data(self.db.as_hir_db())
@@ -304,7 +278,7 @@ impl<'db> AdtTyBuilder<'db> {
     }
 
     fn collect_enum_variant_types(&mut self, variants: VariantDefListId<'db>) {
-        let scope = self.adt.scope(self.db);
+        let scope = self.adt.scope();
 
         variants
             .data(self.db.as_hir_db())

--- a/crates/hir-analysis/src/ty/canonical.rs
+++ b/crates/hir-analysis/src/ty/canonical.rs
@@ -1,4 +1,5 @@
 use rustc_hash::FxHashMap;
+use salsa::Update;
 
 use super::{
     const_ty::{ConstTyData, ConstTyId},
@@ -74,7 +75,7 @@ where
     where
         T: Copy,
         S: UnificationStore<'db>,
-        U: TyFoldable<'db> + Clone,
+        U: TyFoldable<'db> + Clone + Update,
     {
         let solution = solution.fold_with(table);
 
@@ -147,7 +148,7 @@ where
         solution: Solution<U>,
     ) -> U
     where
-        U: TyFoldable<'db>,
+        U: TyFoldable<'db> + Update,
         S: UnificationStore<'db>,
     {
         let map = self.subst.clone();
@@ -166,8 +167,11 @@ where
 ///
 /// To extract the internal value into the environment where the query was
 /// created, use [`Canonicalized::extract_solution`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Solution<T> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Update)]
+pub struct Solution<T>
+where
+    T: Update,
+{
     pub(super) value: T,
 }
 

--- a/crates/hir-analysis/src/ty/def_analysis.rs
+++ b/crates/hir-analysis/src/ty/def_analysis.rs
@@ -1261,7 +1261,7 @@ impl<'db> ImplTraitMethodAnalyzer<'db> {
                 &mut self.diags,
             );
 
-            required_methods.shift_remove(name);
+            required_methods.remove(name);
         }
 
         if !required_methods.is_empty() {

--- a/crates/hir-analysis/src/ty/diagnostics.rs
+++ b/crates/hir-analysis/src/ty/diagnostics.rs
@@ -5,7 +5,7 @@ use hir::{
     },
     span::{expr::LazyMethodCallExprSpan, DynLazySpan},
 };
-use smallvec2::SmallVec;
+use smallvec::SmallVec;
 
 use super::{
     func_def::FuncDef,

--- a/crates/hir-analysis/src/ty/func_def.rs
+++ b/crates/hir-analysis/src/ty/func_def.rs
@@ -7,7 +7,7 @@ use super::{binder::Binder, ty_def::TyId, ty_lower::GenericParamTypeSet};
 use crate::{
     ty::{
         ty_def::InvalidCause,
-        ty_lower::{collect_generic_params, lower_hir_ty, GenericParamOwnerId},
+        ty_lower::{collect_generic_params, lower_hir_ty},
     },
     HirAnalysisDb,
 };
@@ -17,7 +17,7 @@ use crate::{
 #[salsa::tracked]
 pub fn lower_func<'db>(db: &'db dyn HirAnalysisDb, func: Func<'db>) -> Option<FuncDef<'db>> {
     let name = func.name(db.as_hir_db()).to_opt()?;
-    let params_set = collect_generic_params(db, GenericParamOwnerId::new(db, func.into()));
+    let params_set = collect_generic_params(db, func.into());
 
     let args = match func.params(db.as_hir_db()) {
         Partial::Present(args) => args

--- a/crates/hir-analysis/src/ty/method_cmp.rs
+++ b/crates/hir-analysis/src/ty/method_cmp.rs
@@ -269,7 +269,7 @@ fn compare_constraints<'db>(
     let impl_m_constraints = collect_func_def_constraints(db, impl_m, false).instantiate_identity();
     let trait_m_constraints =
         collect_func_def_constraints(db, trait_m, false).instantiate(db, map_to_impl);
-    let mut unsatisfied_goals = smallvec::smallvec![];
+    let mut unsatisfied_goals = vec![];
     for &goal in impl_m_constraints.list(db) {
         let canonical_goal = Canonical::new(db, goal);
         let ingot = trait_m.ingot(db);

--- a/crates/hir-analysis/src/ty/method_cmp.rs
+++ b/crates/hir-analysis/src/ty/method_cmp.rs
@@ -269,7 +269,7 @@ fn compare_constraints<'db>(
     let impl_m_constraints = collect_func_def_constraints(db, impl_m, false).instantiate_identity();
     let trait_m_constraints =
         collect_func_def_constraints(db, trait_m, false).instantiate(db, map_to_impl);
-    let mut unsatisfied_goals = smallvec2::smallvec![];
+    let mut unsatisfied_goals = smallvec::smallvec![];
     for &goal in impl_m_constraints.list(db) {
         let canonical_goal = Canonical::new(db, goal);
         let ingot = trait_m.ingot(db);

--- a/crates/hir-analysis/src/ty/method_table.rs
+++ b/crates/hir-analysis/src/ty/method_table.rs
@@ -1,5 +1,6 @@
 use hir::hir_def::{IdentId, Impl, IngotId};
 use rustc_hash::FxHashMap;
+use salsa::Update;
 
 use super::{
     binder::Binder,
@@ -34,7 +35,7 @@ pub(crate) fn probe_method<'db>(
     table.probe(db, ty, name)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Update)]
 pub struct MethodTable<'db> {
     buckets: FxHashMap<TyBase<'db>, MethodBucket<'db>>,
 }
@@ -89,7 +90,7 @@ impl<'db> MethodTable<'db> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Update)]
 struct MethodBucket<'db> {
     methods: FxHashMap<Binder<TyId<'db>>, FxHashMap<IdentId<'db>, FuncDef<'db>>>,
 }

--- a/crates/hir-analysis/src/ty/mod.rs
+++ b/crates/hir-analysis/src/ty/mod.rs
@@ -1,11 +1,8 @@
+use adt_def::AdtRef;
 use hir::hir_def::TopLevelMod;
 
-use self::{
-    adt_def::AdtRefId,
-    def_analysis::{
-        analyze_adt, analyze_func, analyze_impl, analyze_impl_trait, analyze_trait,
-        analyze_type_alias,
-    },
+use self::def_analysis::{
+    analyze_adt, analyze_func, analyze_impl, analyze_impl_trait, analyze_trait, analyze_type_alias,
 };
 use crate::{analysis_pass::ModuleAnalysisPass, diagnostics::DiagnosticVoucher, HirAnalysisDb};
 
@@ -48,18 +45,15 @@ impl<'db> ModuleAnalysisPass<'db> for AdtDefAnalysisPass<'db> {
         let adts = top_mod
             .all_structs(hir_db)
             .iter()
-            .map(|s| AdtRefId::from_struct(self.db, *s))
-            .chain(
-                top_mod
-                    .all_enums(hir_db)
-                    .iter()
-                    .map(|e| AdtRefId::from_enum(self.db, *e)),
-            )
+            .copied()
+            .map(AdtRef::from)
+            .chain(top_mod.all_enums(hir_db).iter().copied().map(AdtRef::from))
             .chain(
                 top_mod
                     .all_contracts(hir_db)
                     .iter()
-                    .map(|c| AdtRefId::from_contract(self.db, *c)),
+                    .copied()
+                    .map(AdtRef::from),
             );
 
         adts.flat_map(|adt| analyze_adt(self.db, adt).iter())

--- a/crates/hir-analysis/src/ty/trait_def.rs
+++ b/crates/hir-analysis/src/ty/trait_def.rs
@@ -6,6 +6,7 @@ use hir::{
     span::DynLazySpan,
 };
 use rustc_hash::FxHashMap;
+use salsa::Update;
 
 use super::{
     binder::Binder,
@@ -108,7 +109,7 @@ pub(crate) fn impls_for_ty<'db>(
 
 /// Represents the trait environment of an ingot, which maintain all trait
 /// implementors which can be used in the ingot.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Update)]
 pub(crate) struct TraitEnv<'db> {
     pub(super) impls: FxHashMap<TraitDef<'db>, Vec<Binder<Implementor<'db>>>>,
     hir_to_implementor: FxHashMap<ImplTrait<'db>, Binder<Implementor<'db>>>,

--- a/crates/hir-analysis/src/ty/trait_resolution/mod.rs
+++ b/crates/hir-analysis/src/ty/trait_resolution/mod.rs
@@ -1,5 +1,6 @@
 use common::indexmap::IndexSet;
 use hir::hir_def::IngotId;
+use salsa::Update;
 
 use super::{
     canonical::{Canonical, Canonicalized, Solution},
@@ -72,7 +73,7 @@ pub(crate) fn check_ty_wf<'db>(
     WellFormedness::WellFormed
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Update)]
 pub(crate) enum WellFormedness<'db> {
     WellFormed,
     IllFormed {
@@ -114,7 +115,7 @@ pub(crate) fn check_trait_inst_wf<'db>(
     WellFormedness::WellFormed
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Update)]
 pub enum GoalSatisfiability<'db> {
     /// Goal is satisfied with the unique solution.
     Satisfied(Solution<TraitInstId<'db>>),

--- a/crates/hir-analysis/src/ty/ty_check/callable.rs
+++ b/crates/hir-analysis/src/ty/ty_check/callable.rs
@@ -7,6 +7,7 @@ use hir::{
     },
 };
 use if_chain::if_chain;
+use salsa::Update;
 
 use super::{ExprProp, TyChecker};
 use crate::{
@@ -21,7 +22,7 @@ use crate::{
     HirAnalysisDb,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub struct Callable<'db> {
     pub func_def: FuncDef<'db>,
     generic_args: Vec<TyId<'db>>,

--- a/crates/hir-analysis/src/ty/ty_check/env.rs
+++ b/crates/hir-analysis/src/ty/ty_check/env.rs
@@ -6,7 +6,7 @@ use hir::{
     span::DynLazySpan,
 };
 use rustc_hash::FxHashMap;
-use smallvec2::SmallVec;
+use smallvec::SmallVec;
 
 use super::{Callable, TypedBody};
 use crate::{

--- a/crates/hir-analysis/src/ty/ty_check/method_selection.rs
+++ b/crates/hir-analysis/src/ty/ty_check/method_selection.rs
@@ -364,8 +364,8 @@ impl<'db> MethodSelector<'db> {
         is_scope_visible_from(self.db, def.scope(self.db), self.scope)
     }
 
-    fn available_traits(&self) -> FxHashSet<TraitDef<'db>> {
-        let mut traits = FxHashSet::default();
+    fn available_traits(&self) -> IndexSet<TraitDef<'db>> {
+        let mut traits = IndexSet::default();
 
         let mut insert_trait = |trait_def: TraitDef<'db>| {
             traits.insert(trait_def);

--- a/crates/hir-analysis/src/ty/ty_check/mod.rs
+++ b/crates/hir-analysis/src/ty/ty_check/mod.rs
@@ -18,6 +18,7 @@ use hir::{
 pub(crate) use path::RecordLike;
 
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::Update;
 
 use super::{
     diagnostics::{BodyDiag, FuncBodyDiag, TyDiagCollection, TyLowerDiag},
@@ -222,7 +223,7 @@ impl<'db> TyChecker<'db> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Update)]
 pub struct TypedBody<'db> {
     body: Option<Body<'db>>,
     pat_ty: FxHashMap<PatId, TyId<'db>>,

--- a/crates/hir-analysis/src/ty/ty_check/path.rs
+++ b/crates/hir-analysis/src/ty/ty_check/path.rs
@@ -8,7 +8,7 @@ use hir::{
     span::DynLazySpan,
 };
 use rustc_hash::FxHashMap;
-use smallvec2::SmallVec;
+use smallvec::SmallVec;
 
 use super::{env::LocalBinding, TyChecker};
 use crate::{

--- a/crates/hir/src/hir_def/item.rs
+++ b/crates/hir/src/hir_def/item.rs
@@ -213,7 +213,9 @@ impl<'db> From<WhereClauseOwner<'db>> for ItemKind<'db> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, derive_more::From)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, derive_more::From, salsa::Supertype,
+)]
 pub enum GenericParamOwner<'db> {
     Func(Func<'db>),
     Struct(Struct<'db>),
@@ -294,6 +296,11 @@ impl<'db> GenericParamOwner<'db> {
     pub fn where_clause_owner(self) -> Option<WhereClauseOwner<'db>> {
         let item = ItemKind::from(self);
         WhereClauseOwner::from_item_opt(item)
+    }
+
+    pub fn where_clause(self, db: &'db dyn HirDb) -> Option<WhereClauseId<'db>> {
+        self.where_clause_owner()
+            .map(|owner| owner.where_clause(db))
     }
 }
 

--- a/crates/hir/src/hir_def/prim_ty.rs
+++ b/crates/hir/src/hir_def/prim_ty.rs
@@ -1,7 +1,9 @@
+use salsa::Update;
+
 use super::IdentId;
 use crate::HirDb;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Update)]
 pub enum PrimTy {
     Bool,
     Int(IntTy),

--- a/crates/hir/src/hir_def/scope_graph.rs
+++ b/crates/hir/src/hir_def/scope_graph.rs
@@ -1,7 +1,8 @@
 use std::io;
 
-use common::indexmap::IndexSet;
-use rustc_hash::{FxHashMap, FxHashSet};
+use common::indexmap::{IndexMap, IndexSet};
+use rustc_hash::FxHashSet;
+use salsa::Update;
 
 use super::{
     scope_graph_viz::ScopeGraphFormatter, AttrListId, Body, Const, Contract, Enum, ExprId,
@@ -15,12 +16,12 @@ use crate::{
 };
 
 /// Represents a scope relation graph in a top-level module.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Update)]
 pub struct ScopeGraph<'db> {
     /// The top-level module containing the scope graph.
     pub top_mod: TopLevelMod<'db>,
     /// The scopes in the graph.
-    pub scopes: FxHashMap<ScopeId<'db>, Scope<'db>>,
+    pub scopes: IndexMap<ScopeId<'db>, Scope<'db>>,
     /// The all unresolved uses in the graph, this is used in name resolution.
     pub unresolved_uses: FxHashSet<Use<'db>>,
 }
@@ -70,7 +71,7 @@ impl<'db> ScopeGraph<'db> {
 }
 
 /// An reference to a `[ScopeData]` in a `ScopeGraph`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, salsa::Update)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Update)]
 pub enum ScopeId<'db> {
     /// An item scope.
     Item(ItemKind<'db>),
@@ -382,7 +383,7 @@ impl<'db> ScopeId<'db> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, salsa::Update)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Update)]
 pub enum FieldParent<'db> {
     Item(ItemKind<'db>),
     Variant(ItemKind<'db>, usize),
@@ -435,7 +436,7 @@ impl<'db> std::iter::Iterator for ScopeGraphItemIterDfs<'db, '_> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Update)]
 pub struct Scope<'db> {
     pub id: ScopeId<'db>,
     pub edges: IndexSet<ScopeEdge<'db>>,
@@ -456,7 +457,7 @@ impl<'db> Scope<'db> {
 /// The edge contains the destination of the edge and the kind of the edge.
 /// [`EdgeKind`] is contains supplementary information about the destination
 /// scope, which is used for name resolution.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Update)]
 pub struct ScopeEdge<'db> {
     pub dest: ScopeId<'db>,
     pub kind: EdgeKind<'db>,
@@ -467,7 +468,7 @@ pub struct ScopeEdge<'db> {
 /// NOTE: The internal types of each variants contains very small amount of
 /// information, the reason why we need to prepare each internal types is to
 /// allow us to implement traits to each edges directly.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub enum EdgeKind<'db> {
     /// An edge to a lexical parent scope.
     Lex(LexEdge),
@@ -555,25 +556,25 @@ impl<'db> EdgeKind<'db> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LexEdge();
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct ModEdge<'db>(pub IdentId<'db>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct TypeEdge<'db>(pub IdentId<'db>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct TraitEdge<'db>(pub IdentId<'db>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct ValueEdge<'db>(pub IdentId<'db>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct GenericParamEdge<'db>(pub IdentId<'db>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct FieldEdge<'db>(pub IdentId<'db>);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, derive_more::From, Update)]
 pub struct VariantEdge<'db>(pub IdentId<'db>);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/hir/src/lower/types.rs
+++ b/crates/hir/src/lower/types.rs
@@ -60,8 +60,8 @@ impl<'db> TupleTypeId<'db> {
 
 impl<'db> TraitRefId<'db> {
     pub(super) fn lower_ast(ctxt: &mut FileLowerCtxt<'db>, ast: ast::TraitRef) -> Self {
-        let path = ast.path().map(|ast| PathId::lower_ast(ctxt, ast)).into();
-        Self::new(ctxt.db(), path)
+        let path = ast.path().map(|ast| PathId::lower_ast(ctxt, ast));
+        Self::new(ctxt.db(), Partial::from(path))
     }
 
     pub(super) fn lower_ast_partial(

--- a/crates/hir/src/span/expr.rs
+++ b/crates/hir/src/span/expr.rs
@@ -1,4 +1,5 @@
 use parser::ast;
+use salsa::Update;
 
 use super::{
     body_source_map, define_lazy_span_node,
@@ -202,7 +203,7 @@ define_lazy_span_node!(
 
 define_lazy_span_node!(LazyMatchArmSpan);
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Update)]
 pub(crate) struct ExprRoot<'db> {
     expr: ExprId,
     pub(crate) body: Body<'db>,

--- a/crates/hir/src/span/mod.rs
+++ b/crates/hir/src/span/mod.rs
@@ -1,5 +1,6 @@
 use common::diagnostics::Span;
 use parser::ast::{self, prelude::*, AstPtr, SyntaxNodePtr};
+use salsa::Update;
 
 use crate::{
     hir_def::{
@@ -65,7 +66,7 @@ pub mod lazy_spans {
 /// types that implement [`LazySpan`] in this module. We want to avoid `dyn
 /// LazySpan` usage because it doesn't implement `Clone` and `Eq` which leads to
 /// a lot of difficulties in salsa integration
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Update)]
 pub struct DynLazySpan<'db>(pub(super) Option<SpanTransitionChain<'db>>);
 impl<'db> DynLazySpan<'db> {
     pub fn invalid() -> Self {

--- a/crates/hir/src/span/pat.rs
+++ b/crates/hir/src/span/pat.rs
@@ -1,4 +1,5 @@
 use parser::ast;
+use salsa::Update;
 
 use super::{
     body_source_map, define_lazy_span_node,
@@ -87,7 +88,7 @@ define_lazy_span_node!(
     }
 );
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Update)]
 pub(crate) struct PatRoot<'db> {
     pat: PatId,
     pub(crate) body: Body<'db>,

--- a/crates/hir/src/span/stmt.rs
+++ b/crates/hir/src/span/stmt.rs
@@ -1,4 +1,5 @@
 use parser::ast;
+use salsa::Update;
 
 use super::{
     body_source_map, define_lazy_span_node,
@@ -30,7 +31,7 @@ define_lazy_span_node!(
     }
 );
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Update)]
 pub(crate) struct StmtRoot<'db> {
     stmt: StmtId,
     pub(crate) body: Body<'db>,

--- a/crates/hir/src/span/transition.rs
+++ b/crates/hir/src/span/transition.rs
@@ -5,6 +5,7 @@ use common::{
 use parser::{
     ast::prelude::*, syntax_node::NodeOrToken, FeLang, SyntaxNode, SyntaxToken, TextRange,
 };
+use salsa::Update;
 
 use super::{
     body_ast, const_ast, contract_ast, enum_ast, expr::ExprRoot, func_ast, impl_ast,
@@ -39,7 +40,7 @@ pub(crate) enum LazyArg {
     None,
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Update)]
 pub(crate) struct SpanTransitionChain<'db> {
     pub(crate) root: ChainRoot<'db>,
     pub(super) chain: Vec<LazyTransitionFn>,
@@ -88,7 +89,7 @@ impl<'db> SpanTransitionChain<'db> {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, derive_more::From)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, derive_more::From, Update)]
 pub(crate) enum ChainRoot<'db> {
     ItemKind(ItemKind<'db>),
     TopMod(TopLevelMod<'db>),
@@ -305,7 +306,7 @@ macro_rules! define_lazy_span_node {
             )?
         )?
     ) => {
-        #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+        #[derive(Clone, PartialEq, Eq, Hash, Debug, salsa::Update)]
         pub struct $name<'db>(pub(crate) crate::span::transition::SpanTransitionChain<'db>);
         $(
             $(

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -26,7 +26,7 @@ pub fn parse_source_file(text: &str) -> (GreenNode, Vec<ParseError>) {
 /// An parse error which is accumulated in the [`parser::Parser`] while parsing.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ParseError {
-    Expected(SmallVec<[SyntaxKind; 2]>, ExpectedKind, TextSize),
+    Expected(SmallVec<SyntaxKind, 2>, ExpectedKind, TextSize),
     Unexpected(String, TextRange),
     Msg(String, TextRange),
 }

--- a/crates/parser/src/parser/mod.rs
+++ b/crates/parser/src/parser/mod.rs
@@ -107,7 +107,7 @@ impl<S: TokenStream> Parser<S> {
         self.scope_aux_recovery().pop();
     }
 
-    fn scope_aux_recovery(&mut self) -> &mut SmallVec<[SyntaxKind; 4]> {
+    fn scope_aux_recovery(&mut self) -> &mut SmallVec<SyntaxKind, 4> {
         &mut self.parents.last_mut().unwrap().aux_recovery_tokens
     }
 
@@ -699,7 +699,7 @@ struct ScopeEntry {
     scope: Box<dyn ParsingScope>,
     is_newline_trivia: bool,
     is_err: bool,
-    aux_recovery_tokens: SmallVec<[SyntaxKind; 4]>,
+    aux_recovery_tokens: SmallVec<SyntaxKind, 4>,
 }
 impl ScopeEntry {
     fn new(scope: Box<dyn ParsingScope>, is_newline_trivia: bool) -> Self {
@@ -772,7 +772,7 @@ macro_rules! define_scope {
         impl crate::parser::ParsingScope for $scope_name {
             fn recovery_tokens(&self) -> &[crate::SyntaxKind] {
                 lazy_static::lazy_static! {
-                    pub(super) static ref RECOVERY_TOKENS: smallvec::SmallVec<[SyntaxKind; 4]> = {
+                    pub(super) static ref RECOVERY_TOKENS: smallvec::SmallVec<SyntaxKind, 4> = {
                         #[allow(unused)]
                         use crate::SyntaxKind::*;
                         smallvec::SmallVec::from_slice(&[$($recoveries), *])

--- a/crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.snap
+++ b/crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/uitest/tests/ty_check.rs
 expression: diags
-input_file: crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.fe
+input_file: fixtures/ty_check/method_selection/require_explicit_import.fe
 ---
 error[8-0028]: trait is not in the scope
   ┌─ require_explicit_import.fe:2:7
@@ -10,5 +10,5 @@ error[8-0028]: trait is not in the scope
   │       ^^^
   │       │
   │       consider importing one of the following traits into the scope to resolve the ambiguity
-  │       `use require_explicit_import::inner::Bar`
   │       `use require_explicit_import::inner::Foo`
+  │       `use require_explicit_import::inner::Bar`


### PR DESCRIPTION
Bumping the salsa revision again to pick up the latest breaking changes

- "coarse" tracked structs (struct fields aren't tracked as independent entities by default)
- tracked fn return types must impl `salsa::Update` trait
- `derive(salsa::Supertype)` allows us to avoid using `salsa::interned` wrapper structs around enums-of-salsa-ids (eg AdtRefId)