### PR TITLE
lsp: fix hover/goto for type aliases

### DIFF
--- a/crates/hir-analysis/src/name_resolution/mod.rs
+++ b/crates/hir-analysis/src/name_resolution/mod.rs
@@ -475,7 +475,7 @@ impl<'db> Visitor<'db> for EarlyPathVisitor<'db, '_> {
             self.diags.push(diag);
         }
 
-        let is_type = matches!(res, PathRes::Ty(_));
+        let is_type = matches!(res, PathRes::Ty(_) | PathRes::TyAlias(..));
         let is_trait = matches!(res, PathRes::Trait(_));
 
         let span = ctxt

--- a/crates/hir-analysis/src/name_resolution/mod.rs
+++ b/crates/hir-analysis/src/name_resolution/mod.rs
@@ -379,22 +379,21 @@ impl<'db> Visitor<'db> for EarlyPathVisitor<'db, '_> {
             Ok(res) => res,
 
             Err(err) => {
-                let hir_db = self.db;
                 let failed_at = err.failed_at;
                 let span = ctxt
                     .span()
                     .unwrap()
-                    .segment(failed_at.segment_index(hir_db))
+                    .segment(failed_at.segment_index(self.db))
                     .ident();
 
-                let Some(ident) = failed_at.ident(hir_db).to_opt() else {
+                let Some(ident) = failed_at.ident(self.db).to_opt() else {
                     return;
                 };
 
                 let diag = match err.kind {
                     PathResErrorKind::ParseError => unreachable!(),
                     PathResErrorKind::NotFound(bucket) => {
-                        if path.len(hir_db) == 1
+                        if path.len(self.db) == 1
                             && matches!(
                                 self.path_ctxt.last().unwrap(),
                                 ExpectedPathKind::Expr | ExpectedPathKind::Pat
@@ -463,14 +462,13 @@ impl<'db> Visitor<'db> for EarlyPathVisitor<'db, '_> {
         };
 
         if let Some((path, deriv_span)) = invisible {
-            let hir_db = self.db;
             let span = ctxt
                 .span()
                 .unwrap()
-                .segment(path.segment_index(hir_db))
+                .segment(path.segment_index(self.db))
                 .ident();
 
-            let ident = path.ident(hir_db);
+            let ident = path.ident(self.db);
             let diag = NameResDiag::Invisible(span.into(), *ident.unwrap(), deriv_span);
             self.diags.push(diag);
         }

--- a/crates/hir-analysis/src/name_resolution/name_resolver.rs
+++ b/crates/hir-analysis/src/name_resolution/name_resolver.rs
@@ -505,8 +505,6 @@ impl<'db, 'a> NameResolver<'db, 'a> {
     }
 
     pub(crate) fn resolve_query(&mut self, query: EarlyNameQueryId<'db>) -> NameResBucket<'db> {
-        let hir_db = self.db;
-
         let mut bucket = NameResBucket::default();
 
         // The shadowing rule is
@@ -517,7 +515,7 @@ impl<'db, 'a> NameResolver<'db, 'a> {
 
         // 1. Look for the name in the current scope.
         let mut found_scopes = FxHashSet::default();
-        for edge in query.scope(self.db).edges(hir_db) {
+        for edge in query.scope(self.db).edges(self.db) {
             match edge.kind.propagate(self.db, query) {
                 PropagationResult::Terminated => {
                     if found_scopes.insert(edge.dest) {
@@ -575,16 +573,16 @@ impl<'db, 'a> NameResolver<'db, 'a> {
         // 5. Look for the name in the external ingots.
         query
             .scope(self.db)
-            .top_mod(hir_db)
-            .ingot(hir_db)
-            .external_ingots(hir_db)
+            .top_mod(self.db)
+            .ingot(self.db)
+            .external_ingots(self.db)
             .iter()
             .for_each(|(name, ingot)| {
                 if *name == query.name(self.db) {
                     // We don't care about the result of `push` because we assume ingots are
                     // guaranteed to be unique.
                     bucket.push(&NameRes::new_from_scope(
-                        ScopeId::from_item((ingot.root_mod(hir_db)).into()),
+                        ScopeId::from_item((ingot.root_mod(self.db)).into()),
                         NameDomain::TYPE,
                         NameDerivation::External,
                     ))

--- a/crates/hir-analysis/src/name_resolution/visibility_checker.rs
+++ b/crates/hir-analysis/src/name_resolution/visibility_checker.rs
@@ -14,34 +14,33 @@ pub(crate) fn is_scope_visible_from(
     scope: ScopeId,
     from_scope: ScopeId,
 ) -> bool {
-    let hir_db = db;
     // If resolved is public, then it is visible.
-    if scope.data(hir_db).vis.is_pub() {
+    if scope.data(db).vis.is_pub() {
         return true;
     }
 
     let Some(def_scope) = (match scope {
         ScopeId::Item(ItemKind::Func(func)) => {
-            let parent_item = scope.parent_item(hir_db);
+            let parent_item = scope.parent_item(db);
             if matches!(parent_item, Some(ItemKind::Trait(..))) {
                 return true;
             }
 
-            if func.is_associated_func(hir_db) {
+            if func.is_associated_func(db) {
                 scope
-                    .parent_item(hir_db)
-                    .and_then(|item| ScopeId::Item(item).parent(hir_db))
+                    .parent_item(db)
+                    .and_then(|item| ScopeId::Item(item).parent(db))
             } else {
-                scope.parent(hir_db)
+                scope.parent(db)
             }
         }
-        ScopeId::Item(_) => scope.parent(hir_db),
+        ScopeId::Item(_) => scope.parent(db),
         ScopeId::Field(..) | ScopeId::Variant(..) => {
             let parent_item = scope.item();
-            ScopeId::Item(parent_item).parent(hir_db)
+            ScopeId::Item(parent_item).parent(db)
         }
 
-        _ => scope.parent(hir_db),
+        _ => scope.parent(db),
     }) else {
         return false;
     };

--- a/crates/hir-analysis/src/ty/adt_def.rs
+++ b/crates/hir-analysis/src/ty/adt_def.rs
@@ -97,11 +97,10 @@ impl<'db> AdtDef<'db> {
     }
 
     pub(crate) fn ingot(self, db: &'db dyn HirAnalysisDb) -> IngotId<'db> {
-        let hir_db = db;
         match self.adt_ref(db) {
-            AdtRef::Enum(e) => e.top_mod(hir_db).ingot(hir_db),
-            AdtRef::Struct(s) => s.top_mod(hir_db).ingot(hir_db),
-            AdtRef::Contract(c) => c.top_mod(hir_db).ingot(hir_db),
+            AdtRef::Enum(e) => e.top_mod(db).ingot(db),
+            AdtRef::Struct(s) => s.top_mod(db).ingot(db),
+            AdtRef::Contract(c) => c.top_mod(db).ingot(db),
         }
     }
 
@@ -189,14 +188,13 @@ impl<'db> AdtRef<'db> {
     }
 
     pub fn name(self, db: &'db dyn HirAnalysisDb) -> IdentId<'db> {
-        let hir_db = db;
         match self {
-            AdtRef::Enum(e) => e.name(hir_db),
-            AdtRef::Struct(s) => s.name(hir_db),
-            AdtRef::Contract(c) => c.name(hir_db),
+            AdtRef::Enum(e) => e.name(db),
+            AdtRef::Struct(s) => s.name(db),
+            AdtRef::Contract(c) => c.name(db),
         }
         .to_opt()
-        .unwrap_or_else(|| IdentId::new(hir_db, "<unknown>".to_string()))
+        .unwrap_or_else(|| IdentId::new(db, "<unknown>".to_string()))
     }
 
     pub fn kind_name(self) -> &'static str {

--- a/crates/hir-analysis/src/ty/method_cmp.rs
+++ b/crates/hir-analysis/src/ty/method_cmp.rs
@@ -154,23 +154,21 @@ fn compare_arg_label<'db>(
     trait_m: FuncDef<'db>,
     sink: &mut Vec<TyDiagCollection<'db>>,
 ) -> bool {
-    let hir_db = db;
-
     let mut err = false;
     let hir_impl_m = impl_m.hir_func_def(db).unwrap();
     let hir_trait_m = trait_m.hir_func_def(db).unwrap();
 
     let (Some(impl_m_params), Some(trait_m_params)) = (
-        hir_impl_m.params(hir_db).to_opt(),
-        hir_trait_m.params(hir_db).to_opt(),
+        hir_impl_m.params(db).to_opt(),
+        hir_trait_m.params(db).to_opt(),
     ) else {
         return true;
     };
 
     for (idx, (expected_param, method_param)) in trait_m_params
-        .data(hir_db)
+        .data(db)
         .iter()
-        .zip(impl_m_params.data(hir_db))
+        .zip(impl_m_params.data(db))
         .enumerate()
     {
         let Some(expected_label) = expected_param

--- a/crates/hir-analysis/src/ty/trait_def.rs
+++ b/crates/hir-analysis/src/ty/trait_def.rs
@@ -343,8 +343,7 @@ impl<'db> TraitDef<'db> {
 
     /// Returns `ingot` in which this trait is defined.
     pub(crate) fn ingot(self, db: &'db dyn HirAnalysisDb) -> IngotId<'db> {
-        let hir_db = db;
-        self.trait_(db).top_mod(hir_db).ingot(hir_db)
+        self.trait_(db).top_mod(db).ingot(db)
     }
 
     pub(super) fn super_traits(

--- a/crates/hir-analysis/src/ty/trait_lower.rs
+++ b/crates/hir-analysis/src/ty/trait_lower.rs
@@ -53,10 +53,9 @@ pub(crate) fn lower_impl_trait<'db>(
     db: &'db dyn HirAnalysisDb,
     impl_trait: ImplTrait<'db>,
 ) -> Option<Binder<Implementor<'db>>> {
-    let hir_db = db;
     let scope = impl_trait.scope();
 
-    let hir_ty = impl_trait.ty(hir_db).to_opt()?;
+    let hir_ty = impl_trait.ty(db).to_opt()?;
     let ty = lower_hir_ty(db, hir_ty, scope);
     if ty.has_invalid(db) {
         return None;
@@ -65,12 +64,12 @@ pub(crate) fn lower_impl_trait<'db>(
     let trait_ = lower_trait_ref(
         db,
         ty,
-        impl_trait.trait_ref(hir_db).to_opt()?,
+        impl_trait.trait_ref(db).to_opt()?,
         impl_trait.scope(),
     )
     .ok()?;
 
-    let impl_trait_ingot = impl_trait.top_mod(hir_db).ingot(hir_db);
+    let impl_trait_ingot = impl_trait.top_mod(db).ingot(db);
 
     if Some(impl_trait_ingot) != ty.ingot(db) && impl_trait_ingot != trait_.def(db).ingot(db) {
         return None;
@@ -93,14 +92,12 @@ pub(crate) fn lower_trait_ref<'db>(
     trait_ref: TraitRefId<'db>,
     scope: ScopeId<'db>,
 ) -> Result<TraitInstId<'db>, TraitRefLowerError<'db>> {
-    let hir_db = db;
-
     let mut args = vec![self_ty];
-    if let Some(generic_args) = trait_ref.generic_args(hir_db) {
+    if let Some(generic_args) = trait_ref.generic_args(db) {
         args.extend(lower_generic_arg_list(db, generic_args, scope));
     };
 
-    let Partial::Present(path) = trait_ref.path(hir_db) else {
+    let Partial::Present(path) = trait_ref.path(db) else {
         return Err(TraitRefLowerError::Other);
     };
 

--- a/crates/hir-analysis/src/ty/trait_resolution/constraint.rs
+++ b/crates/hir-analysis/src/ty/trait_resolution/constraint.rs
@@ -54,23 +54,22 @@ pub(crate) fn collect_super_traits<'db>(
     trait_: TraitDef<'db>,
 ) -> IndexSet<Binder<TraitInstId<'db>>> {
     let hir_trait = trait_.trait_(db);
-    let hir_db = db;
     let self_param = trait_.self_param(db);
     let scope = trait_.trait_(db).scope();
 
     let mut super_traits = IndexSet::new();
 
-    for &super_ in hir_trait.super_traits(hir_db).iter() {
+    for &super_ in hir_trait.super_traits(db).iter() {
         if let Ok(inst) = lower_trait_ref(db, self_param, super_, scope) {
             super_traits.insert(Binder::bind(inst));
         }
     }
 
-    for pred in hir_trait.where_clause(hir_db).data(hir_db) {
+    for pred in hir_trait.where_clause(db).data(db) {
         if pred
             .ty
             .to_opt()
-            .map(|ty| ty.is_self_ty(hir_db))
+            .map(|ty| ty.is_self_ty(db))
             .unwrap_or_default()
         {
             for bound in &pred.bounds {

--- a/crates/hir-analysis/src/ty/ty_check/callable.rs
+++ b/crates/hir-analysis/src/ty/ty_check/callable.rs
@@ -90,9 +90,7 @@ impl<'db> Callable<'db> {
         span: LazyGenericArgListSpan<'db>,
     ) -> bool {
         let db = tc.db;
-        let hir_db = db;
-
-        if !args.is_given(hir_db) {
+        if !args.is_given(db) {
             return true;
         }
 

--- a/crates/hir-analysis/src/ty/ty_check/env.rs
+++ b/crates/hir-analysis/src/ty/ty_check/env.rs
@@ -46,8 +46,7 @@ pub(super) struct TyCheckEnv<'db> {
 
 impl<'db> TyCheckEnv<'db> {
     pub(super) fn new_with_func(db: &'db dyn HirAnalysisDb, func: Func<'db>) -> Result<Self, ()> {
-        let hir_db = db;
-        let Some(body) = func.body(hir_db) else {
+        let Some(body) = func.body(db) else {
             return Err(());
         };
 
@@ -63,13 +62,13 @@ impl<'db> TyCheckEnv<'db> {
             loop_stack: Vec::new(),
         };
 
-        env.enter_scope(body.expr(hir_db));
+        env.enter_scope(body.expr(db));
 
-        let Some(params) = func.params(hir_db).to_opt() else {
+        let Some(params) = func.params(db).to_opt() else {
             return Err(());
         };
 
-        for (idx, param) in params.data(hir_db).iter().enumerate() {
+        for (idx, param) in params.data(db).iter().enumerate() {
             let Some(name) = param.name() else {
                 continue;
             };

--- a/crates/hir-analysis/src/ty/ty_check/expr.rs
+++ b/crates/hir-analysis/src/ty/ty_check/expr.rs
@@ -429,7 +429,7 @@ impl<'db> TyChecker<'db> {
             ResolvedPathInBody::Invalid => ExprProp::invalid(self.db),
 
             ResolvedPathInBody::Reso(reso) => match reso {
-                PathRes::Ty(ty) => {
+                PathRes::Ty(ty) | PathRes::TyAlias(_, ty) => {
                     if let Some(const_ty_ty) = ty.const_ty_ty(self.db) {
                         ExprProp::new(self.table.instantiate_to_term(const_ty_ty), true)
                     } else {
@@ -510,12 +510,12 @@ impl<'db> TyChecker<'db> {
         };
 
         match reso {
-            PathRes::Ty(ty) if ty.is_record(self.db) => {
+            PathRes::Ty(ty) | PathRes::TyAlias(_, ty) if ty.is_record(self.db) => {
                 self.check_record_init_fields(&ty, expr);
                 ExprProp::new(ty, true)
             }
 
-            PathRes::Ty(ty) | PathRes::Func(ty) | PathRes::Const(ty) => {
+            PathRes::Ty(ty) | PathRes::TyAlias(_, ty) | PathRes::Func(ty) | PathRes::Const(ty) => {
                 let diag = BodyDiag::record_expected(self.db, span.path().into(), Some(ty));
                 self.push_diag(diag);
                 ExprProp::invalid(self.db)

--- a/crates/hir-analysis/src/ty/ty_check/expr.rs
+++ b/crates/hir-analysis/src/ty/ty_check/expr.rs
@@ -1095,12 +1095,11 @@ fn resolve_ident_expr<'db>(
 /// smoothly.
 pub(crate) trait TraitOps {
     fn trait_path<'db>(&self, db: &'db dyn HirAnalysisDb) -> PathId<'db> {
-        let hir_db = db;
         let path = std_ops_path(db);
         path.push(
-            hir_db,
+            db,
             Partial::Present(self.trait_name(db)),
-            GenericArgListId::none(hir_db),
+            GenericArgListId::none(db),
         )
     }
 

--- a/crates/hir-analysis/src/ty/ty_lower.rs
+++ b/crates/hir-analysis/src/ty/ty_lower.rs
@@ -87,7 +87,7 @@ fn lower_path<'db>(
         return TyId::invalid(db, InvalidCause::Other);
     };
     match resolve_path(db, path, scope, false) {
-        Ok(PathRes::Ty(ty) | PathRes::Func(ty)) => ty,
+        Ok(PathRes::Ty(ty) | PathRes::TyAlias(_, ty) | PathRes::Func(ty)) => ty,
         // Other cases should be reported as errors by nameres
         _ => TyId::invalid(db, InvalidCause::Other),
     }
@@ -209,8 +209,8 @@ pub(crate) fn evaluate_params_precursor<'db>(
 /// NOTE: `TyAlias` can't become an alias to partial applied types, i.e., the
 /// right hand side of the alias declaration must be a fully applied type.
 #[derive(Debug, Clone, PartialEq, Eq, Update)]
-pub(crate) struct TyAlias<'db> {
-    alias: HirTypeAlias<'db>,
+pub struct TyAlias<'db> {
+    pub alias: HirTypeAlias<'db>,
     pub alias_to: Binder<TyId<'db>>,
     param_set: GenericParamTypeSet<'db>,
 }

--- a/crates/hir-analysis/src/ty/ty_lower.rs
+++ b/crates/hir-analysis/src/ty/ty_lower.rs
@@ -98,14 +98,13 @@ fn lower_const_ty_ty<'db>(
     scope: ScopeId<'db>,
     ty: HirTyId<'db>,
 ) -> TyId<'db> {
-    let hir_db = db;
-    let HirTyKind::Path(path) = ty.data(hir_db) else {
+    let HirTyKind::Path(path) = ty.data(db) else {
         return TyId::invalid(db, InvalidCause::InvalidConstParamTy);
     };
 
     if !path
         .to_opt()
-        .map(|p| p.generic_args(hir_db).is_empty(hir_db))
+        .map(|p| p.generic_args(db).is_empty(db))
         .unwrap_or(true)
     {
         return TyId::invalid(db, InvalidCause::InvalidConstParamTy);

--- a/crates/language-server/src/functionality/goto.rs
+++ b/crates/language-server/src/functionality/goto.rs
@@ -35,16 +35,15 @@ fn find_path_surrounding_cursor<'db>(
     cursor: Cursor,
     full_paths: Vec<(PathId<'db>, ScopeId<'db>, LazyPathSpan<'db>)>,
 ) -> Option<(PathId<'db>, bool, ScopeId<'db>)> {
-    let hir_db = db;
     for (path, scope, lazy_span) in full_paths {
         let span = lazy_span.resolve(db).unwrap();
         if span.range.contains(cursor) {
-            for idx in 0..=path.segment_index(hir_db) {
+            for idx in 0..=path.segment_index(db) {
                 let seg_span = lazy_span.segment(idx).resolve(db).unwrap();
                 if seg_span.range.contains(cursor) {
                     return Some((
-                        path.segment(hir_db, idx).unwrap(),
-                        idx != path.segment_index(hir_db),
+                        path.segment(db, idx).unwrap(),
+                        idx != path.segment_index(db),
                         scope,
                     ));
                 }
@@ -190,14 +189,13 @@ mod tests {
         db: &LanguageServerDatabase,
         top_mod: TopLevelMod,
     ) -> Vec<parser::TextSize> {
-        let hir_db = db;
-        let mut visitor_ctxt = VisitorCtxt::with_top_mod(hir_db, top_mod);
+        let mut visitor_ctxt = VisitorCtxt::with_top_mod(db, top_mod);
         let mut path_collector = PathSpanCollector::default();
         path_collector.visit_top_mod(&mut visitor_ctxt, top_mod);
 
         let mut cursors = Vec::new();
         for (path, _, lazy_span) in path_collector.paths {
-            for idx in 0..=path.segment_index(hir_db) {
+            for idx in 0..=path.segment_index(db) {
                 let seg_span = lazy_span.segment(idx).resolve(db).unwrap();
                 cursors.push(seg_span.range.start());
             }

--- a/crates/language-server/src/functionality/hover.rs
+++ b/crates/language-server/src/functionality/hover.rs
@@ -27,14 +27,13 @@ pub fn hover_helper(
     let top_mod = map_file_to_mod(db, ingot, file);
     let goto_info = &get_goto_target_scopes_for_cursor(db, top_mod, cursor).unwrap_or_default();
 
-    let hir_db = db;
     let scopes_info = goto_info
         .iter()
         .map(|scope| {
             let item = scope.item();
-            let pretty_path = get_item_path_markdown(item, hir_db);
+            let pretty_path = get_item_path_markdown(item, db);
             let definition_source = get_item_definition_markdown(item, db);
-            let docs = get_docstring(*scope, hir_db);
+            let docs = get_docstring(*scope, db);
 
             let result = [pretty_path, definition_source, docs]
                 .iter()

--- a/crates/language-server/src/functionality/hover.rs
+++ b/crates/language-server/src/functionality/hover.rs
@@ -31,9 +31,9 @@ pub fn hover_helper(
         .iter()
         .map(|scope| {
             let item = scope.item();
-            let pretty_path = get_item_path_markdown(item, db);
-            let definition_source = get_item_definition_markdown(item, db);
-            let docs = get_docstring(*scope, db);
+            let pretty_path = get_item_path_markdown(db, item);
+            let definition_source = get_item_definition_markdown(db, item);
+            let docs = get_docstring(db, *scope);
 
             let result = [pretty_path, definition_source, docs]
                 .iter()


### PR DESCRIPTION
Type aliases are now resolved as `PathRes::TyAlias`, so the language server can get the proper span to use for hover and goto.

Best to look at the commits separately. The second commit is cleanup that I missed in #1074.