### PR TITLE
 Remove db trait upcasting boilerplate (rust 1.86)

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -6,6 +6,9 @@ pub use input::{InputFile, InputIngot};
 #[salsa::db]
 pub trait InputDb: salsa::Database {}
 
+#[salsa::db]
+impl<T> InputDb for T where T: salsa::Database {}
+
 #[doc(hidden)]
 pub use paste::paste;
 
@@ -16,12 +19,5 @@ macro_rules! impl_db_traits {
         impl salsa::Database for $db_type {
             fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
         }
-
-        $(
-            $crate::paste! {
-                #[salsa::db]
-                impl $trait_name for $db_type {}
-            }
-        )+
     };
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -4,9 +4,7 @@ pub mod input;
 pub use input::{InputFile, InputIngot};
 
 #[salsa::db]
-pub trait InputDb: salsa::Database {
-    fn as_input_db(&self) -> &dyn InputDb;
-}
+pub trait InputDb: salsa::Database {}
 
 #[doc(hidden)]
 pub use paste::paste;
@@ -22,11 +20,7 @@ macro_rules! impl_db_traits {
         $(
             $crate::paste! {
                 #[salsa::db]
-                impl $trait_name for $db_type {
-                    fn [<as_ $trait_name:snake>](&self) -> &dyn $trait_name {
-                        self
-                    }
-                }
+                impl $trait_name for $db_type {}
             }
         )+
     };

--- a/crates/driver/src/db.rs
+++ b/crates/driver/src/db.rs
@@ -6,50 +6,35 @@ use codespan_reporting::term::{
 };
 use common::{
     diagnostics::CompleteDiagnostic,
-    impl_db_traits,
     indexmap::IndexSet,
     input::{IngotDependency, IngotKind, Version},
-    InputDb, InputFile, InputIngot,
+    InputFile, InputIngot,
 };
 use hir::{
     hir_def::TopLevelMod,
     lower::{map_file_to_mod, module_tree},
-    HirDb, LowerHirDb, SpannedHirDb,
 };
 use hir_analysis::{
     analysis_pass::{AnalysisPassManager, ParsingPass},
-    diagnostics::{DiagnosticVoucher, SpannedHirAnalysisDb},
+    diagnostics::DiagnosticVoucher,
     name_resolution::{DefConflictAnalysisPass, ImportAnalysisPass, PathAnalysisPass},
     ty::{
         AdtDefAnalysisPass, BodyAnalysisPass, FuncAnalysisPass, ImplAnalysisPass,
         ImplTraitAnalysisPass, TraitAnalysisPass, TypeAliasAnalysisPass,
     },
-    HirAnalysisDb,
 };
 
 use crate::diagnostics::ToCsDiag;
-
-#[salsa::db]
-pub trait DriverDb:
-    salsa::Database + HirAnalysisDb + HirDb + LowerHirDb + SpannedHirDb + InputDb + SpannedHirAnalysisDb
-{
-}
 
 #[derive(Default, Clone)]
 #[salsa::db]
 pub struct DriverDataBase {
     storage: salsa::Storage<Self>,
 }
-impl_db_traits!(
-    DriverDataBase,
-    InputDb,
-    HirDb,
-    LowerHirDb,
-    SpannedHirDb,
-    HirAnalysisDb,
-    SpannedHirAnalysisDb,
-    DriverDb,
-);
+#[salsa::db]
+impl salsa::Database for DriverDataBase {
+    fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
+}
 
 impl DriverDataBase {
     // TODO: An temporary implementation for ui testing.

--- a/crates/driver/src/db.rs
+++ b/crates/driver/src/db.rs
@@ -33,7 +33,6 @@ use crate::diagnostics::ToCsDiag;
 pub trait DriverDb:
     salsa::Database + HirAnalysisDb + HirDb + LowerHirDb + SpannedHirDb + InputDb + SpannedHirAnalysisDb
 {
-    fn as_driver_db(&self) -> &dyn DriverDb;
 }
 
 #[derive(Default, Clone)]

--- a/crates/driver/src/diagnostics.rs
+++ b/crates/driver/src/diagnostics.rs
@@ -9,8 +9,6 @@ use common::{
 use cs::{diagnostic as cs_diag, files as cs_files};
 use hir_analysis::diagnostics::{DiagnosticVoucher, SpannedHirAnalysisDb};
 
-use crate::DriverDb;
-
 pub trait ToCsDiag {
     fn to_cs(&self, db: &dyn SpannedInputDb) -> cs_diag::Diagnostic<InputFile>;
 }
@@ -66,11 +64,11 @@ fn convert_severity(severity: Severity) -> cs_diag::Severity {
 }
 
 #[salsa::tracked(return_ref)]
-pub fn file_line_starts(db: &dyn DriverDb, file: InputFile) -> Vec<usize> {
+pub fn file_line_starts(db: &dyn SpannedHirAnalysisDb, file: InputFile) -> Vec<usize> {
     cs::files::line_starts(file.text(db)).collect()
 }
 
-pub struct CsDbWrapper<'a>(pub &'a dyn DriverDb);
+pub struct CsDbWrapper<'a>(pub &'a dyn SpannedHirAnalysisDb);
 
 impl<'db> cs_files::Files<'db> for CsDbWrapper<'db> {
     type FileId = InputFile;

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -3,7 +3,7 @@ pub mod diagnostics;
 pub mod files;
 use camino::Utf8PathBuf;
 use common::InputIngot;
-pub use db::{DriverDataBase, DriverDb};
+pub use db::DriverDataBase;
 
 use clap::{Parser, Subcommand};
 use hir::hir_def::TopLevelMod;

--- a/crates/hir-analysis/src/diagnostics.rs
+++ b/crates/hir-analysis/src/diagnostics.rs
@@ -21,7 +21,7 @@ use common::diagnostics::{
     SubDiagnostic,
 };
 use either::Either;
-use hir::{hir_def::FieldIndex, span::LazySpan, ParserError};
+use hir::{hir_def::FieldIndex, span::LazySpan, ParserError, SpannedHirDb};
 use itertools::Itertools;
 
 /// All diagnostics accumulated in salsa-db should implement
@@ -59,6 +59,9 @@ pub trait SpannedHirAnalysisDb:
     salsa::Database + hir::HirDb + hir::SpannedHirDb + HirAnalysisDb
 {
 }
+
+#[salsa::db]
+impl<T> SpannedHirAnalysisDb for T where T: HirAnalysisDb + SpannedHirDb {}
 
 // `ParseError` has span information, but this is not a problem because the
 // parsing procedure itself depends on the file content, and thus span

--- a/crates/hir-analysis/src/lib.rs
+++ b/crates/hir-analysis/src/lib.rs
@@ -3,7 +3,10 @@ pub mod analysis_pass;
 pub mod diagnostics;
 
 #[salsa::db]
-pub trait HirAnalysisDb: salsa::Database + HirDb {}
+pub trait HirAnalysisDb: HirDb {}
+
+#[salsa::db]
+impl<T> HirAnalysisDb for T where T: HirDb {}
 
 pub mod name_resolution;
 pub mod ty;

--- a/crates/hir-analysis/src/lib.rs
+++ b/crates/hir-analysis/src/lib.rs
@@ -3,9 +3,7 @@ pub mod analysis_pass;
 pub mod diagnostics;
 
 #[salsa::db]
-pub trait HirAnalysisDb: salsa::Database + HirDb {
-    fn as_hir_analysis_db(&self) -> &dyn HirAnalysisDb;
-}
+pub trait HirAnalysisDb: salsa::Database + HirDb {}
 
 pub mod name_resolution;
 pub mod ty;

--- a/crates/hir-analysis/src/name_resolution/diagnostics.rs
+++ b/crates/hir-analysis/src/name_resolution/diagnostics.rs
@@ -49,17 +49,17 @@ impl<'db> NameResDiag<'db> {
         match self {
             Self::Conflict(_, conflicts) => conflicts
                 .iter()
-                .filter_map(|span| span.top_mod(db.as_hir_db()))
+                .filter_map(|span| span.top_mod(db))
                 .min()
                 .unwrap(),
-            Self::NotFound(span, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::Invisible(span, _, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::Ambiguous(span, _, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::InvalidPathSegment(span, _, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::ExpectedType(span, _, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::ExpectedTrait(span, _, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::ExpectedValue(span, _, _) => span.top_mod(db.as_hir_db()).unwrap(),
-            Self::TooManyGenericArgs { span, .. } => span.top_mod(db.as_hir_db()).unwrap(),
+            Self::NotFound(span, _) => span.top_mod(db).unwrap(),
+            Self::Invisible(span, _, _) => span.top_mod(db).unwrap(),
+            Self::Ambiguous(span, _, _) => span.top_mod(db).unwrap(),
+            Self::InvalidPathSegment(span, _, _) => span.top_mod(db).unwrap(),
+            Self::ExpectedType(span, _, _) => span.top_mod(db).unwrap(),
+            Self::ExpectedTrait(span, _, _) => span.top_mod(db).unwrap(),
+            Self::ExpectedValue(span, _, _) => span.top_mod(db).unwrap(),
+            Self::TooManyGenericArgs { span, .. } => span.top_mod(db).unwrap(),
         }
     }
 

--- a/crates/hir-analysis/src/name_resolution/mod.rs
+++ b/crates/hir-analysis/src/name_resolution/mod.rs
@@ -61,7 +61,7 @@ impl<'db> ModuleAnalysisPass<'db> for ImportAnalysisPass<'db> {
         &mut self,
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
-        let ingot = top_mod.ingot(self.db.as_hir_db());
+        let ingot = top_mod.ingot(self.db);
         resolve_imports(self.db, ingot)
             .0
             .iter()
@@ -99,7 +99,7 @@ impl<'db> ModuleAnalysisPass<'db> for PathAnalysisPass<'db> {
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
         let importer = DefaultImporter;
         let mut visitor = EarlyPathVisitor::new(self.db, &importer);
-        let mut ctxt = VisitorCtxt::with_item(self.db.as_hir_db(), top_mod.into());
+        let mut ctxt = VisitorCtxt::with_item(self.db, top_mod.into());
         visitor.visit_item(&mut ctxt, top_mod.into());
 
         visitor
@@ -131,7 +131,7 @@ impl<'db> ModuleAnalysisPass<'db> for DefConflictAnalysisPass<'db> {
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
         let importer = DefaultImporter;
         let mut visitor = EarlyPathVisitor::new(self.db, &importer);
-        let mut ctxt = VisitorCtxt::with_item(self.db.as_hir_db(), top_mod.into());
+        let mut ctxt = VisitorCtxt::with_item(self.db, top_mod.into());
         visitor.visit_item(&mut ctxt, top_mod.into());
 
         visitor
@@ -169,7 +169,7 @@ impl<'db, 'a> EarlyPathVisitor<'db, 'a> {
     fn new(db: &'db dyn HirAnalysisDb, importer: &'a DefaultImporter) -> Self {
         let resolver = name_resolver::NameResolver::new(db, importer);
         Self {
-            db: db.as_hir_analysis_db(),
+            db,
             inner: resolver,
             diags: Vec::new(),
             item_stack: Vec::new(),
@@ -198,12 +198,12 @@ impl<'db, 'a> EarlyPathVisitor<'db, 'a> {
                     .filter_map(|res| {
                         let conflicted_scope = res.scope()?;
                         self.already_conflicted.insert(conflicted_scope);
-                        conflicted_scope.name_span(self.db.as_hir_db())
+                        conflicted_scope.name_span(self.db)
                     })
                     .collect();
 
                 let diag = diagnostics::NameResDiag::Conflict(
-                    scope.name(self.db.as_hir_db()).unwrap(),
+                    scope.name(self.db).unwrap(),
                     conflicted_span,
                 );
                 self.diags.push(diag);
@@ -214,13 +214,13 @@ impl<'db, 'a> EarlyPathVisitor<'db, 'a> {
     }
 
     fn make_query_for_conflict_check(&self, scope: ScopeId<'db>) -> Option<EarlyNameQueryId<'db>> {
-        let name = scope.name(self.db.as_hir_db())?;
+        let name = scope.name(self.db)?;
         let directive = QueryDirective::new()
             .disallow_lex()
             .disallow_glob()
             .disallow_external();
 
-        let parent_scope = scope.parent(self.db.as_hir_db())?;
+        let parent_scope = scope.parent(self.db)?;
         Some(EarlyNameQueryId::new(
             self.db,
             name,
@@ -379,7 +379,7 @@ impl<'db> Visitor<'db> for EarlyPathVisitor<'db, '_> {
             Ok(res) => res,
 
             Err(err) => {
-                let hir_db = self.db.as_hir_db();
+                let hir_db = self.db;
                 let failed_at = err.failed_at;
                 let span = ctxt
                     .span()
@@ -463,7 +463,7 @@ impl<'db> Visitor<'db> for EarlyPathVisitor<'db, '_> {
         };
 
         if let Some((path, deriv_span)) = invisible {
-            let hir_db = self.db.as_hir_db();
+            let hir_db = self.db;
             let span = ctxt
                 .span()
                 .unwrap()
@@ -481,10 +481,10 @@ impl<'db> Visitor<'db> for EarlyPathVisitor<'db, '_> {
         let span = ctxt
             .span()
             .unwrap()
-            .segment(path.segment_index(self.db.as_hir_db()))
+            .segment(path.segment_index(self.db))
             .into();
 
-        let ident = path.ident(self.db.as_hir_db()).to_opt().unwrap();
+        let ident = path.ident(self.db).to_opt().unwrap();
 
         match expected_path_kind {
             ExpectedPathKind::Type if !is_type => {

--- a/crates/hir-analysis/src/name_resolution/name_resolver.rs
+++ b/crates/hir-analysis/src/name_resolution/name_resolver.rs
@@ -311,7 +311,7 @@ impl<'db> NameRes<'db> {
     pub fn is_enum(&self, db: &dyn HirAnalysisDb) -> bool {
         match self.kind {
             NameResKind::Prim(_) => false,
-            NameResKind::Scope(scope) => scope.resolve_to::<Enum>(db.as_hir_db()).is_some(),
+            NameResKind::Scope(scope) => scope.resolve_to::<Enum>(db).is_some(),
         }
     }
 
@@ -319,8 +319,8 @@ impl<'db> NameRes<'db> {
         match self.kind {
             NameResKind::Prim(_) => false,
             NameResKind::Scope(scope) => {
-                scope.resolve_to::<TopLevelMod>(db.as_hir_db()).is_some()
-                    || scope.resolve_to::<Mod>(db.as_hir_db()).is_some()
+                scope.resolve_to::<TopLevelMod>(db).is_some()
+                    || scope.resolve_to::<Mod>(db).is_some()
             }
         }
     }
@@ -340,12 +340,8 @@ impl<'db> NameRes<'db> {
 
     pub fn pretty_path(&self, db: &dyn HirAnalysisDb) -> Option<String> {
         match self.kind {
-            NameResKind::Scope(scope) => scope.pretty_path(db.as_hir_db()),
-            NameResKind::Prim(prim) => prim
-                .name(db.as_hir_db())
-                .data(db.as_hir_db())
-                .clone()
-                .into(),
+            NameResKind::Scope(scope) => scope.pretty_path(db),
+            NameResKind::Prim(prim) => prim.name(db).data(db).clone().into(),
         }
     }
 
@@ -354,8 +350,8 @@ impl<'db> NameRes<'db> {
             NameDerivation::Def | NameDerivation::Prim | NameDerivation::External => {
                 self.kind.name_span(db)
             }
-            NameDerivation::NamedImported(use_) => use_.imported_name_span(db.as_hir_db()),
-            NameDerivation::GlobImported(use_) => use_.glob_span(db.as_hir_db()),
+            NameDerivation::NamedImported(use_) => use_.imported_name_span(db),
+            NameDerivation::GlobImported(use_) => use_.glob_span(db),
             NameDerivation::Lex(ref inner) => {
                 let mut inner = inner;
                 while let NameDerivation::Lex(parent) = inner.as_ref() {
@@ -413,15 +409,15 @@ pub enum NameResKind<'db> {
 impl<'db> NameResKind<'db> {
     pub fn name_span(self, db: &'db dyn HirAnalysisDb) -> Option<DynLazySpan<'db>> {
         match self {
-            NameResKind::Scope(scope) => scope.name_span(db.as_hir_db()),
+            NameResKind::Scope(scope) => scope.name_span(db),
             NameResKind::Prim(_) => None,
         }
     }
 
     pub fn name(self, db: &'db dyn HirAnalysisDb) -> IdentId<'db> {
         match self {
-            NameResKind::Scope(scope) => scope.name(db.as_hir_db()).unwrap(),
-            NameResKind::Prim(prim) => prim.name(db.as_hir_db()),
+            NameResKind::Scope(scope) => scope.name(db).unwrap(),
+            NameResKind::Prim(prim) => prim.name(db),
         }
     }
 }
@@ -509,7 +505,7 @@ impl<'db, 'a> NameResolver<'db, 'a> {
     }
 
     pub(crate) fn resolve_query(&mut self, query: EarlyNameQueryId<'db>) -> NameResBucket<'db> {
-        let hir_db = self.db.as_hir_db();
+        let hir_db = self.db;
 
         let mut bucket = NameResBucket::default();
 
@@ -599,7 +595,7 @@ impl<'db, 'a> NameResolver<'db, 'a> {
         for &prim in PrimTy::all_types() {
             // We don't care about the result of `push` because we assume builtin types are
             // guaranteed to be unique.
-            if query.name(self.db) == prim.name(self.db.as_hir_db()) {
+            if query.name(self.db) == prim.name(self.db) {
                 bucket.push(&NameRes::new_prim(prim));
             }
         }
@@ -656,7 +652,7 @@ impl<'db, 'a> NameResolver<'db, 'a> {
         let mut found_domains: FxHashMap<IdentId, NameDomain> = FxHashMap::default();
         let mut found_kinds: FxHashSet<(IdentId, NameResKind)> = FxHashSet::default();
 
-        for edge in target.edges(self.db.as_hir_db()) {
+        for edge in target.edges(self.db) {
             let scope = match edge.kind.propagate_glob() {
                 PropagationResult::Terminated => edge.dest,
                 _ => {
@@ -664,7 +660,7 @@ impl<'db, 'a> NameResolver<'db, 'a> {
                 }
             };
 
-            let name = scope.name(self.db.as_hir_db()).unwrap();
+            let name = scope.name(self.db).unwrap();
             if !found_kinds.insert((name, scope.into())) {
                 continue;
             }
@@ -812,7 +808,7 @@ impl NameDomain {
             ScopeId::GenericParam(parent, idx) => {
                 let parent = GenericParamOwner::from_item_opt(parent).unwrap();
 
-                let param = &parent.params(db.as_hir_db()).data(db.as_hir_db())[idx];
+                let param = &parent.params(db).data(db)[idx];
                 match param {
                     GenericParam::Type(_) => NameDomain::TYPE,
                     GenericParam::Const(_) => NameDomain::TYPE | NameDomain::VALUE,
@@ -1001,7 +997,7 @@ impl<'db> QueryPropagator<'db> for SuperEdge {
         db: &'db dyn HirAnalysisDb,
         query: EarlyNameQueryId<'db>,
     ) -> PropagationResult {
-        if query.name(db).is_super(db.as_hir_db()) {
+        if query.name(db).is_super(db) {
             PropagationResult::Terminated
         } else {
             PropagationResult::UnPropagated
@@ -1019,7 +1015,7 @@ impl<'db> QueryPropagator<'db> for IngotEdge {
         db: &'db dyn HirAnalysisDb,
         query: EarlyNameQueryId<'db>,
     ) -> PropagationResult {
-        if query.name(db).is_ingot(db.as_hir_db()) {
+        if query.name(db).is_ingot(db) {
             PropagationResult::Terminated
         } else {
             PropagationResult::UnPropagated
@@ -1037,7 +1033,7 @@ impl<'db> QueryPropagator<'db> for SelfTyEdge {
         db: &'db dyn HirAnalysisDb,
         query: EarlyNameQueryId<'db>,
     ) -> PropagationResult {
-        if query.name(db).is_self_ty(db.as_hir_db()) {
+        if query.name(db).is_self_ty(db) {
             PropagationResult::Terminated
         } else {
             PropagationResult::UnPropagated
@@ -1055,7 +1051,7 @@ impl<'db> QueryPropagator<'db> for SelfEdge {
         db: &'db dyn HirAnalysisDb,
         query: EarlyNameQueryId<'db>,
     ) -> PropagationResult {
-        if query.name(db).is_self(db.as_hir_db()) {
+        if query.name(db).is_self(db) {
             PropagationResult::Terminated
         } else {
             PropagationResult::UnPropagated

--- a/crates/hir-analysis/src/name_resolution/traits_in_scope.rs
+++ b/crates/hir-analysis/src/name_resolution/traits_in_scope.rs
@@ -21,7 +21,7 @@ pub(crate) fn available_traits_in_scope_impl<'db>(
     let mut traits = IndexSet::default();
     let scope = t_scope.inner(db).to_scope();
 
-    let imports = &resolve_imports(db, scope.ingot(db.as_hir_db())).1;
+    let imports = &resolve_imports(db, scope.ingot(db)).1;
     if let Some(named) = imports.named_resolved.get(&scope) {
         named
             .values()
@@ -54,13 +54,13 @@ pub(crate) fn available_traits_in_scope_impl<'db>(
             })
     }
 
-    for child in scope.child_items(db.as_hir_db()) {
+    for child in scope.child_items(db) {
         if let ItemKind::Trait(trait_) = child {
             traits.insert(trait_);
         }
     }
 
-    if let Some(parent) = scope.parent(db.as_hir_db()) {
+    if let Some(parent) = scope.parent(db) {
         let parent_traits = available_traits_in_scope(db, parent);
         traits.extend(parent_traits.iter().copied());
     }
@@ -99,7 +99,7 @@ impl<'db> TraitScopeKind<'db> {
                 }
                 _ => {}
             }
-            scope = scope.parent(db.as_hir_db()).unwrap();
+            scope = scope.parent(db).unwrap();
         }
     }
 

--- a/crates/hir-analysis/src/name_resolution/visibility_checker.rs
+++ b/crates/hir-analysis/src/name_resolution/visibility_checker.rs
@@ -14,7 +14,7 @@ pub(crate) fn is_scope_visible_from(
     scope: ScopeId,
     from_scope: ScopeId,
 ) -> bool {
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
     // If resolved is public, then it is visible.
     if scope.data(hir_db).vis.is_pub() {
         return true;
@@ -46,7 +46,7 @@ pub(crate) fn is_scope_visible_from(
         return false;
     };
 
-    from_scope.is_transitive_child_of(db.as_hir_db(), def_scope)
+    from_scope.is_transitive_child_of(db, def_scope)
 }
 
 pub(crate) fn is_ty_visible_from(db: &dyn HirAnalysisDb, ty: TyId, from_scope: ScopeId) -> bool {
@@ -75,10 +75,10 @@ pub(crate) fn is_ty_visible_from(db: &dyn HirAnalysisDb, ty: TyId, from_scope: S
 pub(super) fn is_use_visible(db: &dyn HirAnalysisDb, ref_scope: ScopeId, use_: Use) -> bool {
     let use_scope = ScopeId::from_item(use_.into());
 
-    if use_scope.data(db.as_hir_db()).vis.is_pub() {
+    if use_scope.data(db).vis.is_pub() {
         return true;
     }
 
-    let use_def_scope = use_scope.parent(db.as_hir_db()).unwrap();
-    ref_scope.is_transitive_child_of(db.as_hir_db(), use_def_scope)
+    let use_def_scope = use_scope.parent(db).unwrap();
+    ref_scope.is_transitive_child_of(db, use_def_scope)
 }

--- a/crates/hir-analysis/src/ty/const_ty.rs
+++ b/crates/hir-analysis/src/ty/const_ty.rs
@@ -33,7 +33,7 @@ pub(crate) fn evaluate_const_ty<'db>(
         };
     };
 
-    let Partial::Present(expr) = body.expr(db.as_hir_db()).data(db.as_hir_db(), *body) else {
+    let Partial::Present(expr) = body.expr(db).data(db, *body) else {
         let data = ConstTyData::Evaluated(
             EvaluatedConstTy::Invalid,
             TyId::invalid(db, InvalidCause::Other),
@@ -180,7 +180,7 @@ impl EvaluatedConstTy<'_> {
     pub fn pretty_print(&self, db: &dyn HirAnalysisDb) -> String {
         match self {
             EvaluatedConstTy::LitInt(val) => {
-                format!("{}", val.data(db.as_hir_db()))
+                format!("{}", val.data(db))
             }
             EvaluatedConstTy::LitBool(val) => format!("{}", val),
             EvaluatedConstTy::Invalid => "<invalid>".to_string(),

--- a/crates/hir-analysis/src/ty/method_cmp.rs
+++ b/crates/hir-analysis/src/ty/method_cmp.rs
@@ -154,7 +154,7 @@ fn compare_arg_label<'db>(
     trait_m: FuncDef<'db>,
     sink: &mut Vec<TyDiagCollection<'db>>,
 ) -> bool {
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
 
     let mut err = false;
     let hir_impl_m = impl_m.hir_func_def(db).unwrap();

--- a/crates/hir-analysis/src/ty/method_table.rs
+++ b/crates/hir-analysis/src/ty/method_table.rs
@@ -19,7 +19,7 @@ pub(crate) fn collect_methods<'db>(
 ) -> MethodTable<'db> {
     let mut collector = MethodCollector::new(db, ingot);
 
-    let impls = ingot.all_impls(db.as_hir_db());
+    let impls = ingot.all_impls(db);
     collector.collect_impls(impls);
     collector.finalize()
 }
@@ -145,7 +145,7 @@ impl<'db> MethodCollector<'db> {
 
     fn collect_impls(&mut self, impls: &[Impl<'db>]) {
         for impl_ in impls {
-            let ty = match impl_.ty(self.db.as_hir_db()).to_opt() {
+            let ty = match impl_.ty(self.db).to_opt() {
                 Some(ty) => lower_hir_ty(self.db, ty, impl_.scope()),
                 None => TyId::invalid(self.db, InvalidCause::Other),
             };
@@ -154,7 +154,7 @@ impl<'db> MethodCollector<'db> {
                 continue;
             }
 
-            for func in impl_.funcs(self.db.as_hir_db()) {
+            for func in impl_.funcs(self.db) {
                 let Some(func) = lower_func(self.db, func) else {
                     continue;
                 };

--- a/crates/hir-analysis/src/ty/mod.rs
+++ b/crates/hir-analysis/src/ty/mod.rs
@@ -49,7 +49,7 @@ impl<'db> ModuleAnalysisPass<'db> for AdtDefAnalysisPass<'db> {
         &mut self,
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
-        let hir_db = self.db.as_hir_db();
+        let hir_db = self.db;
         let adts = top_mod
             .all_structs(hir_db)
             .iter()
@@ -95,7 +95,7 @@ impl<'db> ModuleAnalysisPass<'db> for BodyAnalysisPass<'db> {
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
         top_mod
-            .all_funcs(self.db.as_hir_db())
+            .all_funcs(self.db)
             .iter()
             .flat_map(|func| &ty_check::check_func_body(self.db, *func).0)
             .map(|diag| diag.to_voucher())
@@ -121,7 +121,7 @@ impl<'db> ModuleAnalysisPass<'db> for TraitAnalysisPass<'db> {
         let mut diags = vec![];
         let mut cycle_participants = FxHashSet::<TraitDef<'db>>::default();
 
-        for hir_trait in top_mod.all_traits(self.db.as_hir_db()) {
+        for hir_trait in top_mod.all_traits(self.db) {
             let trait_ = lower_trait(self.db, *hir_trait);
             if !cycle_participants.contains(&trait_) {
                 if let Some(cycle) = super_trait_cycle(self.db, trait_) {
@@ -155,7 +155,7 @@ impl<'db> ModuleAnalysisPass<'db> for ImplAnalysisPass<'db> {
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
         top_mod
-            .all_impls(self.db.as_hir_db())
+            .all_impls(self.db)
             .iter()
             .flat_map(|impl_| analyze_impl(self.db, *impl_))
             .map(|diag| diag.to_voucher())
@@ -180,7 +180,7 @@ impl<'db> ModuleAnalysisPass<'db> for ImplTraitAnalysisPass<'db> {
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
         top_mod
-            .all_impl_traits(self.db.as_hir_db())
+            .all_impl_traits(self.db)
             .iter()
             .flat_map(|trait_| analyze_impl_trait(self.db, *trait_))
             .map(|diag| diag.to_voucher())
@@ -205,7 +205,7 @@ impl<'db> ModuleAnalysisPass<'db> for FuncAnalysisPass<'db> {
         top_mod: TopLevelMod<'db>,
     ) -> Vec<Box<dyn DiagnosticVoucher<'db> + 'db>> {
         top_mod
-            .all_funcs(self.db.as_hir_db())
+            .all_funcs(self.db)
             .iter()
             .flat_map(|func| analyze_func(self.db, *func))
             .map(|diag| diag.to_voucher())
@@ -241,7 +241,7 @@ impl<'db> ModuleAnalysisPass<'db> for TypeAliasAnalysisPass<'db> {
         let mut diags = vec![];
         let mut cycle_participants = FxHashSet::<TypeAlias>::default();
 
-        for alias in top_mod.all_type_aliases(self.db.as_hir_db()) {
+        for alias in top_mod.all_type_aliases(self.db) {
             if cycle_participants.contains(alias) {
                 continue;
             }

--- a/crates/hir-analysis/src/ty/trait_def.rs
+++ b/crates/hir-analysis/src/ty/trait_def.rs
@@ -132,7 +132,7 @@ impl<'db> TraitEnv<'db> {
             FxHashMap::default();
 
         for impl_map in ingot
-            .external_ingots(db.as_hir_db())
+            .external_ingots(db)
             .iter()
             .map(|(_, external)| collect_trait_impls(db, *external))
             .chain(std::iter::once(collect_trait_impls(db, ingot)))
@@ -331,11 +331,7 @@ pub struct TraitMethod<'db>(pub FuncDef<'db>);
 
 impl TraitMethod<'_> {
     pub fn has_default_impl(self, db: &dyn HirAnalysisDb) -> bool {
-        self.0
-            .hir_func_def(db)
-            .unwrap()
-            .body(db.as_hir_db())
-            .is_some()
+        self.0.hir_func_def(db).unwrap().body(db).is_some()
     }
 }
 
@@ -347,7 +343,7 @@ impl<'db> TraitDef<'db> {
 
     /// Returns `ingot` in which this trait is defined.
     pub(crate) fn ingot(self, db: &'db dyn HirAnalysisDb) -> IngotId<'db> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
         self.trait_(db).top_mod(hir_db).ingot(hir_db)
     }
 
@@ -367,8 +363,8 @@ impl<'db> TraitDef<'db> {
 
     fn name(self, db: &'db dyn HirAnalysisDb) -> Option<&'db str> {
         self.trait_(db)
-            .name(db.as_hir_db())
+            .name(db)
             .to_opt()
-            .map(|name| name.data(db.as_hir_db()).as_str())
+            .map(|name| name.data(db).as_str())
     }
 }

--- a/crates/hir-analysis/src/ty/trait_lower.rs
+++ b/crates/hir-analysis/src/ty/trait_lower.rs
@@ -36,12 +36,12 @@ pub(crate) fn collect_trait_impls<'db>(
     ingot: IngotId<'db>,
 ) -> TraitImplTable<'db> {
     let const_impls = ingot
-        .external_ingots(db.as_hir_db())
+        .external_ingots(db)
         .iter()
         .map(|(_, external)| collect_trait_impls(db, *external))
         .collect();
 
-    let impl_traits = ingot.all_impl_traits(db.as_hir_db());
+    let impl_traits = ingot.all_impl_traits(db);
     ImplementorCollector::new(db, const_impls).collect(impl_traits)
 }
 
@@ -53,7 +53,7 @@ pub(crate) fn lower_impl_trait<'db>(
     db: &'db dyn HirAnalysisDb,
     impl_trait: ImplTrait<'db>,
 ) -> Option<Binder<Implementor<'db>>> {
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
     let scope = impl_trait.scope();
 
     let hir_ty = impl_trait.ty(hir_db).to_opt()?;
@@ -93,7 +93,7 @@ pub(crate) fn lower_trait_ref<'db>(
     trait_ref: TraitRefId<'db>,
     scope: ScopeId<'db>,
 ) -> Result<TraitInstId<'db>, TraitRefLowerError<'db>> {
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
 
     let mut args = vec![self_ty];
     if let Some(generic_args) = trait_ref.generic_args(hir_db) {
@@ -173,7 +173,7 @@ pub(crate) fn collect_implementor_methods<'db>(
 ) -> IndexMap<IdentId<'db>, FuncDef<'db>> {
     let mut methods = IndexMap::default();
 
-    for method in implementor.hir_impl_trait(db).methods(db.as_hir_db()) {
+    for method in implementor.hir_impl_trait(db).methods(db) {
         if let Some(func) = lower_func(db, method) {
             methods.insert(func.name(db), func);
         }
@@ -233,7 +233,7 @@ impl<'db> TraitBuilder<'db> {
     }
 
     fn collect_methods(&mut self) {
-        let hir_db = self.db.as_hir_db();
+        let hir_db = self.db;
         for method in self.trait_.methods(hir_db) {
             let Some(func) = lower_func(self.db, method) else {
                 continue;

--- a/crates/hir-analysis/src/ty/trait_resolution/constraint.rs
+++ b/crates/hir-analysis/src/ty/trait_resolution/constraint.rs
@@ -54,7 +54,7 @@ pub(crate) fn collect_super_traits<'db>(
     trait_: TraitDef<'db>,
 ) -> IndexSet<Binder<TraitInstId<'db>>> {
     let hir_trait = trait_.trait_(db);
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
     let self_param = trait_.self_param(db);
     let scope = trait_.trait_(db).scope();
 
@@ -190,7 +190,7 @@ pub(crate) fn collect_func_def_constraints<'db>(
         return func_constraints;
     }
 
-    let parent_constraints = match hir_func.scope().parent_item(db.as_hir_db()) {
+    let parent_constraints = match hir_func.scope().parent_item(db) {
         Some(ItemKind::Trait(trait_)) => collect_trait_constraints(db, lower_trait(db, trait_)),
 
         Some(ItemKind::Impl(impl_)) => collect_impl_block_constraints(db, impl_),
@@ -270,11 +270,11 @@ impl<'db> ConstraintCollector<'db> {
     }
 
     fn collect_constraints_from_where_clause(&mut self) {
-        let Some(where_clause) = self.owner.where_clause(self.db.as_hir_db()) else {
+        let Some(where_clause) = self.owner.where_clause(self.db) else {
             return;
         };
 
-        for hir_pred in where_clause.data(self.db.as_hir_db()) {
+        for hir_pred in where_clause.data(self.db) {
             let Some(hir_ty) = hir_pred.ty.to_opt() else {
                 continue;
             };
@@ -293,9 +293,9 @@ impl<'db> ConstraintCollector<'db> {
 
     fn collect_constraints_from_generic_params(&mut self) {
         let param_set = collect_generic_params(self.db, self.owner);
-        let param_list = self.owner.params(self.db.as_hir_db());
+        let param_list = self.owner.params(self.db);
 
-        for (i, hir_param) in param_list.data(self.db.as_hir_db()).iter().enumerate() {
+        for (i, hir_param) in param_list.data(self.db).iter().enumerate() {
             let GenericParam::Type(hir_param) = hir_param else {
                 continue;
             };

--- a/crates/hir-analysis/src/ty/ty_check/callable.rs
+++ b/crates/hir-analysis/src/ty/ty_check/callable.rs
@@ -90,7 +90,7 @@ impl<'db> Callable<'db> {
         span: LazyGenericArgListSpan<'db>,
     ) -> bool {
         let db = tc.db;
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
 
         if !args.is_given(hir_db) {
             return true;
@@ -148,7 +148,7 @@ impl<'db> Callable<'db> {
         let mut args = if let Some((receiver_expr, receiver_prop)) = receiver {
             let mut args = Vec::with_capacity(call_args.len() + 1);
             let arg = CallArg::new(
-                IdentId::make_self(db.as_hir_db()).into(),
+                IdentId::make_self(db).into(),
                 receiver_prop,
                 None,
                 receiver_expr.lazy_span(tc.body()).into(),
@@ -172,7 +172,7 @@ impl<'db> Callable<'db> {
             if_chain! {
                 // xxx check this
                 if let Some(expected_label) = self.func_def.param_label(db, i);
-                if !expected_label.is_self(db.as_hir_db());
+                if !expected_label.is_self(db);
                 if Some(expected_label) != given.label;
                 then {
                     let diag = BodyDiag::CallArgLabelMismatch {
@@ -207,7 +207,7 @@ impl<'db> CallArg<'db> {
     ) -> Self {
         let ty = tc.fresh_ty();
         let expr_prop = tc.check_expr(arg.expr, ty);
-        let label = arg.label_eagerly(tc.db.as_hir_db(), tc.body());
+        let label = arg.label_eagerly(tc.db, tc.body());
         let label_span = arg.label.is_some().then(|| span.label().into());
         let expr_span = span.expr().into();
 

--- a/crates/hir-analysis/src/ty/ty_check/env.rs
+++ b/crates/hir-analysis/src/ty/ty_check/env.rs
@@ -46,7 +46,7 @@ pub(super) struct TyCheckEnv<'db> {
 
 impl<'db> TyCheckEnv<'db> {
     pub(super) fn new_with_func(db: &'db dyn HirAnalysisDb, func: Func<'db>) -> Result<Self, ()> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
         let Some(body) = func.body(hir_db) else {
             return Err(());
         };
@@ -114,7 +114,7 @@ impl<'db> TyCheckEnv<'db> {
     /// Returns a function if the `body` being checked has `BodyKind::FuncBody`.
     /// If the `body` has `BodyKind::Anonymous`, returns None
     pub(super) fn func(&self) -> Option<FuncDef<'db>> {
-        let func = match self.body.body_kind(self.db.as_hir_db()) {
+        let func = match self.body.body_kind(self.db) {
             BodyKind::FuncBody => self.var_env.first()?.scope.item().try_into().ok(),
             BodyKind::Anonymous => None,
         }?;
@@ -146,7 +146,7 @@ impl<'db> TyCheckEnv<'db> {
     }
 
     pub(super) fn enter_scope(&mut self, block: ExprId) {
-        let new_scope = match block.data(self.db.as_hir_db(), self.body) {
+        let new_scope = match block.data(self.db, self.body) {
             Partial::Present(Expr::Block(_)) => ScopeId::Block(self.body, block),
             _ => self.scope(),
         };
@@ -272,11 +272,11 @@ impl<'db> TyCheckEnv<'db> {
     }
 
     pub(super) fn expr_data(&self, expr: ExprId) -> &'db Partial<Expr<'db>> {
-        expr.data(self.db.as_hir_db(), self.body)
+        expr.data(self.db, self.body)
     }
 
     pub(super) fn stmt_data(&self, stmt: StmtId) -> &'db Partial<Stmt<'db>> {
-        stmt.data(self.db.as_hir_db(), self.body)
+        stmt.data(self.db, self.body)
     }
 
     pub(super) fn scope(&self) -> ScopeId<'db> {
@@ -314,7 +314,7 @@ impl<'db> TyCheckEnv<'db> {
     ) {
         let assumptions = self.assumptions();
         let mut changed = true;
-        let hir_db = self.db.as_hir_db();
+        let hir_db = self.db;
         let ingot = self.body().top_mod(hir_db).ingot(hir_db);
         // Try to perform confirmation until all pending confirmations reaches to
         // the fixed point.
@@ -457,7 +457,7 @@ impl<'db> LocalBinding<'db> {
     }
 
     pub(super) fn binding_name(&self, env: &TyCheckEnv<'db>) -> IdentId<'db> {
-        let hir_db = env.db.as_hir_db();
+        let hir_db = env.db;
         match self {
             Self::Local { pat, .. } => {
                 let Partial::Present(Pat::Path(Partial::Present(path), ..)) =
@@ -515,8 +515,7 @@ impl<'db> TyFolder<'db> for Prober<'db, '_> {
         // String type variable fallback.
         if let TyVarSort::String(len) = var.sort {
             let ty = TyId::new(self.db(), TyData::TyBase(PrimTy::String.into()));
-            let len =
-                EvaluatedConstTy::LitInt(IntegerId::new(self.db().as_hir_db(), BigUint::from(len)));
+            let len = EvaluatedConstTy::LitInt(IntegerId::new(self.db(), BigUint::from(len)));
             let len =
                 ConstTyData::Evaluated(len, ty.applicable_ty(self.db()).unwrap().const_ty.unwrap());
             let len = TyId::const_ty(self.db(), ConstTyId::new(self.db(), len));

--- a/crates/hir-analysis/src/ty/ty_check/method_selection.rs
+++ b/crates/hir-analysis/src/ty/ty_check/method_selection.rs
@@ -160,14 +160,14 @@ impl<'db> CandidateAssembler<'db> {
             .receiver_ty
             .value
             .ingot(self.db)
-            .unwrap_or_else(|| self.scope.ingot(self.db.as_hir_db()));
+            .unwrap_or_else(|| self.scope.ingot(self.db));
         for &method in probe_method(self.db, ingot, self.receiver_ty, self.method_name) {
             self.candidates.insert_inherent_method(method);
         }
     }
 
     fn assemble_trait_method_candidates(&mut self) {
-        let ingot = self.scope.ingot(self.db.as_hir_db());
+        let ingot = self.scope.ingot(self.db);
         let mut table = UnificationTable::new(self.db);
         let extracted_receiver_ty = self.receiver_ty.extract_identity(&mut table);
 
@@ -332,7 +332,7 @@ impl<'db> MethodSelector<'db> {
 
         match is_goal_satisfiable(
             self.db,
-            self.scope.ingot(self.db.as_hir_db()),
+            self.scope.ingot(self.db),
             canonical_cand.value,
             self.assumptions,
         ) {

--- a/crates/hir-analysis/src/ty/ty_check/pat.rs
+++ b/crates/hir-analysis/src/ty/ty_check/pat.rs
@@ -16,7 +16,7 @@ use crate::{
 
 impl<'db> TyChecker<'db> {
     pub(super) fn check_pat(&mut self, pat: PatId, expected: TyId<'db>) -> TyId<'db> {
-        let Partial::Present(pat_data) = pat.data(self.db.as_hir_db(), self.body()) else {
+        let Partial::Present(pat_data) = pat.data(self.db, self.body()) else {
             let actual = TyId::invalid(self.db, InvalidCause::Other);
             return self.unify_ty(pat, actual, expected);
         };
@@ -86,7 +86,7 @@ impl<'db> TyChecker<'db> {
                 break;
             };
 
-            if pat_tup[pat_idx].is_rest(self.db.as_hir_db(), self.body()) {
+            if pat_tup[pat_idx].is_rest(self.db, self.body()) {
                 pat_idx += 1;
                 continue;
             }
@@ -114,7 +114,7 @@ impl<'db> TyChecker<'db> {
         let span = pat.lazy_span(self.body()).into_path_pat();
         let res = self.resolve_path(*path, true);
 
-        if path.is_bare_ident(self.db.as_hir_db()) {
+        if path.is_bare_ident(self.db) {
             match res {
                 Ok(PathRes::Ty(ty)) if ty.is_record(self.db) => {
                     let diag = BodyDiag::unit_variant_expected(
@@ -140,7 +140,7 @@ impl<'db> TyChecker<'db> {
                     }
                 }
                 _ => {
-                    let name = *path.ident(self.db.as_hir_db()).unwrap();
+                    let name = *path.ident(self.db).unwrap();
                     let binding = LocalBinding::local(pat, *is_mut);
                     if let Some(LocalBinding::Local {
                         pat: conflict_with, ..
@@ -266,7 +266,7 @@ impl<'db> TyChecker<'db> {
             Err(_) => return TyId::invalid(self.db, InvalidCause::Other),
         };
 
-        let expected_len = expected_elems.len(self.db.as_hir_db());
+        let expected_len = expected_elems.len(self.db);
 
         let (actual_elems, rest_range) = self.unpack_rest_pat(elems, Some(expected_len));
         if actual_elems.len() != expected_len {
@@ -281,12 +281,12 @@ impl<'db> TyChecker<'db> {
         };
 
         let mut arg_idx = 0;
-        for (i, &hir_ty) in expected_elems.data(self.db.as_hir_db()).iter().enumerate() {
+        for (i, &hir_ty) in expected_elems.data(self.db).iter().enumerate() {
             if arg_idx >= elems.len() {
                 break;
             }
 
-            if elems[arg_idx].is_rest(self.db.as_hir_db(), self.body()) {
+            if elems[arg_idx].is_rest(self.db, self.body()) {
                 arg_idx += 1;
                 continue;
             }
@@ -385,12 +385,11 @@ impl<'db> TyChecker<'db> {
     where
         T: RecordLike<'db>,
     {
-        let Partial::Present(Pat::Record(_, fields)) = pat.data(self.db.as_hir_db(), self.body())
-        else {
+        let Partial::Present(Pat::Record(_, fields)) = pat.data(self.db, self.body()) else {
             unreachable!()
         };
 
-        let hir_db = self.db.as_hir_db();
+        let hir_db = self.db;
         let mut contains_rest = false;
 
         let pat_span = pat.lazy_span(self.body()).into_record_pat();
@@ -436,7 +435,7 @@ impl<'db> TyChecker<'db> {
     ) -> (Vec<TyId<'db>>, std::ops::Range<usize>) {
         let mut rest_start = None;
         for (i, &pat) in pat_tup.iter().enumerate() {
-            if pat.is_rest(self.db.as_hir_db(), self.body()) && rest_start.replace(i).is_some() {
+            if pat.is_rest(self.db, self.body()) && rest_start.replace(i).is_some() {
                 let span = pat.lazy_span(self.body());
                 self.push_diag(BodyDiag::DuplicatedRestPat(span.into()));
                 return (

--- a/crates/hir-analysis/src/ty/ty_check/path.rs
+++ b/crates/hir-analysis/src/ty/ty_check/path.rs
@@ -122,11 +122,7 @@ where
         if is_scope_visible_from(self.tc.db, field_scope, self.tc.env.scope()) {
             Ok(ty)
         } else {
-            let diag = NameResDiag::Invisible(
-                field_span,
-                label,
-                field_scope.name_span(self.tc.db.as_hir_db()),
-            );
+            let diag = NameResDiag::Invisible(field_span, label, field_scope.name_span(self.tc.db));
 
             self.invalid_field_given = true;
             Err(diag.into())
@@ -174,7 +170,7 @@ pub(crate) trait RecordLike<'db> {
 
     fn record_field_idx(&self, db: &'db dyn HirAnalysisDb, name: IdentId<'db>) -> Option<usize> {
         let (hir_field_list, _) = self.record_field_list(db)?;
-        hir_field_list.field_idx(db.as_hir_db(), name)
+        hir_field_list.field_idx(db, name)
     }
 
     fn record_field_scope(
@@ -201,7 +197,7 @@ impl<'db> RecordLike<'db> for TyId<'db> {
 
     fn record_field_ty(&self, db: &'db dyn HirAnalysisDb, name: IdentId<'db>) -> Option<TyId<'db>> {
         let args = self.generic_args(db);
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
 
         let (hir_field_list, field_list) = self.record_field_list(db)?;
 
@@ -220,7 +216,7 @@ impl<'db> RecordLike<'db> for TyId<'db> {
         &self,
         db: &'db dyn HirAnalysisDb,
     ) -> Option<(HirFieldDefListId<'db>, &'db AdtField<'db>)> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
 
         let adt_def = self.adt_def(db)?;
         match adt_def.adt_ref(db) {
@@ -244,7 +240,7 @@ impl<'db> RecordLike<'db> for TyId<'db> {
     }
 
     fn record_labels(&self, db: &'db dyn HirAnalysisDb) -> Vec<IdentId<'db>> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
         let Some(adt_ref) = self.adt_ref(db) else {
             return Vec::default();
         };
@@ -273,7 +269,7 @@ impl<'db> RecordLike<'db> for TyId<'db> {
     }
 
     fn initializer_hint(&self, db: &'db dyn HirAnalysisDb) -> Option<String> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
 
         if self.adt_ref(db).is_some() {
             let AdtRef::Struct(s) = self.adt_ref(db)? else {
@@ -281,7 +277,7 @@ impl<'db> RecordLike<'db> for TyId<'db> {
             };
 
             let name = s.name(hir_db).unwrap().data(hir_db);
-            let init_args = s.format_initializer_args(db.as_hir_db());
+            let init_args = s.format_initializer_args(db);
             Some(format!("{}{}", name, init_args))
         } else {
             None
@@ -296,7 +292,7 @@ impl<'db> RecordLike<'db> for ResolvedVariant<'db> {
 
     fn record_field_ty(&self, db: &'db dyn HirAnalysisDb, name: IdentId<'db>) -> Option<TyId<'db>> {
         let args = self.ty.generic_args(db);
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
 
         let (hir_field_list, field_list) = self.record_field_list(db)?;
         let field_idx = hir_field_list.field_idx(hir_db, name)?;
@@ -328,7 +324,7 @@ impl<'db> RecordLike<'db> for ResolvedVariant<'db> {
     }
 
     fn record_labels(&self, db: &'db dyn HirAnalysisDb) -> Vec<IdentId<'db>> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
 
         let fields = match self.variant_kind(db) {
             hir::hir_def::VariantKind::Record(fields) => fields,
@@ -343,7 +339,7 @@ impl<'db> RecordLike<'db> for ResolvedVariant<'db> {
     }
 
     fn kind_name(&self, db: &'db dyn HirAnalysisDb) -> String {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
         match self.enum_(db).variants(hir_db).data(hir_db)[self.idx].kind {
             HirVariantKind::Unit => "unit variant",
             HirVariantKind::Tuple(_) => "tuple variant",
@@ -353,7 +349,7 @@ impl<'db> RecordLike<'db> for ResolvedVariant<'db> {
     }
 
     fn initializer_hint(&self, db: &'db dyn HirAnalysisDb) -> Option<String> {
-        let hir_db = db.as_hir_db();
+        let hir_db = db;
         let expected_sub_pat =
             self.enum_(db).variants(hir_db).data(hir_db)[self.idx].format_initializer_args(hir_db);
 

--- a/crates/hir-analysis/src/ty/ty_check/stmt.rs
+++ b/crates/hir-analysis/src/ty/ty_check/stmt.rs
@@ -69,7 +69,7 @@ impl<'db> TyChecker<'db> {
             let diag = BodyDiag::TraitNotImplemented {
                 primary: expr.lazy_span(self.body()).into(),
                 ty: expr_ty.pretty_print(self.db).to_string(),
-                trait_name: IdentId::new(self.db.as_hir_db(), "Iterator".to_string()),
+                trait_name: IdentId::new(self.db, "Iterator".to_string()),
             };
             self.push_diag(diag);
 

--- a/crates/hir-analysis/src/ty/ty_def.rs
+++ b/crates/hir-analysis/src/ty/ty_def.rs
@@ -158,7 +158,7 @@ impl<'db> TyId<'db> {
         };
 
         let ty_ingot = self.ingot(db);
-        match ingot.kind(db.as_hir_db()) {
+        match ingot.kind(db) {
             IngotKind::Core => ty_ingot.is_none() || ty_ingot == Some(ingot),
             _ => ty_ingot == Some(ingot),
         }
@@ -205,7 +205,7 @@ impl<'db> TyId<'db> {
     pub(super) fn array_with_len(db: &'db dyn HirAnalysisDb, elem: TyId<'db>, len: usize) -> Self {
         let array = Self::array(db, elem);
 
-        let len = EvaluatedConstTy::LitInt(IntegerId::new(db.as_hir_db(), BigUint::from(len)));
+        let len = EvaluatedConstTy::LitInt(IntegerId::new(db, BigUint::from(len)));
         let len = ConstTyData::Evaluated(len, array.applicable_ty(db).unwrap().const_ty.unwrap());
         let len = TyId::const_ty(db, ConstTyId::new(db, len));
 
@@ -322,14 +322,14 @@ impl<'db> TyId<'db> {
     pub fn name_span(self, db: &'db dyn HirAnalysisDb) -> Option<DynLazySpan<'db>> {
         match self.base_ty(db).data(db) {
             TyData::TyVar(_) => None,
-            TyData::TyParam(param) => param.scope(db).name_span(db.as_hir_db()),
+            TyData::TyParam(param) => param.scope(db).name_span(db),
 
             TyData::TyBase(TyBase::Adt(adt)) => Some(adt.name_span(db)),
             TyData::TyBase(TyBase::Func(func)) => Some(func.name_span(db)),
             TyData::TyBase(TyBase::Prim(_)) => None,
 
             TyData::ConstTy(ty) => match ty.data(db) {
-                ConstTyData::TyParam(param, _) => param.scope(db).name_span(db.as_hir_db()),
+                ConstTyData::TyParam(param, _) => param.scope(db).name_span(db),
                 _ => None,
             },
 
@@ -886,7 +886,7 @@ pub struct TyParam<'db> {
 
 impl<'db> TyParam<'db> {
     pub(super) fn pretty_print(&self, db: &dyn HirAnalysisDb) -> String {
-        self.name.data(db.as_hir_db()).to_string()
+        self.name.data(db).to_string()
     }
 
     pub(super) fn normal_param(
@@ -906,7 +906,7 @@ impl<'db> TyParam<'db> {
 
     pub(super) fn trait_self(db: &'db dyn HirAnalysisDb, kind: Kind, scope: ScopeId<'db>) -> Self {
         Self {
-            name: IdentId::make_self_ty(db.as_hir_db()),
+            name: IdentId::make_self_ty(db),
             idx: 0,
             kind,
             is_trait_self: true,
@@ -987,9 +987,9 @@ impl<'db> TyBase<'db> {
             }
             .to_string(),
 
-            Self::Adt(adt) => adt.name(db).data(db.as_hir_db()).to_string(),
+            Self::Adt(adt) => adt.name(db).data(db).to_string(),
 
-            Self::Func(func) => format!("fn {}", func.name(db).data(db.as_hir_db())),
+            Self::Func(func) => format!("fn {}", func.name(db).data(db)),
         }
     }
 

--- a/crates/hir-analysis/src/ty/unify.rs
+++ b/crates/hir-analysis/src/ty/unify.rs
@@ -354,7 +354,7 @@ where
                     return Ok(());
                 };
 
-                if &BigUint::from(n_var) <= n_value.data(self.db.as_hir_db()) {
+                if &BigUint::from(n_var) <= n_value.data(self.db) {
                     self.table
                         .unify_var_value(root_var.key, InferenceValue::Bound(value))
                 } else {

--- a/crates/hir-analysis/tests/early_path_resolution.rs
+++ b/crates/hir-analysis/tests/early_path_resolution.rs
@@ -6,7 +6,6 @@ use fe_hir_analysis::name_resolution::{resolve_path, NameDomain};
 use hir::{
     hir_def::{Expr, ExprId, ItemKind, Pat, PatId, PathId, TopLevelMod, TypeId},
     visitor::prelude::*,
-    HirDb, SpannedHirDb,
 };
 use test_db::{HirAnalysisTestDb, HirPropertyFormatter};
 use test_utils::snap_test;
@@ -23,7 +22,7 @@ fn early_path_resolution_standalone(fixture: Fixture<&str>) {
     let (top_mod, mut prop_formatter) = db.top_mod(ingot, file);
     db.assert_no_diags(top_mod);
 
-    let mut ctxt = VisitorCtxt::with_top_mod(db.as_hir_db(), top_mod);
+    let mut ctxt = VisitorCtxt::with_top_mod(&db, top_mod);
     PathVisitor {
         db: &db,
         top_mod,
@@ -32,7 +31,7 @@ fn early_path_resolution_standalone(fixture: Fixture<&str>) {
     }
     .visit_top_mod(&mut ctxt, top_mod);
 
-    let res = prop_formatter.finish(db.as_spanned_hir_db());
+    let res = prop_formatter.finish(&db);
     snap_test!(res, fixture.path());
 }
 
@@ -82,7 +81,7 @@ impl<'db> Visitor<'db> for PathVisitor<'db, '_> {
         let span = ctxt
             .span()
             .unwrap()
-            .segment(path.segment_index(self.db.as_hir_db()))
+            .segment(path.segment_index(self.db))
             .ident()
             .into();
         self.prop_formatter.push_prop(self.top_mod, span, prop);

--- a/crates/hir-analysis/tests/repeated_updates.rs
+++ b/crates/hir-analysis/tests/repeated_updates.rs
@@ -3,7 +3,7 @@ mod test_db;
 use fe_hir_analysis::{
     analysis_pass::AnalysisPassManager, name_resolution::PathAnalysisPass, ty::FuncAnalysisPass,
 };
-use hir::{lower::map_file_to_mod, LowerHirDb};
+use hir::lower::map_file_to_mod;
 use test_db::HirAnalysisTestDb;
 
 use salsa::Setter;
@@ -28,7 +28,7 @@ fn test_updated() {
 
     for version in versions {
         {
-            let top_mod = map_file_to_mod(db.as_lower_hir_db(), ingot, file);
+            let top_mod = map_file_to_mod(&db, ingot, file);
             let mut pass_manager = initialize_pass_manager(&db);
             let _ = pass_manager.run_on_module(top_mod);
         }

--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -96,13 +96,7 @@ impl HirAnalysisTestDb {
 
             for diag in diags {
                 let cs_diag = &diag.to_cs(self);
-                term::emit(
-                    &mut buffer,
-                    &config,
-                    &CsDbWrapper(self.as_driver_db()),
-                    cs_diag,
-                )
-                .unwrap();
+                term::emit(&mut buffer, &config, &CsDbWrapper(self), cs_diag).unwrap();
             }
             eprintln!("{}", std::str::from_utf8(buffer.as_slice()).unwrap());
 

--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -10,30 +10,24 @@ use codespan_reporting::{
 };
 use common::{
     diagnostics::Span,
-    impl_db_traits,
     indexmap::{IndexMap, IndexSet},
     input::{IngotKind, Version},
-    InputDb, InputFile, InputIngot,
+    InputFile, InputIngot,
 };
-use driver::{
-    diagnostics::{CsDbWrapper, ToCsDiag},
-    DriverDb,
-};
+use driver::diagnostics::{CsDbWrapper, ToCsDiag};
 use fe_hir_analysis::{
     analysis_pass::{AnalysisPassManager, ParsingPass},
-    diagnostics::SpannedHirAnalysisDb,
     name_resolution::{DefConflictAnalysisPass, ImportAnalysisPass, PathAnalysisPass},
     ty::{
         AdtDefAnalysisPass, BodyAnalysisPass, FuncAnalysisPass, ImplAnalysisPass,
         ImplTraitAnalysisPass, TraitAnalysisPass, TypeAliasAnalysisPass,
     },
-    HirAnalysisDb,
 };
 use hir::{
     hir_def::TopLevelMod,
     lower,
     span::{DynLazySpan, LazySpan},
-    HirDb, LowerHirDb, SpannedHirDb,
+    SpannedHirDb,
 };
 use rustc_hash::FxHashMap;
 
@@ -44,16 +38,10 @@ type CodeSpanFileId = usize;
 pub struct HirAnalysisTestDb {
     storage: salsa::Storage<Self>,
 }
-impl_db_traits!(
-    HirAnalysisTestDb,
-    InputDb,
-    HirDb,
-    LowerHirDb,
-    SpannedHirDb,
-    HirAnalysisDb,
-    SpannedHirAnalysisDb,
-    DriverDb,
-);
+#[salsa::db]
+impl salsa::Database for HirAnalysisTestDb {
+    fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
+}
 
 // https://github.com/rust-lang/rust/issues/46379
 #[allow(dead_code)]

--- a/crates/hir/src/hir_def/mod.rs
+++ b/crates/hir/src/hir_def/mod.rs
@@ -69,7 +69,7 @@ impl<'db> IngotId<'db> {
     #[salsa::tracked(return_ref)]
     pub fn external_ingots(self, db: &'db dyn HirDb) -> Vec<(IdentId<'db>, IngotId<'db>)> {
         self.inner(db)
-            .external_ingots(db.as_input_db())
+            .external_ingots(db)
             .iter()
             .map(|dep| {
                 let name = IdentId::new(db, dep.name.to_string());
@@ -83,7 +83,7 @@ impl<'db> IngotId<'db> {
     }
 
     pub fn kind(self, db: &dyn HirDb) -> IngotKind {
-        self.inner(db).kind(db.as_input_db())
+        self.inner(db).kind(db)
     }
 
     #[salsa::tracked(return_ref)]

--- a/crates/hir/src/hir_def/module_tree.rs
+++ b/crates/hir/src/hir_def/module_tree.rs
@@ -200,11 +200,8 @@ impl<'db> ModuleTreeBuilder<'db> {
         self.set_modules();
         self.build_tree();
 
-        let root_mod = map_file_to_mod_impl(
-            self.db,
-            self.ingot,
-            self.input_ingot.root_file(self.db.as_input_db()),
-        );
+        let root_mod =
+            map_file_to_mod_impl(self.db, self.ingot, self.input_ingot.root_file(self.db));
         let root = self.mod_map[&root_mod];
         ModuleTree {
             root,
@@ -215,28 +212,27 @@ impl<'db> ModuleTreeBuilder<'db> {
     }
 
     fn set_modules(&mut self) {
-        for &file in self.input_ingot.files(self.db.as_input_db()) {
+        for &file in self.input_ingot.files(self.db) {
             let top_mod = map_file_to_mod_impl(self.db, self.ingot, file);
 
             let module_id = self.module_tree.push(ModuleTreeNode::new(top_mod));
-            self.path_map
-                .insert(file.path(self.db.as_input_db()), module_id);
+            self.path_map.insert(file.path(self.db), module_id);
             self.mod_map.insert(top_mod, module_id);
         }
     }
 
     fn build_tree(&mut self) {
-        let root = self.input_ingot.root_file(self.db.as_input_db());
+        let root = self.input_ingot.root_file(self.db);
 
-        for &child in self.input_ingot.files(self.db.as_input_db()) {
+        for &child in self.input_ingot.files(self.db) {
             // Ignore the root file because it has no parent.
             if child == root {
                 continue;
             }
 
-            let root_path = root.path(self.db.as_input_db());
+            let root_path = root.path(self.db);
             let root_mod = map_file_to_mod_impl(self.db, self.ingot, root);
-            let child_path = child.path(self.db.as_input_db());
+            let child_path = child.path(self.db);
             let child_mod = map_file_to_mod_impl(self.db, self.ingot, child);
 
             // If the file is in the same directory as the root file, the file is a direct
@@ -261,7 +257,7 @@ impl<'db> ModuleTreeBuilder<'db> {
     }
 
     fn parent_module(&self, file: InputFile) -> Option<ModuleTreeNodeId> {
-        let file_path = file.path(self.db.as_input_db());
+        let file_path = file.path(self.db);
         let file_dir = file_path.parent()?;
         let parent_dir = file_dir.parent()?;
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -7,9 +7,7 @@ pub mod span;
 pub mod visitor;
 
 #[salsa::db]
-pub trait HirDb: salsa::Database + InputDb {
-    fn as_hir_db(&self) -> &dyn HirDb;
-}
+pub trait HirDb: salsa::Database + InputDb {}
 
 /// `LowerHirDb` is a marker trait for lowering AST to HIR items.
 /// All code that requires [`LowerHirDb`] is considered have a possibility to
@@ -17,9 +15,7 @@ pub trait HirDb: salsa::Database + InputDb {
 /// implementations relying on `LowerHirDb` are prohibited in all
 /// Analysis phases.
 #[salsa::db]
-pub trait LowerHirDb: salsa::Database + HirDb {
-    fn as_lower_hir_db(&self) -> &dyn LowerHirDb;
-}
+pub trait LowerHirDb: salsa::Database + HirDb {}
 
 /// `SpannedHirDb` is a marker trait for extracting span-dependent information
 /// from HIR Items.
@@ -33,9 +29,7 @@ pub trait LowerHirDb: salsa::Database + HirDb {
 /// [DiagnosticVoucher](crate::diagnostics::DiagnosticVoucher).
 /// See also `[LazySpan]`[`crate::span::LazySpan`] for more details.
 #[salsa::db]
-pub trait SpannedHirDb: salsa::Database + HirDb {
-    fn as_spanned_hir_db(&self) -> &dyn SpannedHirDb;
-}
+pub trait SpannedHirDb: salsa::Database + HirDb {}
 
 #[cfg(test)]
 mod test_db {
@@ -92,8 +86,8 @@ mod test_db {
 
         pub fn text_at(&self, top_mod: TopLevelMod, span: &impl LazySpan) -> &str {
             let range = span.resolve(self).unwrap().range;
-            let file = top_mod.file(self.as_hir_db());
-            let text = file.text(self.as_hir_db().as_input_db());
+            let file = top_mod.file(self);
+            let text = file.text(self);
             &text[range.start().into()..range.end().into()]
         }
 

--- a/crates/hir/src/lower/mod.rs
+++ b/crates/hir/src/lower/mod.rs
@@ -35,8 +35,8 @@ mod use_tree;
 /// any parsing or lowering.
 /// To perform the actual lowering, use [`scope_graph`] instead.
 pub fn map_file_to_mod(db: &dyn LowerHirDb, ingot: InputIngot, file: InputFile) -> TopLevelMod {
-    let ingot = module_tree_impl(db.as_hir_db(), ingot).ingot;
-    map_file_to_mod_impl(db.as_hir_db(), ingot, file)
+    let ingot = module_tree_impl(db, ingot).ingot;
+    map_file_to_mod_impl(db, ingot, file)
 }
 
 /// Returns the scope graph of the given top-level module.
@@ -44,12 +44,12 @@ pub fn scope_graph<'db>(
     db: &'db dyn LowerHirDb,
     top_mod: TopLevelMod<'db>,
 ) -> &'db ScopeGraph<'db> {
-    scope_graph_impl(db.as_hir_db(), top_mod)
+    scope_graph_impl(db, top_mod)
 }
 
 /// Returns the ingot module tree of the given ingot.
 pub fn module_tree(db: &dyn LowerHirDb, ingot: InputIngot) -> &ModuleTree {
-    module_tree_impl(db.as_hir_db(), ingot)
+    module_tree_impl(db, ingot)
 }
 
 #[salsa::tracked]
@@ -58,7 +58,7 @@ pub(crate) fn map_file_to_mod_impl<'db>(
     ingot: IngotId<'db>,
     file: InputFile,
 ) -> TopLevelMod<'db> {
-    let path = file.path(db.as_input_db());
+    let path = file.path(db);
     let name = path.file_stem().unwrap();
     let mod_name = IdentId::new(db, name.to_string());
     TopLevelMod::new(db, mod_name, ingot, file)

--- a/crates/hir/src/lower/parse.rs
+++ b/crates/hir/src/lower/parse.rs
@@ -7,7 +7,7 @@ use crate::{hir_def::TopLevelMod, HirDb};
 #[salsa::tracked]
 pub fn parse_file_impl<'db>(db: &'db dyn HirDb, top_mod: TopLevelMod<'db>) -> GreenNode {
     let file = top_mod.file(db);
-    let text = file.text(db.as_input_db());
+    let text = file.text(db);
     let (node, parse_errors) = parser::parse_source_file(text);
 
     for error in parse_errors {

--- a/crates/hir/src/span/expr.rs
+++ b/crates/hir/src/span/expr.rs
@@ -213,7 +213,7 @@ impl ChainInitiator for ExprRoot<'_> {
     fn init(&self, db: &dyn SpannedHirDb) -> ResolvedOrigin {
         let source_map = body_source_map(db, self.body);
         let origin = source_map.expr_map.node_to_source(self.expr);
-        let top_mod = self.body.top_mod(db.as_hir_db());
+        let top_mod = self.body.top_mod(db);
         ResolvedOrigin::resolve(db, top_mod, origin)
     }
 }
@@ -223,7 +223,6 @@ mod tests {
     use crate::{
         hir_def::{ArithBinOp, Body, Expr},
         test_db::TestDb,
-        HirDb,
     };
 
     #[test]
@@ -238,11 +237,11 @@ mod tests {
 
         let (ingot, file) = db.standalone_file(text);
         let body: Body = db.expect_item::<Body>(ingot, file);
-        let bin_expr = match body.exprs(db.as_hir_db()).values().nth(2).unwrap().unwrap() {
+        let bin_expr = match body.exprs(&db).values().nth(2).unwrap().unwrap() {
             Expr::AugAssign(lhs, rhs, bin_op) => (*lhs, *rhs, *bin_op),
             _ => unreachable!(),
         };
-        let top_mod = body.top_mod(db.as_hir_db());
+        let top_mod = body.top_mod(&db);
         assert_eq!("x", db.text_at(top_mod, &bin_expr.0.lazy_span(body)));
         assert_eq!("1", db.text_at(top_mod, &bin_expr.1.lazy_span(body)));
         assert_eq!(ArithBinOp::Add, bin_expr.2);

--- a/crates/hir/src/span/item.rs
+++ b/crates/hir/src/span/item.rs
@@ -360,7 +360,6 @@ mod tests {
     use crate::{
         hir_def::{Enum, Func, Mod, Struct, TypeAlias, Use},
         test_db::TestDb,
-        HirDb,
     };
 
     #[test]
@@ -396,7 +395,7 @@ mod tests {
 
         let (ingot, file) = db.standalone_file(text);
         let mod_ = db.expect_item::<Mod>(ingot, file);
-        let top_mod = mod_.top_mod(db.as_hir_db());
+        let top_mod = mod_.top_mod(&db);
         let mod_span = mod_.lazy_span();
         assert_eq!(
             r#"mod foo {
@@ -419,7 +418,7 @@ mod tests {
         let (ingot, file) = db.standalone_file(text);
 
         let fn_ = db.expect_item::<Func>(ingot, file);
-        let top_mod = fn_.top_mod(db.as_hir_db());
+        let top_mod = fn_.top_mod(&db);
         let fn_span = fn_.lazy_span();
         assert_eq!("my_func", db.text_at(top_mod, &fn_span.name()));
 
@@ -471,7 +470,7 @@ mod tests {
 
         let (ingot, file) = db.standalone_file(text);
         let struct_ = db.expect_item::<Struct>(ingot, file);
-        let top_mod = struct_.top_mod(db.as_hir_db());
+        let top_mod = struct_.top_mod(&db);
         let struct_span = struct_.lazy_span();
         assert_eq!("Foo", db.text_at(top_mod, &struct_span.name()));
 
@@ -503,7 +502,7 @@ mod tests {
 
         let (ingot, file) = db.standalone_file(text);
         let enum_ = db.expect_item::<Enum>(ingot, file);
-        let top_mod = enum_.top_mod(db.as_hir_db());
+        let top_mod = enum_.top_mod(&db);
         let enum_span = enum_.lazy_span();
         assert_eq!("Foo", db.text_at(top_mod, &enum_span.name()));
 
@@ -529,7 +528,7 @@ mod tests {
 
         let (ingot, file) = db.standalone_file(text);
         let type_alias = db.expect_item::<TypeAlias>(ingot, file);
-        let top_mod = type_alias.top_mod(db.as_hir_db());
+        let top_mod = type_alias.top_mod(&db);
         let type_alias_span = type_alias.lazy_span();
         assert_eq!("Foo", db.text_at(top_mod, &type_alias_span.alias()));
         assert_eq!("u32", db.text_at(top_mod, &type_alias_span.ty()));
@@ -547,7 +546,7 @@ mod tests {
         let (ingot, file) = db.standalone_file(text);
         let use_ = db.expect_item::<Use>(ingot, file);
 
-        let top_mod = use_.top_mod(db.as_hir_db());
+        let top_mod = use_.top_mod(&db);
         let use_span = use_.lazy_span();
         let use_path_span = use_span.path();
         assert_eq!("foo", db.text_at(top_mod, &use_path_span.segment(0)));
@@ -570,7 +569,7 @@ mod tests {
         let uses = db.expect_items::<Use>(ingot, file);
         assert_eq!(uses.len(), 2);
 
-        let top_mod = uses[0].top_mod(db.as_hir_db());
+        let top_mod = uses[0].top_mod(&db);
 
         let use_span = uses[0].lazy_span();
         let use_path_span = use_span.path();

--- a/crates/hir/src/span/mod.rs
+++ b/crates/hir/src/span/mod.rs
@@ -78,9 +78,9 @@ impl<'db> DynLazySpan<'db> {
     }
 }
 impl LazySpan for DynLazySpan<'_> {
-    fn resolve<D: SpannedHirDb + ?Sized>(&self, db: &D) -> Option<Span> {
+    fn resolve(&self, db: &dyn SpannedHirDb) -> Option<Span> {
         if let Some(chain) = &self.0 {
-            chain.resolve(db.as_spanned_hir_db())
+            chain.resolve(db)
         } else {
             None
         }
@@ -97,78 +97,78 @@ pub trait SpanDowncast<'db> {
 /// types which don't have a span information directly, but can be resolved into
 /// a span lazily.
 pub trait LazySpan {
-    fn resolve<D: SpannedHirDb + ?Sized>(&self, db: &D) -> Option<Span>;
+    fn resolve(&self, db: &dyn SpannedHirDb) -> Option<Span>;
 }
 
 pub fn toplevel_ast(db: &dyn SpannedHirDb, item: TopLevelMod) -> HirOrigin<ast::Root> {
-    HirOrigin::raw(&top_mod_ast(db.as_hir_db(), item))
+    HirOrigin::raw(&top_mod_ast(db, item))
 }
 
 pub fn mod_ast<'db>(db: &'db dyn SpannedHirDb, item: Mod<'db>) -> &'db HirOrigin<ast::Mod> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn func_ast<'db>(db: &'db dyn SpannedHirDb, item: Func<'db>) -> &'db HirOrigin<ast::Func> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn struct_ast<'db>(
     db: &'db dyn SpannedHirDb,
     item: Struct<'db>,
 ) -> &'db HirOrigin<ast::Struct> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn contract_ast<'db>(
     db: &'db dyn SpannedHirDb,
     item: Contract<'db>,
 ) -> &'db HirOrigin<ast::Contract> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn enum_ast<'db>(db: &'db dyn SpannedHirDb, item: Enum<'db>) -> &'db HirOrigin<ast::Enum> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn type_alias_ast<'db>(
     db: &'db dyn SpannedHirDb,
     item: TypeAlias<'db>,
 ) -> &'db HirOrigin<ast::TypeAlias> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn impl_ast<'db>(db: &'db dyn SpannedHirDb, item: Impl<'db>) -> &'db HirOrigin<ast::Impl> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn trait_ast<'db>(db: &'db dyn SpannedHirDb, item: Trait<'db>) -> &'db HirOrigin<ast::Trait> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn impl_trait_ast<'db>(
     db: &'db dyn SpannedHirDb,
     item: ImplTrait<'db>,
 ) -> &'db HirOrigin<ast::ImplTrait> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn const_ast<'db>(db: &'db dyn SpannedHirDb, item: Const<'db>) -> &'db HirOrigin<ast::Const> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn use_ast<'db>(db: &'db dyn SpannedHirDb, item: Use<'db>) -> &'db HirOrigin<ast::Use> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn body_ast<'db>(db: &'db dyn SpannedHirDb, item: Body<'db>) -> &'db HirOrigin<ast::Expr> {
-    item.origin(db.as_hir_db())
+    item.origin(db)
 }
 
 pub fn body_source_map<'db>(
     db: &'db dyn SpannedHirDb,
     item: Body<'db>,
 ) -> &'db crate::hir_def::BodySourceMap {
-    item.source_map(db.as_hir_db())
+    item.source_map(db)
 }
 
 /// This enum represents the origin of the HIR node in a file.

--- a/crates/hir/src/span/pat.rs
+++ b/crates/hir/src/span/pat.rs
@@ -98,7 +98,7 @@ impl ChainInitiator for PatRoot<'_> {
     fn init(&self, db: &dyn SpannedHirDb) -> ResolvedOrigin {
         let source_map = body_source_map(db, self.body);
         let origin = source_map.pat_map.node_to_source(self.pat);
-        let top_mod = self.body.top_mod(db.as_hir_db());
+        let top_mod = self.body.top_mod(db);
         ResolvedOrigin::resolve(db, top_mod, origin)
     }
 }

--- a/crates/hir/src/span/stmt.rs
+++ b/crates/hir/src/span/stmt.rs
@@ -41,7 +41,7 @@ impl ChainInitiator for StmtRoot<'_> {
     fn init(&self, db: &dyn SpannedHirDb) -> ResolvedOrigin {
         let source_map = body_source_map(db, self.body);
         let origin = source_map.stmt_map.node_to_source(self.stmt);
-        let top_mod = self.body.top_mod(db.as_hir_db());
+        let top_mod = self.body.top_mod(db);
         ResolvedOrigin::resolve(db, top_mod, origin)
     }
 }

--- a/crates/language-server/src/backend/db.rs
+++ b/crates/language-server/src/backend/db.rs
@@ -1,4 +1,4 @@
-use common::{impl_db_traits, InputDb};
+use common::InputDb;
 
 use hir::{HirDb, LowerHirDb, SpannedHirDb};
 use hir_analysis::{diagnostics::SpannedHirAnalysisDb, HirAnalysisDb};
@@ -29,12 +29,7 @@ pub struct LanguageServerDatabase {
     storage: salsa::Storage<Self>,
 }
 
-impl_db_traits!(
-    LanguageServerDatabase,
-    InputDb,
-    HirDb,
-    LowerHirDb,
-    SpannedHirDb,
-    HirAnalysisDb,
-    SpannedHirAnalysisDb,
-);
+#[salsa::db]
+impl salsa::Database for LanguageServerDatabase {
+    fn salsa_event(&self, _event: &dyn Fn() -> salsa::Event) {}
+}

--- a/crates/language-server/src/functionality/diagnostics.rs
+++ b/crates/language-server/src/functionality/diagnostics.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use camino::Utf8Path;
 use codespan_reporting as cs;
-use common::{diagnostics::CompleteDiagnostic, InputDb, InputFile, InputIngot};
+use common::{diagnostics::CompleteDiagnostic, InputFile, InputIngot};
 use cs::files as cs_files;
 use hir::lower::map_file_to_mod;
 use hir_analysis::{
@@ -23,7 +23,7 @@ use crate::{
 
 #[salsa::tracked(return_ref)]
 pub fn file_line_starts(db: &dyn LanguageServerDb, file: InputFile) -> Vec<usize> {
-    cs::files::line_starts(file.text(db.as_input_db())).collect()
+    cs::files::line_starts(file.text(db)).collect()
 }
 
 impl<'a> cs_files::Files<'a> for LanguageServerDatabase {
@@ -111,7 +111,7 @@ impl LanguageServerDatabase {
                 ord => ord,
             });
             for diag in finalized_diags {
-                let lsp_diags = diag_to_lsp(self.as_input_db(), ingot, diag).clone();
+                let lsp_diags = diag_to_lsp(self, ingot, diag).clone();
                 for (uri, more_diags) in lsp_diags {
                     let diags = result.entry(uri.clone()).or_insert_with(Vec::new);
                     diags.extend(more_diags);

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -7,7 +7,6 @@ use async_lsp::{
     },
     LanguageClient, ResponseError,
 };
-use common::InputDb;
 use rustc_hash::FxHashSet;
 use salsa::Setter;
 
@@ -93,7 +92,7 @@ pub async fn initialized(
     info!("language server initialized! recieved notification!");
 
     backend.workspace.all_files().for_each(|file| {
-        let path = file.path(backend.db.as_input_db());
+        let path = file.path(&backend.db);
         let _ = backend
             .client
             .emit(NeedsDiagnostics(url::Url::from_file_path(path).unwrap()));

--- a/crates/language-server/src/functionality/hover.rs
+++ b/crates/language-server/src/functionality/hover.rs
@@ -17,23 +17,23 @@ pub fn hover_helper(
     params: async_lsp::lsp_types::HoverParams,
 ) -> Result<Option<Hover>, Error> {
     info!("handling hover");
-    let file_text = file.text(db.as_input_db());
+    let file_text = file.text(db);
 
     let cursor: Cursor = to_offset_from_position(
         params.text_document_position_params.position,
         file_text.as_str(),
     );
 
-    let top_mod = map_file_to_mod(db.as_lower_hir_db(), ingot, file);
+    let top_mod = map_file_to_mod(db, ingot, file);
     let goto_info = &get_goto_target_scopes_for_cursor(db, top_mod, cursor).unwrap_or_default();
 
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
     let scopes_info = goto_info
         .iter()
         .map(|scope| {
             let item = scope.item();
             let pretty_path = get_item_path_markdown(item, hir_db);
-            let definition_source = get_item_definition_markdown(item, db.as_spanned_hir_db());
+            let definition_source = get_item_definition_markdown(item, db);
             let docs = get_docstring(*scope, hir_db);
 
             let result = [pretty_path, definition_source, docs]

--- a/crates/language-server/src/functionality/item_info.rs
+++ b/crates/language-server/src/functionality/item_info.rs
@@ -27,7 +27,7 @@ pub fn get_item_path_markdown(item: ItemKind, hir_db: &dyn HirDb) -> Option<Stri
 
 pub fn get_item_definition_markdown(item: ItemKind, db: &dyn SpannedHirDb) -> Option<String> {
     // TODO: use pending AST features to get the definition without all this text manipulation
-    let hir_db = db.as_hir_db();
+    let hir_db = db;
     let span = item.lazy_span().resolve(db)?;
 
     let mut start: usize = span.range.start().into();
@@ -48,13 +48,13 @@ pub fn get_item_definition_markdown(item: ItemKind, db: &dyn SpannedHirDb) -> Op
     let name_span = item.name_span()?.resolve(db);
     if let Some(name_span) = name_span {
         let mut name_line_start = name_span.range.start().into();
-        let file_text = span.file.text(db.as_input_db()).as_str();
+        let file_text = span.file.text(db).as_str();
         while name_line_start > 0 && file_text.chars().nth(name_line_start - 1).unwrap() != '\n' {
             name_line_start -= 1;
         }
         start = name_line_start;
     }
 
-    let item_definition = span.file.text(db.as_input_db()).as_str()[start..end].to_string();
+    let item_definition = span.file.text(db).as_str()[start..end].to_string();
     Some(format!("```fe\n{}\n```", item_definition.trim()))
 }

--- a/crates/language-server/src/util.rs
+++ b/crates/language-server/src/util.rs
@@ -58,13 +58,9 @@ pub fn to_lsp_location_from_scope(
     ingot: InputIngot,
     scope: ScopeId,
 ) -> Result<async_lsp::lsp_types::Location, Box<dyn std::error::Error>> {
-    let lazy_span = scope
-        .name_span(db.as_hir_db())
-        .ok_or("Failed to get name span")?;
-    let span = lazy_span
-        .resolve(db.as_spanned_hir_db())
-        .ok_or("Failed to resolve span")?;
-    to_lsp_location_from_span(db.as_input_db(), ingot, span)
+    let lazy_span = scope.name_span(db).ok_or("Failed to get name span")?;
+    let span = lazy_span.resolve(db).ok_or("Failed to resolve span")?;
+    to_lsp_location_from_span(db, ingot, span)
 }
 
 pub fn severity_to_lsp(is_primary: bool, severity: Severity) -> DiagnosticSeverity {
@@ -149,8 +145,8 @@ fn to_lsp_location_from_span(
     ingot: InputIngot,
     span: Span,
 ) -> Result<async_lsp::lsp_types::Location, Box<dyn std::error::Error>> {
-    let uri = span.file.abs_path(db.as_input_db(), ingot);
-    let range = to_lsp_range_from_span(span, db.as_input_db())?;
+    let uri = span.file.abs_path(db, ingot);
+    let range = to_lsp_range_from_span(span, db)?;
     let uri = async_lsp::lsp_types::Url::from_file_path(uri)
         .map_err(|()| "Failed to convert path to URL")?;
     Ok(async_lsp::lsp_types::Location { uri, range })


### PR DESCRIPTION
Rust 1.86 allows dyn trait object upcasting, so we don't need the `.as_hir_db()` etc noise anymore.

Depends on #1071 