### PR TITLE
Fix import resolver cycle

### DIFF
--- a/crates/common/src/core.rs
+++ b/crates/common/src/core.rs
@@ -3,7 +3,7 @@ use rust_embed::Embed;
 use url::Url;
 
 use crate::{
-    ingot::{Ingot, IngotBaseUrl, IngotIndex},
+    ingot::{Ingot, IngotBaseUrl},
     InputDb,
 };
 

--- a/crates/common/src/file/mod.rs
+++ b/crates/common/src/file/mod.rs
@@ -4,10 +4,7 @@ use camino::Utf8PathBuf;
 use url::Url;
 pub use workspace::Workspace;
 
-use crate::{
-    ingot::{Ingot, IngotIndex},
-    InputDb,
-};
+use crate::{ingot::Ingot, InputDb};
 
 #[salsa::input(constructor = __new_impl)]
 #[derive(Debug)]

--- a/crates/common/src/ingot.rs
+++ b/crates/common/src/ingot.rs
@@ -1,5 +1,6 @@
 use camino::Utf8PathBuf;
 use radix_immutable::StringPrefixView;
+use salsa::tracked;
 use serde::Serialize;
 use url::Url;
 
@@ -66,9 +67,11 @@ impl IngotBaseUrl for Url {
 pub struct Ingot<'db> {
     pub base: Url,
     pub standalone_file: Option<File>,
+    #[tracked]
     pub index: Workspace,
     pub version: Version,
     pub kind: IngotKind,
+    #[tracked]
     pub dependencies: Vec<(String, Url)>,
 }
 

--- a/crates/common/src/ingot.rs
+++ b/crates/common/src/ingot.rs
@@ -40,13 +40,19 @@ impl IngotBaseUrl for Url {
     fn touch(
         &self,
         db: &mut dyn InputDb,
-        path: Utf8PathBuf,
+        relative_path: Utf8PathBuf,
         initial_content: Option<String>,
     ) -> File {
+        if relative_path.is_absolute() {
+            panic!(
+                "Expected relative path, got absolute path: {}",
+                relative_path
+            );
+        }
         let path = self
             .directory()
             .expect("failed to parse directory")
-            .join(path.as_str())
+            .join(relative_path.as_str())
             .expect("failed to parse path");
         db.workspace().touch(db, path, initial_content)
     }

--- a/crates/common/src/ingot.rs
+++ b/crates/common/src/ingot.rs
@@ -184,7 +184,7 @@ struct IngotConfig {
 
 /// Private helper to create canonical ingots for regular projects
 #[salsa::tracked]
-pub(super) fn canonical_ingot<'db>(
+pub(super) fn ingot_at_base_url<'db>(
     db: &'db dyn InputDb,
     index: Workspace,
     base_url: Url,
@@ -214,7 +214,7 @@ pub(super) fn canonical_ingot<'db>(
 
 /// Private helper to create canonical standalone ingots
 #[salsa::tracked]
-pub(super) fn canonical_standalone_ingot<'db>(
+pub(super) fn standalone_ingot<'db>(
     db: &'db dyn InputDb,
     index: Workspace,
     base_url: Url,
@@ -249,7 +249,7 @@ pub(super) fn containing_ingot_impl<'db>(
             .expect("Config file should be indexed")
             .directory()
             .expect("Config URL should have a directory");
-        Some(canonical_ingot(db, index, base_url))
+        Some(ingot_at_base_url(db, index, base_url))
     } else {
         // Make a standalone ingot if no config is found
         let base = location.directory().unwrap_or_else(|| location.clone());
@@ -258,12 +258,7 @@ pub(super) fn containing_ingot_impl<'db>(
         } else {
             None
         };
-        Some(canonical_standalone_ingot(
-            db,
-            index,
-            base,
-            specific_root_file,
-        ))
+        Some(standalone_ingot(db, index, base, specific_root_file))
     }
 }
 

--- a/crates/common/src/urlext.rs
+++ b/crates/common/src/urlext.rs
@@ -3,11 +3,13 @@ use url::Url;
 #[derive(Debug)]
 pub enum UrlExtError {
     DirectoryRangeError,
+    AsDirectoryError,
 }
 
 pub trait UrlExt {
     fn parent(&self) -> Option<Url>;
     fn directory(&self) -> Option<Url>;
+    // fn as_directory(&self) -> Result<Url, UrlExtError>;
 }
 
 impl UrlExt for Url {
@@ -28,6 +30,17 @@ impl UrlExt for Url {
 
         Some(url)
     }
+
+    // fn as_directory(&self) -> Result<Url, UrlExtError> {
+    //     let str_url = self.to_string();
+    //     if str_url.ends_with('/') {
+    //         Ok(self.clone())
+    //     } else {
+    //         Ok(Url::fromstr_url
+    //             .join("/")
+    //             .expect("failed to turn this into a directory"))
+    //     }
+    // }
 
     fn parent(&self) -> Option<Url> {
         let directory = self.directory()?;

--- a/crates/common/src/urlext.rs
+++ b/crates/common/src/urlext.rs
@@ -4,14 +4,11 @@ use url::Url;
 pub enum UrlExtError {
     DirectoryRangeError,
     AsDirectoryError,
-    PathConversionError,
 }
 
 pub trait UrlExt {
     fn parent(&self) -> Option<Url>;
     fn directory(&self) -> Option<Url>;
-    fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError>;
-    fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError>;
 }
 
 impl UrlExt for Url {
@@ -51,46 +48,6 @@ impl UrlExt for Url {
             }
             return Some(parent);
         }
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
-        let path_str = path.as_ref().to_string_lossy();
-        let url_str = if path_str.starts_with('/') {
-            format!("file://{}", path_str)
-        } else {
-            format!("file:///{}", path_str)
-        };
-        Url::parse(&url_str).map_err(|_| UrlExtError::PathConversionError)
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
-        Url::from_file_path(path).map_err(|_| UrlExtError::PathConversionError)
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
-        let path_str = path.as_ref().to_string_lossy();
-        let url_str = if path_str.starts_with('/') {
-            if path_str.ends_with('/') {
-                format!("file://{}", path_str)
-            } else {
-                format!("file://{}/", path_str)
-            }
-        } else {
-            if path_str.ends_with('/') {
-                format!("file:///{}", path_str)
-            } else {
-                format!("file:///{}/", path_str)
-            }
-        };
-        Url::parse(&url_str).map_err(|_| UrlExtError::PathConversionError)
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
-        Url::from_directory_path(path).map_err(|_| UrlExtError::PathConversionError)
     }
 }
 

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -3,8 +3,8 @@ pub mod diagnostics;
 pub mod files;
 use camino::Utf8PathBuf;
 use common::core::HasBuiltinCore;
-use common::ingot::{IngotBaseUrl, IngotIndex};
-use common::urlext::UrlExt;
+use common::ingot::IngotBaseUrl;
+
 use common::InputDb;
 pub use db::DriverDataBase;
 
@@ -22,10 +22,6 @@ pub fn run(opts: &Options) {
         Command::Check { path, core } => {
             let base_url = Url::from_directory_path(path.canonicalize_utf8().unwrap())
                 .expect("failed to parse base URL");
-            // Url::from_file_path(path.canonicalize().expect("Failed to canonicalize path"))
-            //     .expect("Failed to parse base URL")
-            //     .as_directory()
-            //     .expect("Failed to convert to directory");
             let mut db = DriverDataBase::default();
             let mut ingot_resolver = IngotResolver::default();
 
@@ -92,7 +88,7 @@ pub fn run(opts: &Options) {
                     config,
                     source_files:
                         Some(SourceFiles {
-                            root: Some(root),
+                            root: Some(_root),
                             files,
                         }),
                 }) => {
@@ -104,12 +100,9 @@ pub fn run(opts: &Options) {
                         }
                         std::process::exit(2)
                     }
-                    eprintln!("local_base_url: {}", base_url);
                     let index = db.workspace();
                     index.touch_ingot(&mut db, &base_url, config.expect("config is required"));
                     for (path, content) in files {
-                        eprintln!("touching {}", path);
-                        // local_base_url.touch(&mut db, path, Some(content));
                         index.touch(
                             &mut db,
                             Url::from_file_path(
@@ -122,7 +115,7 @@ pub fn run(opts: &Options) {
                     base_url
                 }
                 Ok(Ingot::SingleFile { path, content }) => {
-                    let url = Url::from_file_path(&path.canonicalize_utf8().unwrap()).unwrap();
+                    let url = Url::from_file_path(path.canonicalize_utf8().unwrap()).unwrap();
                     db.workspace().touch(&mut db, url.clone(), Some(content));
                     db.workspace()
                         .containing_ingot(&db, &url)

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -8,6 +8,9 @@ use common::ingot::IngotBaseUrl;
 use common::InputDb;
 pub use db::DriverDataBase;
 
+#[cfg(target_arch = "wasm32")]
+use test_utils::url_utils::UrlExt;
+
 use clap::{Parser, Subcommand};
 use hir::hir_def::TopLevelMod;
 use resolver::{

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -8,9 +8,6 @@ use common::ingot::IngotBaseUrl;
 use common::InputDb;
 pub use db::DriverDataBase;
 
-#[cfg(target_arch = "wasm32")]
-use test_utils::url_utils::UrlExt;
-
 use clap::{Parser, Subcommand};
 use hir::hir_def::TopLevelMod;
 use resolver::{
@@ -23,7 +20,7 @@ pub fn run(opts: &Options) {
     match &opts.command {
         Command::Build => eprintln!("`fe build` doesn't work at the moment"),
         Command::Check { path, core } => {
-            let base_url = Url::from_directory_path(path.canonicalize_utf8().unwrap())
+            let base_url = url_from_directory_path(path.canonicalize_utf8().unwrap())
                 .expect("failed to parse base URL");
             let mut db = DriverDataBase::default();
             let mut ingot_resolver = IngotResolver::default();
@@ -56,7 +53,7 @@ pub fn run(opts: &Options) {
                         for (path, content) in files {
                             index.touch(
                                 &mut db,
-                                Url::from_file_path(
+                                url_from_file_path(
                                     path.canonicalize().expect("Failed to canonicalize path"),
                                 )
                                 .expect("Failed to create URL"),
@@ -108,7 +105,7 @@ pub fn run(opts: &Options) {
                     for (path, content) in files {
                         index.touch(
                             &mut db,
-                            Url::from_file_path(
+                            url_from_file_path(
                                 path.canonicalize().expect("Failed to canonicalize path"),
                             )
                             .expect("Failed to create URL"),
@@ -118,7 +115,7 @@ pub fn run(opts: &Options) {
                     base_url
                 }
                 Ok(Ingot::SingleFile { path, content }) => {
-                    let url = Url::from_file_path(path.canonicalize_utf8().unwrap()).unwrap();
+                    let url = url_from_file_path(path.canonicalize_utf8().unwrap()).unwrap();
                     db.workspace().touch(&mut db, url.clone(), Some(content));
                     db.workspace()
                         .containing_ingot(&db, &url)
@@ -177,4 +174,50 @@ fn _dump_scope_graph(db: &DriverDataBase, top_mod: TopLevelMod) -> String {
     let mut s = vec![];
     top_mod.scope_graph(db).write_as_dot(db, &mut s).unwrap();
     String::from_utf8(s).unwrap()
+}
+
+// Maybe the driver should eventually only support WASI?
+
+fn url_from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, ()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        Url::from_file_path(path)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let path_str = path.as_ref().to_string_lossy();
+        let url_str = if path_str.starts_with('/') {
+            format!("file://{}", path_str)
+        } else {
+            format!("file:///{}", path_str)
+        };
+        Url::parse(&url_str).map_err(|_| ())
+    }
+}
+
+fn url_from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, ()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        Url::from_directory_path(path)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let path_str = path.as_ref().to_string_lossy();
+        let url_str = if path_str.starts_with('/') {
+            if path_str.ends_with('/') {
+                format!("file://{}", path_str)
+            } else {
+                format!("file://{}/", path_str)
+            }
+        } else {
+            if path_str.ends_with('/') {
+                format!("file:///{}", path_str)
+            } else {
+                format!("file:///{}/", path_str)
+            }
+        };
+        Url::parse(&url_str).map_err(|_| ())
+    }
 }

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -20,7 +20,8 @@ pub fn run(opts: &Options) {
     match &opts.command {
         Command::Build => eprintln!("`fe build` doesn't work at the moment"),
         Command::Check { path, core } => {
-            let base_url = Url::from_directory_path(path).expect("failed to parse base URL");
+            let base_url = Url::from_directory_path(path.canonicalize_utf8().unwrap())
+                .expect("failed to parse base URL");
             // Url::from_file_path(path.canonicalize().expect("Failed to canonicalize path"))
             //     .expect("Failed to parse base URL")
             //     .as_directory()

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -4,9 +4,9 @@ pub mod files;
 use camino::Utf8PathBuf;
 use common::core::HasBuiltinCore;
 use common::ingot::{IngotBaseUrl, IngotIndex};
+use common::urlext::UrlExt;
 use common::InputDb;
 pub use db::DriverDataBase;
-use test_utils::url_utils::UrlExt;
 
 use clap::{Parser, Subcommand};
 use hir::hir_def::TopLevelMod;
@@ -20,6 +20,11 @@ pub fn run(opts: &Options) {
     match &opts.command {
         Command::Build => eprintln!("`fe build` doesn't work at the moment"),
         Command::Check { path, core } => {
+            let base_url = Url::from_directory_path(path).expect("failed to parse base URL");
+            // Url::from_file_path(path.canonicalize().expect("Failed to canonicalize path"))
+            //     .expect("Failed to parse base URL")
+            //     .as_directory()
+            //     .expect("Failed to convert to directory");
             let mut db = DriverDataBase::default();
             let mut ingot_resolver = IngotResolver::default();
 
@@ -49,7 +54,14 @@ pub fn run(opts: &Options) {
                             config.expect("config is required"),
                         );
                         for (path, content) in files {
-                            core_base_url.touch(&mut db, path, Some(content));
+                            index.touch(
+                                &mut db,
+                                Url::from_file_path(
+                                    path.canonicalize().expect("Failed to canonicalize path"),
+                                )
+                                .expect("Failed to create URL"),
+                                Some(content),
+                            );
                         }
                         core_base_url
                     }
@@ -79,7 +91,7 @@ pub fn run(opts: &Options) {
                     config,
                     source_files:
                         Some(SourceFiles {
-                            root: Some(_root),
+                            root: Some(root),
                             files,
                         }),
                 }) => {
@@ -91,34 +103,39 @@ pub fn run(opts: &Options) {
                         }
                         std::process::exit(2)
                     }
-                    let local_base_url = Url::from_file_path_lossy(&_root);
+                    eprintln!("local_base_url: {}", base_url);
                     let index = db.workspace();
-                    index.touch_ingot(
-                        &mut db,
-                        &local_base_url,
-                        config.expect("config is required"),
-                    );
+                    index.touch_ingot(&mut db, &base_url, config.expect("config is required"));
                     for (path, content) in files {
-                        local_base_url.touch(&mut db, path, Some(content));
+                        eprintln!("touching {}", path);
+                        // local_base_url.touch(&mut db, path, Some(content));
+                        index.touch(
+                            &mut db,
+                            Url::from_file_path(
+                                path.canonicalize().expect("Failed to canonicalize path"),
+                            )
+                            .expect("Failed to create URL"),
+                            Some(content),
+                        );
                     }
-                    local_base_url
+                    base_url
                 }
                 Ok(Ingot::SingleFile { path, content }) => {
-                    let url = Url::from_file_path_lossy(&path);
+                    let url = Url::from_file_path(&path.canonicalize_utf8().unwrap()).unwrap();
                     db.workspace().touch(&mut db, url.clone(), Some(content));
                     db.workspace()
                         .containing_ingot_base(&db, &url)
                         .expect("Failed to find ingot base")
                 }
                 Ok(_) => {
-                    eprintln!("an error was encountered while resolving `{path}`");
+                    eprintln!("an error was encountered while resolving `{base_url}`");
                     for diagnostic in ingot_resolver.take_diagnostics() {
                         eprintln!("{diagnostic}")
                     }
                     std::process::exit(2)
                 }
                 Err(error) => {
-                    eprintln!("an error was encountered while resolving `{path}`");
+                    eprintln!("an error was encountered while resolving `{base_url}`");
                     eprintln!("{error}");
                     std::process::exit(2)
                 }

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -125,8 +125,9 @@ pub fn run(opts: &Options) {
                     let url = Url::from_file_path(&path.canonicalize_utf8().unwrap()).unwrap();
                     db.workspace().touch(&mut db, url.clone(), Some(content));
                     db.workspace()
-                        .containing_ingot_base(&db, &url)
-                        .expect("Failed to find ingot base")
+                        .containing_ingot(&db, &url)
+                        .expect("Failed to find ingot")
+                        .base(&db)
                 }
                 Ok(_) => {
                     eprintln!("an error was encountered while resolving `{base_url}`");

--- a/crates/hir-analysis/tests/corelib.rs
+++ b/crates/hir-analysis/tests/corelib.rs
@@ -6,6 +6,7 @@ use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::url_utils::UrlExt;
+use url::Url;
 
 #[test]
 fn analyze_corelib() {
@@ -28,7 +29,7 @@ fn analyze_corelib() {
 )]
 fn corelib_standalone(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
-    let path = url::Url::from_file_path_lossy(fixture.path());
+    let path = Url::from_file_path(&path.canonicalize_utf8().unwrap()).unwrap();
     db.workspace()
         .touch(&mut db, path.clone(), Some(fixture.content().to_string()));
 

--- a/crates/hir-analysis/tests/corelib.rs
+++ b/crates/hir-analysis/tests/corelib.rs
@@ -2,7 +2,7 @@ mod test_db;
 
 use std::path::Path;
 
-use common::core::HasBuiltinCore;
+use common::{core::HasBuiltinCore, urlext::UrlExt};
 
 use common::InputDb;
 use dir_test::{dir_test, Fixture};
@@ -32,7 +32,7 @@ fn analyze_corelib() {
 fn corelib_standalone(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let path = Path::new(fixture.path()).canonicalize().unwrap();
-    let url = Url::from_file_path(path).unwrap();
+    let url = <Url as UrlExt>::from_file_path(path).unwrap();
     db.workspace()
         .touch(&mut db, url.clone(), Some(fixture.content().to_string()));
 

--- a/crates/hir-analysis/tests/corelib.rs
+++ b/crates/hir-analysis/tests/corelib.rs
@@ -1,14 +1,16 @@
 mod test_db;
 
-use std::path::Path;
-
-use common::{core::HasBuiltinCore, urlext::UrlExt};
+use camino::Utf8Path;
+use common::core::HasBuiltinCore;
 
 use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 
 use url::Url;
+
+#[cfg(target_arch = "wasm32")]
+use test_utils::url_utils::UrlExt;
 
 #[test]
 fn analyze_corelib() {
@@ -31,8 +33,8 @@ fn analyze_corelib() {
 )]
 fn corelib_standalone(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
-    let path = Path::new(fixture.path()).canonicalize().unwrap();
-    let url = <Url as UrlExt>::from_file_path(path).unwrap();
+    let path = Utf8Path::new(fixture.path()).canonicalize().unwrap();
+    let url = Url::from_file_path(path).unwrap();
     db.workspace()
         .touch(&mut db, url.clone(), Some(fixture.content().to_string()));
 

--- a/crates/hir-analysis/tests/corelib.rs
+++ b/crates/hir-analysis/tests/corelib.rs
@@ -1,11 +1,13 @@
 mod test_db;
 
+use std::path::Path;
+
 use common::core::HasBuiltinCore;
-use common::ingot::IngotIndex;
+
 use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
-use test_utils::url_utils::UrlExt;
+
 use url::Url;
 
 #[test]
@@ -29,13 +31,14 @@ fn analyze_corelib() {
 )]
 fn corelib_standalone(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
-    let path = Url::from_file_path(&path.canonicalize_utf8().unwrap()).unwrap();
+    let path = Path::new(fixture.path()).canonicalize().unwrap();
+    let url = Url::from_file_path(path).unwrap();
     db.workspace()
-        .touch(&mut db, path.clone(), Some(fixture.content().to_string()));
+        .touch(&mut db, url.clone(), Some(fixture.content().to_string()));
 
     let local_diags = db.run_on_ingot(
         db.workspace()
-            .containing_ingot(&db, &path)
+            .containing_ingot(&db, &url)
             .expect("Failed to find containing ingot"),
     );
     if !local_diags.is_empty() {

--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -11,7 +11,7 @@ use codespan_reporting::{
 };
 use common::{
     core::HasBuiltinCore, define_input_db, diagnostics::Span, file::File, indexmap::IndexMap,
-    InputDb,
+    urlext::UrlExt, InputDb,
 };
 use driver::diagnostics::{CsDbWrapper, ToCsDiag};
 use fe_hir_analysis::{
@@ -29,6 +29,7 @@ use hir::{
     SpannedHirDb,
 };
 use rustc_hash::FxHashMap;
+use url::Url;
 
 type CodeSpanFileId = usize;
 
@@ -48,7 +49,8 @@ impl HirAnalysisTestDb {
         self.initialize_builtin_core();
         index.touch(
             self,
-            url::Url::from_file_path(&file_name).expect("Failed to create URL from file path"),
+            <Url as UrlExt>::from_file_path(&file_name)
+                .expect("Failed to create URL from file path"),
             Some(text.to_string()),
         )
     }

--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -29,7 +29,6 @@ use hir::{
     SpannedHirDb,
 };
 use rustc_hash::FxHashMap;
-use test_utils::url_utils::UrlExt;
 
 type CodeSpanFileId = usize;
 

--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -11,7 +11,7 @@ use codespan_reporting::{
 };
 use common::{
     core::HasBuiltinCore, define_input_db, diagnostics::Span, file::File, indexmap::IndexMap,
-    urlext::UrlExt, InputDb,
+    InputDb,
 };
 use driver::diagnostics::{CsDbWrapper, ToCsDiag};
 use fe_hir_analysis::{
@@ -29,6 +29,7 @@ use hir::{
     SpannedHirDb,
 };
 use rustc_hash::FxHashMap;
+use test_utils::url_utils::UrlExt;
 use url::Url;
 
 type CodeSpanFileId = usize;
@@ -49,8 +50,7 @@ impl HirAnalysisTestDb {
         self.initialize_builtin_core();
         index.touch(
             self,
-            <Url as UrlExt>::from_file_path(&file_name)
-                .expect("Failed to create URL from file path"),
+            <Url as UrlExt>::from_file_path_lossy(&file_name),
             Some(text.to_string()),
         )
     }

--- a/crates/hir-analysis/tests/test_db.rs
+++ b/crates/hir-analysis/tests/test_db.rs
@@ -49,7 +49,7 @@ impl HirAnalysisTestDb {
         self.initialize_builtin_core();
         index.touch(
             self,
-            url::Url::from_file_path_lossy(&file_name),
+            url::Url::from_file_path(&file_name).expect("Failed to create URL from file path"),
             Some(text.to_string()),
         )
     }

--- a/crates/hir/src/hir_def/mod.rs
+++ b/crates/hir/src/hir_def/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod module_tree;
 
 pub use attr::*;
 pub use body::*;
-use common::ingot::{Ingot, IngotIndex, IngotKind};
+use common::ingot::{Ingot, IngotKind};
 pub use expr::*;
 pub use ident::*;
 pub use item::*;

--- a/crates/hir/src/hir_def/module_tree.rs
+++ b/crates/hir/src/hir_def/module_tree.rs
@@ -307,10 +307,7 @@ impl<'db> ModuleTreeBuilder<'db> {
 #[cfg(test)]
 mod tests {
 
-    use common::{
-        ingot::{IngotBaseUrl, IngotIndex},
-        InputDb,
-    };
+    use common::{ingot::IngotBaseUrl, InputDb};
     use url::Url;
 
     use crate::{lower, test_db::TestDb};

--- a/crates/hir/src/hir_def/module_tree.rs
+++ b/crates/hir/src/hir_def/module_tree.rs
@@ -231,10 +231,14 @@ impl<'db> ModuleTreeBuilder<'db> {
     }
 
     fn build_tree(&mut self) {
-        let root = self
-            .ingot
-            .root_file(self.db)
-            .expect("ingot root file is missing");
+        let root = self.ingot.root_file(self.db).unwrap_or_else(|_| {
+            eprintln!("ingot root file is missing");
+            eprintln!("Files in ingot:");
+            for (url, file) in self.ingot.files(self.db).iter() {
+                eprintln!("  {}: {:?}", url, file.path(self.db));
+            }
+            panic!("ingot root file is missing");
+        });
 
         for (_url, child) in self.ingot.files(self.db).iter() {
             // Ignore the root file because it has no parent.

--- a/crates/hir/src/hir_def/module_tree.rs
+++ b/crates/hir/src/hir_def/module_tree.rs
@@ -219,14 +219,17 @@ impl<'db> ModuleTreeBuilder<'db> {
 
     fn set_modules(&mut self) {
         for (_url, file) in self.ingot.files(self.db).iter() {
-            let top_mod = map_file_to_mod_impl(self.db, file);
+            // Only process source files, skip config files like fe.toml
+            if let Some(IngotFileKind::Source) = file.kind(self.db) {
+                let top_mod = map_file_to_mod_impl(self.db, file);
 
-            let module_id = self.module_tree.push(ModuleTreeNode::new(top_mod));
-            let path = file.path(self.db).as_ref().expect("couldn't get path");
-            // .clone();
-            let path = Utf8Path::new(path);
-            self.path_map.insert(path, module_id);
-            self.mod_map.insert(top_mod, module_id);
+                let module_id = self.module_tree.push(ModuleTreeNode::new(top_mod));
+                let path = file.path(self.db).as_ref().expect("couldn't get path");
+                // .clone();
+                let path = Utf8Path::new(path);
+                self.path_map.insert(path, module_id);
+                self.mod_map.insert(top_mod, module_id);
+            }
         }
     }
 

--- a/crates/language-server/src/backend/workspace.rs
+++ b/crates/language-server/src/backend/workspace.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use common::{ingot::IngotIndex, InputDb};
+use common::InputDb;
 use tracing::info;
 use url::Url;
 

--- a/crates/language-server/src/functionality/goto.rs
+++ b/crates/language-server/src/functionality/goto.rs
@@ -168,7 +168,7 @@ pub async fn handle_goto_definition(
 // }
 #[cfg(test)]
 mod tests {
-    use common::ingot::{IngotIndex, IngotKind};
+    use common::ingot::IngotKind;
     use dir_test::{dir_test, Fixture};
     use std::collections::BTreeMap;
     use test_utils::snap_test;

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -7,7 +7,7 @@ use async_lsp::{
     },
     LanguageClient, ResponseError,
 };
-use common::ingot::IngotIndex;
+
 use common::InputDb;
 use rustc_hash::FxHashSet;
 

--- a/crates/test-utils/src/url_utils.rs
+++ b/crates/test-utils/src/url_utils.rs
@@ -1,41 +1,62 @@
-#[cfg(target_arch = "wasm32")]
-use std::path::Path;
-#[cfg(target_arch = "wasm32")]
+use std::path::{Path, PathBuf};
 use url::Url;
 
-#[cfg(target_arch = "wasm32")]
+/// Extension trait for URL to provide cross-platform compatibility
+#[allow(clippy::result_unit_err)]
 pub trait UrlExt {
+    /// Create a URL from a file path.
+    ///
+    /// This is the native `Url::from_file_path` function on native platforms,
+    /// but implemented manually for WASM targets where the original is unavailable.
     fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()>;
-    fn from_directory_path<P: AsRef<Path>>(path: P) -> Result<Url, ()>;
+
+    /// Creates a URL from a file path with full error handling
+    fn from_file_path_lossy<P: AsRef<Path>>(path: P) -> Url;
+
+    /// Converts a URL to a file path
+    fn to_file_path(&self) -> Result<PathBuf, ()>;
 }
 
-#[cfg(target_arch = "wasm32")]
 impl UrlExt for Url {
     fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {
-        let path_str = path.as_ref().to_string_lossy();
-        let url_str = if path_str.starts_with('/') {
-            format!("file://{}", path_str)
-        } else {
-            format!("file:///{}", path_str)
-        };
-        Url::parse(&url_str).map_err(|_| ())
-    }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            Url::from_file_path(path)
+        }
 
-    fn from_directory_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {
-        let path_str = path.as_ref().to_string_lossy();
-        let url_str = if path_str.starts_with('/') {
-            if path_str.ends_with('/') {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let path = path.as_ref();
+            // For WASM, we need to manually construct the URL
+            let path_str = path.to_string_lossy();
+            let url_str = if path_str.starts_with('/') {
                 format!("file://{}", path_str)
             } else {
-                format!("file://{}/", path_str)
-            }
-        } else {
-            if path_str.ends_with('/') {
                 format!("file:///{}", path_str)
-            } else {
-                format!("file:///{}/", path_str)
+            };
+            Url::parse(&url_str).map_err(|_| ())
+        }
+    }
+
+    fn from_file_path_lossy<P: AsRef<Path>>(path: P) -> Url {
+        Self::from_file_path(path).expect("Failed to create URL from file path")
+    }
+
+    fn to_file_path(&self) -> Result<PathBuf, ()> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            url::Url::to_file_path(self)
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            // Basic implementation for WASM - extract path from URL
+            if self.scheme() != "file" {
+                return Err(());
             }
-        };
-        Url::parse(&url_str).map_err(|_| ())
+
+            let path = self.path();
+            Ok(PathBuf::from(path))
+        }
     }
 }

--- a/crates/test-utils/src/url_utils.rs
+++ b/crates/test-utils/src/url_utils.rs
@@ -10,9 +10,6 @@ pub trait UrlExt {
     /// but implemented manually for WASM targets where the original is unavailable.
     fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()>;
 
-    /// Creates a URL from a file path with full error handling
-    fn from_file_path_lossy<P: AsRef<Path>>(path: P) -> Url;
-
     /// Converts a URL to a file path
     fn to_file_path(&self) -> Result<PathBuf, ()>;
 }
@@ -36,10 +33,6 @@ impl UrlExt for Url {
             };
             Ok(Url::parse(&url_str).map_err(|_| ())?)
         }
-    }
-
-    fn from_file_path_lossy<P: AsRef<Path>>(path: P) -> Url {
-        Self::from_file_path(path).expect("Failed to create URL from file path")
     }
 
     fn to_file_path(&self) -> Result<PathBuf, ()> {

--- a/crates/uitest/tests/name_resolution.rs
+++ b/crates/uitest/tests/name_resolution.rs
@@ -2,7 +2,6 @@ use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
-use test_utils::url_utils::UrlExt;
 
 #[dir_test(
     dir: "$CARGO_MANIFEST_DIR/fixtures/name_resolution",

--- a/crates/uitest/tests/name_resolution.rs
+++ b/crates/uitest/tests/name_resolution.rs
@@ -2,6 +2,10 @@ use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
+use url::Url;
+
+#[cfg(target_arch = "wasm32")]
+use test_utils::url_utils::UrlExt;
 
 #[dir_test(
     dir: "$CARGO_MANIFEST_DIR/fixtures/name_resolution",
@@ -11,7 +15,7 @@ fn run_name_resolution(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let file = db.workspace().touch(
         &mut db,
-        url::Url::from_file_path(fixture.path()).expect("path should be absolute"),
+        Url::from_file_path(fixture.path()).expect("path should be absolute"),
         Some(fixture.content().to_string()),
     );
 
@@ -39,7 +43,7 @@ mod wasm {
         let mut db = DriverDataBase::default();
         let file = db.workspace().touch(
             &mut db,
-            url::Url::from_file_path_lossy(fixture.path()),
+            Url::from_file_path(fixture.path()).unwrap_or_else(|_| Url::parse("file:///").unwrap()),
             Some(fixture.content().to_string()),
         );
 

--- a/crates/uitest/tests/name_resolution.rs
+++ b/crates/uitest/tests/name_resolution.rs
@@ -12,7 +12,7 @@ fn run_name_resolution(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let file = db.workspace().touch(
         &mut db,
-        url::Url::from_file_path_lossy(fixture.path()),
+        url::Url::from_file_path(fixture.path()).expect("path should be absolute"),
         Some(fixture.content().to_string()),
     );
 

--- a/crates/uitest/tests/parser.rs
+++ b/crates/uitest/tests/parser.rs
@@ -4,6 +4,9 @@ use driver::DriverDataBase;
 use hir_analysis::analysis_pass::{AnalysisPassManager, ParsingPass};
 use test_utils::snap_test;
 
+#[cfg(target_arch = "wasm32")]
+use test_utils::url_utils::UrlExt;
+
 #[dir_test(
     dir: "$CARGO_MANIFEST_DIR/fixtures/parser",
     glob: "*.fe"
@@ -32,6 +35,8 @@ fn init_parser_pass() -> AnalysisPassManager {
 #[cfg(target_family = "wasm")]
 mod wasm {
     use super::*;
+    use test_utils::url_utils::UrlExt;
+    use url::Url;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[dir_test(
@@ -46,7 +51,7 @@ mod wasm {
         let mut db = DriverDataBase::default();
         let file = db.workspace().touch(
             &mut db,
-            url::Url::from_file_path_lossy(fixture.path()),
+            <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
             Some(fixture.content().to_string()),
         );
 

--- a/crates/uitest/tests/parser.rs
+++ b/crates/uitest/tests/parser.rs
@@ -51,7 +51,7 @@ mod wasm {
         let mut db = DriverDataBase::default();
         let file = db.workspace().touch(
             &mut db,
-            <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
+            <Url as UrlExt>::from_file_path_lossy(fixture.path()),
             Some(fixture.content().to_string()),
         );
 

--- a/crates/uitest/tests/parser.rs
+++ b/crates/uitest/tests/parser.rs
@@ -13,7 +13,7 @@ fn run_parser(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let file = db.workspace().touch(
         &mut db,
-        url::Url::from_file_path_lossy(fixture.path()),
+        url::Url::from_file_path(fixture.path()).expect("path should be absolute"),
         Some(fixture.content().to_string()),
     );
 

--- a/crates/uitest/tests/parser.rs
+++ b/crates/uitest/tests/parser.rs
@@ -3,7 +3,6 @@ use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use hir_analysis::analysis_pass::{AnalysisPassManager, ParsingPass};
 use test_utils::snap_test;
-use test_utils::url_utils::UrlExt;
 
 #[dir_test(
     dir: "$CARGO_MANIFEST_DIR/fixtures/parser",

--- a/crates/uitest/tests/ty.rs
+++ b/crates/uitest/tests/ty.rs
@@ -106,7 +106,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
+                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
                 Some(fixture.content().to_string()),
             );
 
@@ -131,7 +131,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
+                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
                 Some(fixture.content().to_string()),
             );
 
@@ -156,7 +156,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
+                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
                 Some(fixture.content().to_string()),
             );
 
@@ -183,7 +183,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
+                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
                 Some(fixture.content().to_string()),
             );
 

--- a/crates/uitest/tests/ty.rs
+++ b/crates/uitest/tests/ty.rs
@@ -2,7 +2,7 @@ use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
-use test_utils::url_utils::UrlExt;
+
 use url::Url;
 
 #[dir_test(

--- a/crates/uitest/tests/ty.rs
+++ b/crates/uitest/tests/ty.rs
@@ -13,7 +13,7 @@ fn run_ty_def(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let file = db.workspace().touch(
         &mut db,
-        url::Url::from_file_path_lossy(fixture.path()),
+        url::Url::from_file_path(fixture.path()).expect("path should be absolute"),
         Some(fixture.content().to_string()),
     );
 
@@ -32,7 +32,7 @@ fn run_const_ty(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let file = db.workspace().touch(
         &mut db,
-        url::Url::from_file_path_lossy(fixture.path()),
+        url::Url::from_file_path(fixture.path()).expect("path should be absolute"),
         Some(fixture.content().to_string()),
     );
 

--- a/crates/uitest/tests/ty.rs
+++ b/crates/uitest/tests/ty.rs
@@ -3,6 +3,9 @@ use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
 
+#[cfg(target_arch = "wasm32")]
+use test_utils::url_utils::UrlExt;
+
 use url::Url;
 
 #[dir_test(
@@ -84,12 +87,13 @@ fn run_trait_impl(fixture: Fixture<&str>) {
 #[cfg(target_family = "wasm")]
 mod wasm {
     use super::*;
+    use url::Url;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     mod def {
         use super::*;
+        use test_utils::url_utils::UrlExt;
 
-        // TODO: we opt out the tests for type/alias/trait-infinite recursion checks. See https://github.com/ethereum/fe/issues/939 for more details.
         #[dir_test(
         dir: "$CARGO_MANIFEST_DIR/fixtures/ty/def",
         glob: "*[!_cycle].fe",
@@ -102,7 +106,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                url::Url::from_file_path_lossy(fixture.path()),
+                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
                 Some(fixture.content().to_string()),
             );
 
@@ -113,6 +117,7 @@ mod wasm {
 
     mod const_ty {
         use super::*;
+        use test_utils::url_utils::UrlExt;
 
         #[dir_test(
         dir: "$CARGO_MANIFEST_DIR/fixtures/ty/const_ty",
@@ -126,7 +131,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                url::Url::from_file_path_lossy(fixture.path()),
+                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
                 Some(fixture.content().to_string()),
             );
 
@@ -137,6 +142,7 @@ mod wasm {
 
     mod trait_bound {
         use super::*;
+        use test_utils::url_utils::UrlExt;
 
         #[dir_test(
         dir: "$CARGO_MANIFEST_DIR/fixtures/ty/trait_bound",
@@ -150,7 +156,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                url::Url::from_file_path_lossy(fixture.path()),
+                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
                 Some(fixture.content().to_string()),
             );
 
@@ -160,6 +166,9 @@ mod wasm {
     }
 
     mod trait_impl {
+        use test_utils::url_utils::UrlExt;
+        use url::Url;
+
         use super::*;
 
         #[dir_test(
@@ -174,7 +183,7 @@ mod wasm {
             let mut db = DriverDataBase::default();
             let file = db.workspace().touch(
                 &mut db,
-                url::Url::from_file_path_lossy(fixture.path()),
+                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
                 Some(fixture.content().to_string()),
             );
 

--- a/crates/uitest/tests/ty_check.rs
+++ b/crates/uitest/tests/ty_check.rs
@@ -3,6 +3,9 @@ use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
 
+#[cfg(target_arch = "wasm32")]
+use test_utils::url_utils::UrlExt;
+
 use url::Url;
 
 #[dir_test(
@@ -27,6 +30,8 @@ fn run_ty_check(fixture: Fixture<&str>) {
 #[cfg(target_family = "wasm")]
 mod wasm {
     use super::*;
+    use test_utils::url_utils::UrlExt;
+    use url::Url;
     use wasm_bindgen_test::wasm_bindgen_test;
 
     #[dir_test(
@@ -41,7 +46,7 @@ mod wasm {
         let mut db = DriverDataBase::default();
         let file = db.workspace().touch(
             &mut db,
-            Url::from_file_path_lossy(fixture.path()),
+            <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
             Some(fixture.content().to_string()),
         );
 

--- a/crates/uitest/tests/ty_check.rs
+++ b/crates/uitest/tests/ty_check.rs
@@ -46,7 +46,7 @@ mod wasm {
         let mut db = DriverDataBase::default();
         let file = db.workspace().touch(
             &mut db,
-            <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
+            <Url as UrlExt>::from_file_path_lossy(fixture.path()),
             Some(fixture.content().to_string()),
         );
 

--- a/crates/uitest/tests/ty_check.rs
+++ b/crates/uitest/tests/ty_check.rs
@@ -2,7 +2,7 @@ use common::InputDb;
 use dir_test::{dir_test, Fixture};
 use driver::DriverDataBase;
 use test_utils::snap_test;
-use test_utils::url_utils::UrlExt;
+
 use url::Url;
 
 #[dir_test(

--- a/crates/uitest/tests/ty_check.rs
+++ b/crates/uitest/tests/ty_check.rs
@@ -13,7 +13,7 @@ fn run_ty_check(fixture: Fixture<&str>) {
     let mut db = DriverDataBase::default();
     let file = db.workspace().touch(
         &mut db,
-        Url::from_file_path_lossy(fixture.path()),
+        Url::from_file_path(fixture.path()).expect("path should be absolute"),
         Some(fixture.content().to_string()),
     );
 

--- a/wasm_cleanup.patch
+++ b/wasm_cleanup.patch
@@ -1,0 +1,392 @@
+diff --git a/crates/common/src/urlext.rs b/crates/common/src/urlext.rs
+index c4a7e0d2..ab3ff87c 100644
+--- a/crates/common/src/urlext.rs
++++ b/crates/common/src/urlext.rs
+@@ -4,14 +4,11 @@ use url::Url;
+ pub enum UrlExtError {
+     DirectoryRangeError,
+     AsDirectoryError,
+-    PathConversionError,
+ }
+ 
+ pub trait UrlExt {
+     fn parent(&self) -> Option<Url>;
+     fn directory(&self) -> Option<Url>;
+-    fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError>;
+-    fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError>;
+ }
+ 
+ impl UrlExt for Url {
+@@ -52,46 +49,6 @@ impl UrlExt for Url {
+             return Some(parent);
+         }
+     }
+-
+-    #[cfg(target_arch = "wasm32")]
+-    fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
+-        let path_str = path.as_ref().to_string_lossy();
+-        let url_str = if path_str.starts_with('/') {
+-            format!("file://{}", path_str)
+-        } else {
+-            format!("file:///{}", path_str)
+-        };
+-        Url::parse(&url_str).map_err(|_| UrlExtError::PathConversionError)
+-    }
+-
+-    #[cfg(not(target_arch = "wasm32"))]
+-    fn from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
+-        Url::from_file_path(path).map_err(|_| UrlExtError::PathConversionError)
+-    }
+-
+-    #[cfg(target_arch = "wasm32")]
+-    fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
+-        let path_str = path.as_ref().to_string_lossy();
+-        let url_str = if path_str.starts_with('/') {
+-            if path_str.ends_with('/') {
+-                format!("file://{}", path_str)
+-            } else {
+-                format!("file://{}/", path_str)
+-            }
+-        } else {
+-            if path_str.ends_with('/') {
+-                format!("file:///{}", path_str)
+-            } else {
+-                format!("file:///{}/", path_str)
+-            }
+-        };
+-        Url::parse(&url_str).map_err(|_| UrlExtError::PathConversionError)
+-    }
+-
+-    #[cfg(not(target_arch = "wasm32"))]
+-    fn from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, UrlExtError> {
+-        Url::from_directory_path(path).map_err(|_| UrlExtError::PathConversionError)
+-    }
+ }
+ 
+ #[cfg(test)]
+diff --git a/crates/driver/src/lib.rs b/crates/driver/src/lib.rs
+index d167fb37..f6abce18 100644
+--- a/crates/driver/src/lib.rs
++++ b/crates/driver/src/lib.rs
+@@ -8,9 +8,6 @@ use common::ingot::IngotBaseUrl;
+ use common::InputDb;
+ pub use db::DriverDataBase;
+ 
+-#[cfg(target_arch = "wasm32")]
+-use test_utils::url_utils::UrlExt;
+-
+ use clap::{Parser, Subcommand};
+ use hir::hir_def::TopLevelMod;
+ use resolver::{
+@@ -23,7 +20,7 @@ pub fn run(opts: &Options) {
+     match &opts.command {
+         Command::Build => eprintln!("`fe build` doesn't work at the moment"),
+         Command::Check { path, core } => {
+-            let base_url = Url::from_directory_path(path.canonicalize_utf8().unwrap())
++            let base_url = url_from_directory_path(path.canonicalize_utf8().unwrap())
+                 .expect("failed to parse base URL");
+             let mut db = DriverDataBase::default();
+             let mut ingot_resolver = IngotResolver::default();
+@@ -56,7 +53,7 @@ pub fn run(opts: &Options) {
+                         for (path, content) in files {
+                             index.touch(
+                                 &mut db,
+-                                Url::from_file_path(
++                                url_from_file_path(
+                                     path.canonicalize().expect("Failed to canonicalize path"),
+                                 )
+                                 .expect("Failed to create URL"),
+@@ -108,7 +105,7 @@ pub fn run(opts: &Options) {
+                     for (path, content) in files {
+                         index.touch(
+                             &mut db,
+-                            Url::from_file_path(
++                            url_from_file_path(
+                                 path.canonicalize().expect("Failed to canonicalize path"),
+                             )
+                             .expect("Failed to create URL"),
+@@ -118,7 +115,7 @@ pub fn run(opts: &Options) {
+                     base_url
+                 }
+                 Ok(Ingot::SingleFile { path, content }) => {
+-                    let url = Url::from_file_path(path.canonicalize_utf8().unwrap()).unwrap();
++                    let url = url_from_file_path(path.canonicalize_utf8().unwrap()).unwrap();
+                     db.workspace().touch(&mut db, url.clone(), Some(content));
+                     db.workspace()
+                         .containing_ingot(&db, &url)
+@@ -178,3 +175,49 @@ fn _dump_scope_graph(db: &DriverDataBase, top_mod: TopLevelMod) -> String {
+     top_mod.scope_graph(db).write_as_dot(db, &mut s).unwrap();
+     String::from_utf8(s).unwrap()
+ }
++
++// Maybe the driver should eventually only support WASI?
++
++fn url_from_file_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, ()> {
++    #[cfg(not(target_arch = "wasm32"))]
++    {
++        Url::from_file_path(path)
++    }
++
++    #[cfg(target_arch = "wasm32")]
++    {
++        let path_str = path.as_ref().to_string_lossy();
++        let url_str = if path_str.starts_with('/') {
++            format!("file://{}", path_str)
++        } else {
++            format!("file:///{}", path_str)
++        };
++        Url::parse(&url_str).map_err(|_| ())
++    }
++}
++
++fn url_from_directory_path<P: AsRef<std::path::Path>>(path: P) -> Result<Url, ()> {
++    #[cfg(not(target_arch = "wasm32"))]
++    {
++        Url::from_directory_path(path)
++    }
++
++    #[cfg(target_arch = "wasm32")]
++    {
++        let path_str = path.as_ref().to_string_lossy();
++        let url_str = if path_str.starts_with('/') {
++            if path_str.ends_with('/') {
++                format!("file://{}", path_str)
++            } else {
++                format!("file://{}/", path_str)
++            }
++        } else {
++            if path_str.ends_with('/') {
++                format!("file:///{}", path_str)
++            } else {
++                format!("file:///{}/", path_str)
++            }
++        };
++        Url::parse(&url_str).map_err(|_| ())
++    }
++}
+diff --git a/crates/hir-analysis/tests/corelib.rs b/crates/hir-analysis/tests/corelib.rs
+index 51fc44be..2acaeafb 100644
+--- a/crates/hir-analysis/tests/corelib.rs
++++ b/crates/hir-analysis/tests/corelib.rs
+@@ -1,8 +1,7 @@
+ mod test_db;
+ 
+-use std::path::Path;
+-
+-use common::{core::HasBuiltinCore, urlext::UrlExt};
++use camino::Utf8Path;
++use common::core::HasBuiltinCore;
+ 
+ use common::InputDb;
+ use dir_test::{dir_test, Fixture};
+@@ -10,6 +9,9 @@ use driver::DriverDataBase;
+ 
+ use url::Url;
+ 
++#[cfg(target_arch = "wasm32")]
++use test_utils::url_utils::UrlExt;
++
+ #[test]
+ fn analyze_corelib() {
+     let db = DriverDataBase::default();
+@@ -31,8 +33,8 @@ fn analyze_corelib() {
+ )]
+ fn corelib_standalone(fixture: Fixture<&str>) {
+     let mut db = DriverDataBase::default();
+-    let path = Path::new(fixture.path()).canonicalize().unwrap();
+-    let url = <Url as UrlExt>::from_file_path(path).unwrap();
++    let path = Utf8Path::new(fixture.path()).canonicalize().unwrap();
++    let url = Url::from_file_path(path).unwrap();
+     db.workspace()
+         .touch(&mut db, url.clone(), Some(fixture.content().to_string()));
+ 
+diff --git a/crates/hir-analysis/tests/test_db.rs b/crates/hir-analysis/tests/test_db.rs
+index ad5d28ee..a2ef4106 100644
+--- a/crates/hir-analysis/tests/test_db.rs
++++ b/crates/hir-analysis/tests/test_db.rs
+@@ -11,7 +11,7 @@ use codespan_reporting::{
+ };
+ use common::{
+     core::HasBuiltinCore, define_input_db, diagnostics::Span, file::File, indexmap::IndexMap,
+-    urlext::UrlExt, InputDb,
++    InputDb,
+ };
+ use driver::diagnostics::{CsDbWrapper, ToCsDiag};
+ use fe_hir_analysis::{
+@@ -29,6 +29,7 @@ use hir::{
+     SpannedHirDb,
+ };
+ use rustc_hash::FxHashMap;
++use test_utils::url_utils::UrlExt;
+ use url::Url;
+ 
+ type CodeSpanFileId = usize;
+@@ -49,8 +50,7 @@ impl HirAnalysisTestDb {
+         self.initialize_builtin_core();
+         index.touch(
+             self,
+-            <Url as UrlExt>::from_file_path(&file_name)
+-                .expect("Failed to create URL from file path"),
++            <Url as UrlExt>::from_file_path_lossy(&file_name),
+             Some(text.to_string()),
+         )
+     }
+diff --git a/crates/test-utils/src/url_utils.rs b/crates/test-utils/src/url_utils.rs
+index 15ada6da..0bd8f172 100644
+--- a/crates/test-utils/src/url_utils.rs
++++ b/crates/test-utils/src/url_utils.rs
+@@ -1,41 +1,62 @@
+-#[cfg(target_arch = "wasm32")]
+-use std::path::Path;
+-#[cfg(target_arch = "wasm32")]
++use std::path::{Path, PathBuf};
+ use url::Url;
+ 
+-#[cfg(target_arch = "wasm32")]
++/// Extension trait for URL to provide cross-platform compatibility
++#[allow(clippy::result_unit_err)]
+ pub trait UrlExt {
++    /// Create a URL from a file path.
++    ///
++    /// This is the native `Url::from_file_path` function on native platforms,
++    /// but implemented manually for WASM targets where the original is unavailable.
+     fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()>;
+-    fn from_directory_path<P: AsRef<Path>>(path: P) -> Result<Url, ()>;
++
++    /// Creates a URL from a file path with full error handling
++    fn from_file_path_lossy<P: AsRef<Path>>(path: P) -> Url;
++
++    /// Converts a URL to a file path
++    fn to_file_path(&self) -> Result<PathBuf, ()>;
+ }
+ 
+-#[cfg(target_arch = "wasm32")]
+ impl UrlExt for Url {
+     fn from_file_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {
+-        let path_str = path.as_ref().to_string_lossy();
+-        let url_str = if path_str.starts_with('/') {
+-            format!("file://{}", path_str)
+-        } else {
+-            format!("file:///{}", path_str)
+-        };
+-        Url::parse(&url_str).map_err(|_| ())
+-    }
++        #[cfg(not(target_arch = "wasm32"))]
++        {
++            Url::from_file_path(path)
++        }
+ 
+-    fn from_directory_path<P: AsRef<Path>>(path: P) -> Result<Url, ()> {
+-        let path_str = path.as_ref().to_string_lossy();
+-        let url_str = if path_str.starts_with('/') {
+-            if path_str.ends_with('/') {
++        #[cfg(target_arch = "wasm32")]
++        {
++            let path = path.as_ref();
++            // For WASM, we need to manually construct the URL
++            let path_str = path.to_string_lossy();
++            let url_str = if path_str.starts_with('/') {
+                 format!("file://{}", path_str)
+             } else {
+-                format!("file://{}/", path_str)
+-            }
+-        } else {
+-            if path_str.ends_with('/') {
+                 format!("file:///{}", path_str)
+-            } else {
+-                format!("file:///{}/", path_str)
++            };
++            Url::parse(&url_str).map_err(|_| ())
++        }
++    }
++
++    fn from_file_path_lossy<P: AsRef<Path>>(path: P) -> Url {
++        Self::from_file_path(path).expect("Failed to create URL from file path")
++    }
++
++    fn to_file_path(&self) -> Result<PathBuf, ()> {
++        #[cfg(not(target_arch = "wasm32"))]
++        {
++            url::Url::to_file_path(self)
++        }
++
++        #[cfg(target_arch = "wasm32")]
++        {
++            // Basic implementation for WASM - extract path from URL
++            if self.scheme() != "file" {
++                return Err(());
+             }
+-        };
+-        Url::parse(&url_str).map_err(|_| ())
++
++            let path = self.path();
++            Ok(PathBuf::from(path))
++        }
+     }
+ }
+diff --git a/crates/uitest/tests/parser.rs b/crates/uitest/tests/parser.rs
+index 63451d8b..1f10e298 100644
+--- a/crates/uitest/tests/parser.rs
++++ b/crates/uitest/tests/parser.rs
+@@ -51,7 +51,7 @@ mod wasm {
+         let mut db = DriverDataBase::default();
+         let file = db.workspace().touch(
+             &mut db,
+-            <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
++            <Url as UrlExt>::from_file_path_lossy(fixture.path()),
+             Some(fixture.content().to_string()),
+         );
+ 
+diff --git a/crates/uitest/tests/ty.rs b/crates/uitest/tests/ty.rs
+index a78a4430..59b06c59 100644
+--- a/crates/uitest/tests/ty.rs
++++ b/crates/uitest/tests/ty.rs
+@@ -106,7 +106,7 @@ mod wasm {
+             let mut db = DriverDataBase::default();
+             let file = db.workspace().touch(
+                 &mut db,
+-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
++                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
+                 Some(fixture.content().to_string()),
+             );
+ 
+@@ -131,7 +131,7 @@ mod wasm {
+             let mut db = DriverDataBase::default();
+             let file = db.workspace().touch(
+                 &mut db,
+-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
++                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
+                 Some(fixture.content().to_string()),
+             );
+ 
+@@ -156,7 +156,7 @@ mod wasm {
+             let mut db = DriverDataBase::default();
+             let file = db.workspace().touch(
+                 &mut db,
+-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
++                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
+                 Some(fixture.content().to_string()),
+             );
+ 
+@@ -183,7 +183,7 @@ mod wasm {
+             let mut db = DriverDataBase::default();
+             let file = db.workspace().touch(
+                 &mut db,
+-                <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
++                <Url as UrlExt>::from_file_path_lossy(fixture.path()),
+                 Some(fixture.content().to_string()),
+             );
+ 
+diff --git a/crates/uitest/tests/ty_check.rs b/crates/uitest/tests/ty_check.rs
+index 6a16bdee..17108a94 100644
+--- a/crates/uitest/tests/ty_check.rs
++++ b/crates/uitest/tests/ty_check.rs
+@@ -46,7 +46,7 @@ mod wasm {
+         let mut db = DriverDataBase::default();
+         let file = db.workspace().touch(
+             &mut db,
+-            <Url as UrlExt>::from_file_path(fixture.path()).unwrap(),
++            <Url as UrlExt>::from_file_path_lossy(fixture.path()),
+             Some(fixture.content().to_string()),
+         );
+ 


### PR DESCRIPTION
This fixes a salsa cycle caused by accidentally linking ingot child file paths to the tracked `Ingot` struct creation.  What I learned is that salsa tracked structs are linked to the execution Id of the query (derived from the arguments) that runs their constructor, not strictly to their Id fields.  That's very subtle and I had no idea.

The fix was to ensure that `Ingot` tracked structs are created in a query whose arguments have a 1:1 relationship with the ingot, i.e. the base URL.

### Changes:
- Ensure 1:1 relationship between `Ingot` and the ingot base URL
- WASM doesn't support std `Path`, so this PR includes some shims for `Path` --> `Url` 
- Initialization of `Ingot::files` query... after fixing the salsa cycle, two ambiguous resolution diagnostics weren't collected unless the files query was called before a certain point

### To-do:
- [ ] Ensure diagnostics are emitted for unreachable paths
- [ ] Write tests covering this issue ^

### The cycle problem:
```rust
#[salsa::tracked]
fn containing_ingot_impl<'db>(
    db: &'db dyn InputDb,
    index: Workspace,
    location: Url,  // the `Ingot` created here was actually being linked to this url here... which is passed in per ingot file
) -> Option<Ingot<'db>> {
    match index.containing_ingot_base(db, &location) {
        Some(ingot_url) => Some(Ingot::new(
            db,
            ingot_url, // I mistakenly assumed that the `Ingot` was being uniquely identified by the ingot base url given here
            // ...
        )),
        None => {
            Some(Ingot::new(
                db,
                // ...
            ))
        }
    }
}
```