### PR TITLE
Use salsa to ensure 1:1 map of file paths to inputs

### DIFF
--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -36,6 +36,7 @@ use hir::{
     HirDb, LowerHirDb, SpannedHirDb,
 };
 use rustc_hash::FxHashMap;
+use salsa::Setter;
 
 type CodeSpanFileId = usize;
 
@@ -62,7 +63,8 @@ impl HirAnalysisTestDb {
         let kind = IngotKind::StandAlone;
         let version = Version::new(0, 0, 1);
         let ingot = InputIngot::new(self, file_name, kind, version, IndexSet::default());
-        let root = InputFile::new(self, file_name.into(), text.to_string());
+        let root = InputFile::new(self, file_name.into());
+        root.set_text(self).to(text.to_string());
         ingot.set_root_file(self, root);
         ingot.set_files(self, [root].into_iter().collect());
         (ingot, root)

--- a/crates/hir/src/hir_def/module_tree.rs
+++ b/crates/hir/src/hir_def/module_tree.rs
@@ -266,13 +266,13 @@ mod tests {
             Version::new(0, 0, 1),
             Default::default(),
         );
-        let local_root = InputFile::new(&db, "src/lib.fe".into(), "".into());
-        let mod1 = InputFile::new(&db, "src/mod1.fe".into(), "".into());
-        let mod2 = InputFile::new(&db, "src/mod2.fe".into(), "".into());
-        let foo = InputFile::new(&db, "src/mod1/foo.fe".into(), "".into());
-        let bar = InputFile::new(&db, "src/mod2/bar.fe".into(), "".into());
-        let baz = InputFile::new(&db, "src/mod2/baz.fe".into(), "".into());
-        let floating = InputFile::new(&db, "src/mod3/floating.fe".into(), "".into());
+        let local_root = InputFile::new(&db, "src/lib.fe".into());
+        let mod1 = InputFile::new(&db, "src/mod1.fe".into());
+        let mod2 = InputFile::new(&db, "src/mod2.fe".into());
+        let foo = InputFile::new(&db, "src/mod1/foo.fe".into());
+        let bar = InputFile::new(&db, "src/mod2/bar.fe".into());
+        let baz = InputFile::new(&db, "src/mod2/baz.fe".into());
+        let floating = InputFile::new(&db, "src/mod3/floating.fe".into());
         local_ingot.set_root_file(&mut db, local_root);
         local_ingot.set_files(
             &mut db,

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -46,6 +46,7 @@ mod test_db {
         InputDb, InputFile, InputIngot,
     };
     use derive_more::TryIntoError;
+    use salsa::Setter;
 
     use super::HirDb;
     use crate::{
@@ -102,7 +103,8 @@ mod test_db {
             let kind = IngotKind::StandAlone;
             let version = Version::new(0, 0, 1);
             let ingot = InputIngot::new(self, path, kind, version, IndexSet::default());
-            let file = InputFile::new(self, "test_file.fe".into(), text.to_string());
+            let file = InputFile::new(self, "test_file.fe".into());
+            file.set_text(self).to(text.into());
             ingot.set_root_file(self, file);
             ingot.set_files(self, [file].into_iter().collect());
             (ingot, file)

--- a/crates/language-server/src/backend/workspace.rs
+++ b/crates/language-server/src/backend/workspace.rs
@@ -107,7 +107,7 @@ impl IngotFileContext for LocalIngotContext {
             .files
             .get(path)
             .copied()
-            .unwrap_or_else(|| InputFile::new(db, path.into(), String::new()));
+            .unwrap_or_else(|| InputFile::new(db, path.into()));
         self.files.insert(path, input);
         ingot.set_files(db, self.files.values().copied().collect());
         Some((ingot, input))
@@ -178,7 +178,7 @@ impl IngotFileContext for StandaloneIngotContext {
             .files
             .get(path)
             .copied()
-            .unwrap_or_else(|| InputFile::new(db, path.into(), String::new()));
+            .unwrap_or_else(|| InputFile::new(db, path.into()));
         let mut files = IndexSet::new();
         files.insert(input_file);
         ingot.set_files(db, files);


### PR DESCRIPTION
This current sketch doesn't actually make sense because `InputFile.path` is relative, so `foo/src/lib.fe` and `bar/src/lib.fe` would map to the same thing.  However, we could conceivably do something like this implementing an `InputIngot::file` method:

```rust
#[salsa::tracked]
pub fn input_for_ingot_file_path<'db>(
    db: &'db dyn InputDb,
    _ingot: InputIngot,
    path: FilePath<'db>,
) -> InputFile {
    InputFile::__new_impl(db, path.path(db), String::new())
}

impl InputIngot {
  pub fn file(
    &self,
    db: &dyn InputDb,
    path: Utf8PathBuf
  ) {
    input_for_ingot_file_path(db, self, FilePath::from(db, path))
  }
}
```

In this case we might not want to implement `InputFile::new` to ensure that `InputFile`s always get created in the context of an ingot.