### PR TITLE
Add support for generic parameter defaults

### DIFF
--- a/crates/hir-analysis/src/name_resolution/path_resolver.rs
+++ b/crates/hir-analysis/src/name_resolution/path_resolver.rs
@@ -944,19 +944,6 @@ pub fn resolve_name_res<'db>(
                         }
 
                         let instantiated = alias.alias_to.instantiate(db, &completed);
-                        if let TyData::Invalid(InvalidCause::TooManyGenericArgs {
-                            expected,
-                            given,
-                        }) = instantiated.data(db)
-                        {
-                            return Err(PathResError::new(
-                                PathResErrorKind::ArgNumMismatch {
-                                    expected: *expected,
-                                    given: *given,
-                                },
-                                path,
-                            ));
-                        }
                         PathRes::TyAlias(alias.clone(), instantiated)
                     }
                 }

--- a/crates/hir-analysis/test_files/ty_check/default_generic_struct.fe
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_struct.fe
@@ -1,0 +1,17 @@
+struct Wrap<T = i32> {
+    v: T
+}
+
+struct Wrap2<T, U = T> {
+    a: T,
+    b: U,
+}
+
+fn main() {
+    let a: Wrap
+    let c: Wrap2<u64> = Wrap2 { a: 10, b: 20 }
+
+    let x = Wrap { v: 1 }
+    let z = Wrap<u64> { v: 2 }
+}
+

--- a/crates/hir-analysis/test_files/ty_check/default_generic_struct.snap
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_struct.snap
@@ -1,0 +1,84 @@
+---
+source: crates/hir-analysis/tests/ty_check.rs
+expression: res
+input_file: test_files/ty_check/default_generic_struct.fe
+---
+note: 
+   ┌─ default_generic_struct.fe:10:11
+   │  
+10 │   fn main() {
+   │ ╭───────────^
+11 │ │     let a: Wrap
+12 │ │     let c: Wrap2<u64> = Wrap2 { a: 10, b: 20 }
+13 │ │ 
+14 │ │     let x = Wrap { v: 1 }
+15 │ │     let z = Wrap<u64> { v: 2 }
+16 │ │ }
+   │ ╰─^ ()
+
+note: 
+   ┌─ default_generic_struct.fe:11:9
+   │
+11 │     let a: Wrap
+   │         ^ Wrap<i32>
+
+note: 
+   ┌─ default_generic_struct.fe:12:9
+   │
+12 │     let c: Wrap2<u64> = Wrap2 { a: 10, b: 20 }
+   │         ^ Wrap2<u64, u64>
+
+note: 
+   ┌─ default_generic_struct.fe:12:25
+   │
+12 │     let c: Wrap2<u64> = Wrap2 { a: 10, b: 20 }
+   │                         ^^^^^^^^^^^^^^^^^^^^^^ Wrap2<u64, u64>
+
+note: 
+   ┌─ default_generic_struct.fe:12:36
+   │
+12 │     let c: Wrap2<u64> = Wrap2 { a: 10, b: 20 }
+   │                                    ^^ u64
+
+note: 
+   ┌─ default_generic_struct.fe:12:43
+   │
+12 │     let c: Wrap2<u64> = Wrap2 { a: 10, b: 20 }
+   │                                           ^^ u64
+
+note: 
+   ┌─ default_generic_struct.fe:14:9
+   │
+14 │     let x = Wrap { v: 1 }
+   │         ^ Wrap<i32>
+
+note: 
+   ┌─ default_generic_struct.fe:14:13
+   │
+14 │     let x = Wrap { v: 1 }
+   │             ^^^^^^^^^^^^^ Wrap<i32>
+
+note: 
+   ┌─ default_generic_struct.fe:14:23
+   │
+14 │     let x = Wrap { v: 1 }
+   │                       ^ i32
+
+note: 
+   ┌─ default_generic_struct.fe:15:9
+   │
+15 │     let z = Wrap<u64> { v: 2 }
+   │         ^ Wrap<u64>
+
+note: 
+   ┌─ default_generic_struct.fe:15:13
+   │
+15 │     let z = Wrap<u64> { v: 2 }
+   │             ^^^^^^^^^^^^^^^^^^ Wrap<u64>
+
+note: 
+   ┌─ default_generic_struct.fe:15:28
+   │
+15 │     let z = Wrap<u64> { v: 2 }
+   │                            ^ u64
+

--- a/crates/hir-analysis/test_files/ty_check/default_generic_trait.fe
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_trait.fe
@@ -1,0 +1,14 @@
+trait Add<T = Self> {
+    type Output = Self
+
+    fn add(self: Self, _ rhs: T) -> Self::Output
+}
+
+impl Add for i32 {
+    fn add(self: Self, _ rhs: Self) -> Self { self }
+}
+
+fn f(x: i32) -> i32 {
+    x.add(x)
+}
+

--- a/crates/hir-analysis/test_files/ty_check/default_generic_trait.snap
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_trait.snap
@@ -1,0 +1,44 @@
+---
+source: crates/hir-analysis/tests/ty_check.rs
+expression: res
+input_file: test_files/ty_check/default_generic_trait.fe
+---
+note: 
+  ┌─ default_generic_trait.fe:8:45
+  │
+8 │     fn add(self: Self, _ rhs: Self) -> Self { self }
+  │                                             ^^^^^^^^ i32
+
+note: 
+  ┌─ default_generic_trait.fe:8:47
+  │
+8 │     fn add(self: Self, _ rhs: Self) -> Self { self }
+  │                                               ^^^^ i32
+
+note: 
+   ┌─ default_generic_trait.fe:11:21
+   │  
+11 │   fn f(x: i32) -> i32 {
+   │ ╭─────────────────────^
+12 │ │     x.add(x)
+13 │ │ }
+   │ ╰─^ i32
+
+note: 
+   ┌─ default_generic_trait.fe:12:5
+   │
+12 │     x.add(x)
+   │     ^ i32
+
+note: 
+   ┌─ default_generic_trait.fe:12:5
+   │
+12 │     x.add(x)
+   │     ^^^^^^^^ i32
+
+note: 
+   ┌─ default_generic_trait.fe:12:11
+   │
+12 │     x.add(x)
+   │           ^ i32
+

--- a/crates/hir-analysis/test_files/ty_check/default_generic_type_alias.fe
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_type_alias.fe
@@ -1,0 +1,9 @@
+struct Map<T, U> {}
+
+type Foo<T = i32> = Map<T, ()>
+
+fn main() {
+    let x: Foo
+    let y: Foo<u64>
+}
+

--- a/crates/hir-analysis/test_files/ty_check/default_generic_type_alias.snap
+++ b/crates/hir-analysis/test_files/ty_check/default_generic_type_alias.snap
@@ -1,0 +1,28 @@
+---
+source: crates/hir-analysis/tests/ty_check.rs
+assertion_line: 48
+expression: res
+input_file: test_files/ty_check/default_generic_type_alias.fe
+---
+note: 
+  ┌─ default_generic_type_alias.fe:5:11
+  │  
+5 │   fn main() {
+  │ ╭───────────^
+6 │ │     let x: Foo
+7 │ │     let y: Foo<u64>
+8 │ │ }
+  │ ╰─^ ()
+
+note: 
+  ┌─ default_generic_type_alias.fe:6:9
+  │
+6 │     let x: Foo
+  │         ^ Map<i32, ()>
+
+note: 
+  ┌─ default_generic_type_alias.fe:7:9
+  │
+7 │     let y: Foo<u64>
+  │         ^ Map<u64, ()>
+

--- a/crates/hir/src/hir_def/item.rs
+++ b/crates/hir/src/hir_def/item.rs
@@ -216,7 +216,17 @@ impl<'db> From<WhereClauseOwner<'db>> for ItemKind<'db> {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, derive_more::From, salsa::Supertype,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    derive_more::From,
+    salsa::Supertype,
+    salsa::Update,
 )]
 pub enum GenericParamOwner<'db> {
     Func(Func<'db>),
@@ -242,6 +252,30 @@ impl<'db> GenericParamOwner<'db> {
             GenericParamOwner::Impl(impl_) => impl_.generic_params(db),
             GenericParamOwner::Trait(trait_) => trait_.generic_params(db),
             GenericParamOwner::ImplTrait(impl_trait) => impl_trait.generic_params(db),
+        }
+    }
+
+    pub fn name(self, db: &'db dyn HirDb) -> Option<IdentId<'db>> {
+        match self {
+            GenericParamOwner::Func(func) => func.name(db).to_opt(),
+            GenericParamOwner::Struct(struct_) => struct_.name(db).to_opt(),
+            GenericParamOwner::Enum(enum_) => enum_.name(db).to_opt(),
+            GenericParamOwner::TypeAlias(type_alias) => type_alias.name(db).to_opt(),
+            GenericParamOwner::Impl(_) => None,
+            GenericParamOwner::Trait(trait_) => trait_.name(db).to_opt(),
+            GenericParamOwner::ImplTrait(_) => None,
+        }
+    }
+
+    pub fn kind_name(self) -> &'static str {
+        match self {
+            GenericParamOwner::Func(_) => "fn",
+            GenericParamOwner::Struct(_) => "struct",
+            GenericParamOwner::Enum(_) => "enum",
+            GenericParamOwner::TypeAlias(_) => "type",
+            GenericParamOwner::Impl(_) => "impl",
+            GenericParamOwner::Trait(_) => "trait",
+            GenericParamOwner::ImplTrait(_) => "impl trait",
         }
     }
 

--- a/crates/hir/src/hir_def/params.rs
+++ b/crates/hir/src/hir_def/params.rs
@@ -100,6 +100,7 @@ impl<'db> GenericParam<'db> {
 pub struct TypeGenericParam<'db> {
     pub name: Partial<IdentId<'db>>,
     pub bounds: Vec<TypeBound<'db>>,
+    pub default_ty: Option<TypeId<'db>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/hir/src/lower/params.rs
+++ b/crates/hir/src/lower/params.rs
@@ -79,8 +79,13 @@ impl<'db> TypeGenericParam<'db> {
                     .collect()
             })
             .unwrap_or_default();
+        let default_ty = ast.default_ty().map(|ty| TypeId::lower_ast(ctxt, ty));
 
-        Self { name, bounds }
+        Self {
+            name,
+            bounds,
+            default_ty,
+        }
     }
 }
 

--- a/crates/parser/src/ast/param.rs
+++ b/crates/parser/src/ast/param.rs
@@ -1,7 +1,7 @@
 use rowan::ast::{support, AstNode};
 
 use super::ast_node;
-use crate::{FeLang, SyntaxKind as SK, SyntaxToken};
+use crate::{ast::Type, FeLang, SyntaxKind as SK, SyntaxToken};
 
 ast_node! {
     /// A list of parameters.
@@ -149,6 +149,10 @@ impl TypeGenericParam {
     }
 
     pub fn bounds(&self) -> Option<TypeBoundList> {
+        support::child(self.syntax())
+    }
+
+    pub fn default_ty(&self) -> Option<Type> {
         support::child(self.syntax())
     }
 }

--- a/crates/parser/src/parser/param.rs
+++ b/crates/parser/src/parser/param.rs
@@ -160,6 +160,9 @@ impl super::Parse for TypeGenericParamScope {
         if parser.current_kind() == Some(SyntaxKind::Colon) {
             parser.parse(TypeBoundListScope::new(self.disallow_trait_bound))?;
         }
+        if parser.bump_if(SyntaxKind::Eq) {
+            parse_type(parser, None)?;
+        }
         Ok(())
     }
 }

--- a/crates/parser/test_files/syntax_node/items/trait.fe
+++ b/crates/parser/test_files/syntax_node/items/trait.fe
@@ -31,3 +31,8 @@ impl<S> Parser<S>
 pub trait SubTrait<T>: Parse + Add<T> 
 where T: Add<T>
 {}
+
+pub trait Sub<T = Self> {
+    type Output = Self
+    fn sub(self, rhs: T) -> Self::Output
+}

--- a/crates/parser/test_files/syntax_node/items/trait.snap
+++ b/crates/parser/test_files/syntax_node/items/trait.snap
@@ -3,8 +3,8 @@ source: crates/parser/tests/syntax_node.rs
 expression: node
 input_file: test_files/syntax_node/items/trait.fe
 ---
-Root@0..652
-  ItemList@0..652
+Root@0..746
+  ItemList@0..745
     Item@0..15
       Trait@0..15
         TraitKw@0..5 "trait"
@@ -551,3 +551,74 @@ Root@0..652
         TraitItemList@650..652
           LBrace@650..651 "{"
           RBrace@651..652 "}"
+    Newline@652..654 "\n\n"
+    Item@654..745
+      Trait@654..745
+        ItemModifier@654..657
+          PubKw@654..657 "pub"
+        WhiteSpace@657..658 " "
+        TraitKw@658..663 "trait"
+        WhiteSpace@663..664 " "
+        Ident@664..667 "Sub"
+        GenericParamList@667..677
+          Lt@667..668 "<"
+          TypeGenericParam@668..676
+            Ident@668..669 "T"
+            WhiteSpace@669..670 " "
+            Eq@670..671 "="
+            WhiteSpace@671..672 " "
+            PathType@672..676
+              Path@672..676
+                PathSegment@672..676
+                  SelfTypeKw@672..676 "Self"
+          Gt@676..677 ">"
+        WhiteSpace@677..678 " "
+        TraitItemList@678..745
+          LBrace@678..679 "{"
+          Newline@679..680 "\n"
+          WhiteSpace@680..684 "    "
+          TraitTypeItem@684..702
+            TypeKw@684..688 "type"
+            WhiteSpace@688..689 " "
+            Ident@689..695 "Output"
+            WhiteSpace@695..696 " "
+            Eq@696..697 "="
+            WhiteSpace@697..698 " "
+            PathType@698..702
+              Path@698..702
+                PathSegment@698..702
+                  SelfTypeKw@698..702 "Self"
+          Newline@702..703 "\n"
+          WhiteSpace@703..707 "    "
+          Func@707..743
+            FnKw@707..709 "fn"
+            WhiteSpace@709..710 " "
+            Ident@710..713 "sub"
+            FuncParamList@713..727
+              LParen@713..714 "("
+              FnParam@714..718
+                SelfKw@714..718 "self"
+              Comma@718..719 ","
+              WhiteSpace@719..720 " "
+              FnParam@720..726
+                Ident@720..723 "rhs"
+                Colon@723..724 ":"
+                WhiteSpace@724..725 " "
+                PathType@725..726
+                  Path@725..726
+                    PathSegment@725..726
+                      Ident@725..726 "T"
+              RParen@726..727 ")"
+            WhiteSpace@727..728 " "
+            Arrow@728..730 "->"
+            WhiteSpace@730..731 " "
+            PathType@731..743
+              Path@731..743
+                PathSegment@731..735
+                  SelfTypeKw@731..735 "Self"
+                Colon2@735..737 "::"
+                PathSegment@737..743
+                  Ident@737..743 "Output"
+          Newline@743..744 "\n"
+          RBrace@744..745 "}"
+  Newline@745..746 "\n"

--- a/crates/uitest/fixtures/ty/def/alias_duplicate_param.fe
+++ b/crates/uitest/fixtures/ty/def/alias_duplicate_param.fe
@@ -1,0 +1,2 @@
+struct Map<K, V> {}
+type Foo<T, T> = Map<T, T>

--- a/crates/uitest/fixtures/ty/def/alias_duplicate_param.snap
+++ b/crates/uitest/fixtures/ty/def/alias_duplicate_param.snap
@@ -1,0 +1,30 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/alias_duplicate_param.fe
+---
+error[2-0004]: `T` is ambiguous
+  ┌─ alias_duplicate_param.fe:2:22
+  │
+2 │ type Foo<T, T> = Map<T, T>
+  │          -  -        ^ `T` is ambiguous
+  │          │  │         
+  │          │  candidate 2
+  │          candidate 1
+
+error[2-0004]: `T` is ambiguous
+  ┌─ alias_duplicate_param.fe:2:25
+  │
+2 │ type Foo<T, T> = Map<T, T>
+  │          -  -           ^ `T` is ambiguous
+  │          │  │            
+  │          │  candidate 2
+  │          candidate 1
+
+error[3-0019]: duplicate generic parameter name in type `Foo`
+  ┌─ alias_duplicate_param.fe:2:10
+  │
+2 │ type Foo<T, T> = Map<T, T>
+  │          ^  - `T` is redefined here
+  │          │   
+  │          `T` is defined here

--- a/crates/uitest/fixtures/ty/def/alias_missing_generic_arg.fe
+++ b/crates/uitest/fixtures/ty/def/alias_missing_generic_arg.fe
@@ -1,0 +1,9 @@
+struct Map<T, U> {}
+
+type Bar<U, V = U> = Map<U, V>
+
+fn f() {
+    // Missing required generic argument U
+    let _y: Bar
+}
+

--- a/crates/uitest/fixtures/ty/def/alias_missing_generic_arg.snap
+++ b/crates/uitest/fixtures/ty/def/alias_missing_generic_arg.snap
@@ -1,0 +1,13 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/alias_missing_generic_arg.fe
+---
+error[3-0003]: all type parameters of type alias must be given
+  ┌─ alias_missing_generic_arg.fe:7:13
+  │
+3 │ type Bar<U, V = U> = Map<U, V>
+  │ ------------------------------ type alias defined here
+  ·
+7 │     let _y: Bar
+  │             ^^^ expected at least 2 arguments here

--- a/crates/uitest/fixtures/ty/def/alias_too_many_args.fe
+++ b/crates/uitest/fixtures/ty/def/alias_too_many_args.fe
@@ -1,0 +1,6 @@
+struct Map<K, V> {}
+type IntMap<V> = Map<i32, V>
+
+fn f() {
+    let m: IntMap<i32, i32>
+}

--- a/crates/uitest/fixtures/ty/def/alias_too_many_args.snap
+++ b/crates/uitest/fixtures/ty/def/alias_too_many_args.snap
@@ -1,0 +1,10 @@
+---
+source: crates/uitest/tests/ty.rs
+expression: diags
+input_file: fixtures/ty/def/alias_too_many_args.fe
+---
+error[2-0011]: incorrect number of generic arguments for `IntMap`; expected 1, given 2
+  ┌─ alias_too_many_args.fe:5:12
+  │
+5 │     let m: IntMap<i32, i32>
+  │            ^^^^^^ expected 1 arguments, but 2 were given

--- a/crates/uitest/fixtures/ty_check/default_generic_forward_ref.fe
+++ b/crates/uitest/fixtures/ty_check/default_generic_forward_ref.fe
@@ -1,0 +1,6 @@
+struct Wrap3<A = B, B = i32> {
+    a: A,
+    b: B,
+}
+
+struct S<T = U, U = T> {}

--- a/crates/uitest/fixtures/ty_check/default_generic_forward_ref.snap
+++ b/crates/uitest/fixtures/ty_check/default_generic_forward_ref.snap
@@ -1,0 +1,16 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/default_generic_forward_ref.fe
+---
+error[3-0022]: cannot reference generic parameter before it is declared
+  ┌─ default_generic_forward_ref.fe:1:14
+  │
+1 │ struct Wrap3<A = B, B = i32> {
+  │              ^^^^^ cannot reference `B` before it's declared
+
+error[3-0022]: cannot reference generic parameter before it is declared
+  ┌─ default_generic_forward_ref.fe:6:10
+  │
+6 │ struct S<T = U, U = T> {}
+  │          ^^^^^ cannot reference `U` before it's declared

--- a/crates/uitest/fixtures/ty_check/default_generic_non_trailing.fe
+++ b/crates/uitest/fixtures/ty_check/default_generic_non_trailing.fe
@@ -1,0 +1,9 @@
+struct S<T = i32, U> {}
+
+trait Tr<T = Self, U> {}
+
+struct Map<T, U> {}
+type Alias<T = i32, U> = Map<T, U>
+
+fn foo<T = i32, U>(x: U) {}
+

--- a/crates/uitest/fixtures/ty_check/default_generic_non_trailing.snap
+++ b/crates/uitest/fixtures/ty_check/default_generic_non_trailing.snap
@@ -1,0 +1,29 @@
+---
+source: crates/uitest/tests/ty_check.rs
+expression: diags
+input_file: fixtures/ty_check/default_generic_non_trailing.fe
+---
+error[3-0021]: generic parameters with a default must be trailing
+  ┌─ default_generic_non_trailing.fe:1:10
+  │
+1 │ struct S<T = i32, U> {}
+  │          ^^^^^^^ must not be followed by a parameter with no default
+
+error[3-0021]: generic parameters with a default must be trailing
+  ┌─ default_generic_non_trailing.fe:3:10
+  │
+3 │ trait Tr<T = Self, U> {}
+  │          ^^^^^^^^ must not be followed by a parameter with no default
+
+error[3-0021]: generic parameters with a default must be trailing
+  ┌─ default_generic_non_trailing.fe:6:12
+  │
+6 │ type Alias<T = i32, U> = Map<T, U>
+  │            ^^^^^^^ must not be followed by a parameter with no default
+
+error[3-0021]: generic parameters with a default must be trailing
+  ┌─ default_generic_non_trailing.fe:8:8
+  │
+8 │ fn foo<T = i32, U>(x: U) {}
+  │        ^^^^^^^ must not be followed by a parameter with no default
+


### PR DESCRIPTION
```
struct Foo<T = i32> {
  inner: T
}

trait Add<T: Self> {
  type Output = Self
  fn add(self, _ other: T) -> Self::Output
}
```

I also moved the type alias analysis into DefAnalyzer, where the other item definitions are analyzed. This fixes some missing type alias diagnostics.