### PR TITLE
Fix salsa module tree salsa tracking

### DIFF
--- a/crates/common/src/core.rs
+++ b/crates/common/src/core.rs
@@ -36,7 +36,7 @@ impl<T: InputDb> HasBuiltinCore for T {
     fn builtin_core(&self) -> Ingot {
         let core = self
             .workspace()
-            .containing_ingot(self, Url::parse(BUILTIN_CORE_BASE_URL).as_ref().unwrap());
+            .containing_ingot(self, Url::parse(BUILTIN_CORE_BASE_URL).unwrap());
         core.expect("Built-in core ingot failed to initialize")
     }
 }

--- a/crates/common/src/file/mod.rs
+++ b/crates/common/src/file/mod.rs
@@ -26,16 +26,14 @@ pub enum IngotFileKind {
 impl File {
     #[salsa::tracked]
     pub fn containing_ingot(self, db: &dyn InputDb) -> Option<Ingot<'_>> {
-        let index = db.workspace();
         self.url(db)
-            .and_then(|url| index.containing_ingot(db, &url))
+            .and_then(|url| db.workspace().containing_ingot(db, url))
     }
 
     #[salsa::tracked(return_ref)]
     pub fn path(self, db: &dyn InputDb) -> Option<Utf8PathBuf> {
-        let index = db.workspace();
         self.containing_ingot(db)
-            .and_then(|ingot| index.get_relative_path(db, ingot.base(db), self))
+            .and_then(|ingot| db.workspace().get_relative_path(db, ingot.base(db), self))
     }
 
     #[salsa::tracked]
@@ -52,7 +50,6 @@ impl File {
     }
 
     pub fn url(self, db: &dyn InputDb) -> Option<Url> {
-        let index = db.workspace();
-        index.get_path(db, self)
+        db.workspace().get_path(db, self)
     }
 }

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stderr)]
+
 pub mod db;
 pub mod diagnostics;
 pub mod files;
@@ -60,7 +62,7 @@ pub fn run(opts: &Options) {
                         if !diagnostics.is_empty() {
                             eprintln!("an error was encountered while resolving `{core_path}`");
                             for diagnostic in diagnostics {
-                                eprintln!("{diagnostic}")
+                                eprintln!("{diagnostic}");
                             }
                             std::process::exit(1)
                         }
@@ -98,7 +100,7 @@ pub fn run(opts: &Options) {
                     Ok(_) => {
                         eprintln!("an error was encountered while resolving `{core_path}`");
                         for diagnostic in ingot_resolver.take_diagnostics() {
-                            eprintln!("{diagnostic}")
+                            eprintln!("{diagnostic}");
                         }
                         std::process::exit(1)
                     }
@@ -149,7 +151,7 @@ pub fn run(opts: &Options) {
                     if !diagnostics.is_empty() {
                         eprintln!("an error was encountered while resolving `{path}`");
                         for diagnostic in diagnostics {
-                            eprintln!("{diagnostic}")
+                            eprintln!("{diagnostic}");
                         }
                         std::process::exit(1)
                     }
@@ -182,7 +184,7 @@ pub fn run(opts: &Options) {
                 }
                 Ok(_) => {
                     for diagnostic in ingot_resolver.take_diagnostics() {
-                        eprintln!("{diagnostic}")
+                        eprintln!("{diagnostic}");
                     }
                     std::process::exit(1)
                 }

--- a/crates/hir-analysis/tests/corelib.rs
+++ b/crates/hir-analysis/tests/corelib.rs
@@ -40,7 +40,7 @@ fn corelib_standalone(fixture: Fixture<&str>) {
 
     let local_diags = db.run_on_ingot(
         db.workspace()
-            .containing_ingot(&db, &url)
+            .containing_ingot(&db, url)
             .expect("Failed to find containing ingot"),
     );
     if !local_diags.is_empty() {

--- a/crates/hir-analysis/tests/pattern_matching.rs
+++ b/crates/hir-analysis/tests/pattern_matching.rs
@@ -14,6 +14,7 @@ use test_utils::snap_test;
     dir: "$CARGO_MANIFEST_DIR/test_files/pattern_matching",
     glob: "exhaustive/*.fe"
 )]
+#[allow(clippy::print_stderr)]
 fn exhaustive_matches(fixture: Fixture<&str>) {
     let mut db = HirAnalysisTestDb::default();
     let path = Path::new(fixture.path());

--- a/crates/hir/src/hir_def/mod.rs
+++ b/crates/hir/src/hir_def/mod.rs
@@ -17,6 +17,8 @@ pub mod use_tree;
 mod scope_graph_viz;
 
 pub(crate) mod module_tree;
+#[cfg(test)]
+mod salsa_caching_test;
 
 pub use attr::*;
 pub use body::*;
@@ -36,11 +38,6 @@ pub use use_tree::*;
 
 use crate::HirDb;
 
-// #[salsa::tracked]
-// #[derive(Debug)]
-// pub struct IngotDescription<'db> {
-//     inner: IngotUrl<'db>,
-// }
 pub trait HirIngot<'db> {
     fn module_tree(self, db: &'db dyn HirDb) -> &'db ModuleTree<'db>;
     fn all_modules(self, db: &'db dyn HirDb) -> &'db Vec<TopLevelMod<'db>>;
@@ -82,15 +79,11 @@ impl<'db> HirIngot<'db> for Ingot<'db> {
             .iter()
             .filter_map(|(name, url)| {
                 db.workspace()
-                    .containing_ingot(db, url)
+                    .containing_ingot(db, url.clone())
                     .map(|ingot_description| (IdentId::new(db, name.as_str()), ingot_description))
             })
             .collect()
     }
-
-    // fn kind(self, db: &dyn HirDb) -> IngotKind {
-    //     self.ingot_kind(db)
-    // }
 
     #[salsa::tracked(return_ref)]
     fn all_enums(self, db: &'db dyn HirDb) -> Vec<Enum<'db>> {

--- a/crates/hir/src/hir_def/mod.rs
+++ b/crates/hir/src/hir_def/mod.rs
@@ -17,8 +17,6 @@ pub mod use_tree;
 mod scope_graph_viz;
 
 pub(crate) mod module_tree;
-#[cfg(test)]
-mod salsa_caching_test;
 
 pub use attr::*;
 pub use body::*;

--- a/crates/language-server/src/backend/workspace.rs
+++ b/crates/language-server/src/backend/workspace.rs
@@ -92,7 +92,7 @@ impl Workspace {
         // Get ingot URL and descriptor
         let ingot_url =
             Url::from_file_path(ingot_root).map_err(|_| anyhow::anyhow!("Invalid URL"))?;
-        let ingot = match db.workspace().containing_ingot(db, &ingot_url) {
+        let ingot = match db.workspace().containing_ingot(db, ingot_url) {
             Some(ingot) => ingot,
             None => return Ok(()),
         };
@@ -192,8 +192,8 @@ mod tests {
         let ingot1_url = Url::from_file_path(ingot1_path.parent().unwrap()).unwrap();
         let ingot2_url = Url::from_file_path(ingot2_path.parent().unwrap()).unwrap();
 
-        let ingot1_desc = db.workspace().containing_ingot(&db, &ingot1_url);
-        let ingot2_desc = db.workspace().containing_ingot(&db, &ingot2_url);
+        let ingot1_desc = db.workspace().containing_ingot(&db, ingot1_url);
+        let ingot2_desc = db.workspace().containing_ingot(&db, ingot2_url);
 
         assert!(ingot1_desc.is_some(), "Ingot1 should be discovered");
         assert!(ingot2_desc.is_some(), "Ingot2 should be discovered");
@@ -273,7 +273,7 @@ mod tests {
         // Get the ingot for the file
         let ingot = db
             .workspace()
-            .containing_ingot(&db, &file_url)
+            .containing_ingot(&db, file_url)
             .expect("Ingot should be created for standalone file");
         assert_eq!(ingot.kind(&db), IngotKind::StandAlone);
 

--- a/crates/language-server/src/functionality/goto.rs
+++ b/crates/language-server/src/functionality/goto.rs
@@ -291,7 +291,7 @@ mod tests {
         );
 
         // Get the containing ingot - should be Local now
-        let ingot = db.workspace().containing_ingot(&db, &file_url).unwrap();
+        let ingot = db.workspace().containing_ingot(&db, file_url).unwrap();
         assert_eq!(ingot.kind(&db), IngotKind::Local);
 
         // Introduce a new scope to limit the lifetime of `top_mod`
@@ -307,7 +307,7 @@ mod tests {
 
         // Get the containing ingot for the file path
         let file_url = Url::from_file_path(fixture.path()).unwrap();
-        let ingot = db.workspace().containing_ingot(&db, &file_url);
+        let ingot = db.workspace().containing_ingot(&db, file_url);
         assert_eq!(ingot.unwrap().kind(&db), IngotKind::Local);
     }
 

--- a/crates/language-server/src/functionality/handlers.rs
+++ b/crates/language-server/src/functionality/handlers.rs
@@ -245,7 +245,10 @@ pub async fn handle_files_need_diagnostics(
         .iter()
         .filter_map(|NeedsDiagnostics(url)| {
             // url is already a url::Url
-            backend.db.workspace().containing_ingot(&backend.db, url)
+            backend
+                .db
+                .workspace()
+                .containing_ingot(&backend.db, url.clone())
         })
         .collect();
 

--- a/crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.snap
+++ b/crates/uitest/fixtures/ty_check/method_selection/require_explicit_import.snap
@@ -10,5 +10,5 @@ error[8-0028]: trait is not in the scope
   │       ^^^
   │       │
   │       consider importing one of the following traits into the scope to resolve the ambiguity
-  │       `use require_explicit_import::inner::Foo`
   │       `use require_explicit_import::inner::Bar`
+  │       `use require_explicit_import::inner::Foo`


### PR DESCRIPTION
(followup to #1102)

Previously `Ingot` instances were salsa inputs that held onto their files.  This meant that changing the file simply invalidated the inputs and correctly triggered recomputation of the module tree. 

In the initial file management refactor PR #1081, I'd replaced access to the salsa input `files` accessor with the new `files` query, but what I didn't understand at the time is that the module tree builder wasn't fully salsa tracked, and some of those the untracked calls to `files` relied on the fact that the whole `InputIngot` would be invalidated when `InputIngot::files` changed.

As a hack I'd added `let _ = ingot.files(db)` on the new `Ingot` tracked struct constructors... but what really needed to be done was to ensure all of the calls to `ingot.files` in the module tree builder were in salsa tracked functions.

Furthermore, even though we don't particularly care about locally salsa tracking the result of `Workspace::containing_ingot`, I came to realize that it's necessary to salsa track the function so that the larger salsa dependency chain doesn't get broken, since `File::containing_ingot` calls are critical for so much stuff, this function can be part of larger salsa query graphs, so it's necessary to keep it tracked.