### PR TITLE
Core library support in the language server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "async-channel"
@@ -350,9 +350,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -396,15 +396,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -420,9 +420,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -539,9 +539,9 @@ checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -737,9 +737,9 @@ checksum = "855423f2158bcc73798b3b9a666ec4204597a72370dc91dbdb8e7f9519de8cc3"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ena"
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -814,6 +814,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "criterion",
+ "fe-common",
  "fe-driver",
  "fe-hir-analysis",
  "fe-parser",
@@ -828,7 +829,8 @@ dependencies = [
  "fe-parser",
  "ordermap",
  "paste",
- "rustc-hash 2.1.0",
+ "rust-embed",
+ "rustc-hash 2.1.1",
  "salsa",
  "semver",
  "smol_str 0.3.2",
@@ -845,7 +847,6 @@ dependencies = [
  "fe-hir",
  "fe-hir-analysis",
  "fe-resolver",
- "include_dir",
  "salsa",
 ]
 
@@ -862,7 +863,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "salsa",
  "smallvec 2.0.0-alpha.10",
 ]
@@ -871,7 +872,7 @@ dependencies = [
 name = "fe-hir-analysis"
 version = "0.26.0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "camino",
  "codespan-reporting",
  "cranelift-entity",
@@ -886,7 +887,7 @@ dependencies = [
  "if_chain",
  "itertools 0.14.0",
  "num-bigint",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "salsa",
  "smallvec 2.0.0-alpha.10",
 ]
@@ -913,8 +914,7 @@ dependencies = [
  "futures-batch",
  "glob",
  "patricia_tree",
- "rust-embed",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "salsa",
  "serde",
  "serde_json",
@@ -937,7 +937,7 @@ dependencies = [
  "lazy_static",
  "logos",
  "rowan",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "smallvec 2.0.0-alpha.10",
  "unwrap-infallible",
  "wasm-bindgen",
@@ -970,6 +970,7 @@ version = "0.26.0"
 dependencies = [
  "camino",
  "dir-test",
+ "fe-common",
  "fe-driver",
  "fe-hir",
  "fe-hir-analysis",
@@ -1268,7 +1269,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.13.2",
+ "smallvec 1.14.0",
  "utf16_iter",
  "utf8_iter",
  "write16",
@@ -1337,7 +1338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec 1.13.2",
+ "smallvec 1.14.0",
  "utf8_iter",
 ]
 
@@ -1358,25 +1359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,12 +1370,13 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.42.0"
+version = "1.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
 dependencies = [
  "linked-hash-map",
  "once_cell",
+ "pin-project",
  "similar",
 ]
 
@@ -1434,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -1465,9 +1448,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "linked-hash-map"
@@ -1483,9 +1466,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -1499,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 dependencies = [
  "value-bag",
 ]
@@ -1593,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1669,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -1719,7 +1702,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.13.2",
+ "smallvec 1.14.0",
  "windows-targets",
 ]
 
@@ -1735,7 +1718,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb45b6331bbdbb54c9a29413703e892ab94f83a31e4a546c778495a91e7fbca"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1743,6 +1726,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1812,18 +1815,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -1850,11 +1853,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1915,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+checksum = "0b3aba5104622db5c9fc61098de54708feb732e7763d7faa2fa625899f00bf6f"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -1926,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+checksum = "1f198c73be048d2c5aa8e12f7960ad08443e56fd39cc26336719fdb4ea0ebaae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1939,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+checksum = "5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a"
 dependencies = [
  "sha2",
  "walkdir",
@@ -1961,9 +1964,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1976,11 +1979,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1989,15 +1992,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa"
@@ -2012,10 +2015,10 @@ dependencies = [
  "indexmap",
  "parking_lot",
  "rayon",
- "rustc-hash 2.1.0",
+ "rustc-hash 2.1.1",
  "salsa-macro-rules",
  "salsa-macros",
- "smallvec 1.13.2",
+ "smallvec 1.14.0",
  "tracing",
 ]
 
@@ -2059,24 +2062,24 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2085,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -2097,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2152,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -2167,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "smallvec"
@@ -2237,9 +2240,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2274,18 +2277,18 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2354,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2375,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -2462,7 +2465,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec 1.13.2",
+ "smallvec 1.14.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -2483,15 +2486,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -2863,9 +2866,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
@@ -2908,18 +2911,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -11,6 +11,7 @@ walkdir = "2.4"
 hir-analysis.workspace = true
 driver.workspace = true
 parser.workspace = true
+common.workspace = true
 camino.workspace = true
 
 [[bench]]

--- a/crates/bench/benches/analysis.rs
+++ b/crates/bench/benches/analysis.rs
@@ -1,4 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
+use common::InputIngot;
 use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
 use driver::DriverDataBase;
 use walkdir::WalkDir;
@@ -11,8 +12,8 @@ fn diagnostics(c: &mut Criterion) {
 
     g.bench_function("analyze corelib", |b| {
         b.iter_with_large_drop(|| {
-            let mut db = DriverDataBase::default();
-            let (core, _) = db.static_core_ingot();
+            let db = DriverDataBase::default();
+            let core = InputIngot::core(&db);
             db.run_on_ingot(core);
             db
         });
@@ -31,7 +32,7 @@ fn diagnostics(c: &mut Criterion) {
     g.bench_function("uitest diagnostics", |b| {
         b.iter_with_large_drop(|| {
             let mut db = DriverDataBase::default();
-            let (core, _) = db.static_core_ingot();
+            let core = InputIngot::core(&db);
             for (path, content) in &files {
                 let (ingot, file) = db.standalone(path, content, core);
                 let top_mod = db.top_mod(ingot, file);

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -14,6 +14,7 @@ paste.workspace = true
 salsa.workspace = true
 semver.workspace = true
 smol_str = "0.3.2"
+rust-embed = { version = "8.5.0", features = ["debug-embed"] }
 
 parser.workspace = true
 ordermap = "0.5.5"

--- a/crates/common/src/input.rs
+++ b/crates/common/src/input.rs
@@ -1,8 +1,15 @@
+use core::panic;
+
 use camino::Utf8PathBuf;
+use rust_embed::Embed;
 use salsa::Setter;
 use smol_str::SmolStr;
 
 use crate::{indexmap::IndexSet, InputDb};
+
+#[derive(Embed)]
+#[folder = "../../library/core"]
+struct Core;
 
 /// An ingot is a collection of files which are compiled together.
 /// Ingot can depend on other ingots.
@@ -50,6 +57,44 @@ impl InputIngot {
             version,
             external_ingots,
             IndexSet::default(),
+            root_file,
+        )
+    }
+
+    pub fn core(db: &dyn InputDb) -> InputIngot {
+        let mut files = IndexSet::new();
+        let mut root_file = None;
+        let ingot_path = Utf8PathBuf::from("core");
+
+        for file in Core::iter() {
+            if file.ends_with(".fe") {
+                let path = ingot_path.join(Utf8PathBuf::from(&file));
+                if let Some(content) = Core::get(&file) {
+                    let is_root = path == "core/src/lib.fe";
+                    let input_file = InputFile::new(
+                        db,
+                        path,
+                        String::from_utf8(content.data.into_owned()).unwrap(),
+                    );
+                    if is_root {
+                        root_file = Some(input_file);
+                    }
+                    files.insert(input_file);
+                }
+            }
+        }
+
+        if root_file.is_none() {
+            panic!("root file missing from core")
+        }
+
+        Self::__new_impl(
+            db,
+            ingot_path,
+            IngotKind::Core,
+            Version::new(0, 0, 0),
+            IndexSet::default(),
+            files,
             root_file,
         )
     }

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -13,7 +13,6 @@ camino.workspace = true
 clap.workspace = true
 codespan-reporting.workspace = true
 salsa.workspace = true
-include_dir = "0.7"
 
 common.workspace = true
 hir.workspace = true

--- a/crates/driver/src/db.rs
+++ b/crates/driver/src/db.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::diagnostics::CsDbWrapper;
 use camino::{Utf8Path, Utf8PathBuf};
 use codespan_reporting::term::{
@@ -28,11 +26,8 @@ use hir_analysis::{
     },
     HirAnalysisDb,
 };
-use include_dir::{include_dir, Dir};
 
 use crate::diagnostics::ToCsDiag;
-
-static LIBRARY: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../library");
 
 #[salsa::db]
 pub trait DriverDb:
@@ -190,31 +185,6 @@ impl DriverDataBase {
         (input_ingot, input_files)
     }
 
-    pub fn static_core_ingot(&mut self) -> (InputIngot, IndexSet<InputFile>) {
-        let src = LIBRARY
-            .get_dir("core/src")
-            .expect("static core error. use cli `--core` arg to debug");
-
-        let mut files = vec![];
-        write_files_recursive(src, &mut files);
-
-        let input_ingot = InputIngot::new(
-            self,
-            "core",
-            IngotKind::Core,
-            Version::new(0, 0, 0),
-            IndexSet::default(),
-        );
-
-        let input_files = self.set_ingot_source_files(
-            input_ingot,
-            &Utf8PathBuf::from_str("core/src/lib.fe").unwrap(),
-            files,
-        );
-
-        (input_ingot, input_files)
-    }
-
     fn set_ingot_source_files(
         &mut self,
         ingot: InputIngot,
@@ -297,20 +267,4 @@ fn initialize_analysis_pass(db: &DriverDataBase) -> AnalysisPassManager<'_> {
     pass_manager.add_module_pass(Box::new(FuncAnalysisPass::new(db)));
     pass_manager.add_module_pass(Box::new(BodyAnalysisPass::new(db)));
     pass_manager
-}
-
-fn write_files_recursive(dir: &Dir, files: &mut Vec<(Utf8PathBuf, String)>) {
-    for file in dir.files() {
-        files.push((
-            Utf8PathBuf::from_path_buf(file.path().to_path_buf())
-                .expect("static core error. use cli `--core` arg  to debug"),
-            std::str::from_utf8(file.contents())
-                .expect("static core error. use cli `--core` arg  to debug")
-                .to_string(),
-        ));
-    }
-
-    for subdir in dir.dirs() {
-        write_files_recursive(subdir, files);
-    }
 }

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -2,6 +2,7 @@ pub mod db;
 pub mod diagnostics;
 pub mod files;
 use camino::Utf8PathBuf;
+use common::InputIngot;
 pub use db::{DriverDataBase, DriverDb};
 
 use clap::{Parser, Subcommand};
@@ -60,7 +61,7 @@ pub fn run(opts: &Options) {
                     }
                 }
             } else {
-                db.static_core_ingot().0
+                InputIngot::core(&db)
             };
 
             let local_ingot = match ingot_resolver.resolve(path) {

--- a/crates/hir-analysis/tests/corelib.rs
+++ b/crates/hir-analysis/tests/corelib.rs
@@ -1,13 +1,14 @@
 mod test_db;
 
 use camino::Utf8Path;
+use common::InputIngot;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 
 #[test]
 fn analyze_corelib() {
-    let mut db = DriverDataBase::default();
-    let (core, _) = db.static_core_ingot();
+    let db = DriverDataBase::default();
+    let core = InputIngot::core(&db);
 
     let core_diags = db.run_on_ingot(core);
     if !(core_diags.is_empty()) {
@@ -24,7 +25,7 @@ fn corelib_standalone(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let path = Utf8Path::new(fixture.path());
     let file_name = path.file_name().unwrap();
-    let (core, _) = db.static_core_ingot();
+    let core = InputIngot::core(&db);
     let (ingot, _) = db.standalone(file_name.into(), fixture.content(), core);
 
     let local_diags = db.run_on_ingot(ingot);

--- a/crates/language-server/Cargo.toml
+++ b/crates/language-server/Cargo.toml
@@ -21,7 +21,6 @@ futures = "0.3.31"
 futures-batch = "0.6.1"
 glob.workspace = true 
 patricia_tree = "0.9.0"
-rust-embed = "8.5.0"
 rustc-hash.workspace = true
 salsa.workspace = true
 serde = "1.0.217"

--- a/crates/language-server/src/backend/workspace.rs
+++ b/crates/language-server/src/backend/workspace.rs
@@ -4,7 +4,7 @@ use super::db::LanguageServerDatabase;
 use anyhow::Result;
 use common::{
     indexmap::IndexSet,
-    input::{IngotKind, Version},
+    input::{IngotDependency, IngotKind, Version},
     InputFile, InputIngot,
 };
 
@@ -82,12 +82,15 @@ pub fn get_containing_ingot<'a, T>(
 
 impl LocalIngotContext {
     pub fn new(db: &LanguageServerDatabase, config_path: &str) -> Option<Self> {
+        let external_ingots = [IngotDependency::new("core", InputIngot::core(db))]
+            .into_iter()
+            .collect();
         let ingot = InputIngot::new(
             db,
             config_path,
             IngotKind::Local,
             Version::new(0, 0, 0),
-            IndexSet::new(),
+            external_ingots,
         );
         Some(Self {
             ingot,
@@ -203,12 +206,15 @@ impl IngotFileContext for StandaloneIngotContext {
             .copied()
             .map_or_else(
                 || {
+                    let external_ingots = [IngotDependency::new("core", InputIngot::core(db))]
+                        .into_iter()
+                        .collect();
                     let ingot = InputIngot::new(
                         db,
                         path,
                         IngotKind::StandAlone,
                         Version::new(0, 0, 0),
-                        IndexSet::new(),
+                        external_ingots,
                     );
                     self.ingots.insert(path, ingot);
                     Some(ingot)

--- a/crates/language-server/test_files/goto.fe
+++ b/crates/language-server/test_files/goto.fe
@@ -1,3 +1,5 @@
+use core
+
 struct Foo {}
 struct Bar {}
 
@@ -5,6 +7,7 @@ fn main() {
     let x: Foo
     let y: Bar
     let z: baz::Baz
+    core::todo()
 }
 
 mod baz {

--- a/crates/language-server/test_files/goto.snap
+++ b/crates/language-server/test_files/goto.snap
@@ -1,23 +1,27 @@
 ---
-source: crates/language-server/src/goto.rs
-assertion_line: 283
+source: crates/language-server/src/functionality/goto.rs
 expression: snapshot
-input_file: crates/language-server/test_files/goto.fe
+input_file: test_files/goto.fe
 ---
-0: struct Foo {}
-1: struct Bar {}
-2: 
-3: fn main() {
-4:     let x: Foo
-5:     let y: Bar
-6:     let z: baz::Baz
-7: }
-8: 
-9: mod baz {
-10:    pub struct Baz {}
-11: }
+0: use core
+1: 
+2: struct Foo {}
+3: struct Bar {}
+4: 
+5: fn main() {
+6:     let x: Foo
+7:     let y: Bar
+8:     let z: baz::Baz
+9:     core::todo()
+10: }
+11: 
+12: mod baz {
+13:    pub struct Baz {}
+14: }
 ---
-cursor position (4, 11), path: goto::Foo
-cursor position (5, 11), path: goto::Bar
-cursor position (6, 11), path: goto::baz
-cursor position (6, 16), path: goto::baz::Baz
+cursor position (6, 11), path: goto::Foo
+cursor position (7, 11), path: goto::Bar
+cursor position (8, 11), path: goto::baz
+cursor position (8, 16), path: goto::baz::Baz
+cursor position (9, 4), path: lib
+cursor position (9, 10), path: lib::todo

--- a/crates/uitest/Cargo.toml
+++ b/crates/uitest/Cargo.toml
@@ -15,3 +15,4 @@ driver.workspace = true
 test-utils.workspace = true
 hir.workspace = true
 hir-analysis.workspace = true
+common.workspace = true

--- a/crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.snap
+++ b/crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.snap
@@ -10,5 +10,5 @@ error[8-0028]: trait is not in the scope
   │       ^^^
   │       │
   │       consider importing one of the following traits into the scope to resolve the ambiguity
-  │       `use require_explicit_import::inner::Foo`
   │       `use require_explicit_import::inner::Bar`
+  │       `use require_explicit_import::inner::Foo`

--- a/crates/uitest/tests/name_resolution.rs
+++ b/crates/uitest/tests/name_resolution.rs
@@ -1,4 +1,5 @@
 use camino::Utf8Path;
+use common::InputIngot;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
@@ -11,7 +12,7 @@ fn run_name_resolution(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let path = Utf8Path::new(fixture.path());
 
-    let (core, _) = db.static_core_ingot();
+    let core = InputIngot::core(&db);
     let (ingot, file) = db.standalone(path, fixture.content(), core);
     let top_mod = db.top_mod(ingot, file);
 
@@ -38,7 +39,7 @@ mod wasm {
         let mut db = DriverDataBase::default();
         let path = Utf8Path::new(fixture.path());
 
-        let (core, _) = db.static_core_ingot();
+        let core = InputIngot::core(&db);
         let (ingot, file) = db.standalone(path, fixture.content(), core);
         let top_mod = db.top_mod(ingot, file);
         db.run_on_top_mod(top_mod);


### PR DESCRIPTION
Using rust-embed and moved static core setup to `common::input`. Atm users get an error when goto selecting something in the core library.